### PR TITLE
Command line cleanup

### DIFF
--- a/codechecker_lib/analyzers/analyzer_types.py
+++ b/codechecker_lib/analyzers/analyzer_types.py
@@ -191,7 +191,7 @@ def __build_clangsa_config_handler(args, context):
     config_handler = config_handler_clangsa.ClangSAConfigHandler()
     config_handler.analyzer_plugins_dir = context.checker_plugin
     config_handler.analyzer_binary = context.analyzer_binaries.get(CLANG_SA)
-    config_handler.compiler_resource_dirs = context.compiler_resource_dirs
+    config_handler.compiler_resource_dir = context.compiler_resource_dir
     config_handler.compiler_sysroot = context.compiler_sysroot
     config_handler.system_includes = context.extra_system_includes
     config_handler.includes = context.extra_includes
@@ -240,7 +240,7 @@ def __build_clang_tidy_config_handler(args, context):
 
     config_handler = config_handler_clang_tidy.ClangTidyConfigHandler()
     config_handler.analyzer_binary = context.analyzer_binaries.get(CLANG_TIDY)
-    config_handler.compiler_resource_dirs = context.compiler_resource_dirs
+    config_handler.compiler_resource_dir = context.compiler_resource_dir
     config_handler.compiler_sysroot = context.compiler_sysroot
     config_handler.system_includes = context.extra_system_includes
     config_handler.includes = context.extra_includes

--- a/codechecker_lib/analyzers/config_handler.py
+++ b/codechecker_lib/analyzers/config_handler.py
@@ -24,7 +24,7 @@ class AnalyzerConfigHandler(object):
         self.__analyzer_binary = None
         self.__analyzer_plugins_dir = None
         self.__compiler_sysroot = None
-        self.__compiler_resource_dirs = []
+        self.__compiler_resource_dir = ''
         self.__sys_inc = []
         self.__includes = []
         self.__analyzer_extra_arguments = ''
@@ -121,18 +121,18 @@ class AnalyzerConfigHandler(object):
         self.__compiler_sysroot = compiler_sysroot
 
     @property
-    def compiler_resource_dirs(self):
+    def compiler_resource_dir(self):
         """
         Get compiler resource directories.
         """
-        return self.__compiler_resource_dirs
+        return self.__compiler_resource_dir
 
-    @compiler_resource_dirs.setter
-    def compiler_resource_dirs(self, resource_dirs):
+    @compiler_resource_dir.setter
+    def compiler_resource_dir(self, resource_dir):
         """
         Set compiler resource directories.
         """
-        self.__compiler_resource_dirs = resource_dirs
+        self.__compiler_resource_dir = resource_dir
 
     @property
     def system_includes(self):

--- a/codechecker_lib/generic_package_context.py
+++ b/codechecker_lib/generic_package_context.py
@@ -145,18 +145,15 @@ class Context(context_base.ContextBase):
                             self.variables['path_dumps_name'])
 
     @property
-    def compiler_resource_dirs(self):
-        compiler_resource_dirs = self.pckg_layout.get('compiler_resource_dirs')
-        if not compiler_resource_dirs:
-            return []
+    def compiler_resource_dir(self):
+        resource_dir = self.pckg_layout.get('compiler_resource_dir')
+        if not resource_dir:
+            return ""
         else:
-            inc_dirs = []
-            for path in compiler_resource_dirs:
-                if os.path.isabs(path):
-                    inc_dirs.append(path)
-                else:
-                    inc_dirs.append(os.path.join(self.__package_root, path))
-            return inc_dirs
+            if os.path.isabs(resource_dir):
+                return resource_dir
+            else:
+                return os.path.join(self.__package_root, resource_dir)
 
     @property
     def path_env_extra(self):
@@ -199,7 +196,7 @@ class Context(context_base.ContextBase):
             analyzers[analyzer_types.CLANG_SA] = 'clang'
             analyzers[analyzer_types.CLANG_TIDY] = 'clang-tidy'
         else:
-            for name, value in compiler_binaries.iteritems():
+            for name, value in compiler_binaries.items():
                 if os.path.isabs(value):
                     # Check if it is an absolute path.
                     analyzers[name] = value

--- a/config/package_layout.json
+++ b/config/package_layout.json
@@ -1,41 +1,41 @@
 {
-    "static" : {
-        "bin": "bin",
-        "cc_bin": "cc_bin",
-        "lib": "lib",
-        "plugin": "plugin",
-        "www": "www",
-        "docs": "www/docs",
-        "checker_md_docs": "www/docs/checker_md_docs",
-        "web_client": "www/scripts/codechecker-api",
-        "web_client_plugins": "www/scripts/plugins",
-        "web_client_codemirror": "www/scripts/plugins/codemirror",
-        "web_client_dojo": "www/scripts/plugins/dojo",
-        "web_client_highlightjs": "www/scripts/plugins/highlightjs",
-        "web_client_jsplumb": "www/scripts/plugins/jsplumb",
-        "web_client_marked": "www/scripts/plugins/marked",
-        "js_thrift": "www/scripts/plugins/thrift",
-        "config": "config",
-        "ld_logger": "ld_logger",
-        "codechecker_modules": "cc_lib/python2.7",
-        "codechecker_lib": "cc_lib/python2.7/codechecker_lib",
-        "codechecker_gen": "cc_lib/python2.7/codechecker_gen",
-        "codechecker_db_model": "cc_lib/python2.7/db_model",
-        "codechecker_db_migrate": "cc_lib/python2.7/db_migrate",
-        "storage_server_modules": "cc_lib/python2.7/storage_server",
-        "viewer_server_modules": "cc_lib/python2.7/viewer_server",
-        "cmdline_client": "cc_lib/python2.7/cmdline_client"
+  "static": {
+    "bin": "bin",
+    "cc_bin": "cc_bin",
+    "lib": "lib",
+    "plugin": "plugin",
+    "www": "www",
+    "docs": "www/docs",
+    "checker_md_docs": "www/docs/checker_md_docs",
+    "web_client": "www/scripts/codechecker-api",
+    "web_client_plugins": "www/scripts/plugins",
+    "web_client_codemirror": "www/scripts/plugins/codemirror",
+    "web_client_dojo": "www/scripts/plugins/dojo",
+    "web_client_highlightjs": "www/scripts/plugins/highlightjs",
+    "web_client_jsplumb": "www/scripts/plugins/jsplumb",
+    "web_client_marked": "www/scripts/plugins/marked",
+    "js_thrift": "www/scripts/plugins/thrift",
+    "config": "config",
+    "ld_logger": "ld_logger",
+    "codechecker_modules": "cc_lib/python2.7",
+    "codechecker_lib": "cc_lib/python2.7/codechecker_lib",
+    "codechecker_gen": "cc_lib/python2.7/codechecker_gen",
+    "codechecker_db_model": "cc_lib/python2.7/db_model",
+    "codechecker_db_migrate": "cc_lib/python2.7/db_migrate",
+    "storage_server_modules": "cc_lib/python2.7/storage_server",
+    "viewer_server_modules": "cc_lib/python2.7/viewer_server",
+    "cmdline_client": "cc_lib/python2.7/cmdline_client"
+  },
+  "runtime": {
+    "analyzers": {
+      "clangsa": "clang",
+      "clang-tidy": "clang-tidy"
     },
-    "runtime" : {
-     "analyzers" : {
-       "clangsa" : "clang",
-       "clang-tidy" : "clang-tidy"
-       },
-        "ld_logger_bin" : "bin/ldlogger",
-        "ld_logger_lib_name" : "ldlogger.so",
-        "ld_logger_lib_path" : "ld_logger/lib",
-        "version_file" : "config/version.json",
-        "checkers_severity_map_file" : "config/checker_severity_map.json",
-        "gdb_config_file" : "config/gdbScript.gdb"
-    }
+    "ld_logger_bin": "bin/ldlogger",
+    "ld_logger_lib_name": "ldlogger.so",
+    "ld_logger_lib_path": "ld_logger/lib",
+    "version_file": "config/version.json",
+    "checkers_severity_map_file": "config/checker_severity_map.json",
+    "gdb_config_file": "config/gdbScript.gdb"
+  }
 }


### PR DESCRIPTION
Cleanups to the invocation of clang-tidy and the static analyzer:
* There can be only one resource dir.
* Do not add resource dir as include path.
* Made the code more compact.