### PR TITLE
Use absolute path for the compilation command file

### DIFF
--- a/codechecker_lib/build_manager.py
+++ b/codechecker_lib/build_manager.py
@@ -105,6 +105,7 @@ def default_compilation_db(workspace_path):
     """
     Default compilation commands database file in the workspace.
     """
+    workspace_path = os.path.abspath(workspace_path)
     compilation_commands = os.path.join(workspace_path,
                                         'compilation_commands.json')
     return compilation_commands


### PR DESCRIPTION
The ld logger will not log properly if not the whole absolute path is set
for the log file.
If the user uses a workspace path like this '../workspace' the logger will not
find the log file where the compilation commands should be written.