### PR TITLE
Fix server ignoring direct --sqlite db specification

### DIFF
--- a/libcodechecker/database_handler.py
+++ b/libcodechecker/database_handler.py
@@ -172,19 +172,16 @@ class SQLServer(object):
 
         if args.postgresql:
             LOG.debug("Using PostgreSQLServer")
-            if 'workspace' in args:
-                data_url = os.path.join(args.workspace, 'pgsql_data')
+            # TODO: This will be refactored eventually so that
+            # CodeChecker is no longer bringing up a postgres database...
+            # It is an external dependency, it is an external
+            # responsibility. Until then, use the default folder now
+            # for the new commands who no longer define workspace.
+            if 'dbdatadir' in args:
+                workspace = args.dbdatadir
             else:
-                # TODO: This will be refactored eventually so that
-                # CodeChecker is no longer bringing up a postgres database...
-                # It is an external dependency, it is an external
-                # responbitility. Until then, use the default folder now
-                # for the new commands who no longer define workspace.
-                if 'dbdatadir' in args:
-                    workspace = args.dbdatadir
-                else:
-                    workspace = util.get_default_workspace()
-                data_url = os.path.join(workspace, 'pgsql_data')
+                workspace = util.get_default_workspace()
+            data_url = os.path.join(workspace, 'pgsql_data')
             return PostgreSQLServer(data_url,
                                     migration_root,
                                     args.dbaddress,
@@ -194,11 +191,7 @@ class SQLServer(object):
                                     run_env=env)
         else:
             LOG.debug("Using SQLiteDatabase")
-            if 'workspace' in args:
-                data_file = os.path.join(args.workspace, 'codechecker.sqlite')
-            else:
-                data_file = args.sqlite
-            data_file = os.path.abspath(data_file)
+            data_file = os.path.abspath(args.sqlite)
             return SQLiteDatabase(data_file, migration_root, run_env=env)
 
     def check_db_version(self, db_version_info, session=None):

--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -291,7 +291,7 @@ def add_arguments_to_parser(parser):
         else:
             # Apply the shortcut.
             if len(arg_match(['--not-host-only'])) > 0:
-                args.listen_address = ""  # listen on every interface
+                args.listen_address = ""  # Listen on every interface.
 
             # --not-host-only is just a shortcut optstring, no actual use
             # is intended later on.
@@ -321,16 +321,21 @@ def add_arguments_to_parser(parser):
             args.config_directory = args.workspace
             args.sqlite = os.path.join(args.workspace,
                                        'codechecker.sqlite')
+            setattr(args, 'dbdatadir', os.path.join(args.workspace,
+                                                    'pgsql_data'))
 
         # Workspace should not exist as a Namespace key.
-        # TODO: Keep workspace setting until the separate PostgreSQL
-        # initialization is done, not the current auto setup.
-        # delattr(args, 'workspace')
+        delattr(args, 'workspace')
 
         if 'postgresql' not in args:
             # Later called database modules need the argument to be actually
             # present, even though the default is suppressed in the optstring.
             setattr(args, 'postgresql', False)
+
+            # This is not needed by the database starter as we are
+            # running SQLite.
+            if 'dbdatadir' in args:
+                delattr(args, 'dbdatadir')
         else:
             # If --postgresql is given, --sqlite is useless.
             delattr(args, 'sqlite')


### PR DESCRIPTION
Fixes #741, which broke in #682.

With the onset of the `--host` and `--port` specification in #717, only one module still uses databases, that being `server`.

If the wrapper `--workspace` argument is used, the PostgreSQL database is started in `WORKSPACE/pgsql_data`, which was the behaviour since ages ago. (Assuming `--postgresql` mode is used.)
If `--sqlite` is specified, now the server properly uses the explicitly specified database as backend.

**No** calls to the `db_handler` gives an `args` that contains a `workspace` key anymore. The `--workspace` argument in `server` expands to multiple configuration options, but afterwards has to be removed from the dict.