### PR TITLE
Store checker ID "NOT FOUND" if not found.

### DIFF
--- a/storage_server/report_server.py
+++ b/storage_server/report_server.py
@@ -417,6 +417,8 @@ class CheckerReportHandler(object):
             action = self.session.query(BuildAction).get(build_action_id)
             assert action is not None
 
+            checker_id = checker_id or 'NOT FOUND'
+
             # TODO: perfomance issues when executing the following query on
             # large databaseses?
             reports = self.session.query(self.report_ident) \


### PR DESCRIPTION
Some checkers may have no name. This can be caused by misinterpreting a
plist file or by the fault of a checker. In the long terms if such a
missing name is found, it should be checked individually for the given
checker. This commit is mainly for GUI purposes, because in this case a
dangling node appears in the filter field and choosing it results
selecting all findings.

This commit fixes #422.