### PR TITLE
Fix storing plists without build.json deleting all results already in database

### DIFF
--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -215,14 +215,17 @@ def consume_plist(item):
             LOG.info("Storing analysis results for file '" +
                      analyzed_source + "'")
 
-        LOG.debug("Parsing input file '" + f + "'")
+        LOG.debug("Getting build command for '" + f + "'")
         buildaction.original_command = compile_cmds.get(analyzed_source,
                                                         'MISSING')
 
-        LOG.debug("Parsing input file '" + f + "'")
         if buildaction.original_command == 'MISSING':
-            LOG.warning("Compilation action was not found for file: " +
-                        analyzed_source)
+            # Create a "good enough" command based on the plist's name, so
+            # even without a build command, we can still store the results.
+            LOG.warning("Compilation action was not found for file '" +
+                        analyzed_source + "' (input '" + f + "')")
+            LOG.debug("Considering results in input '" + f + "' brand new.")
+            buildaction.original_command = f
 
         rh = analyzer_types.construct_store_handler(buildaction,
                                                     context.run_id,
@@ -284,8 +287,10 @@ def process_compile_db(compile_db):
     comp_cmds = {}
 
     if not os.path.exists(compile_db):
-        LOG.warning("Compilation command file is missing: " + compile_db)
-        LOG.warning("Update mode will not work properly!!!")
+        LOG.warning("Compilation command file '" + compile_db +
+                    "' is missing.")
+        LOG.warning("Update mode will not work, without compilation "
+                    "command it is not known which file to update.")
         return comp_cmds
 
     with open(compile_db, 'r') as ccdb:

--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -1539,12 +1539,12 @@ class ThriftRequestHandler():
         """
         """
         try:
-            LOG.debug("Storign buildaction")
-            LOG.debug(run_id)
-            LOG.debug(build_cmd_hash)
-            LOG.debug(check_cmd)
-            LOG.debug(analyzer_type)
-            LOG.debug(analyzed_source_file)
+            LOG.debug("Storing buildaction")
+            LOG.debug("run_id {0}".format(run_id))
+            LOG.debug("cmd_hash {0}".format(build_cmd_hash))
+            LOG.debug("check command {0}".format(check_cmd))
+            LOG.debug("analyzer: {0}".format(analyzer_type))
+            LOG.debug("analyzed source file {0}".format(analyzed_source_file))
 
             build_actions = \
                 self.__session.query(BuildAction) \


### PR DESCRIPTION
If the `compile_cmd.json` is not found in the folder from which `store` stores the data, the update mode can result in different plists considered the same, i.e. an empty result set overwriting actual reports stored from _another_ plist already in the database.

This patch **restores** the pre-5.8 behaviour _in this case_. Because we don't know which build action generated the plist, we assign a good-enough unique identifier, the plist's name, and use that to know which reports to replace with the new ones. This can result in bug duplication, but this behaviour were apparent in pre-5.8 too.