### PR TITLE
There is no such thing as an optional argument in Thrift

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -195,7 +195,7 @@ service codeCheckerDBAccess {
   SourceFileData getSourceFileData(
                                    1: i64 fileId,
                                    2: bool fileContent,
-                                   3: optional Encoding encoding)
+                                   3: Encoding encoding)
                                    throws (1: shared.RequestFailed requestError),
 
   // get the file id from the database for a filepath, returns -1 if not found
@@ -371,7 +371,7 @@ service codeCheckerDBAccess {
   bool addFileContent(
                       1: i64 file_id,
                       2: string file_content,
-                      3: optional Encoding encoding)
+                      3: Encoding encoding)
                       throws (1: shared.RequestFailed requestError),
 
   bool finishCheckerRun(1: i64 run_id)


### PR DESCRIPTION
Follow-up for #726. There is no such thing as an `optional` **argument** of a function call in Thrift.
This pull request only removes the _warning_ emitted and does not constitute behaviour change, as the argument was enforced by the server and handled by the clients properly, already.