### PR TITLE
Fix suppress feature in parse broken by plist_parser refactoring

### DIFF
--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
@@ -91,9 +91,13 @@ class PlistToStdout(ResultHandler):
                 LOG.debug(report + ' is skipped (in ' + f_path + ")")
                 continue
 
+            bug = {'hash_value':
+                   report.main['issue_hash_content_of_line_in_context'],
+                   'file_path': f_path
+                   }
             if self.suppress_handler and \
-                    self.suppress_handler.get_suppressed(report):
-                LOG.debug(report + " is suppressed by suppress file.")
+                    self.suppress_handler.get_suppressed(bug):
+                LOG.debug("Suppressed by suppress file: {0}".format(report))
                 continue
 
             last_report_event = report.bug_path[-1]

--- a/libcodechecker/generic_package_suppress_handler.py
+++ b/libcodechecker/generic_package_suppress_handler.py
@@ -72,5 +72,5 @@ class GenericSuppressHandler(suppress_handler.SuppressHandler):
     def get_suppressed(self, bug):
 
         return any([suppress for suppress in self.__suppress_info
-                    if suppress[0] == bug.hash_value and
-                    suppress[1] == os.path.basename(bug.file_path)])
+                    if suppress[0] == bug['hash_value'] and
+                    suppress[1] == os.path.basename(bug['file_path'])])

--- a/libcodechecker/report.py
+++ b/libcodechecker/report.py
@@ -12,6 +12,7 @@ All hash generation algorithms should be documented and implemented here.
 
 """
 import hashlib
+import json
 import linecache
 import os
 


### PR DESCRIPTION
After the refactor in #635, the suppression feature in `CodeChecker parse` broke, as the new `report` object didn't contain the data that was needed to check if the file is suppressed according to the suppress file.