### PR TITLE
update compilation command handling

### DIFF
--- a/libcodechecker/analyze.py
+++ b/libcodechecker/analyze.py
@@ -238,6 +238,10 @@ def main(args):
     # Parse the JSON CCDBs and retrieve the compile commands.
     actions = []
 
+    if len(args.logfile) != 1:
+        LOG.warning("Only one log file can be processed right now!")
+        sys.exit(1)
+
     for log_file in args.logfile:
         if not os.path.exists(log_file):
             LOG.error("The specified logfile '" + log_file + "' does not "
@@ -291,6 +295,17 @@ def main(args):
     LOG.debug("Analysis metadata write to '" + metadata_path + "'")
     with open(metadata_path, 'w') as metafile:
         json.dump(metadata, metafile)
+
+    # WARN: store command will search for this file!!!!
+    compile_cmd_json = os.path.join(args.output_path, 'compile_cmd.json')
+    try:
+        source = os.path.abspath(args.logfile[0])
+        target = os.path.abspath(compile_cmd_json)
+        shutil.copyfile(source, target)
+    except shutil.Error as serr:
+        LOG.debug("Compile command json file is the same")
+    except Exception as ex:
+        LOG.debug("Copying compile command json file failed.")
 
     LOG.info("Analysis finished.")
     LOG.info("To view results in the terminal use the "

--- a/libcodechecker/check.py
+++ b/libcodechecker/check.py
@@ -406,7 +406,7 @@ def main(args):
     try:
         # --- Step 1.: Perform logging if build command was specified.
         if 'command' in args:
-            logfile = os.path.join(workspace, 'build.json')
+            logfile = os.path.join(workspace, 'compile_cmd.json')
 
             # Translate the argument list between quickcheck and log.
             log_args = argparse.Namespace(

--- a/libcodechecker/quickcheck.py
+++ b/libcodechecker/quickcheck.py
@@ -316,7 +316,7 @@ def main(args):
     try:
         # --- Step 1.: Perform logging if build command was specified.
         if 'command' in args:
-            logfile = os.path.join(workspace, 'build.json')
+            logfile = os.path.join(workspace, 'compile_cmd.json')
 
             # Translate the argument list between quickcheck and log.
             log_args = argparse.Namespace(


### PR DESCRIPTION
In the current solution the update mode depends on the compilation
commands. If not given to the store command cleaning up the
previous reports will not work properly.

Introduce a new argument for the store command where the
compilation database (json) generated by the log can be used to
get the compilation commands for each source file.