### PR TITLE
Make source suppress handler report suppression if asked multiple times

### DIFF
--- a/libcodechecker/suppress_handler.py
+++ b/libcodechecker/suppress_handler.py
@@ -75,7 +75,7 @@ class SourceSuppressHandler(object):
         self.__bug_line = report_line
         self.__hash_value = report_hash
         self.__checker_name = checker_name
-        self.__suppressed_checkers = []
+        self.__suppressed_checkers = set()
         self.__suppress_comment = None
 
     def __check_if_comment(self, line):
@@ -115,11 +115,11 @@ class SourceSuppressHandler(object):
         if res:
             checkers = res.group('checkers')
             if checkers == "all":
-                self.__suppressed_checkers.append('all')
+                self.__suppressed_checkers.add('all')
             else:
                 suppress_checker_list = re.findall(r"[^,\s]+",
                                                    checkers.strip())
-                self.__suppressed_checkers.extend(suppress_checker_list)
+                self.__suppressed_checkers.update(suppress_checker_list)
             comment = res.group('comment')
             if comment == '':
                 self.__suppress_comment = \
@@ -197,7 +197,7 @@ class SourceSuppressHandler(object):
         suppress_checkers = self.suppressed_checkers()
 
         if self.__checker_name in suppress_checkers or \
-           suppress_checkers == ['all']:
+           suppress_checkers == {'all'}:
 
             file_path, file_name = os.path.split(self.__source_file)
 

--- a/tests/unit/test_source_suppress.py
+++ b/tests/unit/test_source_suppress.py
@@ -34,7 +34,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                              "")
         res = test_handler.check_source_suppress()
         self.assertFalse(res)
-        self.assertEqual(test_handler.suppressed_checkers(), [])
+        self.assertEqual(test_handler.suppressed_checkers(), set())
         self.assertIsNone(test_handler.suppress_comment())
 
     def test_no_comment(self):
@@ -45,7 +45,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertFalse(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), [])
+        self.assertEqual(sp_handler.suppressed_checkers(), set())
         self.assertIsNone(sp_handler.suppress_comment())
 
     def test_no_suppress_comment(self):
@@ -56,7 +56,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), ['all'])
+        self.assertEqual(sp_handler.suppressed_checkers(), {'all'})
         self.assertEqual(sp_handler.suppress_comment(), 'some comment')
 
     def test_multi_liner_all(self):
@@ -67,7 +67,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), ['all'])
+        self.assertEqual(sp_handler.suppressed_checkers(), {'all'})
         self.assertEqual(sp_handler.suppress_comment(), 'some long comment')
 
     def test_one_liner_all(self):
@@ -79,7 +79,7 @@ class SourceSuppressTestCase(unittest.TestCase):
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
         self.assertEqual(
-            sp_handler.suppressed_checkers(), ['my_checker_1', 'my_checker_2'])
+            sp_handler.suppressed_checkers(), {'my_checker_1', 'my_checker_2'})
         self.assertEqual(sp_handler.suppress_comment(), 'some comment')
 
     def test_multi_liner_all_2(self):
@@ -91,7 +91,7 @@ class SourceSuppressTestCase(unittest.TestCase):
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
         self.assertEqual(
-            sp_handler.suppressed_checkers(), ['my.checker_1', 'my.checker_2'])
+            sp_handler.suppressed_checkers(), {'my.checker_1', 'my.checker_2'})
         self.assertEqual(
             sp_handler.suppress_comment(), 'some really long comment')
 
@@ -104,7 +104,7 @@ class SourceSuppressTestCase(unittest.TestCase):
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
         self.assertEqual(
-            sp_handler.suppressed_checkers(), ['my.Checker_1', 'my.Checker_2'])
+            sp_handler.suppressed_checkers(), {'my.Checker_1', 'my.Checker_2'})
         self.assertEqual(
             sp_handler.suppress_comment(), 'some really really long comment')
 
@@ -116,7 +116,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertFalse(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), [])
+        self.assertEqual(sp_handler.suppressed_checkers(), set())
         self.assertIsNone(sp_handler.suppress_comment())
 
     def test_comment_characters(self):
@@ -128,7 +128,7 @@ class SourceSuppressTestCase(unittest.TestCase):
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
         self.assertEqual(
-            sp_handler.suppressed_checkers(), ['my.checker_1', 'my.checker_2'])
+            sp_handler.suppressed_checkers(), {'my.checker_1', 'my.checker_2'})
         self.assertEqual(sp_handler.suppress_comment(), "i/';0 (*&^%$#@!)")
 
     def test_fancy_comment_characters(self):
@@ -139,7 +139,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), ['my_checker_1'])
+        self.assertEqual(sp_handler.suppressed_checkers(), {'my_checker_1'})
         self.assertEqual(
             sp_handler.suppress_comment(),
             "áúőóüöáé ▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬")
@@ -152,7 +152,7 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertTrue(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), ['my_checker_1'])
+        self.assertEqual(sp_handler.suppressed_checkers(), {'my_checker_1'})
         self.assertEqual(
             sp_handler.suppress_comment(),
             'WARNING! suppress comment is missing')
@@ -165,5 +165,5 @@ class SourceSuppressTestCase(unittest.TestCase):
                                            "")
         res = sp_handler.check_source_suppress()
         self.assertFalse(res)
-        self.assertEqual(sp_handler.suppressed_checkers(), [])
+        self.assertEqual(sp_handler.suppressed_checkers(), set())
         self.assertIsNone(sp_handler.suppress_comment())


### PR DESCRIPTION
If a `SourceSuppressHandler` is constructed for a reportid-checker name-bughash-location tuple and the `get_suppressed()` method is called multiple times on this object, the **first** one will report the actual suppression 3-tuple, but every subsequent call reported `None`. This PR fixes this issue.

Issue arose from the fact that the checker-name specifier `[all]` in the source code was appended multiple times to the list of ignored checkers for the given suppression.