### PR TITLE
Removing BuildAction table and related elements.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -34,7 +34,7 @@ PROJECT_NAME           = "CodeChecker"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 5.9.1
+PROJECT_NUMBER         = 6.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -140,20 +140,6 @@ enum DiffType {
 }
 
 //-----------------------------------------------------------------------------
-struct BuildActionData {
-  1: i64 id,
-  2: i64 runId,
-  3: string buildCmd,
-  4: string analyzerType,
-  5: string file,
-  6: string checkCmd,
-  7: string failure,
-  8: string date,
-  9: i64 duration
-}
-typedef list<BuildActionData> BuildActionDataList
-
-
 struct NeedFileResult {
                 1: bool needed;
                 2: i64 fileId;
@@ -255,11 +241,6 @@ service codeCheckerDBAccess {
   SkipPathDataList getSkipPaths(1: i64 runId)
                                 throws (1: shared.RequestFailed requestError),
 
-  // gives back the build Actions that generate the given report.
-  // multiple build actions can belong to a report in a header.
-  BuildActionDataList getBuildActions(1: i64 reportId)
-                                      throws (1: shared.RequestFailed requestError),
-
   // get all the results for one runId
   // count all results for a checker
   ReportDataTypeCountList getRunResultTypes(1: i64 runId,
@@ -336,16 +317,8 @@ service codeCheckerDBAccess {
 
   // The next few following functions must be called via the same connection.
   // =============================================================
-  i64  addBuildAction(
-                      1: i64 run_id,
-                      2: string build_cmd_hash,
-                      3: string check_cmd,
-                      4: string analyzer_type,
-                      5: string analyzed_source_file)
-                      throws (1: shared.RequestFailed requestError),
-
   i64  addReport(
-                 1: i64 build_action_id,
+                 1: i64 run_id,
                  2: i64 file_id,
                  3: string bug_hash,
                  4: string checker_message,
@@ -357,11 +330,6 @@ service codeCheckerDBAccess {
                  10: shared.Severity severity,
                  11: bool suppress)
                  throws (1: shared.RequestFailed requestError),
-
-  bool finishBuildAction(
-                         1: i64 action_id,
-                         2: string failure)
-                         throws (1: shared.RequestFailed requestError),
 
   NeedFileResult needFileContent(
                                  1: i64 run_id,

--- a/config/version.json
+++ b/config/version.json
@@ -1,8 +1,8 @@
 {
     "version":{
-        "major" : "5",
-        "minor" : "9",
-        "revision" : "1"
+        "major" : "6",
+        "minor" : "0",
+        "revision" : "0"
     },
     "db_version":{
         "major" : "5",

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -155,18 +155,9 @@ class ThriftClientHelper(object):
     # The next few following functions must be called via the same connection.
     # =============================================================
     @ThriftClientCall
-    def addBuildAction(self, run_id, build_cmd_hash, check_cmd, analyzer_type,
-                       analyzed_source_file):
-        pass
-
-    @ThriftClientCall
-    def addReport(self, build_action_id, file_id, bug_hash, checker_message,
-                  bugpath, events, checker_id, checker_cat, bug_type,
-                  severity, suppress):
-        pass
-
-    @ThriftClientCall
-    def finishBuildAction(self, action_id, failure):
+    def addReport(self, run_id, file_id, bug_hash, checker_message, bugpath,
+                  events, checker_id, checker_cat, bug_type, severity,
+                  suppress):
         pass
 
     @ThriftClientCall

--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -376,11 +376,11 @@ def __instance_management(args):
             # A STOP only stops the server associated with the given workspace
             # and view-port.
             if i['hostname'] != socket.gethostname() or (
-                        args.stop and not (i['port'] == args.view_port and
-                                           os.path.abspath(
-                                           i['workspace']) ==
-                                           os.path.abspath(
-                                               args.config_directory))):
+                    args.stop and not (i['port'] == args.view_port and
+                                       os.path.abspath(
+                                       i['workspace']) ==
+                                       os.path.abspath(
+                                           args.config_directory))):
                 continue
 
             try:

--- a/libcodechecker/log/build_action.py
+++ b/libcodechecker/log/build_action.py
@@ -14,7 +14,7 @@ class BuildAction(object):
         self._analyzer_options = []
         self._compiler_includes = []
         self._compiler_defines = []
-        self.analyzer_type = -1
+        self._analyzer_type = -1
         self._original_command = ''
         self._directory = ''
         self._output = ''
@@ -164,7 +164,7 @@ class BuildAction(object):
         """
         hash_content = []
         hash_content.extend(self.analyzer_options)
-        hash_content.append(str(self.analyzer_type))
+        hash_content.append(str(self._analyzer_type))
         hash_content.append(self.output)
         hash_content.append(self.target)
         hash_content.extend(self.sources)

--- a/libcodechecker/orm_model.py
+++ b/libcodechecker/orm_model.py
@@ -62,8 +62,6 @@ class Run(Base):
     # Relationships (One to Many).
     configlist = relationship('Config', cascade="all, delete-orphan",
                               passive_deletes=True)
-    buildactionlist = relationship('BuildAction', cascade="all, delete-orphan",
-                                   passive_deletes=True)
 
     def __init__(self, name, version, command):
         self.date, self.name, self.version, self.command = \
@@ -110,39 +108,6 @@ class File(Base):
 
     def addContent(self, content):
         self.content = content
-
-
-class BuildAction(Base):
-    __tablename__ = 'build_actions'
-
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    run_id = Column(Integer,
-                    ForeignKey('runs.id', deferrable=True,
-                               initially="DEFERRED", ondelete='CASCADE')
-                    )
-    build_cmd_hash = Column('build_cmd', String)
-    analyzer_type = Column(String, nullable=False)
-    analyzed_source_file = Column(String, nullable=False)
-    check_cmd = Column(String)
-    # No failure if the text is empty.
-    failure_txt = Column(String)
-    date = Column(DateTime)
-
-    # Seconds, -1 if unfinished.
-    duration = Column(Integer)
-
-    def __init__(self, run_id, build_cmd_hash, check_cmd, analyzer_type,
-                 analyzed_source_file):
-        self.run_id, self.build_cmd_hash, self.check_cmd, self.failure_txt = \
-            run_id, build_cmd_hash, check_cmd, ''
-        self.date = datetime.now()
-        self.analyzer_type = analyzer_type
-        self.analyzed_source_file = analyzed_source_file
-        self.duration = -1
-
-    def mark_finished(self, failure_txt):
-        self.failure_txt = failure_txt
-        self.duration = (datetime.now() - self.date).total_seconds()
 
 
 class BugPathEvent(Base):
@@ -264,23 +229,6 @@ class Report(Base):
         self.checker_cat = checker_cat
         self.suppressed = suppressed
         self.bug_type = bug_type
-
-
-class ReportsToBuildActions(Base):
-    __tablename__ = 'reports_to_build_actions'
-
-    report_id = Column(Integer, ForeignKey('reports.id', deferrable=True,
-                                           initially="DEFERRED",
-                                           ondelete='CASCADE'),
-                       primary_key=True)
-    build_action_id = Column(
-        Integer,
-        ForeignKey('build_actions.id', deferrable=True, initially="DEFERRED",
-                   ondelete='CASCADE'), primary_key=True)
-
-    def __init__(self, report_id, build_action_id):
-        self.report_id = report_id
-        self.build_action_id = build_action_id
 
 
 class SuppressBug(Base):

--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -775,33 +775,6 @@ class ThriftRequestHandler():
                                               msg)
 
     @timeit
-    def getBuildActions(self, reportId):
-
-        session = self.__session
-        try:
-            build_actions = session.query(BuildAction) \
-                .outerjoin(ReportsToBuildActions) \
-                .filter(ReportsToBuildActions.report_id == reportId) \
-                .all()
-
-            return [BuildActionData(id=ba.id,
-                                    runId=ba.run_id,
-                                    buildCmd=ba.build_cmd_hash,
-                                    analyzerType=ba.analyzer_type,
-                                    file=ba.analyzed_source_file,
-                                    checkCmd=ba.check_cmd,
-                                    failure=ba.failure_txt,
-                                    date=str(ba.date),
-                                    duration=ba.duration) for ba in
-                    build_actions]
-
-        except sqlalchemy.exc.SQLAlchemyError as alchemy_ex:
-            msg = str(alchemy_ex)
-            LOG.error(msg)
-            raise shared.ttypes.RequestFailed(shared.ttypes.ErrorCode.DATABASE,
-                                              msg)
-
-    @timeit
     def getFileId(self, run_id, path):
 
         session = self.__session
@@ -1324,106 +1297,6 @@ class ThriftRequestHandler():
                                            run_id,
                                            report_filters)
 
-    def __sequence_deleter(self, table, first_id):
-        """Delete points of sequence in a general way."""
-        next_id = first_id
-        while next_id:
-            item = self.__session.query(table).get(next_id)
-            if item:
-                next_id = item.next
-                self.__session.delete(item)
-            else:
-                break
-
-    def __del_source_file_for_report(self, run_id, report_id, report_file_id):
-        """
-        Delete the stored file if there are no report references to it
-        in the database.
-        """
-        report_reference_to_file = self.__session.query(Report) \
-            .filter(
-            and_(Report.run_id == run_id,
-                 Report.file_id == report_file_id,
-                 Report.id != report_id))
-        rep_ref_count = report_reference_to_file.count()
-        if rep_ref_count == 0:
-            LOG.debug("No other references to the source file \n id: " +
-                      str(report_file_id) + " can be deleted.")
-            # There are no other references to the file, it can be deleted.
-            self.__session.query(File).filter(File.id == report_file_id) \
-                .delete()
-        return rep_ref_count
-
-    def __del_buildaction_results(self, build_action_id, run_id):
-        """
-        Delete the build action and related analysis results from the database.
-
-        Report entry will be deleted by ReportsToBuildActions cascade delete.
-        """
-        LOG.debug("Cleaning old buildactions")
-
-        try:
-            rep_to_ba = self.__session.query(ReportsToBuildActions) \
-                .filter(ReportsToBuildActions.build_action_id ==
-                        build_action_id)
-
-            reports_to_delete = [r.report_id for r in rep_to_ba]
-
-            LOG.debug("Trying to delete reports belonging to the buildaction:")
-            LOG.debug(reports_to_delete)
-
-            for report_id in reports_to_delete:
-                # Check if there is another reference to this report from
-                # other buildactions.
-                other_reference = self.__session.query(ReportsToBuildActions) \
-                    .filter(
-                    and_(ReportsToBuildActions.report_id == report_id,
-                         ReportsToBuildActions.build_action_id !=
-                         build_action_id))
-
-                LOG.debug("Checking report id:" + str(report_id))
-
-                LOG.debug("Report id " + str(report_id) +
-                          " reference count: " +
-                          str(other_reference.count()))
-
-                if other_reference.count() == 0:
-                    # There is no other reference, data related to the report
-                    # can be deleted.
-                    report = self.__session.query(Report).get(report_id)
-                    if report:
-                        LOG.debug("Removing bug path events.")
-                        self.__sequence_deleter(BugPathEvent,
-                                                report.start_bugevent)
-                        LOG.debug("Removing bug report points.")
-                        self.__sequence_deleter(BugReportPoint,
-                                                report.start_bugpoint)
-
-                        if self.__del_source_file_for_report(run_id, report.id,
-                                                             report.file_id):
-                            LOG.debug("Stored source file needs to be kept, "
-                                      "there is reference to it from another "
-                                      "report.")
-                            # Report needs to be deleted if there is
-                            # no reference the file cascade delete will
-                            # remove it else manual cleanup is needed.
-                            self.__session.delete(report)
-                    else:
-                        LOG.debug("Report migth be deleted already")
-
-            self.__session.query(BuildAction).filter(
-                BuildAction.id == build_action_id) \
-                .delete()
-
-            self.__session.query(ReportsToBuildActions).\
-                filter(ReportsToBuildActions.build_action_id ==
-                       build_action_id).\
-                delete()
-        except Exception as ex:
-            raise shared.ttypes.RequestFailed(
-                shared.ttypes.ErrorCode.GENERAL,
-                str(ex))
-
     @timeit
     def addCheckerRun(self, command, name, version, force):
         """
@@ -1532,80 +1405,6 @@ class ThriftRequestHandler():
             return False
 
     @timeit
-    def addBuildAction(self,
-                       run_id,
-                       build_cmd_hash,
-                       check_cmd,
-                       analyzer_type,
-                       analyzed_source_file):
-        """
-        """
-        try:
-            LOG.debug("Storing buildaction")
-            LOG.debug("run_id {0}".format(run_id))
-            LOG.debug("cmd_hash {0}".format(build_cmd_hash))
-            LOG.debug("check command {0}".format(check_cmd))
-            LOG.debug("analyzer: {0}".format(analyzer_type))
-            LOG.debug("analyzed source file {0}".format(analyzed_source_file))
-
-            build_actions = \
-                self.__session.query(BuildAction) \
-                    .filter(
-                    and_(BuildAction.run_id == run_id,
-                         BuildAction.build_cmd_hash == build_cmd_hash,
-                         or_(
-                             and_(
-                                 BuildAction.analyzer_type == analyzer_type,
-                                 BuildAction.analyzed_source_file ==
-                                 analyzed_source_file),
-                             and_(BuildAction.analyzer_type == "",
-                                  BuildAction.analyzed_source_file == "")
-                         ))) \
-                    .all()
-
-            if build_actions:
-                # Delete the already stored buildaction and analysis results.
-                for build_action in build_actions:
-                    self.__del_buildaction_results(build_action.id, run_id)
-
-                self.__session.commit()
-
-            action = BuildAction(run_id,
-                                 build_cmd_hash,
-                                 check_cmd,
-                                 analyzer_type,
-                                 analyzed_source_file)
-            self.__session.add(action)
-            self.__session.commit()
-
-            return action.id
-
-        except Exception as ex:
-            LOG.error(ex)
-            raise
-
-    @timeit
-    def finishBuildAction(self, action_id, failure):
-        """
-        """
-        try:
-            action = self.__session.query(BuildAction).get(action_id)
-            if action is None:
-                # TODO: if file is not needed update reportsToBuildActions.
-                return False
-
-            failure = \
-                failure.decode('unicode_escape').encode('ascii', 'ignore')
-
-            action.mark_finished(failure)
-            self.__session.commit()
-            return True
-
-        except Exception as ex:
-            LOG.error(ex)
-            return False
-
-    @timeit
     def needFileContent(self, run_id, filepath):
         """
         """
@@ -1681,7 +1480,7 @@ class ThriftRequestHandler():
 
     @timeit
     def storeReportInfo(self,
-                        action,
+                        run_id,
                         file_id,
                         bug_hash,
                         msg,
@@ -1708,13 +1507,13 @@ class ThriftRequestHandler():
             LOG.debug("Checking if suppressed")
             # Old suppress format did not contain file name.
             suppressed = self.__session.query(SuppressBug).filter(
-                and_(SuppressBug.run_id == action.run_id,
+                and_(SuppressBug.run_id == run_id,
                      SuppressBug.hash == bug_hash,
                      or_(SuppressBug.file_name == source_file_name,
                          SuppressBug.file_name == u''))).count() > 0
 
             LOG.debug("initializing report")
-            report = Report(action.run_id,
+            report = Report(run_id,
                             bug_hash,
                             file_id,
                             msg,
@@ -1729,13 +1528,6 @@ class ThriftRequestHandler():
 
             self.__session.add(report)
             self.__session.commit()
-            LOG.debug("extending reports to ba table")
-            # Commit required to get the ID of the newly added report.
-            reportToActions = ReportsToBuildActions(report.id, action.id)
-            self.__session.add(reportToActions)
-            # Avoid data loss for duplicate keys.
-            self.__session.commit()
-            LOG.debug("Storing report done")
             return report.id
         except Exception as ex:
             raise shared.ttypes.RequestFailed(
@@ -1744,7 +1536,7 @@ class ThriftRequestHandler():
 
     @timeit
     def addReport(self,
-                  build_action_id,
+                  run_id,
                   file_id,
                   bug_hash,
                   msg,
@@ -1758,17 +1550,13 @@ class ThriftRequestHandler():
         """
         """
         try:
-            LOG.debug("store report")
-            action = self.__session.query(BuildAction).get(build_action_id)
-            assert action is not None
-
             checker_id = checker_id or 'NOT FOUND'
 
             # TODO: performance issues when executing the following query on
             # large databases?
             reports = self.__session.query(self.report_ident) \
                 .filter(and_(self.report_ident.c.bug_id == bug_hash,
-                             self.report_ident.c.run_id == action.run_id))
+                             self.report_ident.c.run_id == run_id))
             try:
                 # Check for duplicates by bug hash.
                 LOG.debug("checking duplicates")
@@ -1784,25 +1572,14 @@ class ThriftRequestHandler():
                                 dup_report_obj.file_id == file_id and \
                                 self.__is_same_event_path(
                                     dup_report_obj.start_bugevent, events):
-                            # It's a duplicate.
-                            LOG.debug("it is a duplicate")
-                            rtp = self.__session.query(ReportsToBuildActions) \
-                                .get((dup_report_obj.id,
-                                      action.id))
-                            if not rtp:
-                                LOG.debug("no rep to ba entry found")
-                                reportToActions = ReportsToBuildActions(
-                                    dup_report_obj.id, action.id)
-                                self.__session.add(reportToActions)
-                                self.__session.commit()
-                            LOG.debug("rep to ba entry found")
-                            LOG.debug("returning duplicate id")
-                            LOG.debug(dup_report_obj.id)
-
+                            # TODO: It is not clear why this commit is needed
+                            # but if it is not here then the commit in
+                            # finishCheckerRun() hangs.
+                            self.__session.commit()
                             return dup_report_obj.id
 
                 LOG.debug("no duplicate storing report")
-                return self.storeReportInfo(action,
+                return self.storeReportInfo(run_id,
                                             file_id,
                                             bug_hash,
                                             msg,
@@ -1819,7 +1596,7 @@ class ThriftRequestHandler():
 
                 reports = self.__session.query(self.report_ident) \
                     .filter(and_(self.report_ident.c.bug_id == bug_hash,
-                                 self.report_ident.c.run_id == action.run_id))
+                                 self.report_ident.c.run_id == run_id))
                 if reports.count() != 0:
                     return reports.first().report_ident.id
                 else:

--- a/tests/functional/analyze/test_analyze.py
+++ b/tests/functional/analyze/test_analyze.py
@@ -62,8 +62,8 @@ class TestSkeleton(unittest.TestCase):
 
         print(analyze_cmd)
         process = subprocess.Popen(
-                    analyze_cmd, stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE, cwd=self.test_dir)
+            analyze_cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=self.test_dir)
         out, err = process.communicate()
         print(out+err)
         errcode = process.returncode

--- a/tests/functional/update/test_update_mode.py
+++ b/tests/functional/update/test_update_mode.py
@@ -81,5 +81,10 @@ class TestUpdate(unittest.TestCase):
         all_bugs = self._testproject_data[self._clang_to_test]['bugs']
         deadcode_bugs = [bug for bug in all_bugs if bug['checker'] == deadcode]
 
-        self.assertEquals(len(updated_results),
-                          len(all_bugs) - len(deadcode_bugs))
+        # TODO: By removing build actions from the architecture, there is no
+        # update mode. If a run already contains a given bug then it is not
+        # overwritten. Later in "detection status" functionality the status of
+        # these bugs will be set to "resolved" and that will be checked.
+        self.assertEquals(len(updated_results), len(all_bugs))
+        # self.assertEquals(len(updated_results),
+        #                   len(all_bugs) - len(deadcode_bugs))

--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -792,7 +792,6 @@ function (declare, dom, style, on, query, Memory, Observable, topic, entities,
         }
       });
 
-      var detailsDialog = new Dialog({ title : 'Report details' });
       var suppressDialog = new Dialog({ title : 'Suppress bug' });
       var unsuppressDialog = new Dialog({ title : 'Unsuppress bug' });
 
@@ -818,41 +817,6 @@ function (declare, dom, style, on, query, Memory, Observable, topic, entities,
         label : 'Show documentation',
         onClick : function () {
           topic.publish('showDocumentation', that.reportData.checkerId);
-        }
-      }));
-
-      //--- Details ---//
-
-      this.addChild(new Button({
-        label : 'Details',
-        onClick : function () {
-          var content = dom.create('div', { class : 'buildActionInfo' });
-
-          CC_SERVICE.getBuildActions(that.reportData.reportId).forEach(
-          function (buildAction) {
-            var details = dom.create('dl');
-
-            dom.place(
-              dom.create('dt', { innerHTML : 'Check command' }), details);
-            dom.place(
-              dom.create('dd', {
-                innerHTML : buildAction.checkCmd || 'Only in debug mode parsing'
-              }), details);
-            dom.place(
-              dom.create('dt', { innerHTML : 'Failure' }), details);
-            dom.place(
-              dom.create('dd', { innerHTML : buildAction.failure }), details);
-            dom.place(
-              dom.create('dt', { innerHTML : 'Checked file' }), details);
-            dom.place(
-              dom.create('dd', { innerHTML : buildAction.file }), details);
-
-            dom.place(details, content);
-            dom.place(dom.create('hr'), content);
-          });
-
-          detailsDialog.set('content', content);
-          detailsDialog.show();
         }
       }));
 

--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -518,12 +518,12 @@ function (declare, dom, style, on, query, Memory, Observable, topic, entities,
 
     _onNodeMouseEnter : function (node) {
       if (node.item.tooltip)
-        Tooltip.show(node.item.tooltip, node.domNode, ['above']);
+        Tooltip.show(node.item.tooltip, node.labelNode, ['above']);
     },
 
     _onNodeMouseLeave : function (node) {
       if (node.item.isLeaf)
-        Tooltip.hide(node.domNode);
+        Tooltip.hide(node.labelNode);
     },
 
     // Highlight colours go further down this array in a circular fashion


### PR DESCRIPTION
In this commit the BuildAction is removed as a concept. This also means
that update mode doesn't work any more, because a report is connected to
a run instead of the build action. If a report is already found in the
run then it won't be updated, but skipped. Later in this case the
detection status of the report will be updated.