### PR TITLE
Log verbosity -v (cmdline argument change)

### DIFF
--- a/codechecker/CodeChecker.py
+++ b/codechecker/CodeChecker.py
@@ -154,10 +154,10 @@ def add_verbose_arguments(parser):
     """
     Verbosity level arguments.
     """
-    parser.add_argument('--verbose', type=str, dest='verbose',
-                        choices=['info', 'debug', 'debug_analyzer'],
-                        default='info',
-                        help='Set verbosity level.')
+    parser.add_argument('-v', '--verbose', action='count',
+                        help="Set verbosity level. "
+                        "Increase the number of 'v'-s "
+                        "for more verbose output.")
 
 
 # ------------------------------------------------------------------------------
@@ -397,7 +397,7 @@ Build command which is used to build the project.''')
                                    default=util.get_default_workspace(),
                                    help=workspace_help_msg)
 
-        server_parser.add_argument('-v', '--view-port', type=int,
+        server_parser.add_argument('-p', '--view-port', type=int,
                                    dest="view_port",
                                    default=8001, required=False,
                                    help='Port used for viewing.')

--- a/codechecker_lib/logger.py
+++ b/codechecker_lib/logger.py
@@ -70,15 +70,14 @@ class LoggerFactory(object):
 
     @classmethod
     def set_log_level(cls, level):
+
         for logger in cls.loggers:
             logger.removeHandler(cls.handlers[LoggerFactory.log_level])
 
-        if level == 'debug':
-            cls.log_level = logging.DEBUG
-        elif level == 'info':
-            cls.log_level = logging.INFO
-        elif level == 'debug_analyzer':
+        if level == 1:
             cls.log_level = logging.DEBUG_ANALYZER
+        elif level > 1:
+            cls.log_level = logging.DEBUG
         else:
             cls.log_level = logging.INFO
 


### PR DESCRIPTION
With the new command line option logging verbosity levels
can be increased with the given number of 'v'-s in the
command line.
To use a common log verbosity configuration for all
the commands the server view port argument needed to be changed.