### PR TITLE
Disable clang static analyzer checkers in clang-tidy

### DIFF
--- a/codechecker_lib/analyzers/analyzer_clang_tidy.py
+++ b/codechecker_lib/analyzers/analyzer_clang_tidy.py
@@ -75,8 +75,10 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             analyzer_cmd = []
             analyzer_cmd.append(analyzer_bin)
 
-            # disable all checkers by default
-            checkers_cmdline = '-*'
+            # Disable all checkers by default.
+            # The latest clang-tidy (3.9) release enables clang static analyzer
+            # checkers by default. They must be disabled explicitly.
+            checkers_cmdline = '-*,clang-analyzer-*'
 
             # config handler stores which checkers are enabled or disabled
             for checker_name, value in config.checks().iteritems():


### PR DESCRIPTION
The latest clang-tidy (3.9) release enables clang static analyzer
checkers by default. They must be disabled explicitly.
Resolves #371