### PR TITLE
New subcommand infrastructure + splitting out log command

### DIFF
--- a/bin/CodeChecker
+++ b/bin/CodeChecker
@@ -24,10 +24,13 @@ import tempfile
 proc_pid = None
 
 
-def run_codechecker(checker_env):
+def run_codechecker(checker_env, subcommand=None):
     """
     Run the CodeChecker.
         * checker_env - CodeChecker will be run in the checker env.
+        * subcommand - CodeChecker will run the given subcommand by default,
+                       if specified. If not, the main script will run and parse
+                       all the commands.
     """
     package_bin = os.path.dirname(os.path.realpath(__file__))
     package_root, bin_dir = ntpath.split(package_bin)
@@ -52,6 +55,13 @@ def run_codechecker(checker_env):
                                     'CodeChecker.py')
 
     checker_cmd = [python, codechecker_main]
+
+    if subcommand:
+        # If a subcommand is specified (script is executed from a
+        # wrapper entry point, add it to the command list).
+        # E.g. 'codechecker-log ...' is the same as 'CodeChecker log ...'.
+        checker_cmd.append(subcommand)
+
     checker_cmd.extend(sys.argv[1:])
 
     proc = subprocess.Popen(checker_cmd, env=checker_env)
@@ -62,7 +72,7 @@ def run_codechecker(checker_env):
     sys.exit(proc.returncode)
 
 
-def main():
+def main(subcommand=None):
     original_env = os.environ.copy()
     checker_env = original_env
 
@@ -101,10 +111,10 @@ def main():
     signal.signal(signal.SIGINT, signal_term_handler)
 
     try:
-        run_codechecker(checker_env)
+        run_codechecker(checker_env, subcommand)
     finally:
         _remove_tmp()
 
 
 if __name__ == "__main__":
-    main()
+    main(None)

--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -11,12 +11,13 @@ from __future__ import print_function
 
 import argparse
 from argparse import ArgumentDefaultsHelpFormatter as ADHF
+import imp
+import json
 import os
 import signal
 import sys
 
 import shared
-
 
 from libcodechecker import arg_handler
 from libcodechecker import logger
@@ -149,7 +150,7 @@ def add_analyzer_arguments(parser):
                         "without modification.")
 
 
-def main():
+def main(subcommands=None):
     """
     CodeChecker main command line.
     """
@@ -537,8 +538,58 @@ Build command which is used to build the project.''')
         version_parser.set_defaults(func=arg_handler.handle_version_info)
         logger.add_verbose_arguments(version_parser)
 
+        if subcommands:
+            # Load the 'libcodechecker' module and acquire its path.
+            file, path, descr = imp.find_module("libcodechecker")
+            libcc_path = imp.load_module("libcodechecker",
+                                         file, path, descr).__path__[0]
+
+            # Try to check if the user has already given us a subcommand to
+            # execute. If so, don't load every available parts of CodeChecker
+            # to ensure a more optimised run.
+            if len(sys.argv) > 1:
+                first_command = sys.argv[1]
+                if first_command in subcommands:
+                    LOG.debug("Supplied an existing, valid subcommand: " +
+                              first_command)
+
+                    # Consider only the given command as an available one.
+                    subcommands = [first_command]
+
+            for subcommand in subcommands:
+                LOG.debug("Creating arg parser for subcommand " + subcommand)
+
+                try:
+                    # Load the module's source code, located under
+                    # libcodechecker/sub_command.py.
+                    # We can't use find_module() and load_module() here as both
+                    # a file AND a package exists with the same name, and
+                    # find_module() would find
+                    # libcodechecker/sub_command/__init__.py first.
+                    # Thus, manual source-code reading is required.
+                    # NOTE: load_source() loads the compiled .pyc, if such
+                    # exists.
+                    command_module = imp.load_source(subcommand,
+                                                     os.path.join(libcc_path,
+                                                                  subcommand +
+                                                                  ".py"))
+
+                    # Now that the module is loaded, construct an
+                    # ArgumentParser for it.
+                    sc_parser = subparsers.add_parser(
+                        subcommand, **command_module.get_argparser_ctor_args())
+
+                    command_module.add_arguments_to_parser(sc_parser)
+
+                except (IOError, ImportError):
+                    LOG.warning("Couldn't import module for subcommand '" +
+                                subcommand + "'... ignoring.")
+                    import traceback
+                    traceback.print_exc(file=sys.stdout)
+
         args = parser.parse_args()
-        LoggerFactory.set_log_level(args.verbose)
+        if 'verbose' in args:
+            LoggerFactory.set_log_level(args.verbose)
         args.func(args)
 
     except KeyboardInterrupt as kb_err:
@@ -568,4 +619,18 @@ if __name__ == "__main__":
     LOG.debug(sys.executable)
     LOG.debug(os.environ.get('LD_LIBRARY_PATH'))
 
-    main()
+    # Load the available CodeChecker subcommands.
+    # This list is generated dynamically by scripts/build_package.py
+    version_cfg = os.path.join(os.environ['CC_PACKAGE_ROOT'],
+                               "config", "version.json")
+
+    with open(version_cfg) as cfg_file:
+        config = json.load(cfg_file)
+
+    if 'available_commands' not in config:
+        config['available_commands'] = []
+
+    LOG.debug("Available CodeChecker subcommands: ")
+    LOG.debug(config['available_commands'])
+
+    main(config['available_commands'])

--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -347,32 +347,6 @@ Build command which is used to build the project.''')
         qcheck_parser.set_defaults(func=arg_handler.handle_quickcheck)
 
         # --------------------------------------
-        # Log commands.
-        logging_p = subparsers.add_parser('log',
-                                          formatter_class=ADHF,
-                                          help='Runs the given build '
-                                               'command. During the '
-                                               'build the compilation '
-                                               'commands are collected '
-                                               'and stored into a '
-                                               'compilation command '
-                                               'json file '
-                                               '(no analysis is done '
-                                               'during the build).')
-
-        logging_p.add_argument('-o', '--output', type=str, dest="logfile",
-                               default=argparse.SUPPRESS,
-                               required=True,
-                               help='Path to the log file.')
-
-        logging_p.add_argument('-b', '--build', type=str, dest="command",
-                               default=argparse.SUPPRESS,
-                               required=True, help='Build command.')
-
-        logger.add_verbose_arguments(logging_p)
-        logging_p.set_defaults(func=arg_handler.handle_log)
-
-        # --------------------------------------
         # Checkers parser.
         checker_p = subparsers.add_parser('checkers',
                                           formatter_class=ADHF,

--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -560,6 +560,12 @@ Build command which is used to build the project.''')
                 LOG.debug("Creating arg parser for subcommand " + subcommand)
 
                 try:
+                    # Even though command verbs and nouns are joined by a
+                    # hyphen, the Python files contain underscores.
+                    command_file = os.path.join(libcc_path,
+                                                subcommand.replace('-', '_') +
+                                                ".py")
+
                     # Load the module's source code, located under
                     # libcodechecker/sub_command.py.
                     # We can't use find_module() and load_module() here as both
@@ -569,10 +575,7 @@ Build command which is used to build the project.''')
                     # Thus, manual source-code reading is required.
                     # NOTE: load_source() loads the compiled .pyc, if such
                     # exists.
-                    command_module = imp.load_source(subcommand,
-                                                     os.path.join(libcc_path,
-                                                                  subcommand +
-                                                                  ".py"))
+                    command_module = imp.load_source(subcommand, command_file)
 
                     # Now that the module is loaded, construct an
                     # ArgumentParser for it.
@@ -620,17 +623,14 @@ if __name__ == "__main__":
     LOG.debug(os.environ.get('LD_LIBRARY_PATH'))
 
     # Load the available CodeChecker subcommands.
-    # This list is generated dynamically by scripts/build_package.py
-    version_cfg = os.path.join(os.environ['CC_PACKAGE_ROOT'],
-                               "config", "version.json")
+    # This list is generated dynamically by scripts/build_package.py, and is
+    # always meant to be available alongside the CodeChecker.py.
+    commands_cfg = os.path.join(os.path.dirname(__file__), "commands.json")
 
-    with open(version_cfg) as cfg_file:
-        config = json.load(cfg_file)
-
-    if 'available_commands' not in config:
-        config['available_commands'] = []
+    with open(commands_cfg) as cfg_file:
+        commands = json.load(cfg_file)
 
     LOG.debug("Available CodeChecker subcommands: ")
-    LOG.debug(config['available_commands'])
+    LOG.debug(commands)
 
-    main(config['available_commands'])
+    main(commands)

--- a/bin/codechecker-log
+++ b/bin/codechecker-log
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Entry point for the build logger command.
+"""
+
+import imp
+import os
+
+THIS_PATH = os.path.dirname(os.path.abspath(__file__))
+CC = os.path.join(THIS_PATH, "CodeChecker")
+
+# Load CodeChecker from the current folder (the wrapper script (without .py))
+CodeChecker = imp.load_source('CodeChecker', CC)
+
+# Execute CC's main script with the current subcommand.
+CodeChecker.main("log")

--- a/libcodechecker/arg_handler.py
+++ b/libcodechecker/arg_handler.py
@@ -232,21 +232,6 @@ def handle_server(args):
             raise
 
 
-def handle_log(args):
-    """
-    Generates a build log by running the original build command.
-    No analysis is done.
-    """
-    args.logfile = os.path.realpath(args.logfile)
-    if os.path.exists(args.logfile):
-        os.remove(args.logfile)
-
-    context = generic_package_context.get_context()
-    build_manager.perform_build_command(args.logfile,
-                                        args.command,
-                                        context)
-
-
 def handle_debug(args):
     """
     Runs a debug command on the buildactions where the analysis

--- a/libcodechecker/host_check.py
+++ b/libcodechecker/host_check.py
@@ -104,30 +104,3 @@ def check_clang(compiler_bin, env):
             LOG.error(oerr)
             LOG.error('Failed to run: ' + ' '.join(clang_version_cmd) + '"')
             return False
-
-
-# -----------------------------------------------------------------------------
-def check_intercept(env):
-    """
-    Simple check if intercept (scan-build-py) is available.
-    """
-    intercept_cmd = ['intercept-build']
-    try:
-        res = subprocess.call(intercept_cmd,
-                              env=env,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
-
-        if not res:
-            return True
-        else:
-            LOG.debug('Failed to run: "' + ' '.join(intercept_cmd) + '"')
-            return False
-
-    except OSError as oerr:
-        if oerr.errno == errno.ENOENT:
-            # Not just intercept-build can be used for logging.
-            # It is possible that another build logger is available.
-            LOG.debug(oerr)
-            LOG.debug('Failed to run: ' + ' '.join(intercept_cmd) + '"')
-            return False

--- a/libcodechecker/log.py
+++ b/libcodechecker/log.py
@@ -1,0 +1,88 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+'CodeChecker log' executes a build action and registers a compilation database
+for the given build, using an external tool such as scan-build-py or ld-logger.
+
+This module contains the basic definitions for how 'CodeChecker log' is to be
+invoked and ran.
+"""
+
+import argparse
+import os
+
+from libcodechecker import generic_package_context
+from libcodechecker.log import build_manager
+from libcodechecker.log.host_check import check_intercept
+from libcodechecker.logger import add_verbose_arguments
+
+
+def get_argparser_ctor_args():
+    """
+    This method returns a dict containing the kwargs for constructing an
+    argparse.ArgumentParser (either directly or as a subparser).
+    """
+
+    return {
+        'prog': 'CodeChecker log',
+        'formatter_class': argparse.ArgumentDefaultsHelpFormatter,
+
+        # Description is shown when the command's help is queried directly
+        'description': "Runs the given build command and records the executed "
+                       "compilation steps. These steps are written to the "
+                       "output file in a JSON format.\n\nAvailable build "
+                       "logger tool that will be used is '" +
+                       ('intercept-build' if check_intercept(os.environ)
+                        else 'ld-logger') + "'.",
+
+        # Help is shown when the "parent" CodeChecker command lists the
+        # individual subcommands.
+        'help': "Run a build command and collect the executed compilation "
+                "commands, storing them in a JSON file."
+    }
+
+
+def add_arguments_to_parser(parser):
+    """
+    Add the subcommand's arguments to the given argparse.ArgumentParser.
+    """
+
+    parser.add_argument('-o', '--output',
+                        type=str,
+                        dest="logfile",
+                        default=argparse.SUPPRESS,
+                        required=True,
+                        help="Path of the file to write the collected "
+                             "compilation commands to. If the file already "
+                             "exists, it will be overwritten.")
+
+    parser.add_argument('-b', '--build',
+                        type=str,
+                        dest="command",
+                        default=argparse.SUPPRESS,
+                        required=True,
+                        help="The build command to execute. Build commands "
+                             "can be simple calls to 'g++' or 'clang++' or "
+                             "'make', but a more complex command, or the call "
+                             "of a custom script file is also supported.")
+
+    add_verbose_arguments(parser)
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """
+    Generates a build log by running the original build command.
+    No analysis is done.
+    """
+    args.logfile = os.path.realpath(args.logfile)
+    if os.path.exists(args.logfile):
+        os.remove(args.logfile)
+
+    context = generic_package_context.get_context()
+    build_manager.perform_build_command(args.logfile,
+                                        args.command,
+                                        context)

--- a/libcodechecker/log/build_manager.py
+++ b/libcodechecker/log/build_manager.py
@@ -14,10 +14,11 @@ import subprocess
 import sys
 from uuid import uuid4
 
-from libcodechecker import host_check
 from libcodechecker.logger import LoggerFactory
 # TODO: Cross-reference between subpacakges...
 from libcodechecker.analyze import analyzer_env
+
+from . import host_check
 
 LOG = LoggerFactory.get_new_logger('BUILD MANAGER')
 

--- a/libcodechecker/log/build_manager.py
+++ b/libcodechecker/log/build_manager.py
@@ -70,7 +70,9 @@ def perform_build_command(logfile, command, context, silent=False):
     if host_check.check_intercept(original_env):
         LOG.debug_analyzer("with intercept ...")
         final_command = command
-        command = "intercept-build " + "--cdb " + logfile + " " + final_command
+        command = ' '.join(["intercept-build",
+                            "--cdb", logfile,
+                            "sh -c \"" + final_command + "\""])
         log_env = original_env
         LOG.debug_analyzer(command)
 

--- a/libcodechecker/log/host_check.py
+++ b/libcodechecker/log/host_check.py
@@ -1,0 +1,43 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+
+import errno
+import os
+import subprocess
+
+from libcodechecker.logger import LoggerFactory
+
+LOG = LoggerFactory.get_new_logger('HOST CHECK')
+
+
+def check_intercept(env):
+    """
+    Simple check if intercept (scan-build-py) is available.
+    """
+    intercept_cmd = ['intercept-build']
+    try:
+        with open(os.devnull, 'wb') as null:
+            res = subprocess.check_call(intercept_cmd,
+                                        env=env,
+                                        stdout=null,
+                                        stderr=null)
+
+        if not res:
+            return True
+        else:
+            LOG.debug('Failed to run: "' + ' '.join(intercept_cmd) + '"')
+            return False
+    except subprocess.CalledProcessError:
+        LOG.debug('Failed to run: "' + ' '.join(intercept_cmd) + '", process '
+                  'returned non-zero exit code.')
+        return False
+    except OSError as oerr:
+        if oerr.errno == errno.ENOENT:
+            # Not just intercept-build can be used for logging.
+            # It is possible that another build logger is available.
+            LOG.debug(oerr)
+            LOG.debug('Failed to run: "' + ' '.join(intercept_cmd) + '"')
+            return False

--- a/libcodechecker/log/host_check.py
+++ b/libcodechecker/log/host_check.py
@@ -17,7 +17,7 @@ def check_intercept(env):
     """
     Simple check if intercept (scan-build-py) is available.
     """
-    intercept_cmd = ['intercept-build']
+    intercept_cmd = ['intercept-build', '--help']
     try:
         with open(os.devnull, 'wb') as null:
             res = subprocess.check_call(intercept_cmd,

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -639,9 +639,39 @@ def build_package(repository_root, build_package_config, env=None):
     time_now = time.strftime("%Y-%m-%dT%H:%M")
     version_json_data['package_build_date'] = time_now
 
+    version_json_data['available_commands'] = []
+
+    # CodeChecker main scripts.
+    LOG.debug('Copy main codechecker files')
+    source = os.path.join(repository_root, 'bin')
+    target = os.path.join(package_root, package_layout['bin'])
+    target_cc = os.path.join(package_root, package_layout['cc_bin'])
+
+    for _, _, files in os.walk(source):
+        for f in files:
+            if not f.endswith(".py"):
+                # Non-py files use the environment to appear as python files,
+                # they go into the folder in PATH as they are entrypoints.
+                shutil.copy2(os.path.join(source, f), target)
+
+                if f.startswith("codechecker-"):
+                    # Entry points have the format of 'codechecker-sub-command'
+                    # to which the corresponding library file is in
+                    # libcodechecker/sub_command.py, so we register this.
+                    commandname = f.replace("codechecker-", "")
+                    LOG.info("CodeChecker command '{0}' available.".format(
+                        commandname))
+
+                    version_json_data['available_commands'].append(
+                        commandname.replace("-", "_"))
+            else:
+                # .py files are Python code that must run in a valid env.
+                shutil.copy2(os.path.join(source, f), target_cc)
+
     # Rewrite version config file with the extended data.
     with open(version_file, 'w') as v_file:
-        v_file.write(json.dumps(version_json_data, sort_keys=True, indent=4))
+        v_file.write(
+            json.dumps(version_json_data, sort_keys=True, indent=4))
 
     # CodeChecker web client.
     LOG.debug('Copy web client files')
@@ -672,16 +702,6 @@ def build_package(repository_root, build_package_config, env=None):
                                "style", "generated_fonts.css"), 'a') as style:
             with open(os.path.join(root, "generated_fonts.css"), 'r') as css:
                 style.write(css.read() + "\n")
-
-    # CodeChecker main scripts.
-    LOG.debug('Copy main codechecker files')
-    source = os.path.join(repository_root, 'bin', 'CodeChecker.py')
-    target = os.path.join(package_root, package_layout['cc_bin'])
-    shutil.copy2(source, target)
-
-    source = os.path.join(repository_root, 'bin', 'CodeChecker')
-    target = os.path.join(package_root, package_layout['bin'])
-    shutil.copy2(source, target)
 
     # CodeChecker db migrate.
     LOG.debug('Copy codechecker database migration')

--- a/scripts/create_new_subcommand.py
+++ b/scripts/create_new_subcommand.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+"""
+Generate a new CodeChecker subcommand and the structure needed for it in the
+working directory.
+"""
+
+import os
+import sys
+
+
+def main():
+
+    try:
+        command_name = sys.argv[1]
+    except IndexError:
+        print("Please provide the command's name (such as 'log')")
+        sys.exit(1)
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    parent_dir = os.path.abspath(os.path.join(current_dir, '..'))
+
+    bin_dir = os.path.join(parent_dir, 'bin')
+    lib_dir = os.path.join(parent_dir, 'libcodechecker')
+
+    if os.path.exists(os.path.join(bin_dir, 'codechecker-' + command_name)) \
+            or os.path.exists(os.path.join(lib_dir, command_name)) \
+            or os.path.exists(os.path.join(lib_dir, command_name + '.py')):
+        print("This command already exists, refusing to create!")
+        sys.exit(1)
+
+    resource_dir = os.path.join(current_dir, 'resources')
+
+    entryfile = os.path.join(bin_dir, 'codechecker-' + command_name)
+    print("Creating new entrypoint in '" + entryfile + "'")
+    with open(os.path.join(resource_dir,
+                           'entrypoint_template.py')) as template:
+        with open(entryfile, 'w') as entry:
+            contents = template.read()
+            contents = contents.replace("$COMMAND$", command_name)
+            entry.write(contents)
+
+    os.chmod(entryfile, 0o755)
+
+    lib_name = command_name
+    if '-' in command_name:
+        print("- (hyphen) found in command name.")
+        print("Replacing with _ (underscore) to ensure compatibility with ")
+        print("Python coding standards in the library folder.")
+        lib_name = command_name.replace('-', '_')
+
+    print("Creating library package")
+    os.makedirs(os.path.join(lib_dir, lib_name))
+    with open(os.path.join(lib_dir, lib_name, '__init__.py'), 'w') as init:
+        # Write licensing information to init of module
+        s = "# --------------------------------------------------------------"\
+            "---------------""""
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------"""\
+            "----"
+
+        init.write(s)
+
+    lib_file = os.path.join(lib_dir, lib_name + '.py')
+    print("Creating subcommand definition in '" + lib_file + "'")
+    with open(os.path.join(resource_dir, 'command_template.py')) as template:
+        with open(lib_file, 'w') as libfile:
+            contents = template.read()
+            contents = contents.replace("$COMMAND$", command_name)
+            libfile.write(contents)
+
+    print("\n")
+    print("Subcommand created successfully")
+    print("-------------------------------")
+    print("Please see the file ")
+    print("'" + lib_file + "'")
+    print("to add your subcommand's detailed help, argument list")
+    print("and to write the function to execute.")
+    print("")
+    print("Please rebuild CodeChecker to make sure your command is available.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resources/command_template.py
+++ b/scripts/resources/command_template.py
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Handler for the $COMMAND$ subcommand for CodeChecker. This module exposes
+the subcommand-specific argparse.ArgumentParser definitions and the method
+which should be ran as the subcommand's main method.
+"""
+
+import argparse
+
+
+def get_argparser_ctor_args():
+    """
+    This method returns a dict containing the kwargs for constructing an
+    argparse.ArgumentParser (either directly or as a subparser).
+    """
+
+    return {
+        'prog': 'CodeChecker $COMMAND$',
+        'formatter_class': argparse.ArgumentDefaultsHelpFormatter,
+
+        # Description is shown when the command's help is queried directly
+        'description': 'A description about the awesome $COMMAND$ command.',
+
+        # Epilogue is shown after the arguments when the help is queried
+        # directly.
+        'epilog': 'Help about how one should use $COMMAND$, something...',
+
+        # Help is shown when the "parent" CodeChecker command lists the
+        # individual subcommands.
+        'help': 'A shorter help to summarise what $COMMAND$ does.'
+    }
+
+
+def add_arguments_to_parser(parser):
+    """
+    Add the subcommand's arguments to the given argparse.ArgumentParser.
+    """
+
+    parser.add_argument('-a', '--arg', type=str, dest="arg",
+                        default=argparse.SUPPRESS,
+                        required=True,
+                        help='A very good argument to pass for $COMMAND$!')
+
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """
+    Runs the action associated with the current command.
+    """
+    print("Ran subcommand CodeChecker $COMMAND$ with args:")
+    print(args)

--- a/scripts/resources/entrypoint_template.py
+++ b/scripts/resources/entrypoint_template.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Entry point for the $COMMAND$ command.
+"""
+
+import imp
+import os
+
+THIS_PATH = os.path.dirname(os.path.abspath(__file__))
+CC = os.path.join(THIS_PATH, "CodeChecker")
+
+# Load CodeChecker from the current folder (the wrapper script (without .py))
+CodeChecker = imp.load_source('CodeChecker', CC)
+
+# Execute CC's main script with the current subcommand.
+CodeChecker.main("$COMMAND$")


### PR DESCRIPTION
This PR introduces a new command infrastructure to help in further compartmentalising CodeChecker which begun in #584. Closes #593.

# Overview 

## New entrypoints
New CodeChecker entrypoints are introduced, following the "usual scheme" set out by the giants ahead of us. In line with, e.g. how Git works (`git log` and `git-log` are both commands), we will now have each "part"/"subcommand"/"feature" of CodeChecker as a direct entry point, such as `codechecker-log`. This, in the future, will help us create more dynamic helps, such as _man pages_ for a Debian package, or a TAB autocompletion support (#576).

In reality, `codechecker-log` and `CodeChecker log` has the same behaviour, `codechecker-log` is just a directly callable wrapper script that is also put in the `PATH`.

## Putting the argument list and the executed function together

> AKA: The decline of `arg_handler.py`. :wink:

`libcodechecker/arg_handler.py` is a voloptous patchwork, which imports **everything** from all parts of CodeChecker. While the executed code are in this file, their help and argument definitions are in `bin/CodeChecker.py`...

From now on, subcommands of _CodeChecker_ will be located in their own file, `libcodechecker/log.py`, which has an easy interface.

 * `get_argparser_ctor_args` returns a dict which specifies how the subcommand argument parser should be constructed
 * `add_arguments_to_parser(parser)` is the function which puts the arguments into the constructed argument parser.
 * `main(args)` executes the method of the subcommand. (Here `args` is a parsed `argparse.Namespace`.)

## Dynamic package building and loading

The `CodeChecker.py` script will now dynamically load the available subcommands' help and argument list. This dynamic list is created at **package build** via the install script. However, if the user supplies a _valid_ subcommand (either calling `CodeChecker log` or `codechecker-log`, the two are equal), the helpers, **and** executed actions (and thus, every library module that executed function needs) for all the _other_ commands will not be loaded.

While CodeChecker is already really fast on most machines, I hope this will help to increase speed even more, and this will definitely help to further compartmentalise CodeChecker.

----

All the above, as of this PR, only applies to `CodeChecker log`, the remaining commands are untouched, for now.

# Helpers

Just like how the test framework is given a "bootstrap script" to create new test cases, I'm introducing `scripts/create_new_subcommand.py` which, when called with a single `subcommand-name` argument, will create, in the development directory, the neccessary skeleton for a new command, `CodeChecker subcommand-name` (or `codechecker-subcommand-name`).

----

Also, as a minor change, I've updated the `CodeChecker log`'s help message a bit.
