### PR TITLE
Hotfix for #107

### DIFF
--- a/storage_server/report_server.py
+++ b/storage_server/report_server.py
@@ -140,10 +140,13 @@ class CheckerReportHandler(object):
     def addBuildAction(self, run_id, build_cmd, check_cmd):
         '''
         '''
-        build_action = self.session.query(BuildAction) \
-                                   .filter(and_(BuildAction.run_id == run_id,
-                                                BuildAction.build_cmd == build_cmd))
+        build_action = \
+            self.session.query(BuildAction) \
+                        .filter(and_(BuildAction.run_id == run_id,
+                                     BuildAction.build_cmd == build_cmd,
+                                     BuildAction.check_cmd == check_cmd))
         if build_action.count() != 0:
+            # FIXME: should delete this build action only in update mode
             self.deleteBuildAction(build_action.first())
 
         action = BuildAction(run_id, build_cmd, check_cmd)


### PR DESCRIPTION
Do not delete build actions with the same command if the check command is
different:
- add check_cmd to the query filter
- add a FIXME before the deleteBuildAction call

This fixes Ericsson/codechecker#107