### PR TITLE
Replaced missing doc message with links to ClangSA and ClangTidy chec…

### DIFF
--- a/viewer_clients/web-client/index.html
+++ b/viewer_clients/web-client/index.html
@@ -47,13 +47,22 @@
         packages: [
           { name: "dojo",  location: "scripts/plugins/dojo/dojo"  },
           { name: "dijit", location: "scripts/plugins/dojo/dijit" },
-          { name: "dojox", location: "scripts/plugins/dojo/dojox" }
+          { name: "dojox", location: "scripts/plugins/dojo/dojox" },
+          { name: "ccvscripts", location: "scripts/codecheckerviewer" }
         ]
       };
     </script>
 
     <!-- Check browser type and version, and if both are adequate, load CodeChecker Viewer -->
     <script>
+
+      // polyfill missing startsWith from IE
+      if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(searchString, position){
+          position = position || 0;
+          return this.substr(position, searchString.length) === searchString;
+        };
+      }
 
       var getBrowserInfo = function () {
         var ua = navigator.userAgent;

--- a/viewer_clients/web-client/scripts/codecheckerviewer/OverviewTC.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/OverviewTC.js
@@ -226,6 +226,16 @@ return declare(TabContainer, {
    */
   showDocumentation : function (checkerId) {
     CC_SERVICE.getCheckerDoc(checkerId, function (checkerDoc) {
+
+      if (checkerDoc.startsWith("No documentation for checker")) {
+        var ClangSADocLink =
+          "<a target='_blank' href='http://clang-analyzer.llvm.org/available_checks.html'>Clang Static Analyzer checkers</a>";
+        var ClangTidyDocLink =
+          "<a target='_blank' href='http://clang.llvm.org/extra/clang-tidy/checks/list.html'>Clang Tidy checkers</a>";
+
+        checkerDoc = ClangSADocLink + "<br><br>" + ClangTidyDocLink;
+      }
+
       var checkerDocDialog = new Dialog({
         title   : "Documentation for <b>" + checkerId + "</b>",
         content : marked(checkerDoc)


### PR DESCRIPTION
…ker links.

(Added a polyfill to index.html toplevel script so startsWith method of String.prototype is available in IE browsers.)

FIXES Ericsson/codechecker#250

Also missing fix for Ericsson/codechecker#268 added! Please merge asap.