### PR TITLE
Fix accidentally unchanged bad variable for 'Show documentation' feature

### DIFF
--- a/viewer_server/client_db_access_handler.py
+++ b/viewer_server/client_db_access_handler.py
@@ -671,7 +671,7 @@ class ThriftRequestHandler():
         tidy_link = "http://clang.llvm.org/extra/clang-tidy/checks/list.html"
 
         if "." in checkerId:
-            text += "[ClangSA](" + sa_checkers_link + ")"
+            text += "[ClangSA](" + sa_link + ")"
         elif "-" in checkerId:
             text += "[ClangTidy](" + tidy_link + ")"
         text += " homepage."


### PR DESCRIPTION
In commit ec48481e10e5286094bd62c21b4ecb63999c040e, there was a string extraction to a variable but it's use location wasn't named accordingly, thus creating an error in the server if _Show documentation_ is clicked.

> [10:51] - Waiting for client requests on [localhost:8001]
> [ERROR] [10:54] - global name 'sa_checkers_link' is not defined


This didn't result in a server death, only the user not seeing anything when the button is clicked.

(Fixes #566.)