### PR TITLE
Fix missing dash

### DIFF
--- a/codechecker_lib/analyzers/analyzer_clang_tidy.py
+++ b/codechecker_lib/analyzers/analyzer_clang_tidy.py
@@ -78,7 +78,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             # Disable all checkers by default.
             # The latest clang-tidy (3.9) release enables clang static analyzer
             # checkers by default. They must be disabled explicitly.
-            checkers_cmdline = '-*,clang-analyzer-*'
+            checkers_cmdline = '-*,-clang-analyzer-*'
 
             # config handler stores which checkers are enabled or disabled
             for checker_name, value in config.checks().iteritems():


### PR DESCRIPTION
Disable clang static analyzer checkers in clang tidy
Fix #371 