### PR TITLE
Fix various --add-compiler-defaults errors

### DIFF
--- a/libcodechecker/analyze/log_parser.py
+++ b/libcodechecker/analyze/log_parser.py
@@ -52,7 +52,20 @@ def get_compiler_includes(compiler):
     return include_paths
 
 
-# -----------------------------------------------------------------------------
+# Certain includes are defined by GCC to a GCC internal "macro" never exported
+# by the compiler, such as
+# #define __has_include(STR) __has_include__(STR)
+# which causes Clang to fail in certain cross-compiler and cross-architecture
+# setups due to blabla__ not being defined by Clang in a way GCC does it.
+#
+# Thus, we ignore these "defines" and let Clang fall back to its own
+# __has_include definition. List taken from the "extension" list of Clang and
+# the GCC extension list referenced therein:
+# https://clang.llvm.org/docs/LanguageExtensions.html
+IGNORED_DEFINES = ['__has_include',
+                   '__has_include_next']
+
+
 def get_compiler_defines(compiler):
     """
     Returns a list of default defines of the given compiler.
@@ -72,6 +85,9 @@ def get_compiler_defines(compiler):
 
                 variable = define[0]
                 value = ' '.join(define[1:])
+
+                if variable in IGNORED_DEFINES:
+                    continue
 
                 if value:
                     if '"' in value:


### PR DESCRIPTION
* From `#define __VERSION__ "5.4.0 20160609"`, `20160609` would be understood as a file or folder name, resulting in clang erroring away.

* Newer versions of GCC/G++ define `__has_include_next` to `__has_include_next__` which is not understood by Clang, as it supplies its **own** `__has_include_next` internally and does **not** define the postfix `__` version.
Thus, such macro definition retrieved from GCC &mdash; which would inevitably lead to a `undefined macro` error &mdash; should not be passed to clang.