### PR TITLE
Add options to delete multiple runs.

### DIFF
--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -141,9 +141,9 @@ def handle_server(args):
             # A STOP only stops the server associated with the given workspace
             # and view-port.
             if i['hostname'] != socket.gethostname() or (
-                        args.stop and not (i['port'] == args.view_port and
-                                           os.path.abspath(i['workspace']) ==
-                                           os.path.abspath(workspace))):
+                args.stop and not (i['port'] == args.view_port and
+                                   os.path.abspath(i['workspace']) ==
+                                   os.path.abspath(workspace))):
                 continue
 
             try:

--- a/storage_server/report_server.py
+++ b/storage_server/report_server.py
@@ -215,7 +215,7 @@ class CheckerReportHandler(object):
 
         configs = [Config(
             run_id, info.checker_name, info.attribute, info.value) for
-                   info in config_values]
+            info in config_values]
         self.session.bulk_save_objects(configs)
         self.session.commit()
         return True
@@ -330,11 +330,11 @@ class CheckerReportHandler(object):
 
             for point1 in events:
                 if point1.startLine != point2.line_begin or \
-                                point1.startCol != point2.col_begin or \
-                                point1.endLine != point2.line_end or \
-                                point1.endCol != point2.col_end or \
-                                point1.msg != point2.msg or \
-                                point1.fileId != point2.file_id:
+                        point1.startCol != point2.col_begin or \
+                        point1.endLine != point2.line_end or \
+                        point1.endCol != point2.col_end or \
+                        point1.msg != point2.msg or \
+                        point1.fileId != point2.file_id:
                     return False
 
                 if point2.next is None:

--- a/tests/functional/diff/test_regression_diff.py
+++ b/tests/functional/diff/test_regression_diff.py
@@ -186,7 +186,7 @@ class Diff(unittest.TestCase):
         new_run_id = self._new_runid
 
         diff_res_types_filter = self._testproject_data[self._clang_to_test][
-                'diff_res_types_filter']
+            'diff_res_types_filter']
 
         for level in diff_res_types_filter:
             for checker_name, test_result_count in level.items():
@@ -216,7 +216,7 @@ class Diff(unittest.TestCase):
         new_run_id = self._new_runid
 
         diff_res_types_filter = self._testproject_data[self._clang_to_test][
-                'diff_res_types_filter']
+            'diff_res_types_filter']
 
         for level in diff_res_types_filter:
             for checker_name, test_result_count in level.items():

--- a/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/tests/functional/report_viewer_api/test_get_run_results.py
@@ -86,7 +86,7 @@ class RunResults(unittest.TestCase):
         self.assertEqual(run_result_count, len(run_results))
 
         test_project_results = self._testproject_data[
-                self._clang_to_test]['bugs']
+            self._clang_to_test]['bugs']
         for r in test_project_results:
             print(r)
 

--- a/tests/functional/report_viewer_api/test_report_filter.py
+++ b/tests/functional/report_viewer_api/test_report_filter.py
@@ -88,7 +88,7 @@ class TestReportFilter(unittest.TestCase):
         runid = self._runid
 
         severity_test_data = self._testproject_data[self._clang_to_test][
-                'filter_severity_levels']
+            'filter_severity_levels']
 
         for level in severity_test_data:
             for severity_level, test_result_count in level.items():
@@ -112,7 +112,7 @@ class TestReportFilter(unittest.TestCase):
         runid = self._runid
 
         severity_test_data = self._testproject_data[self._clang_to_test][
-                'filter_checker_id']
+            'filter_checker_id']
 
         for level in severity_test_data:
             for checker_id_filter, test_result_count in level.items():
@@ -140,7 +140,7 @@ class TestReportFilter(unittest.TestCase):
         runid = self._runid
 
         severity_test_data = self._testproject_data[self._clang_to_test][
-                'filter_filepath']
+            'filter_filepath']
 
         for level in severity_test_data:
             for filepath_filter, test_result_count in level.items():

--- a/tests/functional/update/test_update_mode.py
+++ b/tests/functional/update/test_update_mode.py
@@ -67,7 +67,7 @@ class TestUpdate(unittest.TestCase):
             sys.exit(ret)
 
         initial_codechecker_cfg = env.import_test_cfg(
-                self._test_workspace)['codechecker_cfg']
+            self._test_workspace)['codechecker_cfg']
 
         # Disable some checkers for the analysis.
         deadcode = 'deadcode.DeadStores'


### PR DESCRIPTION
The user can delete multiple runs by name, by date (before/after), and
by date based on a name (all runs checked after/before a given run.)
Fixes #453.