### PR TITLE
Permalink and browser back/forward support

### DIFF
--- a/thrift_api/report-viewer-server.thrift
+++ b/thrift_api/report-viewer-server.thrift
@@ -17,7 +17,7 @@ namespace js codeCheckerDBAccess
 namespace cpp cc.service.codechecker
 
 //=================================================
-const string API_VERSION = '3.0'
+const string API_VERSION = '4.0'
 const i64 MAX_QUERY_SIZE = 500
 //=================================================
 
@@ -45,10 +45,9 @@ struct ReportData{
                                           // execution step list.
   9: shared.Severity     severity         // checker severity
   10: string             moduleName       // name of the module if available
-  11: optional string    suppressComment // suppress commment if report is suppressed
+  11: optional string    suppressComment  // suppress commment if report is suppressed
 }
 typedef list<ReportData> ReportDataList
-
 
 //-----------------------------------------------------------------------------
 /**
@@ -134,6 +133,10 @@ service codeCheckerDBAccess {
   // get the run Ids and dates from the database to select one run
   RunDataList getRunData()
                          throws (1: shared.RequestFailed requestError),
+
+  ReportData getReport(
+                       1: i64 reportId)
+                       throws (1: shared.RequestFailed requestError),
 
   // get the results for one runId
   ReportDataList getRunResults(
@@ -238,4 +241,3 @@ service codeCheckerDBAccess {
                         throws (1: shared.RequestFailed requestError),
 
 }
-

--- a/viewer_clients/web-client/index.html
+++ b/viewer_clients/web-client/index.html
@@ -61,7 +61,7 @@
       require([
         "scripts/codecheckerviewer/CodeCheckerViewer.js",
         "dojo/domReady!"],
-      function (CodeCheckerViewer) {
+      function (CodeCheckerViewer, hash, topic) {
         CCV = new CodeCheckerViewer();
       });
     </script>

--- a/viewer_clients/web-client/scripts/codecheckerviewer/FileViewBC.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/FileViewBC.js
@@ -29,7 +29,6 @@ return declare(BorderContainer, {
   // currCheckerId
   // suppressed
   // runId
-  // overviewType
 
 
   constructor : function(args) {
@@ -53,7 +52,6 @@ return declare(BorderContainer, {
     var currCheckerId   = that.currCheckerId;
     var suppressed      = that.suppressed;
     var runId           = that.runId;
-    var overviewType    = that.overviewType;
 
     that.viewedFile   = checkedFile;
     that.viewedFileId = fileId;

--- a/viewer_clients/web-client/scripts/codecheckerviewer/Util.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/Util.js
@@ -77,10 +77,19 @@ return declare(null, {
     return null;
   },
 
-
   severityFromStringToCode : function(severityString) {
     return Severity[severityString.toUpperCase()];
+  },
+
+  getOverviewIdFromHashState : function(hashState) {
+    if (hashState.ovType == 'run') {
+      return "runoverviewtc_" + hashState.ovRunId;
+    } else if (hashState.ovType == 'diff') {
+      return "diffoverviewtc_" + hashState.diffRunIds[0] + "_" +  hashState.diffRunIds[1];
+    } else if (JSON.stringify(hashState) == "{}") {
+      return "bc_listofrunsgrid";
+    }
+
+    return undefined;
   }
-
-
 });});

--- a/viewer_clients/web-client/scripts/codecheckerviewer/widgets/MenuButton.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/widgets/MenuButton.js
@@ -35,26 +35,10 @@ return declare(DropDownButton, {
 
     this.menuItemDocumentation = new MenuItem({
       label   : "Documentation",
-      onClick : (function(_this) {
-        return function() {
-
-          var documentationCP;
-
-          documentationCP = new ContentPane({
-            title    : "Documentation",
-            closable : true,
-            style    : "margin: 0px; padding: 0px; border: 0px;",
-            content  : domConstruct.create("iframe", {
-              src   : "/docs/index.html",
-              style : "height: 98%; width: 100%; margin: 0px; border: 0px; padding: 0px; padding-top: 4px;"
-            })
-          });
-
-          _this.mainTC.addChild(documentationCP);
-          _this.mainTC.selectChild(documentationCP);
-
-        };
-      })(this)
+      onClick : function(_this) {
+        var win = window.open("/docs/index.html", '_blank');
+        win.focus();
+      }
     });
 
     this.menuItemCredits = new MenuItem({

--- a/viewer_server/client_db_access_handler.py
+++ b/viewer_server/client_db_access_handler.py
@@ -154,6 +154,76 @@ class ThriftRequestHandler():
             sys.exit(1)
 
     # -----------------------------------------------------------------------
+    def __queryReport(self, reportId):
+        session = self.__session
+
+        try:
+            q = session.query(Report,
+                              File,
+                              ReportsToBuildActions,
+                              BuildAction,
+                              BugPathEvent,
+                              ModuleToReport,
+                              SuppressBug) \
+                .filter(Report.id == reportId) \
+                .outerjoin(File,
+                           Report.file_id == File.id) \
+                .outerjoin(ReportsToBuildActions,
+                           Report.id == ReportsToBuildActions.report_id) \
+                .outerjoin(BuildAction,
+                           ReportsToBuildActions.build_action_id ==
+                           BuildAction.id) \
+                .outerjoin(BugPathEvent,
+                           Report.end_bugevent == BugPathEvent.id) \
+                .outerjoin(ModuleToReport,
+                           Report.id == ModuleToReport.report_id) \
+                .outerjoin(SuppressBug,
+                           SuppressBug.hash == Report.bug_id)
+
+            results = q.limit(1).all()
+            if len(results) < 1:
+                raise shared.ttypes.RequestFailed(
+                    shared.ttypes.ErrorCode.DATABASE,
+                    "Report " + reportId + " not found!")
+
+            report, source_file, reptoba, buildaction, lbpe, module, \
+                suppress_bug = results[0]
+
+            last_event_pos = \
+                shared.ttypes.BugPathEvent(
+                    startLine=lbpe.line_begin,
+                    startCol=lbpe.col_begin,
+                    endLine=lbpe.line_end,
+                    endCol=lbpe.col_end,
+                    msg=lbpe.msg,
+                    fileId=lbpe.file_id,
+                    filePath=source_file.filepath)
+
+            if suppress_bug:
+                suppress_comment = suppress_bug.comment
+            else:
+                suppress_comment = None
+
+            return ReportData(
+                    bugHash=report.bug_id,
+                    checkedFile=source_file.filepath,
+                    checkerMsg=report.checker_message,
+                    suppressed=report.suppressed,
+                    reportId=report.id,
+                    fileId=source_file.id,
+                    lastBugPosition=last_event_pos,
+                    checkerId=report.checker_id,
+                    severity=report.severity,
+                    moduleName=module.module,
+                    suppressComment=suppress_comment)
+        except sqlalchemy.exc.SQLAlchemyError as alchemy_ex:
+            msg = str(alchemy_ex)
+            LOG.error(msg)
+            raise shared.ttypes.RequestFailed(
+                shared.ttypes.ErrorCode.DATABASE,
+                msg)
+
+    # -----------------------------------------------------------------------
     def __queryResults(self, run_id, limit, offset, sort_types, report_filters):
 
         max_query_limit = constants.MAX_QUERY_SIZE
@@ -296,6 +366,10 @@ class ThriftRequestHandler():
             LOG.error(msg)
             raise shared.ttypes.RequestFailed(shared.ttypes.ErrorCode.DATABASE, msg)
 
+    # -----------------------------------------------------------------------
+    @timefunc
+    def getReport(self, reportId):
+        return self.__queryReport(reportId)
 
     # -----------------------------------------------------------------------
     @timefunc
@@ -1033,7 +1107,7 @@ class ThriftRequestHandler():
 
         session = self.__session
         base_line_hashes, new_check_hashes = \
-                                self.__get_hashes_for_diff(session, 
+                                self.__get_hashes_for_diff(session,
                                                            base_run_id,
                                                            new_run_id)
 


### PR DESCRIPTION
__Viewer Thrift API changes__
- New method on codeCheckerDBAccess service: _getReport_
- API version changed from 3.0 to 4.0

Other changes:
- Permalinks for tabs including run list, bug overview, and file view
- Browser back/forward support
- Open documentation on new browser tab

Resolves Ericsson/codechecker#32 .