### PR TITLE
Move version command to new structure

### DIFF
--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -267,16 +267,6 @@ CodeChecker quickcheck -b "cd ~/myproject && make"
         logger.add_verbose_arguments(debug_parser)
         debug_parser.set_defaults(func=arg_handler.handle_debug)
 
-        # --------------------------------------
-        # Package version info.
-        version_parser = subparsers.add_parser('version',
-                                               help='Print package version '
-                                                    'information.')
-        old_subcommands.append('version')
-
-        version_parser.set_defaults(func=arg_handler.handle_version_info)
-        logger.add_verbose_arguments(version_parser)
-
         if subcommands:
             # Load the 'libcodechecker' module and acquire its path.
             file, path, descr = imp.find_module("libcodechecker")

--- a/bin/codechecker-version
+++ b/bin/codechecker-version
@@ -1,0 +1,3 @@
+# DO_NOT_INSTALL_TO_PATH
+This file marks 'CodeChecker version' to be a valid command, but prohibits
+use as 'codechecker-version'.

--- a/libcodechecker/arg_handler.py
+++ b/libcodechecker/arg_handler.py
@@ -235,25 +235,3 @@ def handle_debug(args):
 
     debug_reporter.debug(context, sql_server.get_connection_string(),
                          args.force)
-
-
-def handle_version_info(args):
-    """
-    Get and print the version information from the
-    version config file and thrift API versions.
-    """
-
-    context = generic_package_context.get_context()
-
-    print('Base package version: \t' + context.version).expandtabs(30)
-    print('Package build date: \t' +
-          context.package_build_date).expandtabs(30)
-    print('Git hash: \t' + context.package_git_hash).expandtabs(30)
-    print('Git tag info: \t' + context.package_git_tag).expandtabs(30)
-    print('DB schema version: \t' +
-          str(context.db_version_info)).expandtabs(30)
-
-    # Thift api version for the clients.
-    from codeCheckerDBAccess import constants
-    print(('Thrift client api version: \t' + constants.API_VERSION).
-          expandtabs(30))

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -1,0 +1,82 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Defines a subcommand for CodeChecker which prints version information.
+"""
+
+import argparse
+import json
+
+from codeCheckerDBAccess import constants
+
+from libcodechecker import generic_package_context
+from libcodechecker import output_formatters
+from libcodechecker.logger import add_verbose_arguments
+
+
+def get_argparser_ctor_args():
+    """
+    This method returns a dict containing the kwargs for constructing an
+    argparse.ArgumentParser (either directly or as a subparser).
+    """
+
+    return {
+        'prog': 'CodeChecker version',
+        'formatter_class': argparse.ArgumentDefaultsHelpFormatter,
+
+        # Description is shown when the command's help is queried directly
+        'description': "Print the version of CodeChecker package that is "
+                       "being used.",
+
+        # Help is shown when the "parent" CodeChecker command lists the
+        # individual subcommands.
+        'help': "Print the version of CodeChecker package that is being used."
+    }
+
+
+def add_arguments_to_parser(parser):
+    """
+    Add the subcommand's arguments to the given argparse.ArgumentParser.
+    """
+
+    parser.add_argument('-o', '--output',
+                        dest='output_format',
+                        required=False,
+                        default='table',
+                        choices=output_formatters.USER_FORMATS,
+                        help="The format to use when printing the version.")
+
+    add_verbose_arguments(parser)
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """
+    Get and print the version information from the version config
+    file and Thrift API definition.
+    """
+
+    context = generic_package_context.get_context()
+
+    rows = [
+        ("Base package version", context.version),
+        ("Package build date", context.package_build_date),
+        ("Git commit ID (hash)", context.package_git_hash),
+        ("Git tag information", context.package_git_tag),
+        ("Database schema version", str(context.db_version_info)),
+        ("Client API version (Thrift)", constants.API_VERSION)
+    ]
+
+    if args.output_format != "json":
+        print(output_formatters.twodim_to_str(args.output_format,
+                                              ["Kind", "Version"],
+                                              rows))
+    elif args.output_format == "json":
+        # Use a special JSON format here, instead of
+        # [ {"kind": "something", "version": "0.0.0"}, {"kind": "foo", ... } ]
+        # do
+        # { "something": "0.0.0", "foo": ... }
+        print(json.dumps(dict(rows)))


### PR DESCRIPTION
An extra argument was introduced, so the user can request the version in the "usual" table-output formats.