### PR TITLE
check for psycopg2 module at start

### DIFF
--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -155,6 +155,10 @@ def handle_server(args):
         LOG.error("zlib error")
         sys.exit(1)
 
+    if not host_check.check_psycopg2():
+        LOG.error("psycopg2 error")
+        sys.exit(1)
+
     check_options_validity(args)
     if args.suppress is None:
         LOG.warning('WARNING! No suppress file was given, suppressed results will be only stored in the database.')
@@ -261,6 +265,10 @@ def handle_check(args):
 
     if not host_check.check_zlib():
         LOG.error("zlib error")
+        sys.exit(1)
+
+    if not host_check.check_psycopg2():
+        LOG.error("psycopg2 error")
         sys.exit(1)
 
     args.workspace = os.path.realpath(args.workspace)


### PR DESCRIPTION
check for psycopg2 module at start to see if every dependency is available and codechecker is ready to start