### PR TITLE
Speed up CI

### DIFF
--- a/.ci/python_requirements_psql_pg8000
+++ b/.ci/python_requirements_psql_pg8000
@@ -1,0 +1,6 @@
+sqlalchemy==1.0.9
+alembic==0.8.2
+pg8000==1.10.2
+thrift==0.9.1
+psutil==5.0.1
+portalocker==1.0.0

--- a/.ci/python_requirements_psql_psycopg2
+++ b/.ci/python_requirements_psql_psycopg2
@@ -1,0 +1,6 @@
+sqlalchemy==1.0.9
+alembic==0.8.2
+psycopg2==2.5.4
+thrift==0.9.1
+psutil==5.0.1
+portalocker==1.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,32 @@ matrix:
       sudo: required
       dist: trusty
       python: "2.7"
+      env: DATABASE=sqlite
+    - os: linux
+      sudo: required
+      dist: trusty
+      python: "2.7"
+      env: DATABASE=psql_psycopg2
+    - os: linux
+      sudo: required
+      dist: trusty
+      python: "2.7"
+      env: DATABASE=psql_pg8000
     - os: osx
       osx_image: xcode8
       sudo: false
       language: generic
+      env: DATABASE=sqlite
+    - os: osx
+      osx_image: xcode8
+      sudo: false
+      language: generic
+      env: DATABASE=psql_psycopg2
+    - os: osx
+      osx_image: xcode8
+      sudo: false
+      language: generic
+      env: DATABASE=psql_pg8000
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm; fi
@@ -30,7 +52,6 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build; fi
 
 install:
-    - pip install -r ./.ci/python_requirements
     - pip install nose pep8
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PG_DATA=$(brew --prefix)/var/postgres; fi
@@ -60,5 +81,5 @@ addons:
 
 script:
     - make clean_travis
-    - make test
+    - if [[ ! -z "$DATABASE" ]]; then make test_matrix_${DATABASE}; else make test; fi
     - make clean_travis

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ ROOT = $(CURRENT_DIR)
 ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 
+VENV_REQ_FILE ?= .ci/basic_python_requirements
+VENV_DEV_REQ_FILE ?= .ci/python_requirements
+
 default: package
 
 # Test running related targets.
@@ -43,7 +46,7 @@ build_dir:
 venv:
 	# Create a virtual environment which can be used to run the build package.
 	virtualenv -p python2 venv && \
-		$(ACTIVATE_RUNTIME_VENV) && pip install -r .ci/basic_python_requirements
+		$(ACTIVATE_RUNTIME_VENV) && pip install -r $(VENV_REQ_FILE)
 
 clean_venv:
 	rm -rf venv
@@ -51,7 +54,7 @@ clean_venv:
 venv_dev:
 	# Create a virtual environment for development.
 	virtualenv -p python2 venv_dev && \
-		$(ACTIVATE_DEV_VENV) && pip install -r .ci/python_requirements && \
+		$(ACTIVATE_DEV_VENV) && pip install -r $(VENV_DEV_REQ_FILE) && \
 		pip install -r tests/requirements.txt
 
 clean_venv_dev:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -40,6 +40,7 @@ test_unit_novenv:
 	$(UNIT_TEST_CMD)
 
 test_functional: test_sqlite test_psql
+
 test_functional_novenv: test_sqlite_novenv test_psql_novenv
 
 test_sqlite: package venv_dev
@@ -49,7 +50,8 @@ test_sqlite_novenv: package
 		$(FUNCTIONAL_TEST_CMD)
 
 test_psql: test_psql_psycopg2 test_psql_pg8000
-test_psql: test_psql_psycopg2_novenv test_psql_pg8000_novenv
+
+test_psql_novenv: test_psql_psycopg2_novenv test_psql_pg8000_novenv
 
 test_psql_psycopg2: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
@@ -63,16 +65,24 @@ test_psql_psycopg2_novenv: package
 test_psql_pg8000: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
 		$(PSQL) $(DBUNAME) $(DBPORT) $(PG800) \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
 		$(FUNCTIONAL_TEST_CMD)
 
 test_psql_pg8000_novenv: package
 		$(PSQL) $(DBUNAME) $(DBPORT) $(PG800) \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
 		$(FUNCTIONAL_TEST_CMD)
 
 test_clean:
 	rm -rf build/workspace
+
+# Use the proper requirement file for the given test configuration
+test_matrix_sqlite: VENV_DEV_REQ_FILE = .ci/basic_python_requirements
+test_matrix_sqlite: pep8 test_unit test_sqlite
+
+test_matrix_psql_psycopg2: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_psycopg2
+test_matrix_psql_psycopg2: pep8 test_unit test_psql_psycopg2
+
+test_matrix_psql_pg8000: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_pg8000
+test_matrix_psql_pg8000: pep8 test_unit test_psql_pg8000
 
 clean_travis:
 	# Clean CodeChecker config files stored in the users home directory.


### PR DESCRIPTION
Instead of having two instances on Travis to test Linux and OSX, we can make a bigger build matrix for all three database configurations, totalling 6 different instances.

Why is this good?
 * Better separation of errors that _might_ result only in a particular backend. Currently, if `sqlite` tests fail, `psql` tests are never touched.
 * Better resillience against OSX-test particularities: instead of one download failure from LLVM/Clang, we can now fail three separate times.

Unfortunately, there wasn't an easy way of generating the new build matrix, due to the peculiarities of cross-OS building &mdash; hence the apparently heavy duplication in `.travis.yml`.

----

I have also cleaned up the install script because it used to install, or at least _check if is installed_ dependencies multiple times.