### PR TITLE
Extending documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Introduction
-CodeChecker static analysis infrastructure built on clang static analyzer.  
+CodeChecker is a static analysis infrastructure built on [Clang Static Analyzer](http://clang-analyzer.llvm.org/).  
 
-CodeChecker replaces [scan-build](http://clang-analyzer.llvm.org/scan-build.html) in Clang Static Analizer in Linux systems.
+CodeChecker replaces [scan-build](http://clang-analyzer.llvm.org/scan-build.html) in Clang Static Analyzer in Linux systems.
 
 It provides 
  * a new command line tool for analyzing projects
- * dynamic web based bug defect viewer (instead of static html)
+ * dynamic web based defect viewer (instead of static html)
  * a Postgresql based defect storage & management
  * incremental bug reporting (show only new bugs compared to a baseline)
  * suppression of false positives
  * better integration with build systems (through the LD_PRELOAD mechanism)
+ * Thrift API based server-client model for storing bugs and viewing results. 
+ * It is possible to connect multiple bug viewers. Currently a web-based viewer and a command line viewer are provided.
 
 You can find a high level overview about the infrastructure in the presentation
 at the [2015 Euro LLVM](http://llvm.org/devmtg/2015-04/) Conference:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Introduction
 CodeChecker static analysis infrastructure built on clang static analyzer.  
 
-CodeChecker replaces [scan-build](http://clang-analyzer.llvm.org/scan-build.html) in Clang Static Analizer.
+CodeChecker replaces [scan-build](http://clang-analyzer.llvm.org/scan-build.html) in Clang Static Analizer in Linux systems.
 
 It provides 
  * a new command line tool for analyzing projects
@@ -9,7 +9,7 @@ It provides
  * a Postgresql based defect storage & management
  * incremental bug reporting (show only new bugs compared to a baseline)
  * suppression of false positives
- * better integration with build systems (through LD_PRELOAD mechanism)
+ * better integration with build systems (through the LD_PRELOAD mechanism)
 
 You can find a high level overview about the infrastructure in the presentation
 at the [2015 Euro LLVM](http://llvm.org/devmtg/2015-04/) Conference:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Introduction
 CodeChecker static analysis infrastructure built on clang static analyzer.  
 
+CodeChecker replaces [scan-build](http://clang-analyzer.llvm.org/scan-build.html) in Clang Static Analizer.
+
+It provides 
+ * a new command line tool for analyzing projects
+ * dynamic web based bug defect viewer (instead of static html)
+ * a Postgresql based defect storage & management
+ * incremental bug reporting (show only new bugs compared to a baseline)
+ * suppression of false positives
+ * better integration with build systems (through LD_PRELOAD mechanism)
+
 You can find a high level overview about the infrastructure in the presentation
 at the [2015 Euro LLVM](http://llvm.org/devmtg/2015-04/) Conference:
 

--- a/tests/package_test.md
+++ b/tests/package_test.md
@@ -12,7 +12,7 @@ test_package.py --help
 
 
 # What happens during the test
- * The chosen test project is builded, logged and checked twice. For this step the ld-logger must be present in the package.
+ * The chosen test project is built, logged and checked twice. For this step the ld-logger must be present in the package.
  * The test modules are invoked.
 
 

--- a/thrift_api/thrift_api.md
+++ b/thrift_api/thrift_api.md
@@ -4,8 +4,8 @@ These APIs should be used by the clients using the database to store or to get t
 
 ## Report viewer server API
 The report viewer server API should be used by any client to view the check results.
-See [report-viewer-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-viewer-server.thrift).
+See [report-viewer-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift_api/report-viewer-server.thrift).
 
 ## Report storage server API
 The report storage server API is used internally in the package during runtime to store the results to the database.
-See [report-storage-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-storage-server.thrift).
+See [report-storage-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift_api/report-storage-server.thrift).

--- a/thrift_api/thrift_api.md
+++ b/thrift_api/thrift_api.md
@@ -4,8 +4,8 @@ These APIs should be used by the clients using the database to store or to get t
 
 ## Report viewer server API
 The report viewer server API should be used by any client to view the check results.
-See (report-viewer-server.thrift)[https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-viewer-server.thrift]
+See [report-viewer-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-viewer-server.thrift).
 
 ## Report storage server API
 The report storage server API is used internally in the package during runtime to store the results to the database.
-See (report-storage-server.thrift)[https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-storage-server.thrift]
+See [report-storage-server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-storage-server.thrift).

--- a/thrift_api/thrift_api.md
+++ b/thrift_api/thrift_api.md
@@ -4,6 +4,8 @@ These APIs should be used by the clients using the database to store or to get t
 
 ## Report viewer server API
 The report viewer server API should be used by any client to view the check results.
+See (report-viewer-server.thrift)[https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-viewer-server.thrift]
 
 ## Report storage server API
 The report storage server API is used internally in the package during runtime to store the results to the database.
+See (report-storage-server.thrift)[https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift-api/report-storage-server.thrift]


### PR DESCRIPTION
-Extended main page to better explain what codechecker provides
-Extended thrift API descriptions with links to thrift files