### PR TITLE
SQLite version server start bugfix

### DIFF
--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -98,6 +98,8 @@ def handle_server(args):
     if not args.workspace and util.is_localhost(args.dbaddress):
         LOG.info("Workspace is required when database server run on localhost.")
         sys.exit(1)
+    elif args.workspace and not os.path.exists(args.workspace):
+        os.makedirs(args.workspace)
 
     if args.suppress is None:
         LOG.warning('WARNING! No suppress file was given, suppressed results will be only stored in the database.')


### PR DESCRIPTION
This commit fixes #297. The workspace directory has to exist so SQLite
database can be created there. When CodeChecker server is started
without a previously created workspace, then it causes an error.