### PR TITLE
Fix Travis ci

### DIFF
--- a/.ci/basic_python_requirements
+++ b/.ci/basic_python_requirements
@@ -1,3 +1,3 @@
-sqlalchemy>=1.0.9
-alembic>=0.8.2
-thrift>=0.9.1
+sqlalchemy==1.0.9
+alembic==0.8.2
+thrift==0.9.1

--- a/.ci/python_requirements
+++ b/.ci/python_requirements
@@ -1,5 +1,5 @@
-sqlalchemy>=1.0.9
-alembic>=0.8.2
-psycopg2>=2.5.4
-pg8000>=1.10.2
-thrift>=0.9.1
+sqlalchemy==1.0.9
+alembic==0.8.2
+psycopg2==2.5.4
+pg8000==1.10.2
+thrift==0.9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       dist: trusty
       python: "2.7"
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode8
       sudo: false
       language: generic
 
@@ -20,10 +20,10 @@ before_install:
     - chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build;
     - export PATH=~/llvm/tools/scan-build-py/bin:$PATH;
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;                        fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python;                fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install thrift;                fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install doxygen;               fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install coreutils;             fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall postgresql;          fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz -o clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar xf clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz -C ~/; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/clang+llvm-3.7.0-x86_64-apple-darwin/bin/:$PATH; fi
@@ -33,7 +33,9 @@ install:
     - pip install nose
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PG_DATA=$(brew --prefix)/var/postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres && psql -c 'create database travis_ci_test;' -U postgres && cat postgres.log; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ matrix:
 
 before_install:
     - git clone https://github.com/llvm-mirror/clang.git ~/llvm\
-    - chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build;
-    - export PATH=~/llvm/tools/scan-build-py/bin:$PATH;
+    - chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build
+    - export PATH=~/llvm/tools/scan-build-py/bin:$PATH
+    - export PYTHONPATH=~/llvm/tools/scan-build-py/
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;                        fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install thrift;                fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install doxygen;               fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install coreutils;             fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall postgresql;          fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz -o clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar xf clang+llvm-3.7.0-x86_64-apple-darwin.tar.xz -C ~/; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/clang+llvm-3.7.0-x86_64-apple-darwin/bin/:$PATH; fi
@@ -32,10 +32,12 @@ install:
     - pip install -r ./.ci/python_requirements
     - pip install nose
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PG_DATA=$(brew --prefix)/var/postgres; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}; cat postgres.log; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
+
 
 addons:
     apt:

--- a/codechecker/CodeChecker.py
+++ b/codechecker/CodeChecker.py
@@ -234,6 +234,11 @@ Delete analysis results form the database if a run with the given name already e
         check_parser.add_argument('-s', '--skip', type=str, dest="skipfile",
                                   default=argparse.SUPPRESS,
                                   required=False, help='Path to skip file.')
+        check_parser.add_argument('--quiet-build',
+                                  action='store_true',
+                                  default=False,
+                                  required=False,
+                                  help='Do not print out the output of the original build')
         add_analyzer_arguments(check_parser)
         add_database_arguments(check_parser)
         check_parser.set_defaults(func=arg_handler.handle_check)
@@ -254,6 +259,11 @@ Run CodeChecker for a project without database.''')
                                  help=log_argument_help_msg)
         qcheck_parser.add_argument('-s', '--steps', action="store_true",
                                    dest="print_steps", help='Print steps.')
+        qcheck_parser.add_argument('--quiet-build',
+                                   action='store_true',
+                                   default=False,
+                                   required=False,
+                                   help='Do not print out the output of the original build')
         add_analyzer_arguments(qcheck_parser)
         qcheck_parser.set_defaults(func=arg_handler.handle_quickcheck)
 

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -245,7 +245,8 @@ def handle_check(args):
 
         if not log_file:
             log_file = build_manager.generate_log_file(args,
-                                                       context)
+                                                       context,
+                                                       args.quiet_build)
         if not log_file:
             LOG.error("Failed to generate compilation command file: " +
                       log_file)
@@ -330,7 +331,8 @@ def _do_quickcheck(args):
 
     if not log_file:
         log_file = build_manager.generate_log_file(args,
-                                                   context)
+                                                   context,
+                                                   args.quiet_build)
     if not log_file:
         LOG.error("Failed to generate compilation command file: " + log_file)
         sys.exit(1)

--- a/codechecker_lib/build_manager.py
+++ b/codechecker_lib/build_manager.py
@@ -49,8 +49,7 @@ def perform_build_command(logfile, command, context, silent=False):
     """
     Build the project and create a log file.
     """
-    if not silent:
-        LOG.info("Starting build ...")
+    LOG.info("Starting build ...")
 
     try:
         original_env_file = os.environ['CODECHECKER_ORIGINAL_BUILD_ENV']
@@ -93,13 +92,12 @@ def perform_build_command(logfile, command, context, silent=False):
     try:
         ret_code = execute_buildcmd(command, silent, log_env)
 
-        if not silent:
-            if ret_code == 0:
-                LOG.info("Build finished successfully.")
-                LOG.debug_analyzer("The logfile is: " + logfile)
-            else:
-                LOG.info("Build failed.")
-                sys.exit(ret_code)
+        if ret_code == 0:
+            LOG.info("Build finished successfully.")
+            LOG.debug_analyzer("The logfile is: " + logfile)
+        else:
+            LOG.info("Build failed.")
+            sys.exit(ret_code)
 
     except Exception as ex:
         LOG.error("Calling original build command failed")

--- a/codechecker_lib/build_manager.py
+++ b/codechecker_lib/build_manager.py
@@ -54,14 +54,16 @@ def perform_build_command(logfile, command, context, silent=False):
 
     try:
         original_env_file = os.environ['CODECHECKER_ORIGINAL_BUILD_ENV']
-        LOG.debug_analyzer('Loading original build env from: ' + original_env_file)
+        LOG.debug_analyzer('Loading original build env from: ' +
+                           original_env_file)
 
         with open(original_env_file, 'rb') as env_file:
             original_env = pickle.load(env_file)
 
     except Exception as ex:
         LOG.warning(str(ex))
-        LOG.warning('Failed to get saved original_env using a current copy for logging')
+        LOG.warning('Failed to get saved original_env'
+                    'using a current copy for logging')
         original_env = os.environ.copy()
 
     return_code = 0
@@ -70,7 +72,7 @@ def perform_build_command(logfile, command, context, silent=False):
     if host_check.check_intercept(original_env):
         LOG.debug_analyzer("with intercept ...")
         final_command = command
-        command = "intercept-build " + "--cdb "+ logfile + " " + final_command
+        command = "intercept-build " + "--cdb " + logfile + " " + final_command
         log_env = original_env
         LOG.debug_analyzer(command)
 
@@ -83,7 +85,8 @@ def perform_build_command(logfile, command, context, silent=False):
             if 'CC_LOGGER_GCC_LIKE' not in log_env:
                 log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:cc:c++'
         else:
-            LOG.error("Intercept-build is required to run CodeChecker in OS X.")
+            LOG.error("Intercept-build is required"
+                      " to run CodeChecker in OS X.")
             sys.exit(1)
 
     LOG.debug_analyzer(log_env)
@@ -131,7 +134,8 @@ def check_log_file(args):
     except AttributeError as ex:
         # args.log_file was not set
         LOG.debug_analyzer(ex)
-        LOG.debug_analyzer("Compilation database file was not set in the command line.")
+        LOG.debug_analyzer("Compilation database file was not set"
+                           " in the command line.")
     finally:
         return log_file
 
@@ -144,26 +148,27 @@ def generate_log_file(args, context, silent=False):
     log_file = None
     try:
         if args.command:
-            
+
             intercept_build_executable = find_executable('intercept-build')
-    
-            if intercept_build_executable == None:
+
+            if intercept_build_executable is None:
                 if platform.system() == 'Linux':
                     # check if logger bin exists
                     if not os.path.isfile(context.path_logger_bin):
-                        LOG.error('Logger binary not found! Required for logging.')
+                        LOG.error('Logger binary not found!'
+                                  'Required for logging.')
                         sys.exit(1)
 
                     # check if logger lib exists
                     if not os.path.exists(context.path_logger_lib):
-                        LOG.error('Logger library directory not found! Libs are requires' \
-                                  'for logging.')
+                        LOG.error('Logger library directory not found!'
+                                  'Libs are required for logging.')
                         sys.exit(1)
 
             log_file = default_compilation_db(args.workspace)
             if os.path.exists(log_file):
-                LOG.debug_analyzer("Removing previous compilation command file: " +
-                          log_file)
+                LOG.debug_analyzer("Removing previous"
+                                   "compilation command file: " + log_file)
                 os.remove(log_file)
 
             open(log_file, 'a').close()  # same as linux's touch

--- a/tests/functional/package_test/__init__.py
+++ b/tests/functional/package_test/__init__.py
@@ -271,6 +271,7 @@ def _run_check(shared_test_params, skip_list_file, test_project_build_cmd,
     check_cmd.append("'"+test_project_build_cmd+"'")
     check_cmd.append('--analyzers')
     check_cmd.append('clangsa')
+    check_cmd.append('--quiet-build')
     if shared_test_params['use_postgresql']:
         check_cmd.append('--postgresql')
         check_cmd += _pg_db_config_to_cmdline_params(

--- a/tests/functional/quickcheck_test/quickcheck_test_files/Makefile
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/Makefile
@@ -1,8 +1,8 @@
 multi_error:
-	g++ -w multi_error.cpp -o /dev/null
+	$(CXX) -w multi_error.cpp -o /dev/null
 nofail:
-	g++ -w nofail.cpp -o /dev/null
+	$(CXX) -w nofail.cpp -o /dev/null
 simple1:
-	g++ -w simple1.cpp -o /dev/null
+	$(CXX) -w simple1.cpp -o /dev/null
 simple2:
-	g++ -w simple2.cpp -o /dev/null
+	$(CXX) -w simple2.cpp -o /dev/null

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -e core.StackAddressEscape -d deadcode.DeadStores
+CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -e core.StackAddressEscape -d deadcode.DeadStores --quiet-build
 -----------------------------------------------
 [INFO] - Starting build ...
-g++ -w multi_error.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing multi_error.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -d core.StackAddressEscape -e deadcode.DeadStores
+CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -d core.StackAddressEscape -e deadcode.DeadStores --quiet-build
 -----------------------------------------------
 [INFO] - Starting build ...
-g++ -w multi_error.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing multi_error.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make multi_error"
+CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --quiet-build
 -----------------------------------------------
 [INFO] - Starting build ...
-g++ -w multi_error.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 2 defect(s) while analyzing multi_error.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --steps
+CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --steps --quiet-build
 -------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w multi_error.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 2 defect(s) while analyzing multi_error.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
@@ -1,6 +1,5 @@
-CodeChecker quickcheck --analyzers clangsa -b "make nofail"
+CodeChecker quickcheck --analyzers clangsa -b "make nofail" --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w nofail.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found no defects while analyzing nofail.cpp

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
@@ -1,6 +1,5 @@
-CodeChecker quickcheck --analyzers clangsa -b "make nofail" --steps
+CodeChecker quickcheck --analyzers clangsa -b "make nofail" --steps --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w nofail.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found no defects while analyzing nofail.cpp

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make simple1"
+CodeChecker quickcheck --analyzers clangsa -b "make simple1" --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w simple1.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing simple1.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make simple1" --steps
+CodeChecker quickcheck --analyzers clangsa -b "make simple1" --steps --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w simple1.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing simple1.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make simple2"
+CodeChecker quickcheck --analyzers clangsa -b "make simple2" --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w simple2.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing simple2.cpp
 

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
@@ -1,7 +1,6 @@
-CodeChecker quickcheck --analyzers clangsa -b "make simple2" --steps
+CodeChecker quickcheck --analyzers clangsa -b "make simple2" --steps --quiet-build
 --------------------------------------------------------------------------------
 [INFO] - Starting build ...
-g++ -w simple2.cpp -o /dev/null
 [INFO] - Build finished successfully.
 clangsa found 1 defect(s) while analyzing simple2.cpp
 

--- a/tests/test_projects/test_files/Makefile
+++ b/tests/test_projects/test_files/Makefile
@@ -1,10 +1,10 @@
 all:
-	g++ -c call_and_message.cpp
-	g++ -c divide_zero.cpp
-	g++ -c new_delete.cpp
-	g++ -c null_dereference.cpp
-	g++ -c stack_address_escape.cpp
-	g++ -c file_to_be_skipped.cpp
+	$(CXX) -c call_and_message.cpp
+	$(CXX) -c divide_zero.cpp
+	$(CXX) -c new_delete.cpp
+	$(CXX) -c null_dereference.cpp
+	$(CXX) -c stack_address_escape.cpp
+	$(CXX) -c file_to_be_skipped.cpp
 clean:
 	rm -f call_and_message.o
 	rm -f divide_zero.o


### PR DESCRIPTION
Fix OSX and Linux errors:
- freeze required python module versions (the newer psycopg2 failed with the older PostgreSQL in the current setup)
- modify test makefiles so intercept build can log them
- use new xcode8 where there is already a proper python
  - installing python reinstalls libreadline which broke psql commands
  - reinstalling postgresql could update to the proper libreadline but the default postgresql database setup is done before the install part so the initialized database might not be compatible with the reinstalled version

Other:
 - quiet-build option was added which is useful for tests
 - some pep8 warnings were cleaned up
 - dos file format was changed to unix for a few source files
