### PR TITLE
Fix escaping multiword string literals, once again

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -453,13 +453,21 @@ def parse_options(args):
     not only arguments."""
 
     # Keep " characters.
-    args = args.replace('"', '\\"')
+    args = args.replace(r'"', r'"\"')
 
     result_map = OptionParserResult()
 
     # The first element in the list is the compiler skip it from parsing.
     for it in OptionIterator(shlex.split(args)[1:]):
         arg_check(it, result_map)
+
+    for idx, opt in enumerate(result_map.compile_opts):
+        if '"' in opt:
+            # Arguments with a space in them are given back in a way
+            # (-DVAR="val ue") that they need an extra escape round. We can't
+            # do this earlier because shlex would undo these changes and
+            # mess up the result.
+            result_map.compile_opts[idx] = opt.replace('"', r'"\"')
 
     result_map.compiler = shlex.split(args)[0]
     is_source = False

--- a/tests/unit/logparser_test_files/intercept-new.json
+++ b/tests/unit/logparser_test_files/intercept-new.json
@@ -1,0 +1,14 @@
+[
+    {
+        "arguments": [
+            "c++",
+            "-c",
+            "-DVARIABLE=\"some value\"",
+            "-o",
+            "a.out",
+            "a.cpp"
+        ],
+        "directory": "/tmp",
+        "file": "a.cpp"
+    }
+]

--- a/tests/unit/logparser_test_files/intercept-old.json
+++ b/tests/unit/logparser_test_files/intercept-old.json
@@ -1,0 +1,7 @@
+[
+    {
+        "command": "c++ -c -DVARIABLE=\\\"some value\\\" -o a.out a.cpp",
+        "directory": "/tmp",
+        "file": "/tmp/a.cpp"
+    }
+]

--- a/tests/unit/logparser_test_files/ldlogger-new.json
+++ b/tests/unit/logparser_test_files/ldlogger-new.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ -DVARIABLE=\"some value\" /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	}
+]

--- a/tests/unit/logparser_test_files/ldlogger-old.json
+++ b/tests/unit/logparser_test_files/ldlogger-old.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ \"-DVARIABLE=\"some value\"\" /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	}
+]

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -1,0 +1,112 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Test the log parser which builds build actions from JSON CCDBs. """
+
+import os
+import unittest
+
+from libcodechecker.analyze import log_parser
+from libcodechecker.log import option_parser
+
+
+class LogParserTest(unittest.TestCase):
+    """
+    Test the log parser which convers logfiles (JSON CCDBs) to build action
+    lists.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """Initialize test resources."""
+
+        # Already generated JSONs for the tests.
+        cls.__this_dir = os.path.dirname(__file__)
+        cls.__test_files = os.path.join(cls.__this_dir,
+                                        'logparser_test_files')
+
+    def test_old_ldlogger(self):
+        """
+        Test log file parsing escape behaviour with pre-2017 Q2 LD-LOGGER.
+        """
+        logfile = os.path.join(self.__test_files, "ldlogger-old.json")
+
+        # LD-LOGGER before http://github.com/Ericsson/codechecker/pull/631
+        # used an escape mechanism that, when parsed by the log parser via
+        # shlex, made CodeChecker parse arguments with multiword string
+        # literals in them be considered as "file" (instead of compile option),
+        # eventually ignored by the command builder, thus lessening analysis
+        # accuracy, as defines were lost.
+        #
+        # Logfile contains "-DVARIABLE="some value"".
+        #
+        # There is no good way to back-and-forth convert in log_parser or
+        # option_parser, so here we aim for a non-failing stalemate of the
+        # define being considered a file and ignored, for now.
+
+        build_action = log_parser.parse_log(logfile)[0]
+        results = option_parser.parse_options(build_action.original_command)
+
+        self.assertEqual(' '.join(results.files),
+                         r'"-DVARIABLE="some value"" /tmp/a.cpp')
+        self.assertEqual(len(build_action.analyzer_options), 0)
+
+    def test_new_ldlogger(self):
+        """
+        Test log file parsing escape behaviour with after-#631 LD-LOGGER.
+        """
+        logfile = os.path.join(self.__test_files, "ldlogger-new.json")
+
+        # LD-LOGGERS after http://github.com/Ericsson/codechecker/pull/631
+        # now properly log the multiword arguments. When these are parsed by
+        # the log_parser, the define's value will be passed to the analyzer.
+        #
+        # Logfile contains -DVARIABLE="some value".
+
+        build_action = log_parser.parse_log(logfile)[0]
+
+        self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertEqual(build_action.analyzer_options[0],
+                         r'-DVARIABLE="\"some value"\"')
+
+    def test_old_intercept_build(self):
+        """
+        Test log file parsing escape behaviour with clang-5.0 intercept-build.
+        """
+        logfile = os.path.join(self.__test_files, "intercept-old.json")
+
+        # Scan-build-py shipping with clang-5.0 makes a logfile that contains:
+        # -DVARIABLE=\"some value\"
+        #
+        # The define is passed to the analyzer properly.
+
+        build_action = log_parser.parse_log(logfile)[0]
+
+        self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertEqual(build_action.analyzer_options[0],
+                         r'-DVARIABLE="\"some value"\"')
+
+    def test_new_intercept_build(self):
+        """
+        Test log file parsing escapes with upstream (GitHub) intercept-build.
+        """
+        logfile = os.path.join(self.__test_files, "intercept-new.json")
+
+        # Upstream scan-build-py creates an argument vector, as opposed to a
+        # command string. This argument vector contains the define as it's
+        # element in the following format:
+        # -DVARIABLE=\"some value\"
+        #
+        # The define is passed to the analyzer properly.
+
+        build_action = log_parser.parse_log(logfile)[0]
+
+        self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertEqual(build_action.analyzer_options[0],
+                         r'-DVARIABLE="\"some value"\"')

--- a/vendor/build-logger/src/ldlogger-logger.c
+++ b/vendor/build-logger/src/ldlogger-logger.c
@@ -37,10 +37,9 @@ static char* createJsonCommandString(const LoggerVector* args_)
   /* The final size is:
        The overall size of command * 2 for escaping +
        args_->size character for word separator +
-       args_->size * 2 character for word escaping ('"'' chars) separator +
        1 byte character trailing null
   */
-  cmdSize = (cmdSize * 2) + (args_->size * 3) + 1;
+  cmdSize = cmdSize * 2 + args_->size + 1;
   cmd = (char*) malloc(sizeof(char) * cmdSize);
   if (!cmd)
   {

--- a/vendor/build-logger/src/ldlogger-util.c
+++ b/vendor/build-logger/src/ldlogger-util.c
@@ -14,7 +14,6 @@
 #include <unistd.h>
 #include <assert.h>
 #include <ctype.h>
-#include <string.h>
 
 static char* makePathAbsRec(const char* path_, char* resolved_)
 {
@@ -62,12 +61,6 @@ char* shellEscapeStr(const char* str_, char* buff_)
   char* out = buff_;
   int hasSpace = strchr(str_, ' ') != NULL;
 
-  if (hasSpace)
-  {
-    *out++ = '\\';
-    *out++ = '\"';
-  }
-
   while (*str_)
   {
     switch (*str_)
@@ -83,12 +76,6 @@ char* shellEscapeStr(const char* str_, char* buff_)
         *out++ = *str_++;
         break;
     }
-  }
-
-  if (hasSpace)
-  {
-    *out++ = '\\';
-    *out++ = '\"';
   }
 
   *out = '\0';


### PR DESCRIPTION
Consider the following file:

```c++
int main()
{
  if ( VARIABLE == "a b" )
  {
    int *p = 0;
    *p = 42;
  }
}
```

built with `g++ -DVARIABLE='"a b"' main.cpp`.

# Old behaviour

## LD-LOGGER
If we use _LD_LOGGER_, the resulting output will show no errors, as the string in the `build.json` is `"-DVARIABLE="a b""` (one escape level higher, so after stripping the escapes put in by the JSON serializer!) and the options parser will understand this entry as a _file_ (instead of a _compiler option_) in [`log_parser.py#130`](https://github.com/Ericsson/codechecker/blob/d3e53ff1254509770a7cc535a4a58b53bd9be31c/libcodechecker/analyze/log_parser.py#L130). This way, the define never reaches into the analyzer invocation &mdash; thus the macro expansion is never made.

## Newest intercept-build
The same issue arises with _intercept-build_ **newest version**, as in #610, a makeshift fix was introduced to make the parsed `argument` vector appear as a `command` string in the same way. Removing this makeshift fix would result in the `option_parser` making `-DVARIABLE="a` a command-line argument and `b" main.cpp` the file, making the analysers uncallable.

## intercept-build in clang-5.0
The old _intercept-build_, currently shipping with **upstream** clang also created a `command` format, seen below, which botched analyzer calls, as the part of the define after a space was considered a file input:

```
"command": "c++ -c -DVARIABLE=\\\"a b\\\" -o main.out main.cpp",
```

```
compiler options: -DVARIABLE=\a b\
linker options: 
files: variable.cpp
```

resulting in invocation `clang [...] -x c++  -DVARIABLE=\a b\ /home/user/main.cpp` to which clang said `no such file or directory: 'b /home/user/main.cpp'`, and clang-tidy said `No escaped character`.

This behaviour was applicable even on `master` before #610 had been introduced.

# New behaviour

This pull-request fixes the escape issues once more, agnostic to the logger tool used. The command-line defines (or defines in the `argument` vector) are now properly passed to the analyzers and `clang-tidy` happily reports

```
main.cpp:4:17: both side of operator are equivalent [misc-redundant-expression]
  if ( VARIABLE == "a b" )
                ^

clang-tidy found 1 defect(s) while analyzing main.cpp

[15:44] - [2/2] clang-tidy analyzed main.cpp successfully.
```

showing that the macro is defined properly now.

This change now properly handles arguments with quotes in them, as seen above.

 * If the log has been created by the old _LD-LOGGER_, no functional change, the define does not reach the call.
 * _LD-LOGGER_ introduced in the current patch (which esentially reverts relevant parts of #109) will now properly passes the defines into the logfile and to the analyzers.
 * Using upstream [_intercept-build_](http://github.com/rizsotto/scan-build-py), the defines are also properly passed.
 * Using _intercept-build_ currently shipping with clang also works properly now.

This MR should close #505.