### PR TITLE
Build command storage changed to build cmd hash

### DIFF
--- a/codechecker_lib/analyzers/result_handler_plist_to_db.py
+++ b/codechecker_lib/analyzers/result_handler_plist_to_db.py
@@ -14,6 +14,7 @@ import shared
 from codechecker_lib import client
 from codechecker_lib import plist_parser
 from codechecker_lib import suppress_handler
+from codechecker_lib import logger
 from codechecker_lib.logger import LoggerFactory
 from codechecker_lib.analyzers.result_handler_base import ResultHandler
 
@@ -139,15 +140,18 @@ class PlistToDB(ResultHandler):
 
             _, source_file_name = ntpath.split(self.analyzed_source_file)
 
+            if LoggerFactory.get_log_level() == logger.DEBUG:
+                analyzer_cmd = ' '.join(self.analyzer_cmd)
+            else:
+                analyzer_cmd = ''
+
+            build_cmd_hash = self.buildaction.original_command_hash
             analysis_id = \
                 connection.add_build_action(self.__run_id,
-                                            self.buildaction.original_command,
-                                            ' '.join(
-                                                self.analyzer_cmd),
+                                            build_cmd_hash,
+                                            analyzer_cmd,
                                             self.buildaction.analyzer_type,
                                             source_file_name)
-
-            # Store buildaction and analyzer command to the database.
 
             assert self.analyzer_returncode == 0
 

--- a/codechecker_lib/build_action.py
+++ b/codechecker_lib/build_action.py
@@ -84,6 +84,12 @@ class BuildAction(object):
     def original_command(self):
         return self._original_command
 
+    @property
+    def original_command_hash(self):
+        hash_object = hashlib.sha1(self._original_command)
+        hex_dig = hash_object.hexdigest()
+        return hex_dig
+
     @original_command.setter
     def original_command(self, value):
         self._original_command = value

--- a/codechecker_lib/client.py
+++ b/codechecker_lib/client.py
@@ -154,15 +154,15 @@ class Connection(object):
         '''
         return self._client.replaceConfigInfo(run_id, config_list)
 
-    def add_build_action(self, run_id, build_cmd, check_cmd, analyzer_type,
-                         analyzed_source_file):
+    def add_build_action(self, run_id, build_cmd_hash, check_cmd,
+                         analyzer_type, analyzed_source_file):
         """
         i64  addBuildAction(1: i64 run_id, 2: string build_cmd,
                             3: string check_cmd, 4: string analyzer_type,
                             5: string analyzed_source_file)
         """
         return self._client.addBuildAction(run_id,
-                                           build_cmd,
+                                           build_cmd_hash,
                                            check_cmd,
                                            analyzer_type,
                                            analyzed_source_file)

--- a/codechecker_lib/debug_reporter.py
+++ b/codechecker_lib/debug_reporter.py
@@ -71,9 +71,9 @@ def debug(context, connection_string, force):
 
             with open(debug_log_file, 'w') as log_file:
                 log_file.write('========================\n')
-                log_file.write('Original build command: \n')
+                log_file.write('Build command hash: \n')
                 log_file.write('========================\n')
-                log_file.write(action.build_cmd + '\n')
+                log_file.write(action.build_cmd_hash + '\n')
                 log_file.write('===============\n')
                 log_file.write('Check command: \n')
                 log_file.write('===============\n')

--- a/db_model/orm_model.py
+++ b/db_model/orm_model.py
@@ -116,7 +116,7 @@ class BuildAction(Base):
     run_id = Column(Integer,
                     ForeignKey('runs.id', deferrable=True, initially="DEFERRED",
                                ondelete='CASCADE'))
-    build_cmd = Column(String)
+    build_cmd_hash = Column('build_cmd', String)
     analyzer_type = Column(String, nullable=False)
     analyzed_source_file = Column(String, nullable=False)
     check_cmd = Column(String)
@@ -127,10 +127,10 @@ class BuildAction(Base):
     # Seconds, -1 if unfinished.
     duration = Column(Integer)
 
-    def __init__(self, run_id, build_cmd, check_cmd, analyzer_type,
+    def __init__(self, run_id, build_cmd_hash, check_cmd, analyzer_type,
                  analyzed_source_file):
-        self.run_id, self.build_cmd, self.check_cmd, self.failure_txt = \
-            run_id, build_cmd, check_cmd, ''
+        self.run_id, self.build_cmd_hash, self.check_cmd, self.failure_txt = \
+            run_id, build_cmd_hash, check_cmd, ''
         self.date = datetime.now()
         self.analyzer_type = analyzer_type
         self.analyzed_source_file = analyzed_source_file

--- a/storage_server/report_server.py
+++ b/storage_server/report_server.py
@@ -136,7 +136,6 @@ class CheckerReportHandler(object):
 
             self.session.query(ReportsToBuildActions).filter(
                 ReportsToBuildActions.build_action_id == build_action_id).delete()
-
         except Exception as ex:
             raise shared.ttypes.RequestFailed(
                 shared.ttypes.ErrorCode.GENERAL,
@@ -221,20 +220,18 @@ class CheckerReportHandler(object):
     @timeit
     def addBuildAction(self,
                        run_id,
-                       build_cmd,
+                       build_cmd_hash,
                        check_cmd,
                        analyzer_type,
                        analyzed_source_file):
         """
         """
-        import logging
-
         try:
 
             build_actions = \
                 self.session.query(BuildAction) \
                     .filter(and_(BuildAction.run_id == run_id,
-                                 BuildAction.build_cmd == build_cmd,
+                                 BuildAction.build_cmd_hash == build_cmd_hash,
                                  or_(
                                      and_(
                                          BuildAction.analyzer_type == analyzer_type,
@@ -252,8 +249,8 @@ class CheckerReportHandler(object):
                 self.session.commit()
 
             action = BuildAction(run_id,
-                                 build_cmd if LoggerFactory.get_log_level() == logging.DEBUG else '',
-                                 check_cmd if LoggerFactory.get_log_level() == logging.DEBUG else '',
+                                 build_cmd_hash,
+                                 check_cmd,
                                  analyzer_type,
                                  analyzed_source_file)
             self.session.add(action)

--- a/tests/functional/package_test/test_update_mode.py
+++ b/tests/functional/package_test/test_update_mode.py
@@ -1,0 +1,63 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import json
+import os
+import unittest
+import logging
+
+import shared
+
+from test_utils.thrift_client_to_db import CCViewerHelper
+
+
+class UpdateMode(unittest.TestCase):
+
+    def setUp(self):
+        host = 'localhost'
+        port = int(os.environ['CC_TEST_VIEWER_PORT'])
+        uri = '/'
+        self._testproject_data = json.loads(os.environ['CC_TEST_PROJECT_INFO'])
+        self.assertIsNotNone(self._testproject_data)
+        self._cc_client = CCViewerHelper(host, port, uri)
+
+    # -----------------------------------------------------
+    def test_get_update_run_res(self):
+        """
+        The test depends on a run which was configured for update mode.
+        Compared to the original test analysis in this run
+        the deadcode.Deadstores checker was disabled.
+        """
+        runs = self._cc_client.getRunData()
+        self.assertIsNotNone(runs)
+        self.assertNotEqual(len(runs), 0)
+        self.assertGreaterEqual(len(runs), 2)
+
+        update_run_name = "update_test"
+        updated_run = None
+        for run in runs:
+            print(run.name)
+            if run.name == update_run_name:
+                updated_run = run
+                break
+        print('There should be a run with this name: ' + update_run_name)
+        self.assertIsNotNone(updated_run)
+
+        # get all the results from the test project config
+        bugs = self._testproject_data['bugs']
+        all_results = len(bugs)
+        deadcode_results = [b for b in bugs
+                            if b['checker'] == 'deadcode.DeadStores']
+
+        deadcode_count = len(deadcode_results)
+
+        update_res_count = None
+        results = self._cc_client.getRunResults(updated_run.runId,
+                                                500, 0, [], [])
+        update_res_count = len(results)
+
+        self.assertEqual(all_results - deadcode_count, update_res_count)

--- a/thrift_api/report_storage_server.thrift
+++ b/thrift_api/report_storage_server.thrift
@@ -61,7 +61,7 @@ service CheckerReport {
                 // =============================================================
                 i64  addBuildAction(
                                     1: i64 run_id,
-                                    2: string build_cmd,
+                                    2: string build_cmd_hash,
                                     3: string check_cmd,
                                     4: string analyzer_type,
                                     5: string analyzed_source_file)

--- a/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
@@ -604,12 +604,6 @@ function (declare, dom, style, on, query, Memory, Observable, topic,
             var details = dom.create('dl');
 
             dom.place(
-              dom.create('dt', { innerHTML : 'Build command' }), details);
-            dom.place(
-              dom.create('dd', {
-                innerHTML : buildAction.buildCmd || 'Only in debug mode parsing'
-              }), details);
-            dom.place(
               dom.create('dt', { innerHTML : 'Check command' }), details);
             dom.place(
               dom.create('dd', {

--- a/viewer_server/client_db_access_handler.py
+++ b/viewer_server/client_db_access_handler.py
@@ -741,7 +741,7 @@ class ThriftRequestHandler():
 
             return [BuildActionData(id=ba.id,
                                     runId=ba.run_id,
-                                    buildCmd=ba.build_cmd,
+                                    buildCmd=ba.build_cmd_hash,
                                     analyzerType=ba.analyzer_type,
                                     file=ba.analyzed_source_file,
                                     checkCmd=ba.check_cmd,


### PR DESCRIPTION
In the previous releases the whole original build command from the compilation
command json file was stored. It could take too much space in the database
if the build commands were long (no compression was used).
To address this issue in the commit ffef1ebfb1a831d84d925bef8df9dd78b8ae2ed7
storing the build command was only done in debug mode.
With that solution the update mode did not work correctly because it
depends on the build command right now.

With this commit the hashed build command from the compilation database
is stored to address the storage size problem and the update mode can
use the stored hash values.