### PR TITLE
clean report filtering (issue  #33)

### DIFF
--- a/codechecker_lib/analyzer.py
+++ b/codechecker_lib/analyzer.py
@@ -242,8 +242,7 @@ def run(analyzer, action):
         with client.get_connection() as connection:
 
             action_id = connection.add_build_action(action.original_command,
-                                                    check_cmd_str,
-                                                    action.target)
+                                                    check_cmd_str)
 
             LOG.debug(' '.join(check_cmd))
             result = subprocess.Popen(check_cmd,
@@ -266,8 +265,7 @@ def run(analyzer, action):
                 client.send_plist_content(connection, report_plist, action_id,
                                           analyzer.run_id,
                                           analyzer.severity_map,
-                                          analyzer.should_skip,
-                                          analyzer.module_id)
+                                          analyzer.should_skip)
                 msg = 'Checking %s is done.' % (source_file)
                 LOG.debug(msg + '\n' + check_cmd_str)
                 LOG.info(msg)

--- a/codechecker_lib/client.py
+++ b/codechecker_lib/client.py
@@ -29,7 +29,7 @@ LOG = logger.get_new_logger('CLIENT')
 
 # -----------------------------------------------------------------------------
 def send_plist_content(connection, plist_file, build_action_id, run_id,
-                       severity_map, should_skip, module_id=''):
+                       severity_map, should_skip):
     try:
         files, bugs = plist_parser.parse_plist(plist_file)
     except Exception as ex:
@@ -92,8 +92,6 @@ def send_plist_content(connection, plist_file, build_action_id, run_id,
                                           severity)
 
         report_ids.append(report_id)
-
-    connection.add_module_to_report(run_id, module_id, report_ids)
 
 
 # -----------------------------------------------------------------------------
@@ -218,10 +216,10 @@ class Connection(object):
     #    ''' bool addSkipPath(1: i64 run_id, 2: list<string> paths) '''
     #    return self._client.addSkipPath(ConnectionManager.run_id, path)
 
-    def add_build_action(self, build_cmd, check_cmd, target):
+    def add_build_action(self, build_cmd, check_cmd):
         ''' i64  addBuildAction(1: i64 run_id, 2: string build_cmd) '''
         return self._client.addBuildAction(ConnectionManager.run_id,
-                                            build_cmd, check_cmd, target)
+                                            build_cmd, check_cmd)
 
     def finish_build_action(self, action_id, failure):
         ''' bool finishBuildAction(1: i64 action_id, 2: string failure) '''
@@ -248,9 +246,6 @@ class Connection(object):
     def add_file_content(self, file_id, file_content):
         ''' bool addFileContent(1: i64 file_id, 2: binary file_content) '''
         return self._client.addFileContent(file_id, file_content)
-
-    def add_module_to_report(self, run_id, module_id, report_ids):
-        return self._client.moduleToReport(run_id, module_id, report_ids)
 
 
 # -----------------------------------------------------------------------------

--- a/db_model/orm_model.py
+++ b/db_model/orm_model.py
@@ -106,17 +106,14 @@ class BuildAction(Base):
     # Seconds, -1 if unfinished
     duration = Column(Integer)
 
-    build_target = Column(String)
-
     # Relationships (One to Many)
     # plistlist = relationship('Plist')
 
-    def __init__(self, run_id, build_cmd, check_cmd, build_target):
+    def __init__(self, run_id, build_cmd, check_cmd):
         self.run_id, self.build_cmd, self.check_cmd, self.failure_txt = \
             run_id, build_cmd, check_cmd, ''
         self.date = datetime.now()
         self.duration = -1
-        self.build_target = build_target
 
     def mark_finished(self, failure_txt):
         self.failure_txt = failure_txt
@@ -252,18 +249,6 @@ class SkipPath(Base):
     def __init__(self, run_id, path, comment):
         self.path, self.run_id = path, run_id
         self.comment = comment
-
-
-class ModuleToReport(Base):
-    __tablename__ = 'modules_to_reports'
-
-    report_id = Column(Integer, ForeignKey('reports.id', deferrable = True, initially = "DEFERRED", ondelete='CASCADE'), primary_key=True)
-    run_id = Column(Integer)
-    module = Column(String)
-
-    def __init__(self, run_id, module, report_id):
-        self.module, self.report_id = module, report_id
-        self.run_id = run_id
 
 # End of ORM classes
 

--- a/storage_server/report_server.py
+++ b/storage_server/report_server.py
@@ -140,7 +140,7 @@ class CheckerReportHandler(object):
         return True
 
     @decorators.catch_sqlalchemy
-    def addBuildAction(self, run_id, build_cmd, check_cmd, build_target):
+    def addBuildAction(self, run_id, build_cmd, check_cmd):
         '''
         '''
         build_action = self.session.query(BuildAction) \
@@ -149,7 +149,7 @@ class CheckerReportHandler(object):
         if build_action.count() != 0:
             self.deleteBuildAction(build_action.first())
 
-        action = BuildAction(run_id, build_cmd, check_cmd, build_target)
+        action = BuildAction(run_id, build_cmd, check_cmd)
         self.session.add(action)
         self.session.commit()
         return action.id
@@ -418,27 +418,6 @@ class CheckerReportHandler(object):
             skipPathList.append(skipPath)
         self.session.bulk_save_objects(skipPathList)
         self.session.commit()
-        return True
-
-    @decorators.catch_sqlalchemy
-    def moduleToReport(self, run_id, module, report_ids):
-        '''
-        '''
-        for report_id in report_ids:
-            # check if there is already an entry with this report id
-            report = self.session.query(ModuleToReport) \
-                                 .filter(ModuleToReport.report_id == report_id)
-            if report.count() == 0:
-                # not found add to database
-                obj = ModuleToReport(run_id, module, report_id)
-                for i in xrange(3):
-                    try:
-                        self.session.add(obj)
-                        self.session.commit()
-                        break
-                    except sqlalchemy.exc.IntegrityError as ex:
-                        self.session.rollback()
-
         return True
 
     @decorators.catch_sqlalchemy

--- a/tests/regression_test/test_regression_run_results.py
+++ b/tests/regression_test/test_regression_run_results.py
@@ -184,7 +184,7 @@ class RunResults(unittest.TestCase):
         runid = self._runid
         debug('Get all run results from the db for runid: ' + str(runid))
         sort_mode1 = SortMode(SortType.SEVERITY, Order.ASC)
-        sort_mode2 = SortMode(SortType.MODULE, Order.ASC)
+        sort_mode2 = SortMode(SortType.FILENAME, Order.ASC)
         sort_types = [sort_mode1, sort_mode2]
 
         run_result_count = self._cc_client.getRunResultCount(runid, [])
@@ -200,7 +200,7 @@ class RunResults(unittest.TestCase):
             bug2 = run_results[i + 1]
             self.assertTrue(bug1.severity <= bug2.severity)
             self.assertTrue((bug1.severity != bug2.severity) or
-                            (bug1.moduleName <= bug2.moduleName))
+                            (bug1.checkedFile <= bug2.checkedFile))
 
         for run_res in run_results:
             debug('{0:15s}  {1}'.format(run_res.checkedFile, run_res.checkerId))

--- a/thrift_api/report-storage-server.thrift
+++ b/thrift_api/report-storage-server.thrift
@@ -47,8 +47,7 @@ service CheckerReport {
                 i64  addBuildAction(
                                     1: i64 run_id,
                                     2: string build_cmd,
-                                    3: string check_cmd,
-                                    4: string target)
+                                    3: string check_cmd)
                                     throws (1: shared.RequestFailed requestError),
 
                 i64  addReport(
@@ -78,12 +77,6 @@ service CheckerReport {
                 bool addFileContent(
                                     1: i64 file_id,
                                     2: binary file_content)
-                                    throws (1: shared.RequestFailed requestError),
-
-                bool moduleToReport(
-                                    1: i64 run_id,
-                                    2: string moduleId,
-                                    3: list<i64> report_ids)
                                     throws (1: shared.RequestFailed requestError),
 
                 bool finishCheckerRun(1: i64 run_id)

--- a/thrift_api/report-viewer-server.thrift
+++ b/thrift_api/report-viewer-server.thrift
@@ -44,8 +44,7 @@ struct ReportData{
   8: shared.BugPathEvent lastBugPosition  // This contains the range and message of the last item in the symbolic
                                           // execution step list.
   9: shared.Severity     severity         // checker severity
-  10: string             moduleName       // name of the module if available
-  11: optional string    suppressComment // suppress commment if report is suppressed
+  10: optional string    suppressComment // suppress commment if report is suppressed
 }
 typedef list<ReportData> ReportDataList
 
@@ -60,10 +59,8 @@ struct ReportFilter{
   2: optional string          checkerMsg,
   3: optional shared.Severity severity,
   4: optional string          checkerId,          // should filter in the fully qualified checker id name such as alpha.core.
-  5: optional string          buildTarget,        // such as i386, x86-64
-  6: optional string          moduleName,         // higher concept for identifying software components of
                                                   // the analyzed system. Projects can optionally use this concept.
-  7: optional bool            suppressed = false  // if the bug state is suppressed
+  5: optional bool            suppressed = false  // if the bug state is suppressed
 }
 
 /**
@@ -74,8 +71,7 @@ typedef list<ReportFilter> ReportFilterList
 //-----------------------------------------------------------------------------
 struct ReportDetails{
   1: shared.BugPathEvents pathEvents,
-  2: shared.BugPath       executionPath,
-  3: list<string>         buildTargets    // the report can belong to multiple targets:i386, x86-64 etc.
+  2: shared.BugPath       executionPath
 }
 
 //-----------------------------------------------------------------------------
@@ -89,9 +85,7 @@ struct ReportFileData{
 enum SortType {
   FILENAME,
   CHECKER_NAME,
-  SEVERITY,
-  BUILD_TARGET,
-  MODULE
+  SEVERITY
 }
 
 //-----------------------------------------------------------------------------

--- a/viewer_clients/web-client/scripts/codecheckerviewer/OverviewGrid.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/OverviewGrid.js
@@ -265,7 +265,6 @@ return declare(DataGrid, {
         fileId         : reportDataList[i].fileId,
         lastBugPosition: reportDataList[i].lastBugPosition,
         severity       : CC_UTIL.severityFromCodeToString(reportDataList[i].severity),
-        moduleName     : reportDataList[i].moduleName,
         suppressComment: reportDataList[i].suppressComment === null ? "----" : reportDataList[i].suppressComment,
         fileWithBugPos : reportDataList[i].checkedFile + "\n@ Line " + reportDataList[i].lastBugPosition.startLine,
         runId          : runIdToAdd

--- a/viewer_server/client_db_access_handler.py
+++ b/viewer_server/client_db_access_handler.py
@@ -81,7 +81,6 @@ def construct_report_filter(report_filters):
         AND.append(Report.checker_message.like('%'))
         AND.append(Report.checker_id.like('%'))
         AND.append(File.filepath.like('%'))
-        AND.append(BuildAction.build_target.like('%'))
 
         OR.append(and_(*AND))
         filter_expression = or_(*OR)
@@ -98,15 +97,9 @@ def construct_report_filter(report_filters):
         if report_filter.filepath:
             AND.append(File.filepath.like(
                        conv(report_filter.filepath)))
-        if report_filter.buildTarget:
-            AND.append(BuildAction.build_target.like(
-                       conv(report_filter.buildTarget)))
         if report_filter.severity is not None:
             # severity value can be 0
             AND.append(Report.severity == report_filter.severity)
-        if report_filter.moduleName:
-            AND.append(ModuleToReport.module.like(
-                       conv(report_filter.moduleName)))
         if report_filter.suppressed:
             AND.append(Report.suppressed == 'True')
         else:
@@ -170,9 +163,7 @@ class ThriftRequestHandler():
         sort_type_map = {}
         sort_type_map[SortType.FILENAME] =  File.filepath
         sort_type_map[SortType.CHECKER_NAME] =  Report.checker_id
-        sort_type_map[SortType.BUILD_TARGET] =  BuildAction.build_target
         sort_type_map[SortType.SEVERITY] = Report.severity
-        sort_type_map[SortType.MODULE] = ModuleToReport.module
 
         #mapping the sqlalchemy functions
         order_type_map = {}
@@ -185,26 +176,14 @@ class ThriftRequestHandler():
 
             q = session.query(Report,
                               File,
-                              ReportsToBuildActions,
-                              BuildAction,
                               BugPathEvent,
-                              ModuleToReport,
                               SuppressBug) \
                 .filter(Report.run_id == run_id) \
                 .outerjoin(File,
                            and_(Report.file_id == File.id,
                                 File.run_id == run_id)) \
-                .outerjoin(ReportsToBuildActions,
-                           Report.id == ReportsToBuildActions.report_id) \
-                .outerjoin(BuildAction,
-                           and_(ReportsToBuildActions.build_action_id \
-                                == BuildAction.id,
-                                BuildAction.run_id == run_id)) \
                 .outerjoin(BugPathEvent,
                            Report.end_bugevent == BugPathEvent.id) \
-                .outerjoin(ModuleToReport,
-                           and_(Report.id == ModuleToReport.report_id,
-                                ModuleToReport.run_id == run_id)) \
                 .outerjoin(SuppressBug,
                            and_(SuppressBug.hash == Report.bug_id,
                                 SuppressBug.run_id == run_id)) \
@@ -222,7 +201,7 @@ class ThriftRequestHandler():
 
             results = []
 
-            for report, source_file, reptoba, buildaction, lbpe, module, suppress_bug in \
+            for report, source_file, lbpe, suppress_bug in \
                     q.limit(limit).offset(offset):
 
                 last_event_pos = \
@@ -249,7 +228,6 @@ class ThriftRequestHandler():
                                           lastBugPosition=last_event_pos,
                                           checkerId=report.checker_id,
                                           severity=report.severity,
-                                          moduleName=module.module,
                                           suppressComment=suppress_comment)
                                )
 
@@ -320,17 +298,8 @@ class ThriftRequestHandler():
                 .outerjoin(File,
                            and_(Report.file_id == File.id,
                                 File.run_id == run_id)) \
-                .outerjoin(ReportsToBuildActions,
-                           Report.id == ReportsToBuildActions.report_id) \
-                .outerjoin(BuildAction,
-                           and_(ReportsToBuildActions.build_action_id \
-                                == BuildAction.id,
-                                BuildAction.run_id == run_id)) \
                 .outerjoin(BugPathEvent,
                            Report.end_bugevent == BugPathEvent.id) \
-                .outerjoin(ModuleToReport,
-                           and_(Report.id == ModuleToReport.report_id,
-                                ModuleToReport.run_id == run_id)) \
                 .outerjoin(SuppressBug,
                            and_(SuppressBug.hash == Report.bug_id,
                                 SuppressBug.run_id == run_id)) \
@@ -451,23 +420,7 @@ class ThriftRequestHandler():
                                         fileId=bug_point.file_id,
                                         filePath=file_path))
 
-            reportsToBuild = session.query(ReportsToBuildActions)\
-                                .filter(ReportsToBuildActions.report_id == report.id)
-
-            buildTargets = []
-            if reportsToBuild:
-
-                baIds = [ baid.build_action_id for baid in reportsToBuild ]
-
-                reportBuildActions = session.query(BuildAction) \
-                                            .filter(BuildAction.id.in_(baIds)) \
-                                            .all()
-
-                for rba in reportBuildActions:
-                    buildTargets.append(rba.build_target)
-
-
-            return ReportDetails(bug_events_list, bug_point_list, buildTargets)
+            return ReportDetails(bug_events_list, bug_point_list)
 
         except sqlalchemy.exc.SQLAlchemyError as alchemy_ex:
             msg = str(alchemy_ex)
@@ -786,16 +739,8 @@ class ThriftRequestHandler():
                 .filter(Report.run_id == run_id) \
                 .outerjoin(File,
                            Report.file_id == File.id) \
-                .outerjoin(ReportsToBuildActions,
-                           Report.id == ReportsToBuildActions.report_id) \
-                .outerjoin(BuildAction,
-                           and_(ReportsToBuildActions.build_action_id
-                                == BuildAction.id,
-                                BuildAction.run_id == run_id)) \
                 .outerjoin(BugPathEvent,
                            Report.end_bugevent == BugPathEvent.id) \
-                .outerjoin(ModuleToReport,
-                           Report.id == ModuleToReport.report_id) \
                 .order_by(Report.checker_id) \
                 .filter(filter_expression) \
                 .all()
@@ -868,9 +813,7 @@ class ThriftRequestHandler():
         sort_type_map = {}
         sort_type_map[SortType.FILENAME] = File.filepath
         sort_type_map[SortType.CHECKER_NAME] = Report.checker_id
-        sort_type_map[SortType.BUILD_TARGET] = BuildAction.build_target
         sort_type_map[SortType.SEVERITY] = Report.severity
-        sort_type_map[SortType.MODULE] = ModuleToReport.module
 
         #mapping the sqlalchemy functions
         order_type_map = {}
@@ -882,26 +825,14 @@ class ThriftRequestHandler():
         try:
             q = session.query(Report,
                               File,
-                              ReportsToBuildActions,
-                              BuildAction,
                               BugPathEvent,
-                              ModuleToReport,
                               SuppressBug) \
                 .filter(Report.run_id == run_id) \
                 .outerjoin(File,
                            and_(Report.file_id == File.id,
                                 File.run_id == run_id)) \
-                .outerjoin(ReportsToBuildActions,
-                           Report.id == ReportsToBuildActions.report_id) \
-                .outerjoin(BuildAction,
-                           and_(ReportsToBuildActions.build_action_id \
-                                == BuildAction.id,
-                                BuildAction.run_id == run_id)) \
                 .outerjoin(BugPathEvent,
                            Report.end_bugevent == BugPathEvent.id) \
-                .outerjoin(ModuleToReport,
-                           and_(Report.id == ModuleToReport.report_id,
-                                ModuleToReport.run_id == run_id)) \
                 .outerjoin(SuppressBug,
                            and_(SuppressBug.hash == Report.bug_id,
                                 SuppressBug.run_id == run_id)) \
@@ -921,7 +852,7 @@ class ThriftRequestHandler():
 
             results = []
 
-            for report, source_file, reptoba, buildaction, lbpe, module, suppress_bug \
+            for report, source_file, lbpe, suppress_bug \
                                             in q.limit(limit).offset(offset):
 
                 lastEventPos = \
@@ -945,7 +876,6 @@ class ThriftRequestHandler():
                                           lastBugPosition=lastEventPos,
                                           checkerId=report.checker_id,
                                           severity=report.severity,
-                                          moduleName=module.module,
                                           suppressComment=suppress_comment))
 
             return results


### PR DESCRIPTION
module name and build target was not filled out during the check caused some bugs in the viewer
remove module name, build target from the database and cleanup filtering and thrift API

Fixes  #33