### PR TITLE
Fix doxygen warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ _Daniel Krupp, Gyorgy Orban, Gabor Horvath and Bence Babati___ ([ Slides](http:/
 CodeChecker requires some new features from clang to work properly.
 If your clang version does not have these features you will see in debug log the following messages:
 
-  * `Check name wasn't found in the plist file.` --> use clang = 3.7 or trunk@r228624; otherwise CodeChecker makes a guess based on the report message
-  * `Hash value wasn't found in the plist file.` --> update for a newer clang version; otherwise CodeChecker generates a simple hash based on the filename and the line content, this method is applied for Clang Tidy results too, because Clang Tidy does not support bug identifier hash generation currently
+  * `Check name wasn't found in the plist file.` --> use clang >= 3.7 or trunk r228624; otherwise CodeChecker makes a guess based on the report message
+  * `Hash value wasn't found in the plist file.` --> use clang >= 3.8 or trunk r251011; otherwise CodeChecker generates a simple hash based on the filename and the line content, this method is applied for Clang Tidy results too, because Clang Tidy does not support bug identifier hash generation currently
 
 ## Linux
 For a more detailed dependency list see [Requirements](docs/deps.md)

--- a/build_package.py
+++ b/build_package.py
@@ -111,7 +111,6 @@ def generate_thrift_files(thrift_files_dir, env, silent=True):
         LOG.error('Failed to generate viewer server files')
         return ret
 
-    auth_thrift = os.path.join(thrift_files_dir, 'authentication.thrift')
     auth_thrift = 'authentication.thrift'
     auth_cmd = ['thrift', '-r', '-I', '.',
                 '--gen', 'py', auth_thrift]

--- a/codechecker_lib/session_manager.py
+++ b/codechecker_lib/session_manager.py
@@ -74,7 +74,7 @@ class _Session():
         if (datetime.now() - self.last_access).total_seconds() <= \
                 session_lifetimes["soft"] \
                 and (datetime.now() - self.last_access).total_seconds() <= \
-                session_lifetimes["hard"]:
+                        session_lifetimes["hard"]:
             # If the session is still valid within the "reuse enabled" (soft)
             # past and the check comes from a real user access, we revalidate
             # the session by extending its lifetime --- the user retains their
@@ -95,7 +95,7 @@ class _Session():
         hard lifetime: while a session is reusable, a valid authentication
         from the session's user will return the user to the session."""
         return (datetime.now() - self.last_access).total_seconds() <= \
-            session_lifetimes["hard"]
+               session_lifetimes["hard"]
 
     def revalidate(self):
         if self.still_reusable():
@@ -104,6 +104,7 @@ class _Session():
             # timeframe, it can NOT be resurrected at all --- the user needs
             # to log in into a brand-new session.
             self.last_access = datetime.now()
+
 
 class SessionManager:
     CodeChecker_Workspace = None
@@ -118,8 +119,8 @@ class SessionManager:
         session_cfg_file = os.path.join(SessionManager.CodeChecker_Workspace,
                                         "session_config.json")
         if not os.path.exists(session_cfg_file):
-            LOG.warning("CodeChecker server's authentication example "
-                        "configuration file created at " + session_cfg_file)
+            LOG.info("CodeChecker server's authentication example "
+                     "configuration file created at " + session_cfg_file)
             shutil.copyfile(os.path.join(os.environ['CC_PACKAGE_ROOT'],
                                          "config", "session_config.json"),
                             session_cfg_file)
@@ -167,10 +168,10 @@ class SessionManager:
                             "Falling back to no authentication.")
                 self.__auth_config["enabled"] = False
 
-        session_lifetimes["soft"] = self.__auth_config.get("soft_expire")\
-            or 60
-        session_lifetimes["hard"] = self.__auth_config.get("session_lifetime")\
-            or 300
+        session_lifetimes["soft"] = self.__auth_config.get("soft_expire") \
+                                    or 60
+        session_lifetimes["hard"] = self.__auth_config.get("session_lifetime") \
+                                    or 300
 
     def isEnabled(self):
         return self.__auth_config.get("enabled")
@@ -185,18 +186,18 @@ class SessionManager:
         """Validate an oncoming authorization request
         against some authority controller."""
         return self.__try_auth_dictionary(auth_string) \
-            or self.__try_auth_pam(auth_string) \
-            or self.__try_auth_ldap(auth_string)
+               or self.__try_auth_pam(auth_string) \
+               or self.__try_auth_ldap(auth_string)
 
     def __is_method_enabled(self, method):
         return method not in unsupported_methods and \
-            "method_" + method in self.__auth_config and \
-            self.__auth_config["method_" + method].get("enabled")
+               "method_" + method in self.__auth_config and \
+               self.__auth_config["method_" + method].get("enabled")
 
     def __try_auth_dictionary(self, auth_string):
         return self.__is_method_enabled("dictionary") and \
-            auth_string in \
-            self.__auth_config.get("method_dictionary").get("auths")
+               auth_string in \
+               self.__auth_config.get("method_dictionary").get("auths")
 
     def __try_auth_pam(self, auth_string):
         if self.__is_method_enabled("pam"):
@@ -205,9 +206,9 @@ class SessionManager:
 
             if auth.authenticate(username, pw):
                 allowed_users = self.__auth_config["method_pam"].get("users") \
-                    or []
-                allowed_group = self.__auth_config["method_pam"].get("groups")\
-                    or []
+                                or []
+                allowed_group = self.__auth_config["method_pam"].get("groups") \
+                                or []
 
                 if len(allowed_users) == 0 and len(allowed_group) == 0:
                     # If no filters are set, only authentication is needed.
@@ -268,7 +269,7 @@ class SessionManager:
 
         self.__logins_since_prune += 1
         if self.__logins_since_prune >= \
-           self.__auth_config["logins_until_cleanup"]:
+                self.__auth_config["logins_until_cleanup"]:
             self.__cleanup_sessions()
 
         if self.__handle_validation(auth_string):
@@ -366,9 +367,9 @@ class SessionManager_Client:
                     or mode & stat.S_IROTH \
                     or mode & stat.S_IWOTH:
                 LOG.warning("Credential file at '" + session_cfg_file + "' is "
-                            "readable by users other than you! This poses a "
-                            "risk of others getting your passwords!\n"
-                            "Please `chmod 0600 " + session_cfg_file + "`")
+                                                                        "readable by users other than you! This poses a "
+                                                                        "risk of others getting your passwords!\n"
+                                                                        "Please `chmod 0600 " + session_cfg_file + "`")
         else:
             with open(self.token_file, 'w') as f:
                 json.dump({'tokens': {}}, f)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,16 +29,16 @@ CodeChecker check -e alpha -e llvm -b make
 CodeChecker check –u /home/myuser/myproject/suppress.list -b make
 CodeChecker server –u /home/myuser/myproject/suppress.list
 
-#suppress list will be stored in suppress.list with the bug hashes in the file
-#the user checks in the suppress.list file with the source code
+# Suppress list will be stored in suppress.list.
+# The suppress.list file can be checked in the source control system.
 ```
 ###5.	Same as use case 2., but the developer wants to give extra Config to clang-tidy or clang-sa
 ```
 CodeChecker check --saargs clangsa.config --tidyargs clang-tidy.config -b make
 
-#clang-sa and clang-tidy parameters are stored in simple text files, 
-#is expected to be in the same format as clang-sa/tidy 
-#command line parameters and will be passed to every clang-sa/tidy calls
+# The clang-sa and clang-tidy parameters are stored in simple text files. 
+# The format is the same as clang-sa/tidy command line parameters and will
+# be passed to every clang-sa/tidy calls
 ```
 
 ###6.	Asking for command line help for the check subcommand (all other subcommands would be the same: server, checkers,cmd…)
@@ -58,9 +58,9 @@ Large projects should use postgresql for performance reasons.
 CodeChecker check -n myproject_v1 –postgresql -b make
 CodeChecker check -n myproject_v2 –postgresql -b make
 
-#runs analysis, assumes that postgres is available on the default 5432 TCP port, 
-#codechecker db user exists and codechecker db can be created
-#please note that this use case is also supported with SQLITE db
+# Runs analysis, assumes that postgres is available on the default 5432 TCP port, 
+# codechecker db user exists and codechecker db can be created.
+# Please note that this use case is also supported with SQLITE db.
 ```
 
 Start the webserver and view the diff between the two results in the web browser
@@ -73,16 +73,16 @@ Start the webserver and view the diff between the two results in command line
 ```
 CodeChecker cmd diff –b myproject_v1 –n myproject_v2 –p 8001 -new
 
-#assumes that the server is started on port 8001
-#then shows the new bugs in myproject_v2 compared to baseline myproject_v1
+# Assumes that the server is started on port 8001
+# then shows the new bugs in myproject_v2 compared to baseline myproject_v1.
 
 CodeChecker cmd diff –b myproject_v1 –n myproject_v2 –p 8001 -unresolved
 
-#assumes that the server is started on port 8001
-#then shows the unresolved bugs in myproject_v2 compared to baseline myproject_v1
+# Assumes that the server is started on port 8001
+# then shows the unresolved bugs in myproject_v2 compared to baseline myproject_v1.
 
 CodeChecker cmd diff –b myproject_v1 –n myproject_v2 –p 8001 -resolved
 
-#assumes that the server is started on port 8001
-#then shows the resolved bugs in myproject_v2 compared to baseline myproject_v1
+# Assumes that the server is started on port 8001
+# then shows the resolved bugs in myproject_v2 compared to baseline myproject_v1.
 ```

--- a/tests/unit/plist_test_files/gen_plist/gen_plist.md
+++ b/tests/unit/plist_test_files/gen_plist/gen_plist.md
@@ -1,4 +1,4 @@
-## Generate plist files
+# Generate plist files
 
 Use these scripts and source files to generate plist report files.
 

--- a/thrift_api/thrift_api.md
+++ b/thrift_api/thrift_api.md
@@ -1,5 +1,5 @@
 
-#Thrift APIs
+# Thrift APIs
 These APIs should be used by the clients using the database to store or to get the results. Any new client should only interact with the database through these APIs.
 
 ## Report viewer server API


### PR DESCRIPTION
Fixed the following Doxygen warnings:
```
/home/egborho/codechecker-sources/codechecker/tests/unit/plist_test_files/gen_plist/README.md:1: warning: found more than one \mainpage comment block! Skipping this block.
/home/egborho/codechecker-sources/codechecker/docs/usage.md:33: warning: explicit link request to 'suppress' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:34: warning: explicit link request to 'the' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:40: warning: explicit link request to 'clang' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:41: warning: explicit link request to 'is' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:42: warning: explicit link request to 'command' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:62: warning: explicit link request to 'runs' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:63: warning: explicit link request to 'codechecker' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:64: warning: explicit link request to 'please' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:77: warning: explicit link request to 'assumes' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:78: warning: explicit link request to 'then' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:82: warning: explicit link request to 'assumes' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:83: warning: explicit link request to 'then' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:87: warning: explicit link request to 'assumes' could not be resolved
/home/egborho/codechecker-sources/codechecker/docs/usage.md:88: warning: explicit link request to 'then' could not be resolved
/home/egborho/codechecker-sources/codechecker/thrift_api/thrift_api.md:3: warning: explicit link request to 'Thrift' could not be resolved
/home/egborho/codechecker-sources/codechecker/README.md:34: warning: Found unknown command `\r228624'
```

Other changes:
* Generating example auth config should only be an info, not a warning.
* Added clang version info about bug hashes.
* Minor doc style improvements.
* Removed a dead store.
* Fixed some PEP8 warnings.