### PR TITLE
Better error handling for calling external commands

### DIFF
--- a/codechecker_lib/util.py
+++ b/codechecker_lib/util.py
@@ -186,6 +186,9 @@ def call_command(command, env=None):
         LOG.debug(str(ex.returncode))
         LOG.debug(ex.output)
         return ex.output, ex.returncode
+    except OSError as oerr:
+        LOG.warning(oerr.strerror)
+        return oerr.strerror, oerr.errno
 
 
 def get_default_workspace():


### PR DESCRIPTION
Handle OSError exception, the called command might be missing.