### PR TITLE
"Report a bug here" link in the GUI

### DIFF
--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -93,6 +93,13 @@ function (declare, topic, domConstruct, Dialog, DropDownMenu, MenuItem,
     }));
 
     menuItems.addChild(new MenuItem({
+      label : 'Report a bug here',
+      onClick : function () {
+        window.open('https://github.com/Ericsson/codechecker/issues/new', '_blank');
+      }
+    }));
+
+    menuItems.addChild(new MenuItem({
       label : 'Credits',
       onClick : function () { credits.show(); }
     }));


### PR DESCRIPTION
The menu in the GUI now contains a link which directly navigates to the
GitHub new issue page.
Fixes #585