### PR TITLE
escape unicode chars from failure messages

### DIFF
--- a/libcodechecker/storage/report_server.py
+++ b/libcodechecker/storage/report_server.py
@@ -277,6 +277,8 @@ class CheckerReportHandler(object):
             # TODO: if file is not needed update reportsToBuildActions.
             return False
 
+        failure = failure.decode('unicode_escape').encode('ascii', 'ignore')
+
         action.mark_finished(failure)
         self.session.commit()
         return True


### PR DESCRIPTION
Storing Unicode chars for failure messages fails with the current schema.

This is a temporary solution until the new schema is done.
Resolves #618