### PR TITLE
Analysis progress reporting.

### DIFF
--- a/codechecker_lib/analyzer.py
+++ b/codechecker_lib/analyzer.py
@@ -93,10 +93,11 @@ def run_check(args, actions, context):
         if os.path.exists(suppress_file):
             client.send_suppress(context.run_id, connection, suppress_file)
 
-        analyzer_config_map = analyzer_types.build_config_handlers(args,
-                                                                   context,
-                                                                   enabled_analyzers,
-                                                                   connection)
+        analyzer_config_map = \
+            analyzer_types.build_config_handlers(args,
+                                                 context,
+                                                 enabled_analyzers,
+                                                 connection)
         if skip_handler:
             connection.add_skip_paths(context.run_id,
                                       skip_handler.get_skiplist())
@@ -136,13 +137,5 @@ def run_quick_check(args,
                                              context,
                                              enabled_analyzers)
 
-    for action in actions:
-        check_data = (args,
-                      action,
-                      context,
-                      analyzer_config_map,
-                      None,
-                      args.workspace,
-                      False)
-
-        analysis_manager.check(check_data)
+    analysis_manager.start_workers(args, actions, context, analyzer_config_map,
+                                   None, False)

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -324,6 +324,8 @@ def _do_quickcheck(args):
         workspace = util.get_default_workspace()
 
     context.codechecker_workspace = workspace
+    args.jobs = 1
+    args.name = "quickcheck"
 
     # Load severity map from config file.
     if os.path.exists(context.checkers_severity_map_file):

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
@@ -8,3 +8,9 @@ multi_error.cpp:2:3: Address of stack memory associated with local variable 'x' 
   int x = 42;
   ^
 
+[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
@@ -8,3 +8,9 @@ multi_error.cpp:9:7: Value stored to 'y' is never read
   y = 7;
       ^
 
+[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
@@ -12,3 +12,9 @@ multi_error.cpp:9:7: Value stored to 'y' is never read
   y = 7;
       ^
 
+[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
@@ -19,3 +19,9 @@ multi_error.cpp:9:7: Value stored to 'y' is never read
   Steps:
     1, multi_error.cpp:9:7: Value stored to 'y' is never read
 
+[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
@@ -3,3 +3,9 @@ CodeChecker quickcheck --analyzers clangsa -b "make nofail" --quiet-build
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.
 clangsa found no defects while analyzing nofail.cpp
+[INFO] - [1/1] clangsa analyzed nofail.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
@@ -3,3 +3,9 @@ CodeChecker quickcheck --analyzers clangsa -b "make nofail" --steps --quiet-buil
 [INFO] - Starting build ...
 [INFO] - Build finished successfully.
 clangsa found no defects while analyzing nofail.cpp
+[INFO] - [1/1] clangsa analyzed nofail.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
@@ -8,3 +8,9 @@ simple1.cpp:18:10: Division by zero
   return 2015 / x;
          ^
 
+[INFO] - [1/1] clangsa analyzed simple1.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
@@ -16,3 +16,9 @@ simple1.cpp:18:10: Division by zero
     6, simple1.cpp:16:3: The value 0 is assigned to 'x'
     7, simple1.cpp:18:10: Division by zero
 
+[INFO] - [1/1] clangsa analyzed simple1.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
@@ -8,3 +8,9 @@ simple2.cpp:17:9: Division by zero
   return 2015 / x;
          ^
 
+[INFO] - [1/1] clangsa analyzed simple2.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
@@ -16,3 +16,9 @@ simple2.cpp:17:9: Division by zero
     6, simple2.cpp:15:2: The value 0 is assigned to 'x'
     7, simple2.cpp:17:9: Division by zero
 
+[INFO] - [1/1] clangsa analyzed simple2.cpp successfully.
+[INFO] - ----==== Summary ====----
+[INFO] - Total compilation commands: 1
+[INFO] - Successfully analyzed
+[INFO] -   clangsa: 1
+[INFO] - ----=================----


### PR DESCRIPTION
Fixes  #370.

Some notes to the changes:
- Shared memory values can not be passed as function arguments, that is the reason for the globals.
    - They could be moved into an empty imported module
- Result handler no longer prints successful analysis message. It was asymmetric. Now successful and unsuccessful results are printed from the same location.
- Result handler only invoked to process results, when the analysis succeeded. Updated the code to reflect this.
- Invoke the process pool implementation from the quickcheck command. This way multiprocess checking with quickcheck can be implemented in the future. (We might need to lock the standard output for concurrent writes.)