### PR TITLE
Logger arg size increase

### DIFF
--- a/external-source-deps/build-logger/src/ldlogger-hooks.c
+++ b/external-source-deps/build-logger/src/ldlogger-hooks.c
@@ -21,7 +21,7 @@
 
 #include "ldlogger-hooks.h"
 
-#define CC_LOGGER_MAX_ARGS 2048
+#define CC_LOGGER_MAX_ARGS 4096
 
 #define CC_LOGGER_CALL_EXEC(funName_, arglist, ...) \
   tryLog(__VA_ARGS__); \


### PR DESCRIPTION
It is possible that the logged exec call has more than 2048 arguments. In that case the preloaded shared library will crash the original process. The maximum argument count number was increased but further increase might be needed in the future.