### PR TITLE
turn off g++ warnings for quickcheck tests, not needed

### DIFF
--- a/tests/quickcheck_test/multi_error.en1.output
+++ b/tests/quickcheck_test/multi_error.en1.output
@@ -1,10 +1,6 @@
--b 'g++ multi_error.cpp -o /dev/null' -e core.StackAddressEscape -d deadcode.DeadStores
+-b 'g++ -w multi_error.cpp -o /dev/null' -e core.StackAddressEscape -d deadcode.DeadStores
 -----------------------------------------------
 [INFO] - Starting build ...
-multi_error.cpp: In function ‘int* foo()’:
-multi_error.cpp:2:7: warning: address of local variable ‘x’ returned [-Wreturn-local-addr]
-   int x = 42;
-       ^
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing multi_error.cpp 
 

--- a/tests/quickcheck_test/multi_error.en2.output
+++ b/tests/quickcheck_test/multi_error.en2.output
@@ -1,10 +1,6 @@
--b 'g++ multi_error.cpp -o /dev/null' -d core.StackAddressEscape -e deadcode.DeadStores
+-b 'g++ -w multi_error.cpp -o /dev/null' -d core.StackAddressEscape -e deadcode.DeadStores
 -----------------------------------------------
 [INFO] - Starting build ...
-multi_error.cpp: In function ‘int* foo()’:
-multi_error.cpp:2:7: warning: address of local variable ‘x’ returned [-Wreturn-local-addr]
-   int x = 42;
-       ^
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing multi_error.cpp 
 

--- a/tests/quickcheck_test/multi_error.output
+++ b/tests/quickcheck_test/multi_error.output
@@ -1,10 +1,6 @@
--b 'g++ multi_error.cpp -o /dev/null'
+-b 'g++ -w multi_error.cpp -o /dev/null'
 -----------------------------------------------
 [INFO] - Starting build ...
-multi_error.cpp: In function ‘int* foo()’:
-multi_error.cpp:2:7: warning: address of local variable ‘x’ returned [-Wreturn-local-addr]
-   int x = 42;
-       ^
 [INFO] - Build finished successfully.
 clangsa found 2 defect(s) while analyzing multi_error.cpp 
 

--- a/tests/quickcheck_test/multi_error.steps.output
+++ b/tests/quickcheck_test/multi_error.steps.output
@@ -1,10 +1,6 @@
--b 'g++ multi_error.cpp -o /dev/null' --steps
+-b 'g++ -w multi_error.cpp -o /dev/null' --steps
 -------------------------------------------------------
 [INFO] - Starting build ...
-multi_error.cpp: In function ‘int* foo()’:
-multi_error.cpp:2:7: warning: address of local variable ‘x’ returned [-Wreturn-local-addr]
-   int x = 42;
-       ^
 [INFO] - Build finished successfully.
 clangsa found 2 defect(s) while analyzing multi_error.cpp 
 

--- a/tests/quickcheck_test/nofail.output
+++ b/tests/quickcheck_test/nofail.output
@@ -1,4 +1,4 @@
--b "g++ nofail.cpp -o /dev/null"
+-b "g++ -w nofail.cpp -o /dev/null"
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.

--- a/tests/quickcheck_test/nofail.steps.output
+++ b/tests/quickcheck_test/nofail.steps.output
@@ -1,4 +1,4 @@
--b "g++ nofail.cpp -o /dev/null" --steps
+-b "g++ -w nofail.cpp -o /dev/null" --steps
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.

--- a/tests/quickcheck_test/simple1.output
+++ b/tests/quickcheck_test/simple1.output
@@ -1,4 +1,4 @@
--b "g++ simple1.cpp -o /dev/null"
+-b "g++ -w simple1.cpp -o /dev/null"
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.

--- a/tests/quickcheck_test/simple1.steps.output
+++ b/tests/quickcheck_test/simple1.steps.output
@@ -1,4 +1,4 @@
--b "g++ simple1.cpp -o /dev/null" --steps
+-b "g++ -w simple1.cpp -o /dev/null" --steps
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.

--- a/tests/quickcheck_test/simple2.output
+++ b/tests/quickcheck_test/simple2.output
@@ -1,4 +1,4 @@
--b "g++ simple2.cpp -o /dev/null"
+-b "g++ -w simple2.cpp -o /dev/null"
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.

--- a/tests/quickcheck_test/simple2.steps.output
+++ b/tests/quickcheck_test/simple2.steps.output
@@ -1,4 +1,4 @@
--b "g++ simple2.cpp -o /dev/null" --steps
+-b "g++ -w simple2.cpp -o /dev/null" --steps
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.


### PR DESCRIPTION
turn off g++ warnings for quickcheck tests, not relevant for the tests