### PR TITLE
Tidy output converter

### DIFF
--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
@@ -80,20 +80,24 @@ class PlistToDB(ResultHandler):
             report_path = [i for i in report.bug_path if
                            i.get('kind') == 'control']
             for path in report_path:
-                start_range = path['edges'][0]['start']
-                start_line = start_range[1]['line']
-                start_col = start_range[1]['col']
+                try:
+                    start_range = path['edges'][0]['start']
+                    start_line = start_range[1]['line']
+                    start_col = start_range[1]['col']
 
-                end_range = path['edges'][0]['end']
-                end_line = end_range[1]['line']
-                end_col = end_range[1]['col']
-                source_file_path = files[end_range[1]['file']]
-                bug_paths.append(
-                    shared.ttypes.BugPathPos(start_line,
-                                             start_col,
-                                             end_line,
-                                             end_col,
-                                             file_ids[source_file_path]))
+                    end_range = path['edges'][0]['end']
+                    end_line = end_range[1]['line']
+                    end_col = end_range[1]['col']
+                    source_file_path = files[end_range[1]['file']]
+                    bug_paths.append(
+                        shared.ttypes.BugPathPos(start_line,
+                                                 start_col,
+                                                 end_line,
+                                                 end_col,
+                                                 file_ids[source_file_path]))
+                except IndexError as iex:
+                    # Edges might be empty nothing can be stored.
+                    continue
 
             bug_events = []
             for event in events:

--- a/libcodechecker/analyze/tidy_output_converter.py
+++ b/libcodechecker/analyze/tidy_output_converter.py
@@ -9,6 +9,7 @@ for the plist_parser module.
 """
 
 import copy
+import json
 import os
 import plistlib
 import re
@@ -380,3 +381,6 @@ class PListConverter(object):
         """
 
         plistlib.writePlist(self.plist, file)
+
+    def __str__(self):
+        return str(json.dumps(self.plist, indent=4, separators=(',', ': ')))

--- a/libcodechecker/analyze/tidy_output_converter.py
+++ b/libcodechecker/analyze/tidy_output_converter.py
@@ -354,10 +354,12 @@ class PListConverter(object):
                 note, fmap))
             last = note
 
-        diag['path'].append({
-            'kind': 'control',
-            'edges': edges
-        })
+        # Add control items only if there is any.
+        if edges:
+            diag['path'].append({
+                'kind': 'control',
+                'edges': edges
+            })
 
     def add_messages(self, messages):
         """

--- a/tests/unit/tidy_output_test_files/tidy1.plist
+++ b/tests/unit/tidy_output_test_files/tidy1.plist
@@ -40,13 +40,6 @@
 					<string>Division by zero</string>
 				</dict>
 				<dict>
-					<key>edges</key>
-					<array>
-					</array>
-					<key>kind</key>
-					<string>control</string>
-				</dict>
-				<dict>
 					<key>depth</key>
 					<integer>0</integer>
 					<key>kind</key>
@@ -85,13 +78,6 @@
 			</dict>
 			<key>path</key>
 			<array>
-				<dict>
-					<key>edges</key>
-					<array>
-					</array>
-					<key>kind</key>
-					<string>control</string>
-				</dict>
 				<dict>
 					<key>depth</key>
 					<integer>0</integer>

--- a/tests/unit/tidy_output_test_files/tidy2.plist
+++ b/tests/unit/tidy_output_test_files/tidy2.plist
@@ -23,13 +23,6 @@
 			<key>path</key>
 			<array>
 				<dict>
-					<key>edges</key>
-					<array>
-					</array>
-					<key>kind</key>
-					<string>control</string>
-				</dict>
-				<dict>
 					<key>depth</key>
 					<integer>0</integer>
 					<key>kind</key>
@@ -245,13 +238,6 @@
 			</dict>
 			<key>path</key>
 			<array>
-				<dict>
-					<key>edges</key>
-					<array>
-					</array>
-					<key>kind</key>
-					<string>control</string>
-				</dict>
 				<dict>
 					<key>depth</key>
 					<integer>0</integer>

--- a/tests/unit/tidy_output_test_files/tidy3.plist
+++ b/tests/unit/tidy_output_test_files/tidy3.plist
@@ -40,13 +40,6 @@
 					<string>nullptr (fixit)</string>
 				</dict>
 				<dict>
-					<key>edges</key>
-					<array>
-					</array>
-					<key>kind</key>
-					<string>control</string>
-				</dict>
-				<dict>
 					<key>depth</key>
 					<integer>0</integer>
 					<key>kind</key>


### PR DESCRIPTION
The tidy output parser created control nodes with even if the edges were
empty. Without range information a control section can not be used.

The result storage handler assumed that if a control node exists there
will be edges in it. If there is no edge no information can be stored
about the source positions.

Tidy output parser is modified to do not create a control sections if no
edge is available and storage handler will skip control nodes without
any edges in it.