### PR TITLE
Update some dependencies.

### DIFF
--- a/.ci/basic_python_requirements
+++ b/.ci/basic_python_requirements
@@ -1,5 +1,5 @@
-sqlalchemy==1.0.9
-alembic==0.8.2
+sqlalchemy==1.0.17
+alembic==0.9.2
 thrift==0.9.1
-portalocker==1.0.0
-psutil==5.0.1
+portalocker==1.1.0
+psutil==5.2.2

--- a/.ci/python_requirements
+++ b/.ci/python_requirements
@@ -1,7 +1,7 @@
-sqlalchemy==1.0.9
-alembic==0.8.2
-psycopg2==2.5.4
+sqlalchemy==1.0.17
+alembic==0.9.2
+psycopg2==2.7.1
 pg8000==1.10.2
 thrift==0.9.1
-psutil==5.0.1
-portalocker==1.0.0
+psutil==5.2.2
+portalocker==1.1.0

--- a/.ci/python_requirements_psql_pg8000
+++ b/.ci/python_requirements_psql_pg8000
@@ -1,6 +1,6 @@
-sqlalchemy==1.0.9
-alembic==0.8.2
+sqlalchemy==1.0.17
+alembic==0.9.2
 pg8000==1.10.2
 thrift==0.9.1
-psutil==5.0.1
-portalocker==1.0.0
+psutil==5.2.2
+portalocker==1.1.0

--- a/.ci/python_requirements_psql_psycopg2
+++ b/.ci/python_requirements_psql_psycopg2
@@ -1,6 +1,6 @@
-sqlalchemy==1.0.9
-alembic==0.8.2
-psycopg2==2.5.4
+sqlalchemy==1.0.17
+alembic==0.9.2
+psycopg2==2.7.1
 thrift==0.9.1
-psutil==5.0.1
-portalocker==1.0.0
+psutil==5.2.2
+portalocker==1.1.0


### PR DESCRIPTION
Update some of the dependencies.
In case of portalocker, there is a crash fix with python 3.6, see https://github.com/WoLpH/portalocker/releases/tag/v1.1.0
