### PR TITLE
Fix command line escaping

### DIFF
--- a/codechecker_lib/option_parser.py
+++ b/codechecker_lib/option_parser.py
@@ -5,6 +5,7 @@
 # -------------------------------------------------------------------------
 
 import re
+import shlex
 
 from codechecker_lib import logger
 
@@ -323,7 +324,7 @@ def parse_options(args):
     '''Requires a full compile command with the compiler, not only arguments.'''
 
     result_map = OptionParserResult()
-    for it in OptionIterator(args.split()[1:]):
+    for it in OptionIterator(shlex.split(args)[1:]):
         arg_check(it, result_map)  # TODO: do sth at False result, actually skip
 
     return result_map

--- a/external-source-deps/build-logger/src/ldlogger-logger.c
+++ b/external-source-deps/build-logger/src/ldlogger-logger.c
@@ -37,9 +37,10 @@ static char* createJsonCommandString(const LoggerVector* args_)
   /* The final size is:
        The overall size of command * 2 for escaping +
        args_->size character for word separator +
+       args_->size * 2 character for word escaping ('"'' chars) separator +
        1 byte character trailing null
   */
-  cmdSize = cmdSize * 2 + args_->size + 1;
+  cmdSize = (cmdSize * 2) + (args_->size * 3) + 1;
   cmd = (char*) malloc(sizeof(char) * cmdSize);
   if (!cmd)
   {

--- a/external-source-deps/build-logger/src/ldlogger-util.c
+++ b/external-source-deps/build-logger/src/ldlogger-util.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <ctype.h>
+#include <string.h>
 
 static char* makePathAbsRec(const char* path_, char* resolved_)
 {
@@ -59,6 +60,14 @@ static char* makePathAbsRec(const char* path_, char* resolved_)
 char* shellEscapeStr(const char* str_, char* buff_)
 {
   char* out = buff_;
+  int hasSpace = strchr(str_, ' ') != NULL;
+
+  if (hasSpace)
+  {
+    *out++ = '\\';
+    *out++ = '\"';
+  }
+
   while (*str_)
   {
     switch (*str_)
@@ -66,22 +75,23 @@ char* shellEscapeStr(const char* str_, char* buff_)
       case '\\':
       case '\'':
       case '\"':
-      case ' ':
       case '\t':
-        *out = '\\';
-        ++out;
-        *out = *str_;
+        *out++ = '\\';
+        *out++ = *str_++;
         break;
-        
+
       default:
-        *out = *str_;
+        *out++ = *str_++;
         break;
     }
-    
-    ++str_;
-    ++out;
   }
-  
+
+  if (hasSpace)
+  {
+    *out++ = '\\';
+    *out++ = '\"';
+  }
+
   *out = '\0';
   return buff_;
 }
@@ -113,7 +123,7 @@ char* loggerMakePathAbs(const char* path_, char* resolved_, int mustExist_)
     strcat(newPath, path_);
     return makePathAbsRec(newPath, resolved_);
   }
-  
+
   return makePathAbsRec(path_, resolved_);
 }
 
@@ -394,4 +404,3 @@ char* loggerGetFileName(const char* absPath_, int withoutExt_)
 
   return loggerStrDup(fileName);
 }
-


### PR DESCRIPTION
- Remove incorrect space escaping from ldlogger
- Add quotation marks around arguments with spaces
- Use shlex for splitting command line arguments

Fixes Ericsson/codechecker#62