### PR TITLE
Yet another fix for slash replacement

### DIFF
--- a/viewer_clients/web-client/scripts/codecheckerviewer/ListOfBugs.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/ListOfBugs.js
@@ -73,9 +73,8 @@ function (declare, Deferred, ObjectStore, Store, QueryResults, topic,
         reportData.severity
           = util.severityFromCodeToString(reportData.severity);
 
-        // (via http://stackoverflow.com/a/27961022/1428773)
-        reportData.checkedFile = '&lrm;' + reportData.checkedFile +
-            ' @ Line ' + reportData.lastBugPosition.startLine;
+        reportData.checkedFile = reportData.checkedFile +
+          ' @ Line ' + reportData.lastBugPosition.startLine;
       });
 
       return reportDataList;

--- a/viewer_clients/web-client/style/codecheckerviewer.css
+++ b/viewer_clients/web-client/style/codecheckerviewer.css
@@ -70,6 +70,11 @@ html, body {
   direction: rtl;
 }
 
+/* (via http://stackoverflow.com/a/27961022/1428773) */
+.compact:before {
+  content: '\200e';
+}
+
 /*** Filter fields ***/
 
 .filterText {


### PR DESCRIPTION
If the path is modified then in the bug list on the next page can't be
queried, since the filtering happens based on this path. So this change
has to be done with CSS. Fixes #502.