### PR TITLE
Handle a Thrift exception if file content contains Unicode char that escapes as \u01?? by b64ing source text

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -17,7 +17,7 @@ namespace js codeCheckerDBAccess
 namespace cpp cc.service.codechecker
 
 //=================================================
-const string API_VERSION = '5.2'
+const string API_VERSION = '5.3'
 const i64 MAX_QUERY_SIZE = 500
 //=================================================
 
@@ -77,6 +77,7 @@ struct ReportDetails{
 }
 
 //-----------------------------------------------------------------------------
+// TODO: This type is unused.
 struct ReportFileData{
   1: i64    reportFileId,
   2: string reportFileContent
@@ -88,6 +89,12 @@ enum SortType {
   FILENAME,
   CHECKER_NAME,
   SEVERITY
+}
+
+//-----------------------------------------------------------------------------
+enum Encoding {
+  DEFAULT,
+  BASE64
 }
 
 //-----------------------------------------------------------------------------
@@ -183,11 +190,12 @@ service codeCheckerDBAccess {
                                  1: i64 reportId)
                                  throws (1: shared.RequestFailed requestError),
 
-  // get file informations if fileContent is true the content of the source file
-  // will be also returned
+  // get file information, if fileContent is true the content of the source
+  // file will be also returned
   SourceFileData getSourceFileData(
                                    1: i64 fileId,
-                                   2: bool fileContent)
+                                   2: bool fileContent,
+                                   3: optional Encoding encoding)
                                    throws (1: shared.RequestFailed requestError),
 
   // get the file id from the database for a filepath, returns -1 if not found
@@ -362,7 +370,8 @@ service codeCheckerDBAccess {
 
   bool addFileContent(
                       1: i64 file_id,
-                      2: string file_content)
+                      2: string file_content,
+                      3: optional Encoding encoding)
                       throws (1: shared.RequestFailed requestError),
 
   bool finishCheckerRun(1: i64 run_id)

--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
@@ -11,6 +11,7 @@ import os
 import traceback
 
 import shared
+from codeCheckerDBAccess.ttypes import Encoding
 
 from libcodechecker import logger
 from libcodechecker import suppress_handler
@@ -57,7 +58,8 @@ class PlistToDB(ResultHandler):
 
                     source64 = base64.b64encode(source)
                     res = client.addFileContent(file_descriptor.fileId,
-                                                source64)
+                                                source64,
+                                                Encoding.BASE64)
                     if not res:
                         LOG.debug("Failed to store file content")
 

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -4,14 +4,14 @@
 #   License. See LICENSE.TXT for details.
 # -------------------------------------------------------------------------
 
+import base64
 from datetime import datetime
 import json
 import os
 import sys
 
-import codeCheckerDBAccess
 import shared
-from Authentication import ttypes as AuthTypes
+import codeCheckerDBAccess
 from codeCheckerDBAccess import ttypes
 
 from libcodechecker import suppress_file_handler
@@ -234,11 +234,10 @@ def handle_diff_results(args):
         return ""
 
     def getLineFromRemoteFile(client, fid, lineno):
-        # FIXME: Certain UTF8 file content
-        # causes connection abort.
-        source = client.getSourceFileData(fid, True)
-        i = 1
-        lines = source.fileContent.split('\n')
+        # Thrift Python client cannot decode JSONs that contain non '\u00??'
+        # characters, so we instead ask for a Base64-encoded version.
+        source = client.getSourceFileData(fid, True, ttypes.Encoding.BASE64)
+        lines = base64.b64decode(source.fileContent).split('\n')
         return "" if len(lines) < lineno else lines[lineno - 1]
 
     def getDiffReportDir(getterFn, baseid, report_dir, suppr, diff_type):

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -81,7 +81,7 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def getSourceFileData(self, fileId, fileContent):
+    def getSourceFileData(self, fileId, fileContent, encoding):
         pass
 
     @ThriftClientCall
@@ -174,7 +174,7 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def addFileContent(self, file_id, file_content):
+    def addFileContent(self, file_id, file_content, encoding):
         pass
 
     @ThriftClientCall

--- a/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/tests/functional/report_viewer_api/test_get_run_results.py
@@ -5,11 +5,13 @@
 #   License. See LICENSE.TXT for details.
 # -----------------------------------------------------------------------------
 
+import base64
 import logging
 import os
 import re
 import unittest
 
+from codeCheckerDBAccess.ttypes import Encoding
 from codeCheckerDBAccess.ttypes import Order
 from codeCheckerDBAccess.ttypes import ReportFilter
 from codeCheckerDBAccess.ttypes import SortMode
@@ -124,7 +126,9 @@ class RunResults(unittest.TestCase):
 
             logging.debug('Getting the content of ' + run_res.checkedFile)
 
-            file_data = self._cc_client.getSourceFileData(run_res.fileId, True)
+            file_data = self._cc_client.getSourceFileData(run_res.fileId,
+                                                          True,
+                                                          None)
             self.assertIsNotNone(file_data)
 
             file_content1 = file_data.fileContent
@@ -134,6 +138,15 @@ class RunResults(unittest.TestCase):
                 file_content2 = source_file.read()
 
             self.assertEqual(file_content1, file_content2)
+
+            file_data_b64 = self._cc_client.getSourceFileData(
+                run_res.fileId, True, Encoding.BASE64)
+            self.assertIsNotNone(file_data_b64)
+
+            file_content1_b64 = base64.b64decode(file_data_b64.fileContent)
+            self.assertIsNotNone(file_content1_b64)
+
+            self.assertEqual(file_content1_b64, file_content2)
 
         logging.debug('got ' + str(len(run_results)) + ' files')
 

--- a/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/tests/functional/report_viewer_api/test_hash_clash.py
@@ -73,7 +73,7 @@ class HashClash(unittest.TestCase):
 
         content = _generate_content(cols, lines)
         content = base64.b64encode(content)
-        success = self._report.addFileContent(need.fileId, content)
+        success = self._report.addFileContent(need.fileId, content, None)
         self.assertTrue(success)
 
         return need.fileId, path

--- a/tests/performance/run_performance_test.py
+++ b/tests/performance/run_performance_test.py
@@ -195,7 +195,7 @@ def store_reports(run_id, file_content, test_conf):
                                                    str(file_count)
                                                    ).fileId
 
-            store_server.addFileContent(file_id, file_content)
+            store_server.addFileContent(file_id, file_content, None)
 
             store_server.finishBuildAction(ba_id, '')
             for bug_count in range(bug_per_file):

--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -895,7 +895,7 @@ function (declare, dom, style, on, query, Memory, Observable, topic, entities,
         runData : this.runData
       });
 
-      CC_SERVICE.getSourceFileData(this.reportData.fileId, true,
+      CC_SERVICE.getSourceFileData(this.reportData.fileId, true, null,
       function (sourceFileData) {
         that._editor.set('sourceFileData', sourceFileData);
         that._editor.drawBugPath();


### PR DESCRIPTION
Issue appeared to @dkrupp when doing the "show bug's line in diff" for #723.

For example, in _FFMpeg_, some files' header contains the following line:

```c
* Copyright (c) 2013 Clément Bœsch
```

`œ` is encoded in Unicode as `\u0153`, but Thrift's python client used by `CodeChecker cmd` [only accepts `\u00xy` in the transmitted JSON](https://gist.github.com/fdelbos/3948701#file-tjsonprotocol-py-L206-L211), otherwise, an `Unexpected token: 1` is thrown and the connection dies.

Solution is to introduce a new method to encode the file output (optionally) as a _base64_ string, which in turn can be sent over Thrift via no exceptions and decoded later on.