### PR TITLE
Use BUILD_DIR in Makefile everywhere it's applicable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,29 +14,32 @@ CLANG_VERSION = TEST_CLANG_VERSION=stable
 TEST_PROJECT = TEST_PROJ=$(CURRENT_DIR)/tests/test_projects/test_files
 
 # the build package which should be tested
-PKG_TO_TEST = CC_PACKAGE=$(CURRENT_DIR)/build/CodeChecker
+PKG_TO_TEST = CC_PACKAGE=$(BUILD_DIR)/CodeChecker
 
 # test runner needs to know the root of the repository
 ROOT = REPO_ROOT=$(CURRENT_DIR)
+
+default: package
 
 pep8:
 	pep8 codechecker codechecker_lib tests db_model viewer_server viewer_clients
 
 gen-docs:
-	doxygen ./Doxyfile.in
+	doxygen ./Doxyfile.in && \
+	cp -a ./gen-docs $(BUILD_DIR)/gen-docs
 
 thrift: build_dir
 
-	if [ ! -d "$(BUILD_DIR)/gen-py" ]; then rm -rf build/gen-py; fi
-	if [ ! -d "$(BUILD_DIR)/gen-js" ]; then rm -rf build/gen-js; fi
+	if [ ! -d "$(BUILD_DIR)/gen-py" ]; then rm -rf $(BUILD_DIR)/gen-py; fi
+	if [ ! -d "$(BUILD_DIR)/gen-js" ]; then rm -rf $(BUILD_DIR)/gen-js; fi
 
-	thrift -r -o build -I thrift_api/ --gen py thrift_api/report_storage_server.thrift
-	thrift -r -o build -I thrift_api/ --gen py --gen js:query thrift_api/report_viewer_server.thrift
-	thrift -r -o build -I thrift_api/ --gen py thrift_api/authentication.thrift
+	thrift -r -o $(BUILD_DIR) -I thrift_api/ --gen py thrift_api/report_storage_server.thrift
+	thrift -r -o $(BUILD_DIR) -I thrift_api/ --gen py --gen js:query thrift_api/report_viewer_server.thrift
+	thrift -r -o $(BUILD_DIR) -I thrift_api/ --gen py thrift_api/authentication.thrift
 
 package: build_dir gen-docs thrift
 	if [ ! -d "$(BUILD_DIR)/CodeChecker" ]; then \
-		$(ROOT) ./scripts/build_package.py -o $(CURRENT_DIR)/build; \
+		$(ROOT) ./scripts/build_package.py -o $(BUILD_DIR) -b $(BUILD_DIR); \
 	fi
 
 travis:

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -409,7 +409,8 @@ def build_package(repository_root, build_package_config, env=None):
             else:
                 LOG.info('Skipping ld logger from package')
 
-    thrift_files_dir = os.path.join(repository_root, 'build')
+    thrift_files_dir = os.path.join(repository_root,
+                                    build_package_config['local_build_folder'])
     generated_py_files = os.path.join(thrift_files_dir, 'gen-py')
     generated_js_files = os.path.join(thrift_files_dir, 'gen-js')
 
@@ -426,7 +427,10 @@ def build_package(repository_root, build_package_config, env=None):
     target = os.path.join(package_root, package_layout['cmdline_client'])
     copy_tree(cmdline_client_files, target)
 
-    source = os.path.join(repository_root, 'gen-docs', 'html')
+    # Documentation files.
+    source = os.path.join(repository_root,
+                          build_package_config['local_build_folder'],
+                          'gen-docs', 'html')
     target = os.path.join(package_root, package_layout['docs'])
     copy_tree(source, target)
 
@@ -612,6 +616,11 @@ def main():
                         help="Package layout configuration file.")
     parser.add_argument("-o", "--output", required=True, action="store",
                         dest="output_dir")
+    parser.add_argument("-b", "--build-folder",
+                        dest="local_build_folder",
+                        default="build",
+                        help="The local dependency folder under which Thrift "
+                             "and documentation files have been generated.")
     parser.add_argument("--clean",
                         action="store_true",
                         dest='clean',


### PR DESCRIPTION
There were some duplicate instances of `$(CURRENT_DIR)/build` used instead of `$(BUILD_DIR)`.