### PR TITLE
Catch the exception 'TypeError' when parse_compile_commands_json fails

### DIFF
--- a/codechecker_lib/log_parser.py
+++ b/codechecker_lib/log_parser.py
@@ -75,7 +75,7 @@ def parse_log(logfilepath):
     with open(logfilepath) as logfile:
         try:
             actions = parse_compile_commands_json(logfile)
-        except (ValueError, KeyError) as ex:
+        except (ValueError, KeyError, TypeError) as ex:
             if os.stat(logfilepath).st_size == 0:
                 LOG.error('The compile database is empty.')
             else:

--- a/codechecker_lib/log_parser.py
+++ b/codechecker_lib/log_parser.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import traceback
 
 from codechecker_lib import build_action
 from codechecker_lib import logger
@@ -80,6 +81,7 @@ def parse_log(logfilepath):
                 LOG.error('The compile database is empty.')
             else:
                 LOG.error('The compile database is not valid.')
+            print(traceback.format_exc())
             raise ex
 
     LOG.info('Parsing log file done.')


### PR DESCRIPTION
Exemple:
coercing to Unicode: need string or buffer, file found