### PR TITLE
Improve makefile, fix Doxyfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 build
 venv
+Makefile.local
 
 # build-logger build dir
 external-source-deps/build-logger/build/

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -654,7 +654,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  =  . docs docs/checker_docs thrift_api 
+INPUT                  = docs docs/checker_docs thrift_api 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
+-include Makefile.local
+
 CURRENT_DIR = $(shell pwd)
 BUILD_DIR = $(CURRENT_DIR)/build
 
 # environment variables to run tests
 # database settings
-PSQL = TEST_USE_POSTGRESQL=true
-PG800 = CODECHECKER_DB_DRIVER=pg8000
-PSYCOPG2 = CODECHECKER_DB_DRIVER=psycopg2
-DBPORT = TEST_DBPORT=5432
-DBUNAME = TEST_DBUSERNAME=postgres
+PSQL ?= TEST_USE_POSTGRESQL=true
+PG800 ?= CODECHECKER_DB_DRIVER=pg8000
+PSYCOPG2 ?= CODECHECKER_DB_DRIVER=psycopg2
+DBPORT ?= TEST_DBPORT=5432
+DBUNAME ?= TEST_DBUSERNAME=postgres
 
 # test project configuration, tests are run on these files
-CLANG_VERSION = TEST_CLANG_VERSION=stable
-TEST_PROJECT = TEST_PROJ=$(CURRENT_DIR)/tests/test_projects/test_files
+CLANG_VERSION ?= TEST_CLANG_VERSION=stable
+TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/test_projects/test_files
 
 # the build package which should be tested
 PKG_TO_TEST = CC_PACKAGE=$(BUILD_DIR)/CodeChecker
@@ -24,7 +26,7 @@ default: package
 pep8:
 	pep8 codechecker codechecker_lib tests db_model viewer_server viewer_clients
 
-gen-docs:
+gen-docs: build_dir
 	doxygen ./Doxyfile.in && \
 	cp -a ./gen-docs $(BUILD_DIR)/gen-docs
 


### PR DESCRIPTION
Use a local Makefile to set environment variables, makes testing easier.
Doxygen documentation should not be generated for the external
dependecies.