### PR TITLE
Arrow drawing bugfix

### DIFF
--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -440,21 +440,24 @@ function (declare, dom, style, on, query, Memory, Observable, topic, entities,
         var column = item.report.lastBugPosition.startCol;
       }
 
-      if (fileId !== this.editor.get('sourceFileData').fileId) {
+      var isOtherFile = fileId !== this.editor.get('sourceFileData').fileId;
+      var isOtherReport = item.parent != this.editor.get('reportData').reportId;
+
+      if (isOtherFile)
         this.editor.set(
           'sourceFileData',
           CC_SERVICE.getSourceFileData(fileId, true));
 
+      if (isOtherReport) {
+        this.editor.set('reportData', item.report);
+        hashHelper.setReport(item.report.reportId);
+      }
+
+      if (isOtherFile || isOtherReport)
         // TODO: Now arrows are redrawn only if new file is opened. But what if
         // in the same file the path goes out of the CodeMirror-rendered area?
         if (this.buttonPane.showArrowCheckbox.get('checked'))
           this.editor.drawBugPath();
-      }
-
-      if (this.editor.reportData.reportId != item.parent) {
-        this.editor.set('reportData', item.report);
-        hashHelper.setReport(item.report.reportId);
-      }
 
       this.editor.jumpTo(line, column);
 


### PR DESCRIPTION
When in the same file another report is clicked then the arrows and bubbles weren't redrawn.
Resolves #641