### PR TITLE
Use timestamps in the logs

### DIFF
--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en1.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -e core.StackAddressEscape -d deadcode.DeadStores --quiet-build
 -----------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 multi_error.cpp:2:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   int x = 42;
   ^
 
 clangsa found 1 defect(s) while analyzing multi_error.cpp
 
-[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.en2.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error" -d core.StackAddressEscape -e deadcode.DeadStores --quiet-build
 -----------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 multi_error.cpp:9:7: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;
       ^
 
 clangsa found 1 defect(s) while analyzing multi_error.cpp
 
-[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.output
@@ -1,9 +1,9 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --quiet-build
 -----------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 multi_error.cpp:2:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   int x = 42;
   ^
@@ -14,9 +14,9 @@ multi_error.cpp:9:7: Value stored to 'y' is never read [deadcode.DeadStores]
 
 clangsa found 2 defect(s) while analyzing multi_error.cpp
 
-[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error.steps.output
@@ -1,9 +1,9 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --steps --quiet-build
 -------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 multi_error.cpp:2:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   int x = 42;
   ^
@@ -21,9 +21,9 @@ multi_error.cpp:9:7: Value stored to 'y' is never read [deadcode.DeadStores]
 
 clangsa found 2 defect(s) while analyzing multi_error.cpp
 
-[INFO] - [1/1] clangsa analyzed multi_error.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed multi_error.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error_skipped.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error_skipped.output
@@ -1,10 +1,10 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error" --quiet-build --skip skiplist.txt
 -----------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Skipped compilation commands: 1
-[INFO] - ----=================----
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Skipped compilation commands: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/multi_error_suppress.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/multi_error_suppress.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clangsa -b "make multi_error_suppress" --quiet-build
 -----------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 multi_error_suppress.cpp:2:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   int x = 42;
   ^
 
 clangsa found 1 defect(s) while analyzing multi_error_suppress.cpp
 
-[INFO] - [1/1] clangsa analyzed multi_error_suppress.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed multi_error_suppress.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.output
@@ -1,13 +1,13 @@
 CodeChecker quickcheck --analyzers clangsa -b "make nofail" --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 clangsa found no defects while analyzing nofail.cpp
-[INFO] - [1/1] clangsa analyzed nofail.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed nofail.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/nofail.steps.output
@@ -1,13 +1,13 @@
 CodeChecker quickcheck --analyzers clangsa -b "make nofail" --steps --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 clangsa found no defects while analyzing nofail.cpp
-[INFO] - [1/1] clangsa analyzed nofail.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed nofail.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clangsa -b "make simple1" --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 simple1.cpp:18:10: Division by zero [core.DivideZero]
   return 2015 / x;
          ^
 
 clangsa found 1 defect(s) while analyzing simple1.cpp
 
-[INFO] - [1/1] clangsa analyzed simple1.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple1.steps.output
@@ -1,9 +1,9 @@
 CodeChecker quickcheck --analyzers clangsa -b "make simple1" --steps --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 simple1.cpp:18:10: Division by zero [core.DivideZero]
   return 2015 / x;
          ^
@@ -18,9 +18,9 @@ simple1.cpp:18:10: Division by zero [core.DivideZero]
 
 clangsa found 1 defect(s) while analyzing simple1.cpp
 
-[INFO] - [1/1] clangsa analyzed simple1.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clangsa -b "make simple2" --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 simple2.cpp:17:9: Division by zero [core.DivideZero]
   return 2015 / x;
          ^
 
 clangsa found 1 defect(s) while analyzing simple2.cpp
 
-[INFO] - [1/1] clangsa analyzed simple2.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed simple2.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/simple2.steps.output
@@ -1,9 +1,9 @@
 CodeChecker quickcheck --analyzers clangsa -b "make simple2" --steps --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 simple2.cpp:17:9: Division by zero [core.DivideZero]
   return 2015 / x;
          ^
@@ -18,9 +18,9 @@ simple2.cpp:17:9: Division by zero [core.DivideZero]
 
 clangsa found 1 defect(s) while analyzing simple2.cpp
 
-[INFO] - [1/1] clangsa analyzed simple2.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clangsa: 1
-[INFO] - ----=================----
+[] - [1/1] clangsa analyzed simple2.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/quickcheck_test_files/tidy_check.output
+++ b/tests/functional/quickcheck_test/quickcheck_test_files/tidy_check.output
@@ -1,18 +1,18 @@
 CodeChecker quickcheck --analyzers clang-tidy -b "make tidy_check" -d "misc" -e "misc-assert-side-effect" --quiet-build
 --------------------------------------------------------------------------------
-[INFO] - Starting build ...
-[INFO] - Build finished successfully.
-[INFO] - Using analyzer:
-[INFO] - Static analysis is starting ...
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Using analyzer:
+[] - Static analysis is starting ...
 tidy_check.cpp:5:5: found assert() with side effect [misc-assert-side-effect]
     assert(++i);
     ^
 
 clang-tidy found 1 defect(s) while analyzing tidy_check.cpp
 
-[INFO] - [1/1] clang-tidy analyzed tidy_check.cpp successfully.
-[INFO] - ----==== Summary ====----
-[INFO] - Total compilation commands: 1
-[INFO] - Successfully analyzed
-[INFO] -   clang-tidy: 1
-[INFO] - ----=================----
+[] - [1/1] clang-tidy analyzed tidy_check.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total compilation commands: 1
+[] - Successfully analyzed
+[] -   clang-tidy: 1
+[] - ----=================----

--- a/tests/functional/quickcheck_test/test_quickcheck.py
+++ b/tests/functional/quickcheck_test/test_quickcheck.py
@@ -8,6 +8,7 @@
 
 import glob
 import os
+import re
 import subprocess
 import unittest
 
@@ -54,20 +55,23 @@ class QuickCheckTestCase(unittest.TestCase):
 
             # skip the analyzer version info between these two lines
             # it might be different in the test running environments
-            skip_version_after = "[INFO] - Using analyzer:"
-            skip_version_before = "[INFO] - Static analysis is starting"
+            skip_version_after = "[] - Using analyzer:"
+            skip_version_before = "[] - Static analysis is starting"
             skipline = False
 
             post_processed_output = []
-            for l in output.splitlines(True):
-                if l.startswith(skip_version_before):
+            for line in output.splitlines(True):
+                # replace timestamps
+                line = re.sub(r'\[\d{2}:\d{2}\]', '[]', line)
+                if line.startswith(skip_version_before):
                     skipline = False
                 if not skipline:
-                    post_processed_output.append(l)
-                if l.startswith(skip_version_after):
+                    post_processed_output.append(line)
+                if line.startswith(skip_version_after):
                     skipline = True
 
             print("Test file path: " + path)
+
             self.assertEqual(''.join(post_processed_output), correct_output)
             return 0
         except CalledProcessError as cerr:


### PR DESCRIPTION
Timestamps give more information about the analysis and build
process than the current log levels. Resolves #465