### PR TITLE
Fix delete runs test cases.

### DIFF
--- a/tests/functional/delete_runs/__init__.py
+++ b/tests/functional/delete_runs/__init__.py
@@ -105,6 +105,12 @@ def setup_package():
 
         print("Analyzing the test project was successful {}.".format(str(i)))
 
+        # If the check process is very fast, datetime of multiple runs can be
+        # almost the same different in microseconds. Test cases of delete runs
+        # can be failed for this reason because we didn't process microseconds
+        # in command line arguments.
+        time.sleep(1)
+
     # Save the run names in the configuration.
     codechecker_cfg['run_names'] \
         = [test_project_name + '_' + str(i) for i in range(0, 5)]


### PR DESCRIPTION
E.g.:

| id | date | name |
|----|-------|----------|
|1| 2017-07-18 15:27:47.505669 | simple_0|
|2| **2017-07-18 15:27:48.205769** | simple_1|
|3| **2017-07-18 15:27:48.895728** | simple_2|
|4| 2017-07-18 15:27:49.236572 | simple_3|
|5| 2017-07-18 15:27:49.296572 | simple_4|

In delete runs test cases we first remove runs after **simple_2** (*datetime > 2017-07-18 15:27:48*):
Remaining runs: [simple_0, simple_1, simple_2] :heavy_check_mark:

Secondly, we remove runs before **simple_2** (*datetime < 2017-07-18 15:27:48*):
Remaining runs: [simple_1, simple_2] :x: