### PR TITLE
Refurbish 2d-array to (table|json|csv) converters

### DIFF
--- a/libcodechecker/arg_handler.py
+++ b/libcodechecker/arg_handler.py
@@ -134,7 +134,7 @@ def handle_server(args):
                              str(instance['port'])))
 
         print("Your running CodeChecker servers:")
-        util.print_table(rows)
+        print(util.twodim_to_table(rows))
         sys.exit(0)
     elif args.stop or args.stop_all:
         for i in instance_manager.list():

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -20,7 +20,7 @@ from Authentication import ttypes as AuthTypes
 
 from libcodechecker import session_manager
 from libcodechecker import logger
-from libcodechecker.util import print_table
+from libcodechecker.output_formatters import twodim_to_str
 
 from . import thrift_helper
 from . import authentication_helper
@@ -258,15 +258,12 @@ def handle_list_runs(args):
         print(CmdLineOutputEncoder().encode(results))
 
     else:  # plaintext, csv
-        rows = [('Name', 'ResultCount', 'RunDate')]
+        header = ['Name', 'ResultCount', 'RunDate']
+        rows = []
         for run in runs:
             rows.append((run.name, str(run.resultCount), run.runDate))
 
-        if args.output_format == 'csv':
-            writer = csv.writer(sys.stdout)
-            writer.writerows(rows)
-        else:
-            print_table(rows)
+        print(twodim_to_str(args.output_format, header, rows))
 
 
 def handle_list_results(args):
@@ -302,13 +299,13 @@ def handle_list_results(args):
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(all_results))
     else:
-        rows = []
-        if args.suppressed:
-            rows.append(
-                ('File', 'Checker', 'Severity', 'Msg', 'Suppress comment'))
-        else:
-            rows.append(('File', 'Checker', 'Severity', 'Msg'))
 
+        if args.suppressed:
+            header = ['File', 'Checker', 'Severity', 'Msg', 'Suppress comment']
+        else:
+            header = ['File', 'Checker', 'Severity', 'Msg']
+
+        rows = []
         for res in all_results:
             bug_line = res.lastBugPosition.startLine
             checked_file = res.checkedFile + ' @ ' + str(bug_line)
@@ -321,11 +318,7 @@ def handle_list_results(args):
                 rows.append(
                     (checked_file, res.checkerId, sev, res.checkerMsg))
 
-        if args.output_format == 'csv':
-            writer = csv.writer(sys.stdout)
-            writer.writerows(rows)
-        else:
-            print_table(rows)
+        print(twodim_to_str(args.output_format, header, rows))
 
 
 def handle_list_result_types(args):
@@ -361,16 +354,12 @@ def handle_list_result_types(args):
             print('Check date: ' + run_date)
             print('Check name: ' + name)
             rows = []
-            rows.append(('Checker', 'Severity', 'Count'))
+            header = ['Checker', 'Severity', 'Count']
             for res in results:
                 sev = shared.ttypes.Severity._VALUES_TO_NAMES[res.severity]
                 rows.append((res.checkerId, sev, str(res.count)))
 
-            if args.output_format == 'csv':
-                writer = csv.writer(sys.stdout)
-                writer.writerows(rows)
-            else:
-                print_table(rows)
+            print(twodim_to_str(args.output_format, header, rows))
 
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(results_collector))
@@ -447,8 +436,8 @@ def handle_diff_results(args):
         if output_format == 'json':
             print(CmdLineOutputEncoder().encode(all_results))
         else:
+            header = ['File', 'Checker', 'Severity', 'Msg']
             rows = []
-            rows.append(('File', 'Checker', 'Severity', 'Msg'))
             for res in all_results:
                 bug_line = res.lastBugPosition.startLine
                 sev = shared.ttypes.Severity._VALUES_TO_NAMES[res.severity]
@@ -456,11 +445,7 @@ def handle_diff_results(args):
                 rows.append(
                     (checked_file, res.checkerId, sev, res.checkerMsg))
 
-            if output_format == 'csv':
-                writer = csv.writer(sys.stdout)
-                writer.writerows(rows)
-            else:
-                print_table(rows)
+            print(twodim_to_str(output_format, header, rows))
 
     client = setupClient(args.host, args.port, '/')
     run_info = check_run_names(client, [args.basename, args.newname])

--- a/libcodechecker/output_formatters.py
+++ b/libcodechecker/output_formatters.py
@@ -1,0 +1,186 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Contains functions to format and pretty-print data from two-dimensional arrays.
+"""
+
+import json
+
+# The supported formats the users should specify. (This is not an exhaustive
+# list of ALL formats available.)
+USER_FORMATS = ['rows', 'table', 'csv', 'json']
+
+
+def twodim_to_str(format, keys, rows):
+    """
+    Converts the given two-dimensional array (with the specified keys)
+    to the given format.
+    """
+
+    all_rows = rows
+    if keys is not None and len(keys) > 0:
+        all_rows = [keys] + rows
+
+    if format == 'rows':
+        return twodim_to_rows(rows)
+    elif format == 'table' or format == 'plaintext':
+        # TODO: 'plaintext' for now to support the 'CodeChecker cmd' interface.
+        return twodim_to_table(all_rows)
+    elif format == 'csv':
+        return twodim_to_csv(all_rows)
+    elif format == 'dictlist':
+        return twodim_to_dictlist(keys, rows)
+    elif format == 'json':
+        return json.dumps(twodim_to_dictlist(keys, rows))
+    else:
+        raise ValueError("Unsupported format")
+
+
+def twodim_to_rows(lines):
+    """
+    Prints the given rows with minimal formatting.
+    """
+
+    str_parts = []
+
+    # Count the column width.
+    widths = []
+    for line in lines:
+        for i, size in enumerate([len(x) for x in line]):
+            while i >= len(widths):
+                widths.append(0)
+            if size > widths[i]:
+                widths[i] = size
+
+    # Generate the format string to pad the columns.
+    print_string = " "
+    for i, width in enumerate(widths):
+        if i == 0 or i == len(widths) - 1:
+            print_string += "{" + str(i) + "} "
+        else:
+            print_string += "{" + str(i) + ":" + str(width) + "} "
+    if len(print_string) == 0:
+        return
+    print_string = print_string[:-1]
+
+    # Print the actual data.
+    for i, line in enumerate(lines):
+        try:
+            str_parts.append(print_string.format(*line))
+        except IndexError:
+            raise TypeError("One of the rows have a different number of "
+                            "columns than the others")
+
+    return '\n'.join(str_parts)
+
+
+def twodim_to_table(lines, separate_head=True):
+    """
+    Pretty-prints the given two-dimensional array's lines.
+    """
+
+    str_parts = []
+
+    # Count the column width.
+    widths = []
+    for line in lines:
+        for i, size in enumerate([len(x) for x in line]):
+            while i >= len(widths):
+                widths.append(0)
+            if size > widths[i]:
+                widths[i] = size
+
+    # Generate the format string to pad the columns.
+    print_string = ""
+    for i, width in enumerate(widths):
+        print_string += "{" + str(i) + ":" + str(width) + "} | "
+    if len(print_string) == 0:
+        return
+    print_string = print_string[:-3]
+
+    # Print the actual data.
+    print("-" * (sum(widths) + 3 * (len(widths) - 1)))
+    for i, line in enumerate(lines):
+        try:
+            str_parts.append(print_string.format(*line))
+        except IndexError:
+            raise TypeError("One of the rows have a different number of "
+                            "columns than the others")
+        if i == 0 and separate_head:
+            str_parts.append("-" * (sum(widths) + 3 * (len(widths) - 1)))
+    str_parts.append("-" * (sum(widths) + 3 * (len(widths) - 1)))
+
+    return '\n'.join(str_parts)
+
+
+def twodim_to_csv(lines):
+    """
+    Pretty-print the given two-dimensional array's lines in CSV format.
+    """
+
+    str_parts = []
+
+    # Count the columns.
+    columns = 0
+    for line in lines:
+        if len(line) > columns:
+            columns = len(line)
+
+    print_string = ""
+    for i in range(columns):
+        print_string += "{" + str(i) + "},"
+
+    if len(print_string) == 0:
+        return
+    print_string = print_string[:-1]
+
+    # Print the actual data.
+    for line in lines:
+        try:
+            str_parts.append(print_string.format(*line))
+        except IndexError:
+            raise TypeError("One of the rows have a different number of "
+                            "columns than the others")
+
+    return '\n'.join(str_parts)
+
+
+def twodim_to_dictlist(key_list, lines):
+    """
+    Pretty-print the given two-dimensional array's lines into a JSON
+    object list. The key_list acts as the "header" of the table, specifying the
+    keys to use in the resulting object.
+
+    This function expects values to be the same number as the length of
+    key_list, and that the order of values in a line corresponds to the order
+    of keys.
+    """
+
+    res = []
+    for line in lines:
+        res.append({key: value for (key, value) in zip(key_list, line)})
+
+    return res
+
+
+def dictlist_to_twodim(key_list, dictlist, key_convert=None):
+    """
+    Converts the given list of dict objects to a two-dimensional array.
+
+    If key_convert is specified, the resulting array will have the converted
+    strings in its "header" row. key_list and key_convert must correspond with
+    each other in order.
+    """
+
+    if not key_convert:
+        lines = [key_list]
+    else:
+        lines = [key_convert]
+
+    for d in dictlist:
+        lines.append([d[key] for key in key_list])
+
+    return lines

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -200,33 +200,3 @@ def get_default_workspace():
     """
     workspace = os.path.join(os.path.expanduser("~"), '.codechecker')
     return workspace
-
-
-def print_table(lines, separate_head=True):
-    """Prints a formatted table given a 2 dimensional array."""
-
-    # Count the column width.
-    widths = []
-    for line in lines:
-        for i, size in enumerate([len(x) for x in line]):
-            while i >= len(widths):
-                widths.append(0)
-            if size > widths[i]:
-                widths[i] = size
-
-    # Generate the format string to pad the columns.
-    print_string = ""
-    for i, width in enumerate(widths):
-        print_string += "{" + str(i) + ":" + str(width) + "} | "
-    if len(print_string) == 0:
-        return
-    print_string = print_string[:-3]
-
-    # Print the actual data.
-    print("-" * (sum(widths) + 3 * (len(widths) - 1)))
-    for i, line in enumerate(lines):
-        print(print_string.format(*line))
-        if i == 0 and separate_head:
-            print("-" * (sum(widths) + 3 * (len(widths) - 1)))
-    print("-" * (sum(widths) + 3 * (len(widths) - 1)))
-    print('')


### PR DESCRIPTION
Introduce a more reusable module for formatting 2d-array data matrices to various formats, such as:

 * `rows`: minimal formatting, just rows printed after each other (currently analogue to how `CodeChecker checkers`) output
 * `table`: `libcodechecker.util.print_table`
 * `dictlist`: _zip_ (the list-to-tuple, not the archiver) the "header" row and each "data" rows into a list of dict objects
 * `json`: the `dictlist` in JSON format

`dictlist_to_twodim` is the inverse of `dictlist`.

----

Some of these functions might appear unused as of now, they are getting used in features that I'm introducing later. The reason for this PR is to tighten the scope of features added.