### PR TITLE
Fixing blinking arrows.

### DIFF
--- a/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
@@ -79,7 +79,8 @@ function (declare, dom, style, on, query, Memory, Observable, topic,
         mode : 'text/x-c++src',
         foldGutter : true,
         gutters : ['CodeMirror-linenumbers', 'bugInfo'],
-        extraKeys : {}
+        extraKeys : {},
+        viewportMargin : 500
       });
 
       this.codeMirror.on('viewportChange', function (cm, from, to) {


### PR DESCRIPTION
CodeMirror renders only the currently visible lines (+-)10 lines by
default. This means that in case of a bug path arrow the source or the
target of the arrow is not rendered where one of the end of the arrow
can bind. Here we raise number of rendered lines. 1000 is an empirical
value. Loading the file and rendering these lines seems to be fast
enough, and the arrows have stopped blinking too.

Fixes #518