### PR TITLE
change thift compiler version for OSX install

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ LLVM/Clang](http://clang.llvm.org/get_started.html) documentation.
 ~~~{.sh}
 # Download and install dependencies
 brew update
-brew install doxygen thrift gcc git
+brew install doxygen gcc git
+brew install homebrew/versions/thrift090
 
 # Fetch source code
 git clone https://github.com/Ericsson/CodeChecker.git --depth 1 ~/codechecker


### PR DESCRIPTION
There is a newer thrift compiler v0.10 available in OSX,
and we depend on an older compiler until this new version
will be available in Ubuntu LTS release.