### PR TITLE
filter duplicate compilation commands from the build action log (issue #34)

### DIFF
--- a/codechecker_lib/build_action.py
+++ b/codechecker_lib/build_action.py
@@ -5,6 +5,8 @@
 # -------------------------------------------------------------------------
 ''''''
 
+import hashlib
+
 # -----------------------------------------------------------------------------
 class BuildAction(object):
     def __init__(self, build_action_id=0):
@@ -109,3 +111,17 @@ class BuildAction(object):
 
     def __eq__(self, other):
         return other._original_command == self._original_command
+
+    @property
+    def cmp_key(self):
+        '''
+        If the compilation database contains the same compilation action
+        multiple times it should be checked only once.
+        Use this key to compare compilation commands for the analysis.
+        '''
+        hash_content = []
+        hash_content.extend(self.analyzer_options)
+        hash_content.append(self.output)
+        hash_content.append(self.target)
+        hash_content.extend(self.sources)
+        return hashlib.sha1(''.join(hash_content)).hexdigest()

--- a/codechecker_lib/log_parser.py
+++ b/codechecker_lib/log_parser.py
@@ -18,6 +18,7 @@ def parse_compile_commands_json(logfile):
     import json
 
     actions = []
+    filtered_build_actions = {}
 
     logfile.seek(0)
     data = json.load(logfile)
@@ -50,9 +51,16 @@ def parse_compile_commands_json(logfile):
         action.sources = sourcefile
         action.lang = lang
 
-        actions.append(action)
+        # filter out duplicate compilation commands
+        unique_key = action.cmp_key
+        if filtered_build_actions.get(unique_key) is None:
+            filtered_build_actions[unique_key] = action
+
         del action
         counter += 1
+
+    for ba_hash, ba in filtered_build_actions.iteritems():
+        actions.append(ba)
 
     return actions
 
@@ -73,4 +81,5 @@ def parse_log(logfilepath):
                 LOG.error('The compile database is not valid.')
             raise ex
 
+    LOG.info('Parsing log file done.')
     return actions


### PR DESCRIPTION
resolves Ericsson/codechecker#34
Uses a hash to compare if a compilation command was already found in the build log file.