### PR TITLE
--export-plist command in CodeChecker quickcheck

### DIFF
--- a/codechecker/CodeChecker.py
+++ b/codechecker/CodeChecker.py
@@ -340,6 +340,13 @@ Build command which is used to build the project.''')
                                         ' and defines and pass them to Clang.'
                                         'This is useful when you'
                                         'do cross-compilation.')
+        qcheck_parser.add_argument('--export-plist',
+                                   type=str,
+                                   required=False,
+                                   help='Instead of printing analysis '
+                                        'results to the standard output, '
+                                        'export the generated plist files '
+                                        'to the specified directory.')
         add_analyzer_arguments(qcheck_parser)
         logger.add_verbose_arguments(qcheck_parser)
         qcheck_parser.set_defaults(func=arg_handler.handle_quickcheck)

--- a/codechecker_lib/analysis_manager.py
+++ b/codechecker_lib/analysis_manager.py
@@ -79,7 +79,7 @@ def check(check_data):
     skiplist handler is None if no skip file was configured.
     """
     args, action, context, analyzer_config_map, skp_handler, \
-        report_output_dir, use_db = check_data
+        report_output_dir, use_db, plist_export_path = check_data
 
     skipped = False
     try:
@@ -111,7 +111,8 @@ def check(check_data):
                                                          context.severity_map,
                                                          skp_handler,
                                                          progress_lock,
-                                                         use_db)
+                                                         use_db,
+                                                         plist_export_path)
 
             # Create a source analyzer.
             source_analyzer = \
@@ -161,7 +162,7 @@ def check(check_data):
 
 
 def start_workers(args, actions, context, analyzer_config_map, skp_handler,
-                  use_db=True):
+                  use_db=True, export_plist_path=True):
     """
     Start the workers in the process pool
     for every buildaction there is worker which makes the analysis.
@@ -207,7 +208,8 @@ def start_workers(args, actions, context, analyzer_config_map, skp_handler,
                              analyzer_config_map,
                              skp_handler,
                              report_output,
-                             use_db) for build_action in actions]
+                             use_db,
+                             export_plist_path) for build_action in actions]
 
         pool.map_async(check,
                        analyzed_actions,

--- a/codechecker_lib/analysis_manager.py
+++ b/codechecker_lib/analysis_manager.py
@@ -162,7 +162,7 @@ def check(check_data):
 
 
 def start_workers(args, actions, context, analyzer_config_map, skp_handler,
-                  use_db=True, export_plist_path=True):
+                  use_db=True, export_plist_path=None):
     """
     Start the workers in the process pool
     for every buildaction there is worker which makes the analysis.

--- a/codechecker_lib/analyzer.py
+++ b/codechecker_lib/analyzer.py
@@ -141,7 +141,8 @@ def run_check(args, actions, context):
 
 def run_quick_check(args,
                     context,
-                    actions):
+                    actions,
+                    export_plist_path=None):
     """
     This function implements the "quickcheck" feature.
     No result is stored to a database.
@@ -162,4 +163,5 @@ def run_quick_check(args,
     LOG.info("Static analysis is starting ...")
 
     analysis_manager.start_workers(args, actions, context, analyzer_config_map,
-                                   _get_skip_handler(args), False)
+                                   _get_skip_handler(args),
+                                   False, export_plist_path)

--- a/codechecker_lib/analyzers/analyzer_types.py
+++ b/codechecker_lib/analyzers/analyzer_types.py
@@ -354,7 +354,6 @@ def construct_result_handler(args,
             res_handler = result_handler_plist_to_file.PlistToFile(
                 buildaction,
                 report_output,
-                lock,
                 export_plist_path)
             res_handler.print_steps = args.print_steps
 
@@ -362,7 +361,6 @@ def construct_result_handler(args,
             res_handler = result_handler_clang_tidy.ClangTidyPlistToFile(
                 buildaction,
                 report_output,
-                lock,
                 export_plist_path)
 
     res_handler.severity_map = severity_map

--- a/codechecker_lib/analyzers/analyzer_types.py
+++ b/codechecker_lib/analyzers/analyzer_types.py
@@ -21,6 +21,7 @@ from codechecker_lib.analyzers import config_handler_clang_tidy
 from codechecker_lib.analyzers import config_handler_clangsa
 from codechecker_lib.analyzers import result_handler_clang_tidy
 from codechecker_lib.analyzers import result_handler_plist_to_db
+from codechecker_lib.analyzers import result_handler_plist_to_file
 from codechecker_lib.analyzers import result_handler_plist_to_stdout
 
 LOG = LoggerFactory.get_new_logger('ANALYZER TYPES')
@@ -313,7 +314,8 @@ def construct_result_handler(args,
                              severity_map,
                              skiplist_handler,
                              lock,
-                             store_to_db=False):
+                             store_to_db=False,
+                             export_plist_path=None):
     """
     Construct a result handler.
     """
@@ -334,7 +336,7 @@ def construct_result_handler(args,
                 report_output,
                 run_id)
 
-    else:
+    elif not store_to_db and not export_plist_path:
         if buildaction.analyzer_type == CLANG_SA:
             res_handler = result_handler_plist_to_stdout.PlistToStdout(
                 buildaction,
@@ -347,6 +349,21 @@ def construct_result_handler(args,
                 buildaction,
                 report_output,
                 lock)
+    elif export_plist_path:
+        if buildaction.analyzer_type == CLANG_SA:
+            res_handler = result_handler_plist_to_file.PlistToFile(
+                buildaction,
+                report_output,
+                lock,
+                export_plist_path)
+            res_handler.print_steps = args.print_steps
+
+        elif buildaction.analyzer_type == CLANG_TIDY:
+            res_handler = result_handler_clang_tidy.ClangTidyPlistToFile(
+                buildaction,
+                report_output,
+                lock,
+                export_plist_path)
 
     res_handler.severity_map = severity_map
     res_handler.skiplist_handler = skiplist_handler

--- a/codechecker_lib/analyzers/result_handler_clang_tidy.py
+++ b/codechecker_lib/analyzers/result_handler_clang_tidy.py
@@ -8,6 +8,7 @@ from codechecker_lib import tidy_output_converter
 from codechecker_lib.logger import LoggerFactory
 
 from codechecker_lib.analyzers.result_handler_plist_to_db import PlistToDB
+from codechecker_lib.analyzers.result_handler_plist_to_file import PlistToFile
 from codechecker_lib.analyzers.result_handler_plist_to_stdout import \
     PlistToStdout
 
@@ -45,6 +46,22 @@ class ClangTidyPlistToDB(PlistToDB):
 
 
 class ClangTidyPlistToStdout(PlistToStdout):
+    """
+    Print the clang tidy results to the standard output.
+    """
+
+    def postprocess_result(self):
+        """
+        Clang-tidy results are post processed to have the same format as the
+        clang static analyzer result files.
+        """
+
+        output_file = self.analyzer_result_file
+        tidy_stdout = self.analyzer_stdout.splitlines()
+        generate_plist_from_tidy_result(output_file, tidy_stdout)
+
+
+class ClangTidyPlistToFile(PlistToFile):
     """
     Print the clang tidy results to the standard output.
     """

--- a/codechecker_lib/analyzers/result_handler_plist_to_file.py
+++ b/codechecker_lib/analyzers/result_handler_plist_to_file.py
@@ -23,9 +23,8 @@ class PlistToFile(ResultHandler):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, buildaction, workspace, lock, export_plist_path):
+    def __init__(self, buildaction, workspace, export_plist_path):
         super(PlistToFile, self).__init__(buildaction, workspace)
-        self.__lock = lock
         self.__folder = export_plist_path
 
     @property
@@ -61,14 +60,9 @@ class PlistToFile(ResultHandler):
             return err_code
 
         if err_code == 0:
-            try:
-                # No lock when consuming plist.
-                self.__lock.acquire() if self.__lock else None
-                shutil.copy(plist, os.path.join(self.__folder,
-                                                os.path.basename(plist)))
-                LOG.debug("Exported '" + os.path.basename(plist) + "'")
-            finally:
-                self.__lock.release() if self.__lock else None
+            shutil.copy(plist, os.path.join(self.__folder,
+                                            os.path.basename(plist)))
+            LOG.debug("Exported '" + os.path.basename(plist) + "'")
         else:
             LOG.error('Analyzing %s with %s failed.\n' %
                       (ntpath.basename(self.analyzed_source_file),

--- a/codechecker_lib/analyzers/result_handler_plist_to_file.py
+++ b/codechecker_lib/analyzers/result_handler_plist_to_file.py
@@ -1,0 +1,82 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+
+import ntpath
+import os
+import shutil
+from abc import ABCMeta
+
+from codechecker_lib import plist_parser
+from codechecker_lib.logger import LoggerFactory
+from codechecker_lib.analyzers.result_handler_base import ResultHandler
+
+LOG = LoggerFactory.get_new_logger('PLIST TO FILE')
+
+
+class PlistToFile(ResultHandler):
+    """
+    Result handler for copying a plist file to a different location.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, buildaction, workspace, lock, export_plist_path):
+        super(PlistToFile, self).__init__(buildaction, workspace)
+        self.__lock = lock
+        self.__folder = export_plist_path
+
+    @property
+    def print_steps(self):
+        """
+        Print the multiple steps for a bug if there is any.
+        """
+        return self.__print_steps
+
+    @print_steps.setter
+    def print_steps(self, value):
+        """
+        Print the multiple steps for a bug if there is any.
+        """
+        self.__print_steps = value
+
+    def handle_results(self):
+        """This handler copies the plist file into the jailed_root."""
+        plist = self.analyzer_result_file
+
+        try:
+            files, _ = plist_parser.parse_plist(plist)
+        except Exception as ex:
+            LOG.error('The generated plist is not valid!')
+            LOG.error(ex)
+            return 1
+
+        err_code = self.analyzer_returncode
+
+        if len(files) == 0:
+            LOG.debug("Will not export '" +
+                      plist + "', because plist is empty.")
+            return err_code
+
+        if err_code == 0:
+            try:
+                # No lock when consuming plist.
+                self.__lock.acquire() if self.__lock else None
+                shutil.copy(plist, os.path.join(self.__folder,
+                                                os.path.basename(plist)))
+                LOG.debug("Exported '" + os.path.basename(plist) + "'")
+            finally:
+                self.__lock.release() if self.__lock else None
+        else:
+            LOG.error('Analyzing %s with %s failed.\n' %
+                      (ntpath.basename(self.analyzed_source_file),
+                       self.buildaction.analyzer_type))
+        return err_code
+
+    def postprocess_result(self):
+        """
+        No postprocessing required for plists.
+        """
+        pass

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -295,7 +295,8 @@ def _do_quickcheck(args):
         log_file, set_in_cmdline = build_manager.check_log_file(args, context)
         actions = log_parser.parse_log(log_file,
                                        args.add_compiler_defaults)
-        analyzer.run_quick_check(args, context, actions)
+        analyzer.run_quick_check(args, context, actions,
+                                 args.export_plist)
 
     except Exception as ex:
         LOG.error("Running quickcheck failed.")
@@ -316,6 +317,12 @@ def handle_quickcheck(args):
     """
 
     args.workspace = tempfile.mkdtemp(prefix='codechecker-qc')
+
+    if args.export_plist:
+        if not os.path.exists(args.export_plist):
+            os.mkdir(args.export_plist)
+        args.export_plist = os.path.abspath(args.export_plist)
+
     try:
         _do_quickcheck(args)
     finally:

--- a/codechecker_lib/arg_handler.py
+++ b/codechecker_lib/arg_handler.py
@@ -319,7 +319,8 @@ def handle_quickcheck(args):
     try:
         _do_quickcheck(args)
     finally:
-        shutil.rmtree(args.workspace)
+        if not args.keep_tmp:
+            shutil.rmtree(args.workspace)
 
 
 def consume_plist(item):


### PR DESCRIPTION
Specifying a path to this **extra** argument will output the generated plist files into the given folder.

    CodeChecker quickcheck --build "the usual" [...] --export-plist ~/myplists