### PR TITLE
configurable test projects directory

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,7 @@ DBUNAME ?= TEST_DBUSERNAME=postgres
 
 # Test project configuration, tests are run on these files.
 CLANG_VERSION ?= TEST_CLANG_VERSION=stable
-TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects/cpp
+TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 

--- a/tests/libtest/env.py
+++ b/tests/libtest/env.py
@@ -91,6 +91,10 @@ def repository_root():
     return os.path.abspath(os.environ['REPO_ROOT'])
 
 
+def test_proj_root():
+    return os.path.abspath(os.environ['TEST_PROJ'])
+
+
 def setup_test_proj_cfg(workspace):
     return import_test_cfg(workspace)['test_project']
 

--- a/tests/libtest/project.py
+++ b/tests/libtest/project.py
@@ -19,10 +19,7 @@ def get_info(test_project):
 
 
 def path(test_project):
-    return os.path.join(env.repository_root(),
-                        'tests',
-                        'projects',
-                        test_project)
+    return os.path.join(env.test_proj_root(), test_project)
 
 
 def get_build_cmd(test_project):


### PR DESCRIPTION
Test projects directory can be configured in the Makefile.local
for different test environments.