### PR TITLE
Work on test helper

### DIFF
--- a/tests/regression_test/test_regression_getall_wrapper.py
+++ b/tests/regression_test/test_regression_getall_wrapper.py
@@ -15,7 +15,6 @@ from codeCheckerDBAccess.ttypes import *
 
 from test_helper.thrift_client_to_db import CCViewerHelper
 
-from test_helper.testlog import info
 from test_helper.testlog import debug
 
 
@@ -148,7 +147,9 @@ class RunResults(unittest.TestCase):
         self.assertIsNotNone(run_results)
         self.assertNotEqual(len(run_results), 0)
 
-        filtered_run_results = filter( lambda result: (result.reportId == bug.reportId) and result.suppressed,
+        filtered_run_results = filter(
+            lambda result:
+                (result.reportId == bug.reportId) and result.suppressed,
             run_results)
         self.assertEqual(len(filtered_run_results), 1)
         suppressed_bug = filtered_run_results[0]

--- a/tests/regression_test/test_regression_getall_wrapper.py
+++ b/tests/regression_test/test_regression_getall_wrapper.py
@@ -1,0 +1,232 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import json
+import os
+import random
+import re
+import unittest
+
+from codeCheckerDBAccess.ttypes import *
+
+from test_helper.thrift_client_to_db import CCViewerHelper
+
+from test_helper.testlog import info
+from test_helper.testlog import debug
+
+
+class RunResults(unittest.TestCase):
+
+    _ccClient = None
+
+    # selected runid for running the tests
+    _runid = None
+
+    def _select_one_runid(self):
+        runs = self._cc_client.getRunData()
+        self.assertIsNotNone(runs)
+        self.assertNotEqual(len(runs), 0)
+        # select one random run
+        idx = random.randint(0, len(runs) - 1)
+        return runs[idx].runId
+
+    def setUp(self):
+        host = 'localhost'
+        port = int(os.environ['CC_TEST_VIEWER_PORT'])
+        uri = '/'
+        self._testproject_data = json.loads(os.environ['CC_TEST_PROJECT_INFO'])
+        self.assertIsNotNone(self._testproject_data)
+
+        self._cc_client = CCViewerHelper(host, port, uri)
+        self._runid = self._select_one_runid()
+
+    # -----------------------------------------------------
+    def test_get_run_results_no_filter(self):
+        runid = self._runid
+        debug('Get all run results from the db for runid: ' + str(runid))
+
+        run_result_count = self._cc_client.getRunResultCount(runid, [])
+        self.assertTrue(run_result_count)
+
+        run_results = self._cc_client.getAllRunResults(runid, [], [])
+        self.assertIsNotNone(run_results)
+        self.assertEqual(run_result_count, len(run_results))
+
+        for run_res in run_results:
+            debug('{0:15s}  {1}'.format(run_res.checkedFile, run_res.checkerId))
+            debug('{0:15d}  {1}'.format(run_res.reportId, run_res.suppressed))
+            debug(run_res.lastBugPosition)
+            debug('-------------------------------------------------')
+        debug('got ' + str(len(run_results)) + ' reports')
+        debug('Done.\n')
+
+    # -----------------------------------------------------
+    def test_get_run_results_checker_id_and_file_path(self):
+        runid = self._runid
+        debug('Get all run results from the db for runid: ' + str(runid))
+
+        run_result_count = self._cc_client.getRunResultCount(runid, [])
+        self.assertTrue(run_result_count)
+
+        run_results = self._cc_client.getAllRunResults(runid, [], [])
+        self.assertIsNotNone(run_results)
+        self.assertEqual(run_result_count, len(run_results))
+
+        found_all = True
+        for bug in self._testproject_data['bugs']:
+            found = False
+            for run_res in run_results:
+                found |= (run_res.checkedFile.endswith(bug['file'])) and \
+                         (run_res.lastBugPosition.startLine == bug['line']) and \
+                         (run_res.checkerId == bug['checker']) and \
+                         (run_res.bugHash == bug['hash'])
+            found_all &= found
+        self.assertTrue(found_all)
+
+        for run_res in run_results:
+            debug('{0:15s}  {1}'.format(run_res.checkedFile, run_res.checkerId))
+            debug('reportId: {0} suppressed: {1}'.format(run_res.reportId,
+                                                         run_res.suppressed))
+            debug(run_res.lastBugPosition)
+            debug('-------------------------------------------------')
+        debug('got ' + str(len(run_results)) + ' reports')
+
+    # -----------------------------------------------------
+    def test_get_source_file_content(self):  # also for testing Unicode support
+        runid = self._runid
+        simple_filters = [ReportFilter(checkerId='*', filepath='*.c*')]
+
+        run_result_count = self._cc_client.getRunResultCount(runid,
+                                                             simple_filters)
+        self.assertTrue(run_result_count)
+
+        run_results = self._cc_client.getAllRunResults(runid, [], simple_filters)
+        self.assertIsNotNone(run_results)
+        self.assertEqual(run_result_count, len(run_results))
+
+        for run_res in run_results:
+            self.assertTrue(re.match(r'.*\.c(pp)?$', run_res.checkedFile))
+
+            debug('Getting the content of ' + run_res.checkedFile)
+
+            file_data = self._cc_client.getSourceFileData(run_res.fileId, True)
+            self.assertIsNotNone(file_data)
+
+            file_content1 = file_data.fileContent
+            self.assertIsNotNone(file_content1)
+
+            with open(run_res.checkedFile) as source_file:
+                file_content2 = source_file.read()
+
+            self.assertEqual(file_content1, file_content2)
+
+        debug('got ' + str(len(run_results)) + ' files')
+
+    # -----------------------------------------------------
+    def test_zzzzz_get_run_results_checker_msg_filter_suppressed(self):
+        # this function must be run for last
+        runid = self._runid
+        debug('Get all run results from the db for runid: ' + str(runid))
+
+        simple_filters = [ReportFilter(suppressed=False)]
+        run_results = self._cc_client.getAllRunResults(runid, [], simple_filters)
+        self.assertIsNotNone(run_results)
+        self.assertNotEqual(len(run_results), 0)
+
+        suppress_msg = r'My beautiful Unicode comment.'
+        bug = run_results[0]
+        success = self._cc_client.suppressBug([runid], bug.reportId, suppress_msg)
+        self.assertTrue(success)
+        debug('Bug suppressed successfully')
+
+        simple_filters = [ReportFilter(suppressed=True)]
+        run_results = self._cc_client.getAllRunResults(runid, [], simple_filters)
+        self.assertIsNotNone(run_results)
+        self.assertNotEqual(len(run_results), 0)
+
+        filtered_run_results = filter( lambda result: (result.reportId == bug.reportId) and result.suppressed,
+            run_results)
+        self.assertEqual(len(filtered_run_results), 1)
+        suppressed_bug = filtered_run_results[0]
+        self.assertEqual(suppressed_bug.suppressComment, suppress_msg)
+
+        success = self._cc_client.unSuppressBug([runid], suppressed_bug.reportId)
+        self.assertTrue(success)
+        debug('Bug unsuppressed successfully')
+
+        simple_filters = [ReportFilter(suppressed=False)]
+        run_results = self._cc_client.getAllRunResults(runid, [], simple_filters)
+        self.assertIsNotNone(run_results)
+        self.assertNotEqual(len(run_results), 0)
+
+        filtered_run_results = filter(
+            lambda result:
+                (result.reportId == bug.reportId) and not result.suppressed,
+            run_results)
+        self.assertEqual(len(filtered_run_results), 1)
+
+        debug('Done.\n')
+
+    # -----------------------------------------------------
+    def test_get_run_results_severity_sort(self):
+        runid = self._runid
+        debug('Get all run results from the db for runid: ' + str(runid))
+        sort_mode1 = SortMode(SortType.SEVERITY, Order.ASC)
+        sort_mode2 = SortMode(SortType.FILENAME, Order.ASC)
+        sort_types = [sort_mode1, sort_mode2]
+
+        run_result_count = self._cc_client.getRunResultCount(runid, [])
+        self.assertTrue(run_result_count)
+
+        run_results = self._cc_client.getAllRunResults(runid, sort_types, [])
+        self.assertIsNotNone(run_results)
+        self.assertEqual(run_result_count, len(run_results))
+
+        for i in range(run_result_count - 1):
+            bug1 = run_results[i]
+            bug2 = run_results[i + 1]
+            self.assertTrue(bug1.severity <= bug2.severity)
+            self.assertTrue((bug1.severity != bug2.severity) or
+                            (bug1.checkedFile <= bug2.checkedFile))
+
+        for run_res in run_results:
+            debug('{0:15s}  {1}'.format(run_res.checkedFile, run_res.checkerId))
+            debug('{0:15d}  {1}'.format(run_res.reportId, run_res.suppressed))
+            debug(run_res.lastBugPosition)
+            debug('-------------------------------------------------')
+        debug('got ' + str(len(run_results)) + ' reports')
+        debug('Done.\n')
+
+    # -----------------------------------------------------
+    def test_get_run_results_sorted2(self):
+        runid = self._runid
+        debug('Get all run results from the db for runid: ' + str(runid))
+        sortMode1 = SortMode(SortType.FILENAME, Order.ASC)
+        sortMode2 = SortMode(SortType.CHECKER_NAME, Order.ASC)
+        sort_types = [sortMode1, sortMode2]
+
+        run_result_count = self._cc_client.getRunResultCount(runid, [])
+        self.assertTrue(run_result_count)
+
+        run_results = self._cc_client.getAllRunResults(runid, sort_types, [])
+        self.assertIsNotNone(run_results)
+        self.assertEqual(run_result_count, len(run_results))
+
+        for i in range(run_result_count - 1):
+            bug1 = run_results[i]
+            bug2 = run_results[i + 1]
+            self.assertTrue(bug1.checkedFile <= bug2.checkedFile)
+            self.assertTrue((bug1.checkedFile != bug2.checkedFile) or
+                            (bug1.checkerId <= bug2.checkerId))
+
+        for run_res in run_results:
+            debug('{0:15s}  {1}'.format(run_res.checkedFile, run_res.checkerId))
+            debug('{0:15d}  {1}'.format(run_res.reportId, run_res.suppressed))
+            debug(run_res.lastBugPosition)
+            debug('-------------------------------------------------')
+        debug('got ' + str(len(run_results)) + ' reports')
+        debug('Done.\n')

--- a/tests/test_helper/__init__.py
+++ b/tests/test_helper/__init__.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 
+
 def set_cc_env():
     cc_root = os.environ['CC_PACKAGE_ROOT']
     layout_file_path = os.path.join(cc_root, 'config', 'package_layout.json')
@@ -20,6 +21,7 @@ def set_cc_env():
         os.path.join(cc_root, package_layout['static']['codechecker_gen'])
 
     sys.path.append(gen_modules)
+
 
 def get_free_port():
     ''' get a free port from the os'''

--- a/tests/test_helper/__init__.py
+++ b/tests/test_helper/__init__.py
@@ -5,18 +5,21 @@
 #   License. See LICENSE.TXT for details.
 # -----------------------------------------------------------------------------
 
+import json
 import os
 import sys
 
 def set_cc_env():
     cc_root = os.environ['CC_PACKAGE_ROOT']
-    sys.path.append(os.path.join(ccRoot, 'lib/python2.7/report-viewer'))
-    sys.path.append(os.path.join(ccRoot, 'lib/python2.7/report-server'))
-    sys.path.append(os.path.join(ccRoot, 'lib/python2.7'))
-    sys.path.append(os.path.join(ccRoot, 'python/lib/python2.7'))
+    layout_file_path = os.path.join(cc_root, 'config', 'package_layout.json')
 
-    os.environ['LD_LIBRARY_PATH'] = os.path.join(ccRoot, 'python/lib/python2.7/lib-dynload') + ':' \
-                                    + os.path.join(ccRoot, 'postgres/lib') + ':' + os.getenv('LD_LIBRARY_PATH', '')
+    with open(layout_file_path) as layout_file:
+        package_layout = json.load(layout_file)
+
+    gen_modules = \
+        os.path.join(cc_root, package_layout['static']['codechecker_gen'])
+
+    sys.path.append(gen_modules)
 
 def get_free_port():
     ''' get a free port from the os'''

--- a/tests/test_helper/thrift_client_to_db.py
+++ b/tests/test_helper/thrift_client_to_db.py
@@ -5,11 +5,9 @@
 #   License. See LICENSE.TXT for details.
 # -----------------------------------------------------------------------------
 
-import errno
 import os
 import re
 import socket
-import sys
 from functools import partial
 
 from thrift.transport import THttpClient
@@ -18,7 +16,6 @@ from thrift.transport import TTransport
 
 from thrift.protocol import TBinaryProtocol
 from thrift.protocol import TJSONProtocol
-from thrift.protocol import TProtocol
 
 import shared
 


### PR DESCRIPTION
I've been putting `run_performance_test.py` in shape, for which I need unlimited versions (aka getAll) of `getRunResults, getNewResults, getResolvedResults, getUnresolvedResults`.
Since these functions are very similar I added an universal `getAll` function to the test helper to minimize redundant code.