### PR TITLE
Fix directory rename missing in Doxyfile

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "Code Checker"
+PROJECT_NAME           = "CodeChecker"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or
@@ -40,7 +40,7 @@ PROJECT_NUMBER         = 5.9.0
 # for a project that appears at the top of each page and should give viewer
 # a quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Static analysis tool for C/C++ projects."
+PROJECT_BRIEF          = "Static analysis, defect database and viewer tool for C/C++ projects"
 
 # With the PROJECT_LOGO tag one can specify an logo or icon that is
 # included in the documentation. The maximum height of the logo should not
@@ -654,7 +654,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = docs docs/checker_docs thrift_api 
+INPUT                  = api docs docs/checker_docs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -714,7 +714,7 @@ EXCLUDE_SYMBOLS        =
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = thrift_api config docs
+EXAMPLE_PATH           = config docs
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp

--- a/docs/deps.md
+++ b/docs/deps.md
@@ -29,5 +29,3 @@ Javascript dependencies are automatically downloaded based on the ext_source_dep
 
 #### PostgreSQL
 For the additional PostgreSQL dependencies see the [PostgreSQL setup](postgresql_setup.md) documentation.
-
-\include ext_source_deps_config.json

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,10 @@
-#CodeChecker command line examples
-###1.	Quickly check some files and print results in command line
+# CodeChecker command line examples
+### 1. Quickly check some files and print results in command line
 ```
 CodeChecker quickcheck -b make
 ```
-###2.	Check a project, update earlier results  and view results from a browser
+
+### 2. Check a project, update earlier results  and view results from a browser
 Runs make, logs build, run analyzers and store the results in sqlite db.
 ```
 CodeChecker check -b make
@@ -20,11 +21,11 @@ At the end, the project can be rechecked.
 ```
 CodeChecker check make
 ```
-###3. Same as use case 2., but the developer would like to enable alpha checkers and llvm checkers
+### 3. Same as use case 2., but the developer would like to enable alpha checkers and llvm checkers
 ```
 CodeChecker check -e alpha -e llvm -b make
 ```
-###4.	Same as use case 2., but the developer stores suppressed false positives in a text file that is checked in into version control
+### 4. Same as use case 2., but the developer stores suppressed false positives in a text file that is checked in into version control
 ```
 CodeChecker check –u /home/myuser/myproject/suppress.list -b make
 CodeChecker server –u /home/myuser/myproject/suppress.list
@@ -32,7 +33,7 @@ CodeChecker server –u /home/myuser/myproject/suppress.list
 # Suppress list will be stored in suppress.list.
 # The suppress.list file can be checked in the source control system.
 ```
-###5.	Same as use case 2., but the developer wants to give extra Config to clang-tidy or clang-sa
+### 5. Same as use case 2., but the developer wants to give extra Config to clang-tidy or clang-sa
 ```
 CodeChecker check --saargs clangsa.config --tidyargs clang-tidy.config -b make
 
@@ -41,13 +42,13 @@ CodeChecker check --saargs clangsa.config --tidyargs clang-tidy.config -b make
 # be passed to every clang-sa/tidy calls
 ```
 
-###6.	Asking for command line help for the check subcommand (all other subcommands would be the same: server, checkers,cmd…)
+### 6. Asking for command line help for the check subcommand (all other subcommands would be the same: server, checkers,cmd…)
 ```
 CodeChecker check -h
 ```
 
 
-###7.	Run analysis on 2 versions of the project
+### 7. Run analysis on 2 versions of the project
 Analyze a large project from a script/Jenkins job periodically. Developers view the results on a central web-server.
 If a hit is false positive, developers can mark it and comment it on the web interface and the suppress hashes are stored in a text file that can be version controlled.
 Different versions of the project can be compared for new/resolved/unresolved bugs. Differences between runs can be viewed in the web browser or from command line (and can be sent in email if needed).


### PR DESCRIPTION
This will eliminate the warnings given by Doxygen in the build process.