### PR TITLE
Better ship file handling (issue #20)

### DIFF
--- a/codechecker_lib/analyzer.py
+++ b/codechecker_lib/analyzer.py
@@ -193,9 +193,6 @@ def run(analyzer, action):
             sys.exit(os.EX_OK)
 
     signal.signal(signal.SIGINT, signal_handler)
-
-    LOG.info(id(analyzer))
-
     current_cmd = list(analyzer.cmd)
 
     for checker_name, enabled in analyzer.checkers:


### PR DESCRIPTION
* Better skip file handling:
  Skip files using the last event's location. This resolves Ericsson/codechecker#20 .
* Set skip messages to debug log level from info.
* Don't write out python object ids