### PR TITLE
Fix webgui file path having '/' on the right

### DIFF
--- a/viewer_clients/web-client/scripts/codecheckerviewer/ListOfBugs.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/ListOfBugs.js
@@ -73,8 +73,9 @@ function (declare, Deferred, ObjectStore, Store, QueryResults, topic,
         reportData.severity
           = util.severityFromCodeToString(reportData.severity);
 
-        reportData.checkedFile
-          += ' @ Line ' + reportData.lastBugPosition.startLine;
+        // (via http://stackoverflow.com/a/27961022/1428773)
+        reportData.checkedFile = '&lrm;' + reportData.checkedFile +
+            ' @ Line ' + reportData.lastBugPosition.startLine;
       });
 
       return reportDataList;

--- a/viewer_clients/web-client/style/codecheckerviewer.css
+++ b/viewer_clients/web-client/style/codecheckerviewer.css
@@ -67,6 +67,7 @@ html, body {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  direction: rtl;
 }
 
 /*** Filter fields ***/


### PR DESCRIPTION
Simply removing `direction: rtl;` would cause the ellipses to appear on the left again on small screen. This now properly makes the ellipses work and forces the foreslash to appear on the left.

Solution via [http://stackoverflow.com/a/27961022/1428773](http://stackoverflow.com/a/27961022/1428773).

----
Follow-up for #507, this fixes #502.