### PR TITLE
Privileged access subsystem

### DIFF
--- a/.ci/auth_requirements
+++ b/.ci/auth_requirements
@@ -1,0 +1,2 @@
+python-ldap==2.4.22.0
+python-pam==1.8.2

--- a/.ci/basic_python_requirements
+++ b/.ci/basic_python_requirements
@@ -1,4 +1,3 @@
 sqlalchemy==1.0.9
 alembic==0.8.2
 thrift==0.9.1
-python-ldap==2.4.22.0

--- a/.ci/basic_python_requirements
+++ b/.ci/basic_python_requirements
@@ -1,3 +1,4 @@
 sqlalchemy==1.0.9
 alembic==0.8.2
 thrift==0.9.1
+portalocker=1.0.0

--- a/.ci/basic_python_requirements
+++ b/.ci/basic_python_requirements
@@ -1,3 +1,4 @@
 sqlalchemy==1.0.9
 alembic==0.8.2
 thrift==0.9.1
+python-ldap==2.4.22.0

--- a/.ci/python_requirements
+++ b/.ci/python_requirements
@@ -3,5 +3,4 @@ alembic==0.8.2
 psycopg2==2.5.4
 pg8000==1.10.2
 thrift==0.9.1
-python-ldap==2.4.22.0
-python-pam==1.8.2
+portalocker==1.0.0

--- a/.ci/python_requirements
+++ b/.ci/python_requirements
@@ -3,3 +3,4 @@ alembic==0.8.2
 psycopg2==2.5.4
 pg8000==1.10.2
 thrift==0.9.1
+python-ldap==2.4.22.0

--- a/.ci/python_requirements
+++ b/.ci/python_requirements
@@ -4,3 +4,4 @@ psycopg2==2.5.4
 pg8000==1.10.2
 thrift==0.9.1
 python-ldap==2.4.22.0
+python-pam==1.8.2

--- a/README.md
+++ b/README.md
@@ -176,3 +176,5 @@ See user guide for further configuration and check options.
 [Test documentation](tests/functional/package_test.md)
 
 [Database schema migration](docs/db_schema_guide.md)
+
+[Privileged server and authentication in client](docs/authentication.md)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Tested on Ubuntu LTS 14.04.2
 
 # get ubuntu packages
 # clang-3.6 can be replaced by any later versions of clang
-sudo apt-get install clang-3.6 doxygen build-essential thrift-compiler python-virtualenv gcc-multilib git wget libldap2-dev libsasl2-dev libssl-dev
+sudo apt-get install clang-3.6 doxygen build-essential thrift-compiler python-virtualenv gcc-multilib git wget
 
 # create new python virtualenv
 virtualenv -p /usr/bin/python2.7 ~/checker_env

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Tested on Ubuntu LTS 14.04.2
 
 # get ubuntu packages
 # clang-3.6 can be replaced by any later versions of clang
-sudo apt-get install clang-3.6 doxygen build-essential thrift-compiler python-virtualenv gcc-multilib git wget
+sudo apt-get install clang-3.6 doxygen build-essential thrift-compiler python-virtualenv gcc-multilib git wget libldap2-dev libsasl2-dev libssl-dev
 
 # create new python virtualenv
 virtualenv -p /usr/bin/python2.7 ~/checker_env

--- a/build_package.py
+++ b/build_package.py
@@ -111,6 +111,15 @@ def generate_thrift_files(thrift_files_dir, env, silent=True):
         LOG.error('Failed to generate viewer server files')
         return ret
 
+    auth_thrift = os.path.join(thrift_files_dir, 'authentication.thrift')
+    auth_thrift = 'authentication.thrift'
+    auth_cmd = ['thrift', '-r', '-I', '.',
+               '--gen', 'py', auth_thrift]
+    ret = run_cmd(auth_cmd, thrift_files_dir, env, silent=silent)
+    if ret:
+        LOG.error('Failed to generate authentication interface files')
+        return ret
+
 
 # -------------------------------------------------------------------
 def generate_documentation(doc_root, env, silent=True):

--- a/build_package.py
+++ b/build_package.py
@@ -114,7 +114,7 @@ def generate_thrift_files(thrift_files_dir, env, silent=True):
     auth_thrift = os.path.join(thrift_files_dir, 'authentication.thrift')
     auth_thrift = 'authentication.thrift'
     auth_cmd = ['thrift', '-r', '-I', '.',
-               '--gen', 'py', auth_thrift]
+                '--gen', 'py', auth_thrift]
     ret = run_cmd(auth_cmd, thrift_files_dir, env, silent=silent)
     if ret:
         LOG.error('Failed to generate authentication interface files')

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -118,6 +118,7 @@ def handle_server(args):
 
     context = generic_package_context.get_context()
     context.codechecker_workspace = workspace
+    session_manager.SessionManager.CodeChecker_Workspace = workspace
     context.db_username = args.dbusername
 
     check_env = analyzer_env.get_check_env(context.path_env_extra,
@@ -436,7 +437,6 @@ def handle_plist(args):
         raise
     finally:
         pool.join()
-
 
 def handle_version_info(args):
     """

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -24,6 +24,7 @@ from codechecker_lib import generic_package_suppress_handler
 from codechecker_lib import host_check
 from codechecker_lib import log_parser
 from codechecker_lib import logger
+from codechecker_lib import session_manager
 from codechecker_lib import util
 from codechecker_lib.analyzers import analyzer_types
 from codechecker_lib.database_handler import SQLServer

--- a/codechecker_lib/session_manager.py
+++ b/codechecker_lib/session_manager.py
@@ -1,0 +1,109 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+'''
+Handles the allocation and destruction of privileged sessions associated
+with a particular CodeChecker server.
+'''
+
+import os
+import uuid
+
+from codechecker_lib import logger
+
+LOG = logger.get_new_logger("SESSION MANAGER")
+
+session_cookie_name = "__ccPrivilegedAccessToken"
+
+
+# ----------- SERVER -----------
+
+class sessionManager:
+    valid_sessions = []
+
+    @staticmethod
+    def validate(sessToken):
+        sessionManager.valid_sessions.append(sessToken)
+
+    @staticmethod
+    def invalidate(sessToken):
+        if sessToken in sessionManager.valid_sessions:
+            sessionManager.valid_sessions.remove(sessToken)
+
+    @staticmethod
+    def isValid(sessToken):
+        if not sessionManager().isEnabled():
+            # If authentication is disabled, any kind of session token is valid.
+            return True
+
+        return sessToken in sessionManager.valid_sessions
+
+    def __init__(self):
+        LOG.debug('Loading session config')
+
+        session_cfg_file = os.path.join(os.environ['CC_PACKAGE_ROOT'], "config", "session_config.json")
+        LOG.debug(session_cfg_file)
+        with open(session_cfg_file, 'r') as scfg:
+            scfg_dict = json.loads(scfg.read())
+
+        if not scfg_dict["authentication"]:
+            scfg_dict["authentication"] = {'enabled': False}
+
+        self.__auth_config = scfg_dict["authentication"]
+        print self
+
+    def isEnabled(self):
+        return self.__auth_config.get("enabled")
+
+
+
+def validate_session_token(token):
+    '''Validates a given token (cookie) against the known list of privileged sessions'''
+    return sessionManager.isValid(token)
+
+def validate_auth_request(authString):
+    '''Validate an oncoming authorization request against some authority controller'''
+    return authString == "cc:valid"
+
+def create_session():
+    # TODO: More secure way for token generation?
+    token = uuid.UUID(bytes = os.urandom(16)).__str__()
+    sessionManager.validate(token)
+
+    return token
+
+# ----------- CLIENT -----------
+class sessionManager_Client:
+    def __init__(self):
+        LOG.debug('Loading session config')
+
+        session_cfg_file = os.path.join(os.environ['CC_PACKAGE_ROOT'], "config", "session_config.json")
+        LOG.debug(session_cfg_file)
+        with open(session_cfg_file, 'r') as scfg:
+            scfg_dict = json.loads(scfg.read())
+
+        if not scfg_dict["credentials"]:
+            scfg_dict["credentials"] = {}
+        if not scfg_dict["tokens"]:
+            scfg_dict["tokens"] = {}
+
+        self.__save = scfg_dict
+        print self
+
+    def getToken(self, host):
+        return self.__save["tokens"].get(host)
+
+    def getAuthString(self, host):
+        return self.__save["credentials"].get(host)
+
+    def saveToken(self, host, token, destroy = False):
+        if not destroy:
+            self.__save["tokens"][host] = token
+        else:
+            del self.__save["tokens"][host]
+
+        session_cfg_file = os.path.join(os.environ['CC_PACKAGE_ROOT'], "config", "session_config.json")
+        with open(session_cfg_file, 'w') as scfg:
+            json.dump(self.__save, scfg, indent = 2, sort_keys = True)

--- a/codechecker_lib/session_manager.py
+++ b/codechecker_lib/session_manager.py
@@ -176,8 +176,8 @@ class sessionManager:
             return False
 
     def create_or_get_session(self, client, auth_string):
-        '''Create a new session for the given client and auth-string, if
-        it is valid. If an existing session is found, return that instead.'''
+        """Create a new session for the given client and auth-string, if
+        it is valid. If an existing session is found, return that instead."""
         if not self.__auth_config["enabled"]:
             return None
 

--- a/config/config.md
+++ b/config/config.md
@@ -8,13 +8,21 @@ checker name and a severity level. Severity levels can be found in the shared.th
 ### Package configuration
   *  environment variables section  
      Contains enviroment variable names set and used during the static analysis
-  *  package variables section
+  *  package variables section  
      Default database username which will be used to initialize postgres database.  
 
   *  checker config section
-     + checkers
+     + checkers  
        This section contains the default checkers set used for analysis.
        The order of the checkers will be kept. (To enable set to true, to disable set to false)
+
+### Session configuration
+  * authentication section  
+    Contains configuration for a **server** on how to handle authentication
+  * credentials section  
+    Contains the **client** user's preconfigured authentication tokens.
+  * tokens section  
+    Contains session tokens the **client** user has received through authentication. This section is **not** meant to be configured by hand.
 
 ### gdb script
 Contains an automated gdb script which can be used for debug. In debug mode the failed build commands will be rerun with gdb.

--- a/config/session_client.json
+++ b/config/session_client.json
@@ -2,12 +2,9 @@
   "client_autologin" : true,
   "credentials": {
     "*" : "global:admin",
-    "*:6251" : "cc:valid",
-    "127.0.0.1" : "cc:bad",
-    "localhost" : "global:admin",
-    "localhost:6252" : "cc:invalid"
+    "localhost:14444" : "test:test"
   },
   "tokens": {
-    "localhost:6251" : "dummy_token"
+    "localhost:14444" : "dummy_token"
   }
 }

--- a/config/session_client.json
+++ b/config/session_client.json
@@ -1,0 +1,13 @@
+{
+  "client_autologin" : true,
+  "credentials": {
+    "*" : "global:admin",
+    "*:6251" : "cc:valid",
+    "127.0.0.1" : "cc:bad",
+    "localhost" : "global:admin",
+    "localhost:6252" : "cc:invalid"
+  },
+  "tokens": {
+    "localhost:6251" : "dummy_token"
+  }
+}

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -1,6 +1,6 @@
 {
   "authentication": {
-    "enabled" : true,
+    "enabled" : false,
     "realm_name" : "CodeChecker Privileged server",
     "realm_error" : "Access requires valid credentials.",
     "soft_expire" : 60,

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -22,6 +22,15 @@
           ]
         }
       ]
+    },
+    "method_pam": {
+      "enabled" : false,
+      "users": [
+        "root", "myname"
+      ],
+      "groups": [
+        "adm", "cc-users"
+      ]
     }
   }
 }

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -2,13 +2,18 @@
   "authentication": {
     "enabled" : true,
     "realm_name" : "CodeChecker Privileged server",
-    "realm_error": "Access requires valid credentials.",
-
+    "realm_error" : "Access requires valid credentials.",
+    "soft_expire" : 60,
+    "session_lifetime" : 300,
+    "logins_until_cleanup" : 30,
     "method_dictionary": {
       "enabled" : false,
       "auths" : [
         "global:admin", "test:test"
       ]
+    },
+    "method_ldap": {
+      "enabled" : false
     }
   }
 }

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -13,7 +13,15 @@
       ]
     },
     "method_ldap": {
-      "enabled" : false
+      "enabled" : false,
+      "authorities": [
+        {
+          "connection_url": "ldap://ldap.example.org",
+          "queries": [
+            "uid=$USN$,ou=admins,o=mycompany"
+          ]
+        }
+      ]
     }
   }
 }

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -1,7 +1,9 @@
 {
   "authentication": {
     "client_autologin" : true,
-    "enabled" : true
+    "enabled" : true,
+    "realm_name" : "CodeChecker Privileged server",
+    "realm_error": "Access requires valid credentials."
   },
   "credentials": {
     "*" : "global:admin",

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -1,11 +1,15 @@
 {
   "authentication": {
-      "enabled": false
+    "client_autologin" : true,
+    "enabled" : true
   },
   "credentials": {
-      "localhost:6251" : "cc:valid"
+    "*" : "global:admin",
+    "*:6251" : "super:secret",
+    "localhost" : "cc:bad",
+    "localhost:6252" : "cc:invalid"
   },
   "tokens": {
-      "localhost:6251" : "dummy_token"
+    "localhost:6251" : "dummy_token"
   }
 }

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -1,0 +1,11 @@
+{
+  "authentication": {
+      "enabled": false
+  },
+  "credentials": {
+      "localhost:6251" : "cc:valid"
+  },
+  "tokens": {
+      "localhost:6251" : "dummy_token"
+  }
+}

--- a/config/session_config.json
+++ b/config/session_config.json
@@ -1,17 +1,14 @@
 {
   "authentication": {
-    "client_autologin" : true,
     "enabled" : true,
     "realm_name" : "CodeChecker Privileged server",
-    "realm_error": "Access requires valid credentials."
-  },
-  "credentials": {
-    "*" : "global:admin",
-    "*:6251" : "super:secret",
-    "localhost" : "cc:bad",
-    "localhost:6252" : "cc:invalid"
-  },
-  "tokens": {
-    "localhost:6251" : "dummy_token"
+    "realm_error": "Access requires valid credentials.",
+
+    "method_dictionary": {
+      "enabled" : false,
+      "auths" : [
+        "global:admin", "test:test"
+      ]
+    }
   }
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,12 +1,19 @@
 CodeChecker authentication subsytem
 ===================================
-
+ 
 CodeChecker also supports only allowing a privileged set of users to access the results stored on a server.
 Authentication configuration is stored in the `config/session_config.json` file, both for the client and the serverside.
-
+ 
 ## Serverside configuration
+ 
+The `authentication` section of the config file controls how authentication is handled.
 
-> TBD
+ * `enabled`  
+    setting this to `false` disables privileged access
+ * `realm_name`  
+    The name to show for web-browser viewers' pop-up login window via *HTTP Authenticate*
+ * `realm_error`  
+    The error message shown in the browser when the user fails to authenticate
 
 ## Clientside configuration
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,11 +1,16 @@
 CodeChecker authentication subsytem
 ===================================
- 
+
+# Please be advised, that currently, login credentials travel on an unencrypted channel!
+
 CodeChecker also supports only allowing a privileged set of users to access the results stored on a server.
-Authentication configuration is stored in the `config/session_config.json` file for the server and a template in `config/session_client.json` for the client.
-The user's own configuration is copied by the client &ndash; at first launch &ndash; to `~/.codechecker_passwords.json`.
+
+> **NOTICE!** Some authentication subsystems require additional packages to be installed before they can be used.
  
 ## Serverside configuration
+
+The server's configuration is stored in the server's *workspace* folder, in `session_config.json`.
+This file is created, at the first start of the server, using the package's installed `config/session_config.json` as a template.
  
 The `authentication` section of the config file controls how authentication is handled.
 
@@ -46,6 +51,24 @@ If the user's login matches any of the credentials listed, the user will be auth
 ```
 
 ### *LDAP* authentication
+
+#### Prerequisites
+
+Using the *LDAP* authentication requires some additional packages to be installed on the system.
+
+~~~~~~{.sh}
+
+# get additional system libraries
+sudo apt-get install libldap2-dev libsasl2-dev libssl-dev
+
+# the python virtual environment must be sourced!
+source ~/checker_env/bin/activate
+
+# install required basic python modules
+pip install python-ldap
+~~~~~~
+
+#### Settings
 
 CodeChecker also supports *LDAP*-based authentication. The `authentication.method_ldap` section contains the configuration for LDAP authentication:
 the server can be configured to connect to as much LDAP-servers as the administrator wants. Each LDAP server is identified by a `connection_url` and a list of `queries`
@@ -89,6 +112,9 @@ For browser authentication to work, cookies must be enabled!
 ### Command-line client
 
 The `CodeChecker cmd` client needs to be authenticated for a server before any data communication could take place.
+
+The client's configuration file is expected to be at `~/.codechecker_passwords.json`, which is created at the first command executed
+by using the package's `config/session_client.json` as an example.
 
 ~~~~~~~~~~~~~~~~~~~~~
 usage: CodeChecker cmd login [-h] [--host HOST] -p PORT [-u USERNAME]
@@ -142,4 +168,4 @@ This behaviour can be disabled by setting `client_autologin` to `false`.
 
 #### Currently active tokens
 
-The configuration file's `tokens` section contains the user's currently active sessions' tokens. This is not meant to be edited by hand, the client manages this section.
+The user's currently active sessions' token are stored in the `/tmp/.codechecker_USERNAME.session.json` (where `/tmp` is the environment's *temp* folder) file.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -15,6 +15,15 @@ The `authentication` section of the config file controls how authentication is h
     The name to show for web-browser viewers' pop-up login window via *HTTP Authenticate*
  * `realm_error`  
     The error message shown in the browser when the user fails to authenticate
+ * `logins_until_cleanup`  
+    After this many login attempts made towards the server, it will perform an automatic cleanup of old, expired sessions.
+ * `soft_expire`  
+    (in seconds) When a user is authenticated, a session is created for them and this session identifies the user's access.
+    This configuration variable sets how long the session considered "valid" before the user is needed
+    to reauthenticate again &mdash; if this time expires, the session will be *hibernated*: the next access will be denied,
+    but if the user presents a valid login, they will get their session reused.
+ * `session_lifetime`  
+    (in seconds) The lifetime of the session sets that after this many seconds since last session access the session is permanently invalidated.
 
 Every authentication method is its own JSON object in this section. Every authentication method has its
 own `enabled` key which dictates whether it is used at live authentication or not.
@@ -23,16 +32,22 @@ Users are authenticated if **any** authentication method successfully authentica
 
 ### *Dictionary* authentication
 
-The `authentication.method_dictionary` contains a plaintext username-password configuration for authentication.
+The `authentication.method_dictionary` contains a plaintext `username:password` credentials for authentication.
+If the user's login matches any of the credentials listed, the user will be authenticated.
 
 ```json
 "method_dictionary": {
   "enabled" : true,
   "auths" : [
-      "global:admin", "test:test"
+      "global:admin",
+      "test:test"
   ]
 }
 ```
+
+### `LDAP` authentication
+
+> TBD
 
 ----
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -116,6 +116,9 @@ The `CodeChecker cmd` client needs to be authenticated for a server before any d
 The client's configuration file is expected to be at `~/.codechecker_passwords.json`, which is created at the first command executed
 by using the package's `config/session_client.json` as an example.
 
+> Please make sure, as a security precaution, that **only you** are allowed to access this file.
+> Executing `chmod 0600 ~/.codechecker_passwords.json` will limit access to your user only.
+
 ~~~~~~~~~~~~~~~~~~~~~
 usage: CodeChecker cmd login [-h] [--host HOST] -p PORT [-u USERNAME]
                              [-pw PASSWORD] [-d]
@@ -168,4 +171,4 @@ This behaviour can be disabled by setting `client_autologin` to `false`.
 
 #### Currently active tokens
 
-The user's currently active sessions' token are stored in the `/tmp/.codechecker_USERNAME.session.json` (where `/tmp` is the environment's *temp* folder) file.
+The configuration file's `tokens` section contains the user's currently active sessions' tokens. This is not meant to be edited by hand, the client manages this section.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -28,7 +28,7 @@ The `authentication` section of the config file controls how authentication is h
 Every authentication method is its own JSON object in this section. Every authentication method has its
 own `enabled` key which dictates whether it is used at live authentication or not.
 
-Users are authenticated if **any** authentication method successfully authenticates them.
+Users are authenticated if **any** authentication method successfully authenticates them. If both methods are enabled, *dictionary* authentication takes precedence.
 
 ### *Dictionary* authentication
 
@@ -45,9 +45,36 @@ If the user's login matches any of the credentials listed, the user will be auth
 }
 ```
 
-### `LDAP` authentication
+### *LDAP* authentication
 
-> TBD
+CodeChecker also supports *LDAP*-based authentication. The `authentication.method_ldap` section contains the configuration for LDAP authentication:
+the server can be configured to connect to as much LDAP-servers as the administrator wants. Each LDAP server is identified by a `connection_url` and a list of `queries`
+to attempt to log in the username given.
+
+Servers are connected to and queries are executed in the order they appear in the configuration file.
+Because of this, it is not advised to list too many servers as it can elongenate the authentication process.
+
+The special `$USN$` token in the query is replaced to the *username* at login.
+
+```json
+"method_ldap": {
+  "enabled" : true,
+  "authorities": [
+    {
+      "connection_url": "ldap://ldap.example.org",
+      "queries": [
+        "uid=$USN$,ou=admins,o=mycompany"
+      ]
+    },
+    {
+      "connection_url" : "ldaps://secure.internal.example.org:636",
+      "queries": [
+        "uid=$USN$,ou=owners,ou=secure,o=company"
+      ]
+    }
+  ]
+}
+```
 
 ----
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,7 +2,8 @@ CodeChecker authentication subsytem
 ===================================
  
 CodeChecker also supports only allowing a privileged set of users to access the results stored on a server.
-Authentication configuration is stored in the `config/session_config.json` file, both for the client and the serverside.
+Authentication configuration is stored in the `config/session_config.json` file for the server and a template in `config/session_client.json` for the client.
+The user's own configuration is copied by the client &ndash; at first launch &ndash; to `~/.codechecker_passwords.json`.
  
 ## Serverside configuration
  
@@ -14,6 +15,26 @@ The `authentication` section of the config file controls how authentication is h
     The name to show for web-browser viewers' pop-up login window via *HTTP Authenticate*
  * `realm_error`  
     The error message shown in the browser when the user fails to authenticate
+
+Every authentication method is its own JSON object in this section. Every authentication method has its
+own `enabled` key which dictates whether it is used at live authentication or not.
+
+Users are authenticated if **any** authentication method successfully authenticates them.
+
+### *Dictionary* authentication
+
+The `authentication.method_dictionary` contains a plaintext username-password configuration for authentication.
+
+```json
+"method_dictionary": {
+  "enabled" : true,
+  "auths" : [
+      "global:admin", "test:test"
+  ]
+}
+```
+
+----
 
 ## Clientside configuration
 
@@ -53,7 +74,7 @@ Privileged session expire after a set amount of time. To log out manually, issue
 
 To alleviate the need for supplying authentication in the command-line every time a server is connected to, users can pre-configure their credentials to be used in authentication.
 
-To do so, open `config/session_config.json`. The `credentials` section is used by the client to read pre-saved authentication data in `username:password` format.
+To do so, open `~/.codechecker_passwords.json`. The `credentials` section is used by the client to read pre-saved authentication data in `username:password` format.
 
 ```json
   "credentials": {
@@ -76,3 +97,7 @@ Credentials are matched for any particular server at login in the following orde
 If authentication is required by the server and the user hasn't logged in but there are saved credentials for the server, `CodeChecker cmd` will automatically try to log in.
 
 This behaviour can be disabled by setting `client_autologin` to `false`.
+
+#### Currently active tokens
+
+The configuration file's `tokens` section contains the user's currently active sessions' tokens. This is not meant to be edited by hand, the client manages this section.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,71 @@
+CodeChecker authentication subsytem
+===================================
+
+CodeChecker also supports only allowing a privileged set of users to access the results stored on a server.
+Authentication configuration is stored in the `config/session_config.json` file, both for the client and the serverside.
+
+## Serverside configuration
+
+> TBD
+
+## Clientside configuration
+
+### Web-browser client
+
+Authentication in the web browser is handled via standard *HTTP Authenticate* headers, the browser will prompt the user to supply their crendentials.
+
+For browser authentication to work, cookies must be enabled!
+
+### Command-line client
+
+The `CodeChecker cmd` client needs to be authenticated for a server before any data communication could take place.
+
+~~~~~~~~~~~~~~~~~~~~~
+usage: CodeChecker cmd login [-h] [--host HOST] -p PORT [-u USERNAME]
+                             [-pw PASSWORD] [-d]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           Server host.
+  -p PORT, --port PORT  HTTP Server port.
+  -u USERNAME, --username USERNAME
+                        Username to use on authentication
+  -pw PASSWORD, --password PASSWORD
+                        Password for username-password authentication
+                        (optional)
+  -d, --deactivate, --logout
+                        Send a logout request for the server
+~~~~~~~~~~~~~~~~~~~~~
+
+The user can log in onto the server by issuing the command `CodeChecker cmd login -h host -p port -u username -pw passphrase`.
+After receiving an *Authentication successful!* message, access to the analysis information is given; otherwise, *Invalid access* is shown instead of real data.
+
+Privileged session expire after a set amount of time. To log out manually, issue the command `CodeChecker cmd login -h host -p port --logout`.
+
+#### Preconfigured credentials
+
+To alleviate the need for supplying authentication in the command-line every time a server is connected to, users can pre-configure their credentials to be used in authentication.
+
+To do so, open `config/session_config.json`. The `credentials` section is used by the client to read pre-saved authentication data in `username:password` format.
+
+```json
+  "credentials": {
+    "*" : "global:passphrase",
+    "*:8080" : "webserver:1234",
+    "localhost" : "local:admin",
+    "localhost:6251" : "super:secret"
+  },
+```
+
+Credentials are matched for any particular server at login in the following order:
+
+  1. An exact `host:port` match is tried
+  2. Matching for the `host` (on any port) is tried
+  3. Matching for a particular port (on any host address), in the form of `*:port`, is tried
+  4. Global credentials for the installation is stored with the `*` key
+
+#### Automatic login
+
+If authentication is required by the server and the user hasn't logged in but there are saved credentials for the server, `CodeChecker cmd` will automatically try to log in.
+
+This behaviour can be disabled by setting `client_autologin` to `false`.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -5,7 +5,7 @@ CodeChecker authentication subsytem
 
 CodeChecker also supports only allowing a privileged set of users to access the results stored on a server.
 
-> **NOTICE!** Some authentication subsystems require additional packages to be installed before they can be used.
+> **NOTICE!** Some authentication subsystems require additional packages to be installed before they can be used. See below.
  
 ## Serverside configuration
 
@@ -52,22 +52,24 @@ If the user's login matches any of the credentials listed, the user will be auth
 }
 ```
 
-### *PAM* authentication
+### External authentication methods
 
-#### Prerequisites
+External authentication methods connect to a privilege manager to authenticate users against.
 
-Using the *PAM* authentication requires some additional packages to be installed on the system.
+Using external authentication methods - such as *PAM* or *LDAP* - require additional packages and libraries to be installed on the system.
 
 ~~~~~~{.sh}
+# get additional system libraries
+sudo apt-get install libldap2-dev libsasl2-dev libssl-dev
 
 # the python virtual environment must be sourced!
 source ~/checker_env/bin/activate
 
 # install required python modules
-pip install python-pam
+pip install -r .ci/auth_requirements
 ~~~~~~
 
-#### Settings
+#### *PAM* authentication
 
 To access the server via PAM authentication, the user must provide valid username and password which is accepted by PAM.
 
@@ -92,25 +94,7 @@ In the example below, `root` and `myname` can access the server, and **everyone*
 }
 ```
 
-### *LDAP* authentication
-
-#### Prerequisites
-
-Using the *LDAP* authentication requires some additional packages to be installed on the system.
-
-~~~~~~{.sh}
-
-# get additional system libraries
-sudo apt-get install libldap2-dev libsasl2-dev libssl-dev
-
-# the python virtual environment must be sourced!
-source ~/checker_env/bin/activate
-
-# install required python modules
-pip install python-ldap
-~~~~~~
-
-#### Settings
+#### *LDAP* authentication
 
 CodeChecker also supports *LDAP*-based authentication. The `authentication.method_ldap` section contains the configuration for LDAP authentication:
 the server can be configured to connect to as much LDAP-servers as the administrator wants. Each LDAP server is identified by a `connection_url` and a list of `queries`
@@ -213,4 +197,4 @@ This behaviour can be disabled by setting `client_autologin` to `false`.
 
 #### Currently active tokens
 
-The configuration file's `tokens` section contains the user's currently active sessions' tokens. This is not meant to be edited by hand, the client manages this section.
+The user's currently active sessions' token are stored in the `/tmp/.codechecker_USERNAME.session.json` (where `/tmp` is the environment's *temp* folder) file.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -33,7 +33,9 @@ The `authentication` section of the config file controls how authentication is h
 Every authentication method is its own JSON object in this section. Every authentication method has its
 own `enabled` key which dictates whether it is used at live authentication or not.
 
-Users are authenticated if **any** authentication method successfully authenticates them. If both methods are enabled, *dictionary* authentication takes precedence.
+Users are authenticated if **any** authentication method successfully authenticates them.
+Authentications are attempted in the order they are described here: *dicitonary* takes precedence,
+*pam* is a secondary and *ldap* is a tertiary backend, if enabled.
 
 ### *Dictionary* authentication
 
@@ -46,6 +48,46 @@ If the user's login matches any of the credentials listed, the user will be auth
   "auths" : [
       "global:admin",
       "test:test"
+  ]
+}
+```
+
+### *PAM* authentication
+
+#### Prerequisites
+
+Using the *PAM* authentication requires some additional packages to be installed on the system.
+
+~~~~~~{.sh}
+
+# the python virtual environment must be sourced!
+source ~/checker_env/bin/activate
+
+# install required python modules
+pip install python-pam
+~~~~~~
+
+#### Settings
+
+To access the server via PAM authentication, the user must provide valid username and password which is accepted by PAM.
+
+```json
+"method_pam": {
+  "enabled" : true
+}
+```
+
+The module can be configured to allow specific users or users belonging to specific groups only.
+In the example below, `root` and `myname` can access the server, and **everyone** who belongs to the `adm` or `cc-users` group can access the server.
+
+```json
+"method_pam": {
+  "enabled" : true,
+  "users": [
+    "root", "myname"
+  ],
+  "groups": [
+    "adm", "cc-users"
   ]
 }
 ```
@@ -64,7 +106,7 @@ sudo apt-get install libldap2-dev libsasl2-dev libssl-dev
 # the python virtual environment must be sourced!
 source ~/checker_env/bin/activate
 
-# install required basic python modules
+# install required python modules
 pip install python-ldap
 ~~~~~~
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-which nosetests || (echo "[ERROR] nosetests framework is needen to run the tests" && exit 1)
+which nosetests || (echo "[ERROR] nosetests framework is needed to run the tests" && exit 1)
 which clang || (echo "[ERROR] clang required to run functional tests" && exit 1)
 
 # setup environment variables, temporary directories

--- a/tests/functional/package_test/__init__.py
+++ b/tests/functional/package_test/__init__.py
@@ -174,25 +174,29 @@ def setup_package():
     _start_server(shared_test_params, test_config, False)
 
     #
-    # Create a dummy authentication-enabled configuration and an auth-enabled server
+    # Create a dummy authentication-enabled configuration and an auth-enabled server.
+    #
+    # Running the tests only work if the initial value (in package
+    # session_config.json) is FALSE for authentication.enabled.
+    os.remove(os.path.join(shared_test_params['workspace'], "session_config.json"))
     session_cfg_file = os.path.join(pkg_root, "config", "session_config.json")
-    with open(session_cfg_file, 'r') as scfg:
+    with open(session_cfg_file, 'r+') as scfg:
         __scfg_original = scfg.read()
+        scfg.seek(0)
+        scfg_dict = json.loads(__scfg_original)
 
-    scfg_dict = json.loads(__scfg_original)
+        scfg_dict["authentication"]["enabled"] = True
+        scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
+        scfg_dict["authentication"]["method_dictionary"]["auths"] = ["cc:test"]
 
-
-    scfg_dict["authentication"]["enabled"] = True
-    scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
-    scfg_dict["authentication"]["method_dictionary"]["auths"] = ["cc:test"]
-
-    with open(session_cfg_file, 'w') as scfg:
         json.dump(scfg_dict, scfg, indent=2, sort_keys=True)
+        scfg.truncate()
 
     print("Starting server to test authentication")
     _start_server(shared_test_params, test_config, True)
 
     # Need to save the original configuration back so multiple tests can work after each other
+    os.remove(os.path.join(shared_test_params['workspace'], "session_config.json"))
     with open(session_cfg_file, 'w') as scfg:
         scfg.writelines(__scfg_original)
 

--- a/tests/functional/package_test/__init__.py
+++ b/tests/functional/package_test/__init__.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 
 """Setup for the package tests."""
+
 import json
 import multiprocessing
 import os
@@ -93,7 +94,11 @@ def setup_package():
         'CC_TEST_SERVER_PORT': get_free_port(),
         'CC_TEST_SERVER_HOST': 'localhost',
         'CC_TEST_VIEWER_PORT': get_free_port(),
-        'CC_TEST_VIEWER_HOST': 'localhost'
+        'CC_TEST_VIEWER_HOST': 'localhost',
+        'CC_AUTH_SERVER_PORT': get_free_port(),
+        'CC_AUTH_SERVER_HOST': 'localhost',
+        'CC_AUTH_VIEWER_PORT': get_free_port(),
+        'CC_AUTH_VIEWER_HOST': 'localhost',
     }
 
     test_project_clean_cmd = project_info['clean_cmd']
@@ -102,6 +107,8 @@ def setup_package():
     # setup env vars for test cases
     os.environ['CC_TEST_VIEWER_PORT'] = str(test_config['CC_TEST_VIEWER_PORT'])
     os.environ['CC_TEST_SERVER_PORT'] = str(test_config['CC_TEST_SERVER_PORT'])
+    os.environ['CC_AUTH_SERVER_PORT'] = str(test_config['CC_AUTH_SERVER_PORT'])
+    os.environ['CC_AUTH_VIEWER_PORT'] = str(test_config['CC_AUTH_VIEWER_PORT'])
     os.environ['CC_TEST_PROJECT_INFO'] = \
         json.dumps(project_info['clang_' + clang_version])
     # -------------------------------------------------------------------------
@@ -164,7 +171,30 @@ def setup_package():
 
     # Start the CodeChecker server.
     print("Starting server to get results")
-    _start_server(shared_test_params, test_config)
+    _start_server(shared_test_params, test_config, False)
+
+    #
+    # Create a dummy authentication-enabled configuration and an auth-enabled server
+    session_cfg_file = os.path.join(pkg_root, "config", "session_config.json")
+    with open(session_cfg_file, 'r') as scfg:
+        __scfg_original = scfg.read()
+
+    scfg_dict = json.loads(__scfg_original)
+
+
+    scfg_dict["authentication"]["enabled"] = True
+    scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
+    scfg_dict["authentication"]["method_dictionary"]["auths"] = ["cc:test"]
+
+    with open(session_cfg_file, 'w') as scfg:
+        json.dump(scfg_dict, scfg, indent=2, sort_keys=True)
+
+    print("Starting server to test authentication")
+    _start_server(shared_test_params, test_config, True)
+
+    # Need to save the original configuration back so multiple tests can work after each other
+    with open(session_cfg_file, 'w') as scfg:
+        scfg.writelines(__scfg_original)
 
 
 def teardown_package():
@@ -279,7 +309,7 @@ def _run_check(shared_test_params, skip_list_file, test_project_build_cmd,
         return cerr.returncode
 
 
-def _start_server(shared_test_params, test_config):
+def _start_server(shared_test_params, test_config, auth=False):
     """Start the CodeChecker server."""
     def start_server_proc(event, server_cmd, checking_env):
         """Target function for starting the CodeChecker server."""
@@ -293,10 +323,19 @@ def _start_server(shared_test_params, test_config):
             proc.terminate()
 
     server_cmd = ['CodeChecker', 'server',
-                  '--check-port', str(test_config['CC_TEST_SERVER_PORT']),
-                  '--view-port', str(test_config['CC_TEST_VIEWER_PORT']),
                   '-w', shared_test_params['workspace'],
                   '--suppress', shared_test_params['suppress_file']]
+	
+    if auth:
+	server_cmd.extend(['--check-port',
+                           str(test_config['CC_AUTH_SERVER_PORT']),
+                           '--view-port',
+                           str(test_config['CC_AUTH_VIEWER_PORT'])])
+    else:
+	server_cmd.extend(['--check-port',
+                           str(test_config['CC_TEST_SERVER_PORT']),
+                           '--view-port',
+                           str(test_config['CC_TEST_VIEWER_PORT'])])
     if shared_test_params['use_postgresql']:
         server_cmd.append('--postgresql')
         server_cmd += _pg_db_config_to_cmdline_params(

--- a/tests/functional/package_test/test_authentication.py
+++ b/tests/functional/package_test/test_authentication.py
@@ -1,0 +1,94 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import json
+import logging
+import os
+import re
+import unittest
+
+from thrift.protocol.TProtocol import TProtocolException
+
+from test_utils.thrift_client_to_db import CCViewerHelper
+from test_utils.thrift_client_to_db import CCAuthHelper
+
+class RunResults(unittest.TestCase):
+    def setUp(self):
+        self.host = 'localhost'
+        self.port = int(os.environ['CC_AUTH_VIEWER_PORT'])
+        self.uri = '/Authentication'
+
+    def test_initial_access(self):
+        """Tests that initially, a non-authenticating server is accessible,
+        but an authenticating one is not."""
+        client_unprivileged = CCViewerHelper(self.host,int(
+            os.environ['CC_TEST_VIEWER_PORT']), '/', True, None)
+        client_privileged = CCViewerHelper(self.host, self.port, '/', True, None)
+
+        self.assertIsNotNone(client_unprivileged.getAPIVersion(),
+                             "Unprivileged client was not accessible.")
+
+        try:
+            client_privileged.getAPIVersion()
+            success = False
+        except TProtocolException as tpe:
+            # The server reports a HTTP 401 error which is not a valid Thrift response
+            # But if it does so, it passes the test!
+            success = True
+        self.assertTrue(success, "Privileged client allowed access without session.")
+
+    def test_privileged_access(self):
+        """Tests that initially, a non-authenticating server is accessible,
+        but an authenticating one is not."""
+        auth_client = CCAuthHelper(self.host, self.port, self.uri, True, None)
+
+        handshake = auth_client.getAuthParameters()
+        self.assertTrue(handshake.requiresAuthentication, "Privileged server " +
+                        "did not report that it requires authentication.")
+        self.assertFalse(handshake.sessionStillActive, "Empty session was " +
+                         "reported to be still active.")
+
+        sessionToken = auth_client.performLogin("Username:Password",
+                                                "invalid:invalid")
+        self.assertIsNone(sessionToken, "Invalid credentials gave us a token!")
+
+        self.sessionToken = auth_client.performLogin("Username:Password",
+                                                     "cc:test")
+        self.assertIsNotNone(self.sessionToken,
+                            "Valid credentials didn't give us a token!")
+
+        handshake = auth_client.getAuthParameters()
+        self.assertTrue(handshake.requiresAuthentication, "Privileged server " +
+                        "did not report that it requires authentication.")
+        self.assertFalse(handshake.sessionStillActive, "Valid session was " +
+                         "reported not to be active.")
+
+        client = CCViewerHelper(self.host, self.port, '/', True, self.sessionToken)
+
+        self.assertIsNotNone(client.getAPIVersion(),
+                             "Privileged server didn't respond properly.")
+
+        auth_client = CCAuthHelper(self.host, self.port, self.uri, True,
+                                   self.sessionToken)
+        result = auth_client.destroySession()
+
+        self.assertTrue(result, "Server did not allow us to destroy session.")
+
+        try:
+            client.getAPIVersion()
+            success = False
+        except TProtocolException as tpe:
+            # The server reports a HTTP 401 error which is not a valid Thrift response
+            # But if it does so, it passes the test!
+            success = True
+        self.assertTrue(success, "Privileged client allowed access after logout.")
+
+        handshake = auth_client.getAuthParameters()
+        self.assertFalse(handshake.sessionStillActive, "Destroyed session was " +
+                         "reported to be still active.")
+
+

--- a/thrift_api/authentication.thrift
+++ b/thrift_api/authentication.thrift
@@ -10,7 +10,7 @@ namespace py Authentication
 
 struct HandshakeInformation {
   1: bool requiresAuthentication,       // true if the server has a privileged zone --- the state of having a valid access is not considered here
-  2: bool sessionStillActive,
+  2: bool sessionStillActive,           // whether the session in which the HandshakeInformation is returned is a valid one
 }
 
 service codeCheckerAuthentication {

--- a/thrift_api/authentication.thrift
+++ b/thrift_api/authentication.thrift
@@ -1,0 +1,31 @@
+// -------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -------------------------------------------------------------------------
+
+include "shared.thrift"
+
+namespace py Authentication
+
+struct HandshakeInformation {
+  1: bool requiresAuthentication,       // true if the server has a privileged zone --- the state of having a valid access is not considered here
+  2: bool sessionStillActive,
+}
+
+service codeCheckerAuthentication {
+  // get basic authentication information from the server
+  HandshakeInformation getAuthParameters(),
+
+  // retrieves a list of accepted authentication methods from the server
+  list<string> getAcceptedAuthMethods(),
+
+  // handles creating a session token for the user
+  string performLogin(1: string auth_method,
+                      2: string auth_string)
+                      throws (1: shared.RequestFailed requestError),
+
+  // performs logout action for the user (must be called from the corresponding valid session)
+  bool destroySession()
+             throws (1: shared.RequestFailed requestError)
+}

--- a/thrift_api/shared.thrift
+++ b/thrift_api/shared.thrift
@@ -49,7 +49,8 @@ enum Severity{
 enum ErrorCode{
   DATABASE,
   IOERROR,
-  GENERAL
+  GENERAL,
+  PRIVILEGE
 }
 
 //-----------------------------------------------------------------------------

--- a/thrift_api/thrift_api.md
+++ b/thrift_api/thrift_api.md
@@ -9,3 +9,7 @@ See [report_viewer_server.thrift](https://raw.githubusercontent.com/Ericsson/cod
 ## Report storage server API
 The report storage server API is used internally in the package during runtime to store the results to the database.
 See [report_storage_server.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift_api/report_storage_server.thrift).
+
+## Authentication system API
+The authentication layer is used for supporting privileged-access only access.
+See [authentication.thrift](https://raw.githubusercontent.com/Ericsson/codechecker/master/thrift_api/authentication.thrift)

--- a/viewer_clients/cmdline_client/authentication_helper.py
+++ b/viewer_clients/cmdline_client/authentication_helper.py
@@ -30,7 +30,8 @@ class ThriftAuthHelper():
         self.client = codeCheckerAuthentication.Client(self.protocol)
 
         if session_token:
-            headers = {'Cookie': session_manager.session_cookie_name + "=" + session_token}
+            headers = {'Cookie': session_manager.SESSION_COOKIE_NAME +
+                       "=" + session_token}
             self.transport.setCustomHeaders(headers)
 
             # ------------------------------------------------------------
@@ -97,5 +98,3 @@ class ThriftAuthHelper():
     @ThriftClientCall
     def destroySession(self):
         pass
-
-

--- a/viewer_clients/cmdline_client/authentication_helper.py
+++ b/viewer_clients/cmdline_client/authentication_helper.py
@@ -52,8 +52,7 @@ class ThriftAuthHelper():
                     print('Database error on server')
                     print(str(reqfailure.message))
                 if reqfailure.error_code == shared.ttypes.ErrorCode.PRIVILEGE:
-                    print('Unauthorized access')
-                    print(str(reqfailure.message))
+                    raise reqfailure
                 else:
                     print('Other error')
                     print(str(reqfailure))

--- a/viewer_clients/cmdline_client/authentication_helper.py
+++ b/viewer_clients/cmdline_client/authentication_helper.py
@@ -5,8 +5,9 @@
 # -------------------------------------------------------------------------
 
 import os
-import socket
 import sys
+# import datetime
+import socket
 
 from thrift import Thrift
 from thrift.Thrift import TException, TApplicationException
@@ -16,29 +17,31 @@ from thrift.protocol.TProtocol import TProtocolException
 
 from codechecker_lib import session_manager
 
-from codeCheckerDBAccess import codeCheckerDBAccess
+from Authentication import codeCheckerAuthentication
 import shared
 
-class ThriftClientHelper():
 
-    def __init__(self, host, port, uri, session_token = None):
+class ThriftAuthHelper():
+    def __init__(self, host, port, uri, session_token=None):
         self.__host = host
         self.__port = port
         self.transport = THttpClient.THttpClient(self.__host, self.__port, uri)
         self.protocol = TJSONProtocol.TJSONProtocol(self.transport)
-        self.client = codeCheckerDBAccess.Client(self.protocol)
+        self.client = codeCheckerAuthentication.Client(self.protocol)
 
         if session_token:
             headers = {'Cookie': session_manager.session_cookie_name + "=" + session_token}
             self.transport.setCustomHeaders(headers)
 
-# ------------------------------------------------------------
+            # ------------------------------------------------------------
+
     def ThriftClientCall(function):
-        #print type(function)
+        # print type(function)
         funcName = function.__name__
+
         def wrapper(self, *args, **kwargs):
-            #print('['+host+':'+str(port)+'] >>>>> ['+funcName+']')
-            #before = datetime.datetime.now()
+            # print('['+host+':'+str(port)+'] >>>>> ['+funcName+']')
+            # before = datetime.datetime.now()
             self.transport.open()
             func = getattr(self.client, funcName)
             try:
@@ -56,7 +59,7 @@ class ThriftClientHelper():
                     print(str(reqfailure))
 
                 sys.exit(1)
-            except TProtocolException:
+            except TProtocolException as ex:
                 print("Connection failed to {0}:{1}"
                       .format(self.__host, self.__port))
                 sys.exit(1)
@@ -66,56 +69,34 @@ class ThriftClientHelper():
                 print(str(serr))
                 sys.exit(1)
 
+            # after = datetime.datetime.now()
+            # timediff = after - before
+            # diff = timediff.microseconds/1000
+            # print('['+str(diff)+'ms] <<<<< ['+host+':'+str(port)+']')
+            # print res
             self.transport.close()
             return res
 
         return wrapper
 
-    # ------------------------------------------------------------
+    # -----------------------------------------------------------------------
     @ThriftClientCall
-    def getRunData():
-        pass
-
-    # ------------------------------------------------------------
-    @ThriftClientCall
-    def getRunResults(self, runId, resultBegin, resultEnd, sortType,
-                      reportFilters):
-        pass
-
-    # ------------------------------------------------------------
-    @ThriftClientCall
-    def getRunResultCount(self, runId, reportFilters):
+    def getAuthParameters(self):
         pass
 
     # -----------------------------------------------------------------------
     @ThriftClientCall
-    def getRunResultTypes(self, runId, reportFilters):
+    def getAcceptedAuthMethods(self):
         pass
 
     # -----------------------------------------------------------------------
     @ThriftClientCall
-    def getAPIVersion(self):
+    def performLogin(self, auth_method, auth_string):
         pass
 
     # -----------------------------------------------------------------------
     @ThriftClientCall
-    def removeRunResults(self, run_ids):
+    def destroySession(self):
         pass
 
-    # -----------------------------------------------------------------------
-    @ThriftClientCall
-    def getNewResults(self, base_run_id, new_run_id, limit, offset, sortType,
-                      reportFilters):
-        pass
 
-    # -----------------------------------------------------------------------
-    @ThriftClientCall
-    def getUnresolvedResults(self, base_run_id, new_run_id, limit, offset,
-                             sortType, reportFilters):
-        pass
-
-    # -----------------------------------------------------------------------
-    @ThriftClientCall
-    def getResolvedResults(self, base_run_id, new_run_id, limit, offset,
-                           sortType, reportFilters):
-        pass

--- a/viewer_clients/cmdline_client/cmd_line_client.py
+++ b/viewer_clients/cmdline_client/cmd_line_client.py
@@ -65,7 +65,6 @@ def handle_auth_requests(args):
         return
 
     methods = auth_client.getAcceptedAuthMethods()
-
     # Attempt username-password auth first
     if 'Username:Password' in str(methods):
         if not args.username or not args.password:

--- a/viewer_clients/cmdline_client/cmd_line_client.py
+++ b/viewer_clients/cmdline_client/cmd_line_client.py
@@ -38,7 +38,7 @@ class CmdLineOutputEncoder(json.JSONEncoder):
         return d
 
 def handle_auth_requests(args):
-    session = session_manager.sessionManager_Client()
+    session = session_manager.SessionManager_Client()
     auth_client = authentication_helper.ThriftAuthHelper(args.host,
                                                          args.port,
                                                          '/Authentication',
@@ -104,7 +104,7 @@ def __check_authentication(client):
 def setupClient(host, port, uri):
     ''' setup the thrift client and check
     API version and authentication needs'''
-    manager = session_manager.sessionManager_Client()
+    manager = session_manager.SessionManager_Client()
     session_token = manager.getToken(host, port)
 
     # Before actually communicating with the server,

--- a/viewer_clients/cmdline_client/cmd_line_client.py
+++ b/viewer_clients/cmdline_client/cmd_line_client.py
@@ -39,7 +39,12 @@ class CmdLineOutputEncoder(json.JSONEncoder):
 
 def handle_auth_requests(args):
     session = session_manager.sessionManager_Client()
-    auth_client = authentication_helper.ThriftAuthHelper(args.host, args.port, '/Authentication', session.getToken(args.host, args.port))
+    auth_client = authentication_helper.ThriftAuthHelper(args.host,
+                                                         args.port,
+                                                         '/Authentication',
+                                                         session.getToken(
+                                                             args.host,
+                                                             args.port))
 
     handshake = auth_client.getAuthParameters()
     if not handshake.requiresAuthentication:
@@ -48,7 +53,8 @@ def handle_auth_requests(args):
 
     if args.logout:
         if args.username or args.password:
-            print('ERROR! Do not supply username and password with `--logout` command.')
+            print('ERROR! Do not supply username and password '
+                  'with `--logout` command.')
             sys.exit(1)
 
         logout_done = auth_client.destroySession()
@@ -71,11 +77,14 @@ def handle_auth_requests(args):
                 args.username = savedAuth.split(":")[0]
                 args.password = savedAuth.split(":")[1]
             else:
-                print('Can not authenticate with username and password if it is not specified...')
+                print('Can not authenticate with username'
+                      'and password if it is not specified...')
                 sys.exit(1)
 
         try:
-            session_token = auth_client.performLogin("Username:Password", args.username + ":" + args.password)
+            session_token = auth_client.performLogin("Username:Password",
+                                                     args.username + ":" +
+                                                     args.password)
             session.saveToken(args.host, args.port, session_token)
             print("Server reported successful authentication!")
         except shared.ttypes.RequestFailed as reqfail:
@@ -84,7 +93,8 @@ def handle_auth_requests(args):
 
 
 def __check_authentication(client):
-    '''communicate with the authentication server to handle authentication requests'''
+    """Communicate with the authentication server
+    to handle authentication requests."""
     result = client.getAuthParameters()
 
     if result.sessionStillActive:
@@ -93,22 +103,32 @@ def __check_authentication(client):
         return False
 
 def setupClient(host, port, uri):
-    ''' setup the thrift client and check API version and authentication needs'''
+    ''' setup the thrift client and check
+    API version and authentication needs'''
     manager = session_manager.sessionManager_Client()
     session_token = manager.getToken(host, port)
 
-    # Before actually communicating with the server, we need to check authentication first
-    auth_client = authentication_helper.ThriftAuthHelper(host, port, uri + 'Authentication', session_token)
+    # Before actually communicating with the server,
+    # we need to check authentication first
+    auth_client = authentication_helper.ThriftAuthHelper(host,
+                                                         port,
+                                                         uri +
+                                                         'Authentication',
+                                                         session_token)
     auth_response = auth_client.getAuthParameters()
-    if auth_response.requiresAuthentication and not auth_response.sessionStillActive:
+    if auth_response.requiresAuthentication and \
+            not auth_response.sessionStillActive:
         print_err = False
 
         if manager.is_autologin_enabled():
             auto_auth_string = manager.getAuthString(host, port)
             if auto_auth_string:
-                # Try to automatically log in with a saved credential if it exists for the server
+                # Try to automatically log in with a saved credential
+                # if it exists for the server
                 try:
-                    session_token = auth_client.performLogin("Username:Password", auto_auth_string)
+                    session_token = auth_client.performLogin(
+                        "Username:Password",
+                        auto_auth_string)
                     manager.saveToken(host, port, session_token)
                     print("Authenticated using pre-configured credentials...")
                 except shared.ttypes.RequestFailed:
@@ -118,7 +138,8 @@ def setupClient(host, port, uri):
 
         if print_err:
             print('Access denied. This server requires authentication.')
-            print('Please log in onto the server using `CodeChecker cmd login`')
+            print('Please log in onto the server '
+                  'using `CodeChecker cmd login`')
             sys.exit(1)
 
     client = thrift_helper.ThriftClientHelper(host, port, uri, session_token)

--- a/viewer_clients/cmdline_client/cmd_line_client.py
+++ b/viewer_clients/cmdline_client/cmd_line_client.py
@@ -12,6 +12,9 @@ import sys
 import codeCheckerDBAccess
 import shared
 from . import thrift_helper
+from . import authentication_helper
+
+from codechecker_lib import session_manager
 
 SUPPORTED_VERSION = '5.0'
 
@@ -34,11 +37,65 @@ class CmdLineOutputEncoder(json.JSONEncoder):
         d.update(obj.__dict__)
         return d
 
+def handle_auth_requests(args):
+    session = session_manager.sessionManager_Client()
+    auth_client = authentication_helper.ThriftAuthHelper(args.host, args.port, '/Authentication', session.getToken(args.host + ":" + args.port))
+
+    handshake = auth_client.getAuthParameters()
+    if not handshake.requiresAuthentication:
+        print("This server does not require privileged access.")
+        return
+
+    if args.logout:
+        logout_done = auth_client.destroySession()
+        if logout_done:
+            session.saveToken(args.host + ":" + args.port, None, True)
+            print('Successfully deauthenticated from server.')
+
+        return
+
+    methods = auth_client.getAcceptedAuthMethods()
+
+    # Attempt username-password auth first
+    if 'Username:Password' in str(methods):
+        if not args.username or not args.password:
+            # Try to use a previously saved credential from configuration file
+            savedAuth = session.getAuthString(args.host + ":" + args.port)
+
+            if savedAuth:
+                args.username = savedAuth.split(":")[0]
+                args.password = savedAuth.split(":")[1]
+            else:
+                print('Can not authenticate with username and password if it is not specified...')
+                sys.exit(1)
+
+        session_token = auth_client.performLogin("Username:Password", args.username + ":" + args.password)
+        session.saveToken(args.host + ":" + args.port, session_token)
+        print("Server reported successful authentication!")
+
+
+def __check_authentication(client):
+    '''communicate with the authentication server to handle authentication requests'''
+    result = client.getAuthParameters()
+
+    if result.sessionStillActive:
+        return True
+    else:
+        return False
 
 def setupClient(host, port, uri):
     """ Setup the thrift client and check API version. """
 
-    client = thrift_helper.ThriftClientHelper(host, port, uri)
+    client = thrift_helper.ThriftClientHelper(host, port, uri, None)
+
+    # Before actually communicating with the server, we need to check authentication first
+    auth_client = authentication_helper.ThriftAuthHelper(host, port, uri + 'Authentication', None)
+    auth_response = auth_client.getAuthParameters()
+    if auth_response.requiresAuthentication and not auth_response.sessionStillActive:
+        print('Access denied.')
+        print('Please log in onto the server using `CodeChecker cmd login`')
+        sys.exit(1)
+
     # Test if client can work with thrift API getVersion.
     if not check_API_version(client):
         print('Backward incompatible change was in the API.')
@@ -420,6 +477,19 @@ def register_client_command_line(argument_parser):
                             required=True, help='Server port.')
     sum_parser.set_defaults(func=handle_remove_run_results)
 
+    # Handle authentication.
+    auth_parser = subparsers.add_parser('login', help='Log in onto a CodeChecker server')
+    auth_parser.add_argument('--host', type=str, dest="host", default='localhost',
+                             help='Server host.')
+    auth_parser.add_argument('-p', '--port', type=str, dest="port", default=11444,
+                             required=True, help='HTTP Server port.')
+    auth_parser.add_argument('-u', '--username', type=str, dest="username",
+                             required=False, help='Username to use on authentication')
+    auth_parser.add_argument('-pw', '--password', type=str, dest="password",
+                             required=False, help="Password for username-password authentication (optional)")
+    auth_parser.add_argument('-d', '--deactivate', '--logout', action='store_true',
+                             dest='logout', help='Send a logout request for the server')
+    auth_parser.set_defaults(func=handle_auth_requests)
 
 def main():
     parser = argparse.ArgumentParser(

--- a/viewer_clients/cmdline_client/thrift_helper.py
+++ b/viewer_clients/cmdline_client/thrift_helper.py
@@ -29,7 +29,8 @@ class ThriftClientHelper():
         self.client = codeCheckerDBAccess.Client(self.protocol)
 
         if session_token:
-            headers = {'Cookie': session_manager.session_cookie_name + "=" + session_token}
+            headers = {'Cookie': session_manager.SESSION_COOKIE_NAME +
+                       "=" + session_token}
             self.transport.setCustomHeaders(headers)
 
 # ------------------------------------------------------------

--- a/viewer_clients/cmdline_client/thrift_helper.py
+++ b/viewer_clients/cmdline_client/thrift_helper.py
@@ -21,7 +21,7 @@ import shared
 
 class ThriftClientHelper():
 
-    def __init__(self, host, port, uri, session_token = None):
+    def __init__(self, host, port, uri, session_token=None):
         self.__host = host
         self.__port = port
         self.transport = THttpClient.THttpClient(self.__host, self.__port, uri)

--- a/viewer_server/client_auth_handler.py
+++ b/viewer_server/client_auth_handler.py
@@ -71,14 +71,18 @@ class ThriftAuthHandler():
     Handle Thrift authentication requests
     '''
 
-    def __init__(self, manager, client_host, session_token = None):
+    def __init__(self, manager, client_host, session_token=None):
         self.__manager = manager
         self.__client_host = client_host
         self.__session_token = session_token
 
     @timefunc
     def getAuthParameters(self):
-        return HandshakeInformation(self.__manager.isEnabled(), self.__manager.is_valid(self.__client_host, self.__session_token, True))
+        return HandshakeInformation(self.__manager.isEnabled(),
+                                    self.__manager.is_valid(
+                                        self.__client_host,
+                                        self.__session_token,
+                                        True))
 
     @timefunc
     def getAcceptedAuthMethods(self):
@@ -89,7 +93,9 @@ class ThriftAuthHandler():
     @timefunc
     def performLogin(self, auth_method, auth_string):
         if auth_method == "Username:Password":
-            authToken = self.__manager.create_or_get_session(self.__client_host, auth_string)
+            authToken = self.__manager.create_or_get_session(
+                self.__client_host,
+                auth_string)
             if authToken:
                 return authToken
             else:
@@ -103,4 +109,5 @@ class ThriftAuthHandler():
 
     @timefunc
     def destroySession(self):
-        return self.__manager.invalidate(self.__client_host, self.__session_token)
+        return self.__manager.invalidate(self.__client_host,
+                                         self.__session_token)

--- a/viewer_server/client_auth_handler.py
+++ b/viewer_server/client_auth_handler.py
@@ -1,0 +1,107 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+'''
+Handle thrift requests for authentication
+'''
+import zlib
+import os
+import datetime
+from collections import defaultdict
+import ntpath
+import codecs
+
+
+import shared
+from Authentication import constants
+from Authentication.ttypes import *
+
+from codechecker_lib import logger
+from codechecker_lib import session_manager
+
+LOG = logger.get_new_logger('AUTH HANDLER')
+
+
+# -----------------------------------------------------------------------
+def timefunc(function):
+    '''
+    timer function
+    '''
+
+    func_name = function.__name__
+
+    def debug_wrapper(*args, **kwargs):
+        '''
+        wrapper for debug log
+        '''
+        before = datetime.now()
+        res = function(*args, **kwargs)
+        after = datetime.now()
+        timediff = after - before
+        diff = timediff.microseconds/1000
+        LOG.debug('['+str(diff)+'ms] ' + func_name)
+        return res
+
+    def release_wrapper(*args, **kwargs):
+        '''
+        no logging
+        '''
+        res = function(*args, **kwargs)
+        return res
+
+    if logger.get_log_level() == logger.DEBUG:
+        return debug_wrapper
+    else:
+        return release_wrapper
+
+
+def conv(text):
+    '''
+    Convert * to % got from clients for the database queries
+    '''
+    if text is None:
+        return '%'
+    return text.replace('*', '%')
+
+
+class ThriftAuthHandler():
+    '''
+    Handle Thrift authentication requests
+    '''
+
+    def __init__(self, session_token = None):
+        self.__session_token = session_token
+
+    @timefunc
+    def getAuthParameters(self):
+        sessions = session_manager.sessionManager()
+        return HandshakeInformation(sessions.isEnabled(), session_manager.validate_session_token(self.__session_token))
+
+    @timefunc
+    def getAcceptedAuthMethods(self):
+        result = []
+        result.append("Username:Password")
+        return result
+
+    @timefunc
+    def performLogin(self, auth_method, auth_string):
+        if auth_method == "Username:Password":
+            if session_manager.validate_auth_request(auth_string):
+                authToken = session_manager.create_session()
+                return authToken
+            else:
+                raise shared.ttypes.RequestFailed(
+                    shared.ttypes.ErrorCode.PRIVILEGE,
+                    "Invalid credentials supplied. Refusing authentication!")
+
+        raise shared.ttypes.RequestFailed(
+            shared.ttypes.ErrorCode.PRIVILEGE,
+            "Could not negotiate via common authentication method")
+
+    @timefunc
+    def destroySession(self):
+        # TODO: Only let users to validate/invalidate their own tokens... :D
+        session_manager.sessionManager.invalidate(self.__session_token)
+        return True

--- a/viewer_server/client_auth_handler.py
+++ b/viewer_server/client_auth_handler.py
@@ -78,7 +78,7 @@ class ThriftAuthHandler():
 
     @timefunc
     def getAuthParameters(self):
-        return HandshakeInformation(self.__manager.isEnabled(), self.__manager.is_valid(self.__client_host, self.__session_token))
+        return HandshakeInformation(self.__manager.isEnabled(), self.__manager.is_valid(self.__client_host, self.__session_token, True))
 
     @timefunc
     def getAcceptedAuthMethods(self):

--- a/viewer_server/client_db_access_server.py
+++ b/viewer_server/client_db_access_server.py
@@ -87,10 +87,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
         client_host, client_port = self.client_address
 
         for k in self.headers.getheaders("Cookie"):
-            print "Begin iter."
             split = k.split("; ")
             for cookie in split:
-                print cookie
                 values = cookie.split("=")
                 if len(values) == 2 and \
                         values[0] == session_manager.SESSION_COOKIE_NAME:
@@ -175,7 +173,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         if self.path != '/Authentication' and not sess_token:
             # Bail out if the user is not authenticated...
             # This response has the possibility of melting down Thrift clients,
-            # but the user is expected to properly authenticate first
+            # but the user is expected to properly authenticate first.
 
             LOG.debug(client_host + ":" + str(client_port) +
                       " Invalid access, credentials not found " +
@@ -197,7 +195,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
                                                self.db_version_info)
 
             if self.path == '/Authentication':
-                # Authentication requests must be routed to a different handler
+                # Authentication requests must be routed to a different handler.
                 auth_handler = ThriftAuthHandler(self.manager,
                                                  client_host,
                                                  sess_token)
@@ -335,7 +333,7 @@ def start_server(package_data, port, db_conn_string, suppress_handler,
                                      package_data,
                                      suppress_handler,
                                      db_version_info,
-                                     session_manager.sessionManager())
+                                     session_manager.SessionManager())
 
     LOG.info('Waiting for client requests on [' +
              access_server_host + ':' + str(port) + ']')

--- a/viewer_server/client_db_access_server.py
+++ b/viewer_server/client_db_access_server.py
@@ -129,7 +129,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         authToken = self.check_auth_in_request()
         if authToken:
             self.send_response(200)
-            if authToken:
+            if isinstance(authToken, str):
                 self.send_header("Set-Cookie",
                                  session_manager.SESSION_COOKIE_NAME + "=" +
                                  authToken + "; Path=/")

--- a/viewer_server/client_db_access_server.py
+++ b/viewer_server/client_db_access_server.py
@@ -15,8 +15,8 @@ import socket
 import urllib
 from multiprocessing.pool import ThreadPool
 
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import scoped_session
 
 try:
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler


### PR DESCRIPTION
This merge requests contains the privileged access infrastructure &mdash; closes #339.

If a user **is** authenticated (via any means described below), full access to the server is given: they can view results and destroy them. If the user **is not** authenticated, the entire access is denied &ndash; there are no further fine-graining, as per discussed with @dkrupp and @gyorb.

# The changes &mdash; summed up

 * A new *Thrift* endpoint at `/Authentication` was implemented, this handles authentication requests
 * Authentication can happen against a username-password storage, an LDAP server or the local PAM chain.
 * Existing interface was **not** changed, though an invalid session, on a **privileged** server, returns a HTTP error code which can make the `CodeChecker cmd` client fail on an exception &mdash; clients are expected to handle authentication before live request.
 * Two new configuration files, `config/session_config.json` and `config/session_client.json`. Both are created as working and descriptive templates.
    * The first one is the server's configuration. It is copied to `WORKSPACE/session_config.json` for every server started and contains the authentication setup.
    * The latter one gets copied for every user into their `~/.codechecker_passwords.json` as it contains per-user credentials.
 * Web-browser client authenticates via basic pop-ups (`HTTP WWW-Authenticate` header)
 * `CodeChecker cmd` got a new subcommand: `login`. With this, users can authenticate on a server and kill their session.
    * The `~/.codechecker_passwords.json` file can contain preconfigured credentials &mdash; if they are valid, executing a live query without a session will automatically log the user in for screen security and convenience.
    * Session information for a user is stored in a temporary file, identified on the system with the running user's name.

Full documentation for public use is available in `docs/authentication.md`.