### PR TITLE
Wait for PostgreSQL shutdown after each check

### DIFF
--- a/tests/functional/delete_runs/__init__.py
+++ b/tests/functional/delete_runs/__init__.py
@@ -98,11 +98,12 @@ def setup_package():
                                 test_proj_path)
         if ret:
             sys.exit(1)
-        print("Analyzing the test project was successful {}.".format(str(i)))
 
-    if pg_db_config:
-        print("Waiting for PostgreSQL to stop.")
-        codechecker.wait_for_postgres_shutdown(TEST_WORKSPACE)
+        if pg_db_config:
+            print("Waiting for PostgreSQL to stop.")
+            codechecker.wait_for_postgres_shutdown(TEST_WORKSPACE)
+
+        print("Analyzing the test project was successful {}.".format(str(i)))
 
     # Save the run names in the configuration.
     codechecker_cfg['run_names'] \


### PR DESCRIPTION
The next check in delete test might fail if the previous failed to fully stop the
locally started PostgreSQL instance.