### PR TITLE
Fix bug classification in the plist importer

### DIFF
--- a/codechecker_lib/analyzer.py
+++ b/codechecker_lib/analyzer.py
@@ -87,14 +87,6 @@ def run_check(args, actions, context):
         args.analyzers,
         context)
 
-    # Load severity map from config file.
-    LOG.debug_analyzer("Loading checker severity map.")
-    if os.path.exists(context.checkers_severity_map_file):
-        with open(context.checkers_severity_map_file, 'r') as sev_conf_file:
-            severity_config = sev_conf_file.read()
-
-        context.severity_map = json.loads(severity_config)
-
     actions = prepare_actions(actions, enabled_analyzers)
 
     suppress_file = ''

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -292,13 +292,6 @@ def _do_quickcheck(args):
         context.codechecker_workspace = args.workspace
         args.name = "quickcheck"
 
-        # Load severity map from config file.
-        if os.path.exists(context.checkers_severity_map_file):
-            with open(context.checkers_severity_map_file, 'r') as sev_file:
-                severity_config = sev_file.read()
-
-            context.severity_map = json.loads(severity_config)
-
         log_file, set_in_cmdline = build_manager.check_log_file(args, context)
         actions = log_parser.parse_log(log_file,
                                        args.add_compiler_defaults)
@@ -341,7 +334,7 @@ def consume_plist(item):
                                                  action,
                                                  context.run_id,
                                                  args.directory,
-                                                 {},
+                                                 context.severity_map,
                                                  None,
                                                  None,
                                                  not args.stdout)

--- a/codechecker_lib/context_base.py
+++ b/codechecker_lib/context_base.py
@@ -5,7 +5,11 @@
 # -------------------------------------------------------------------------
 
 import abc
+import json
 import os
+from codechecker_lib.logger import LoggerFactory
+
+LOG = LoggerFactory.get_new_logger("CONTEXT BASE")
 
 
 # -----------------------------------------------------------------------------
@@ -59,6 +63,14 @@ class ContextBase(object):
         codechecker_workspace = os.environ.get('codechecker_workspace')
         if codechecker_workspace:
             self._codechecker_workspace = codechecker_workspace
+
+        try:
+            with open(self.checkers_severity_map_file) as severity_file:
+                self._severity_map = json.load(severity_file)
+        except (IOError, ValueError):
+            LOG.warning(self.checkers_severity_map_file + " doesn't exist or "
+                        "not JSON format. Severity levels will not be "
+                        "available!")
 
     @property
     def package_root(self):
@@ -189,7 +201,3 @@ class ContextBase(object):
     @property
     def severity_map(self):
         return self._severity_map
-
-    @severity_map.setter
-    def severity_map(self, value):
-        self._severity_map = value

--- a/viewer_clients/cmdline_client/cmd_line_client.py
+++ b/viewer_clients/cmdline_client/cmd_line_client.py
@@ -258,7 +258,7 @@ def add_filter_conditions(report_filter, filter_str):
 
     if severity:
         report_filter.severity = \
-                shared.ttypes.Severity._NAMES_TO_VALUES[severity.upper()]
+            shared.ttypes.Severity._NAMES_TO_VALUES[severity.upper()]
     if checker:
         report_filter.checkerId = '*' + checker + '*'
     if path:
@@ -373,7 +373,6 @@ def handle_list_result_types(args):
         run_id, run_date = run_info
         results = client.getRunResultTypes(run_id, filters)
 
-
         if args.output_format == 'json':
             results_collector.append({name: results})
         else:  # plaintext, csv
@@ -393,6 +392,7 @@ def handle_list_result_types(args):
 
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(results_collector))
+
 
 # ------------------------------------------------------------
 def handle_remove_run_results(args):
@@ -422,7 +422,7 @@ def handle_diff_results(args):
         limit = 500
         offset = 0
 
-        all_results=[]
+        all_results = []
         results = getterFn(baseid, newid, limit, offset, sort_type,
                            report_filter)
 
@@ -431,7 +431,6 @@ def handle_diff_results(args):
             offset += limit
             results = getterFn(baseid, newid, limit, offset, sort_type,
                                report_filter)
-
 
         if output_format == 'json':
             print(CmdLineOutputEncoder().encode(all_results))


### PR DESCRIPTION
The context reads the severity map file so the clients don't need to
reproduce this code.
The plist importer now also can use this severity map.

Fixes #499