### PR TITLE
An empty init directory shouldn't be created in the package.

### DIFF
--- a/config/package_layout.json
+++ b/config/package_layout.json
@@ -1,6 +1,5 @@
 {
     "static" : {
-        "init": "init",
         "bin": "bin",
         "cc_bin": "cc_bin",
         "lib": "lib",


### PR DESCRIPTION
In a previous commit it has been solved that sourcing init.sh is unnecessary.
In that commit the init.sh script was also deleted, but the init directory is
still there. This is now fixed.