### PR TITLE
Show all bugs in bug tree

### DIFF
--- a/viewer_clients/web-client/scripts/codecheckerviewer/BugStoreModelTree.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/BugStoreModelTree.js
@@ -134,7 +134,7 @@ return declare(null, {
     bugStore.push({
       name       : "Line " + report.lastBugPosition.startLine + " : " +
         report.checkerId,
-      id         : report.bugHash,
+      id         : report.reportId,
       parent     : CC_UTIL.severityFromCodeToString(report.severity),
       range      : report.lastBugPosition,
       reportId   : report.reportId,
@@ -145,8 +145,8 @@ return declare(null, {
 
     bugStore.push({
       name       : "<b><u>Result</u> : " + report.checkerMsg + "</b>",
-      id         : report.bugHash + "_0",
-      parent     : report.bugHash,
+      id         : report.reportId + "_0",
+      parent     : report.reportId,
       range      : report.lastBugPosition,
       filePath   : that.filePath,
       fileId     : report.fileId,
@@ -166,8 +166,8 @@ return declare(null, {
       details.pathEvents.forEach(function (step, index) {
         bugStore.push({
           name       : "Line " + step.startLine + " : " + step.msg,
-          id         : report.bugHash + "_" + (index + 1),
-          parent     : report.bugHash,
+          id         : report.reportId + "_" + (index + 1),
+          parent     : report.reportId,
           range      : step,
           filePath   : step.filePath,
           fileId     : step.fileId,

--- a/viewer_clients/web-client/scripts/codecheckerviewer/FileViewBC.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/FileViewBC.js
@@ -107,8 +107,8 @@ return declare(BorderContainer, {
       fileId          : fileId,
       filePath        : checkedFile,
       onLoaded        : function () {
-        that.bugStoreModelTree.bugTree.set("path", ["root", severity, bugHash,
-          bugHash + "_0"]);
+        that.bugStoreModelTree.bugTree.set("path",
+          ["root", severity, reportId + '', reportId + "_0"]);
       }
     });
 


### PR DESCRIPTION
This commit fixes #277. All bugs are now shown in the bug tree even if
they have the same bugHash. This happens when a bug is reached on
differet bug paths.