### PR TITLE
Add resource path as isystem path

### DIFF
--- a/codechecker_lib/analyzers/analyzer_clangsa.py
+++ b/codechecker_lib/analyzers/analyzer_clangsa.py
@@ -88,6 +88,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             if len(config.compiler_resource_dir) > 0:
                 analyzer_cmd.extend(['-resource-dir',
+                                     config.compiler_resource_dir,
+                                     '-isystem',
                                      config.compiler_resource_dir])
 
             # Compiling is enough.


### PR DESCRIPTION
Currently it is not enough to forward the compiler resource dir only
with the -resource-dir argument to clang in the current setup.
The resource dir should be set as an isystem argument too to find the
necessary headers.