### PR TITLE
Fix server starting hint command

### DIFF
--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -258,8 +258,16 @@ def handle_check(args):
                            context)
 
         LOG.info("Analysis has finished.")
+
+        db_data = ""
+        if args.postgresql:
+            db_data += " --postgresql" \
+                    +  " --dbname " + args.dbname \
+                    +  " --dbport " + str(args.dbport) \
+                    +  " --dbusername " + args.dbusername
+
         LOG.info("To view results run:\nCodeChecker server -w " +
-                 args.workspace)
+                 args.workspace + db_data)
 
     except Exception as ex:
         LOG.error(ex)


### PR DESCRIPTION
This commit fixes #298. It would be nice to print only those PostgreSQL
parameters which differ from the default ones, but unfortunately at this
point we don't have this information.