### PR TITLE
PostgreSQL server output in debug log level.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -466,6 +466,7 @@ Turn on CodeChecker debug level logging
 ~~~~~~~~~~~~~~~~~~~~~
 export CODECHECKER_VERBOSE=debug
 ~~~~~~~~~~~~~~~~~~~~~
+If debug logging is enabled and PostgreSQL database is used, PostgreSQL logs are written to postgresql.log in the workspace directory.
 
 Turn on SQL_ALCHEMY debug level logging
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This commit fixes #235. Now the PostgreSQL server output is written to a postgresql.log file into the workspace directory