### PR TITLE
Separate clean target for package and vendor.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,17 @@ venv_dev:
 clean_venv_dev:
 	rm -rf venv_dev
 
-clean:
+clean: clean_package clean_vendor
+
+clean_package:
 	rm -rf $(BUILD_DIR)
 	rm -rf gen-docs
 
+clean_vendor:
+	rm -rf vendor/codemirror
+	rm -rf vendor/dojotoolkit
+	rm -rf vendor/fonts
+	rm -rf vendor/highlightjs
+	rm -rf vendor/jsplumb
+	rm -rf vendor/marked
+	rm -rf vendor/thrift


### PR DESCRIPTION
The simple clean did not deleted the vendor projects.

There are separate clean targets because during development it is usually enough to clean just the package so you do not have to wait for download of the vendor projects.

Resolves #625