### PR TITLE
Show only bugs in the current file on page reload

### DIFF
--- a/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
+++ b/viewer_clients/web-client/scripts/codecheckerviewer/BugViewer.js
@@ -392,8 +392,11 @@ function (declare, dom, style, on, query, Memory, Observable, topic,
         that.bugStore.put(item);
       });
 
-      var filepath = this.reportData.checkedFile.substr(
-        0, this.reportData.checkedFile.indexOf(' '));
+      var endPos = this.reportData.checkedFile.indexOf(' ');
+      if (endPos === -1)
+        endPos = this.reportData.checkedFile.length;
+
+      var filepath = this.reportData.checkedFile.substr(0, endPos);
 
       var filter_sup = new CC_OBJECTS.ReportFilter();
       filter_sup.filepath = filepath;


### PR DESCRIPTION
When the page is reloaded and a result is shown in the text view then in
the bug path viewer at the left all bugs of the project were shown.
Fixes #517.