### PR TITLE
Clang tidy resource dir as isystem argument

### DIFF
--- a/codechecker_lib/analyzers/analyzer_clang_tidy.py
+++ b/codechecker_lib/analyzers/analyzer_clang_tidy.py
@@ -93,6 +93,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             # Options before the analyzer options.
             if len(config.compiler_resource_dir) > 0:
                 analyzer_cmd.extend(['-resource-dir',
+                                     config.compiler_resource_dir,
+                                     '-isystem',
                                      config.compiler_resource_dir])
 
             if config.compiler_sysroot:


### PR DESCRIPTION
The resource dir should be set with the isystem flag too
to find the necessary include paths.