### PR TITLE
Compress full source and metadata if analysis failed

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -8,12 +8,15 @@
 
 from collections import defaultdict
 import glob
+import json
 import multiprocessing
 import os
 import signal
 import sys
 import traceback
+import zipfile
 
+from libcodechecker import util
 from libcodechecker.analyze import analyzer_env
 from libcodechecker.analyze.analyzers import analyzer_types
 from libcodechecker.logger import LoggerFactory
@@ -76,6 +79,50 @@ def worker_result_handler(results, metadata, output_path):
         os.remove(f)
 
     metadata['result_source_files'] = source_map
+
+
+def create_dependencies(action):
+    """
+    Transforms the given original build 'command' to a command that, when
+    executed, is able to generate a dependency list.
+    """
+    if 'CC_LOGGER_GCC_LIKE' not in os.environ:
+        os.environ['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:cc:c++'
+
+    command = action.original_command.split(' ')
+    if any(binary_substring in command[0] for binary_substring
+           in os.environ['CC_LOGGER_GCC_LIKE'].split(':')):
+        # gcc and clang can generate makefile-style dependency list.
+        command = [command[0], '-E', '-M', '-MQ', '__dummy'] + command[1:]
+
+        option_index = next(
+            (i for i, c in enumerate(command) if c == '-o' or c == '--output'),
+            None)
+
+        if option_index:
+            # If an output file is set, the dependency is not written to the
+            # standard output but rather into the given file.
+            # We need to first eliminate the output from the command.
+            command = command[0:option_index] + command[option_index+2:]
+
+        output, rc = util.call_command(command, env=os.environ)
+        if rc == 0:
+            # Parse 'Makefile' syntax dependency output.
+            dependencies = output.replace('__dummy: ', '') \
+                .replace('\\', '') \
+                .replace('  ', '') \
+                .replace(' ', '\n')
+
+            # The dependency list already contains the source file's path.
+            return [dep for dep in dependencies.split('\n') if dep != ""]
+        else:
+            raise IOError("Failed to generate dependency list for " +
+                          ' '.join(command) + "\n\nThe original output was: " +
+                          output)
+    else:
+        raise ValueError("Cannot generate dependency list for build "
+                         "command '" + ' '.join(command) + "'")
+
 
 # Progress reporting.
 progress_checked_num = None
@@ -161,23 +208,55 @@ def check(check_data):
                          (progress_checked_num.value, progress_actions.value,
                           action.analyzer_type, source_file_name))
             else:
-                # Analysis failed.
+                # If the analysis has failed, we help debugging.
                 failed_dir = os.path.join(output_dir, "failed")
                 if not os.path.exists(failed_dir):
                     os.makedirs(failed_dir)
-                (res_file, ext) = os.path.splitext(rh.analyzer_result_file)
-                err_file = os.path.basename(res_file)
-                err_file = os.path.join(failed_dir, err_file)
-                LOG.debug("Writing error into:" + err_file + ".error")
-                result_file = err_file
-                if (len(rh.analyzer_stderr) > 0):
-                    with open(err_file + ".error", 'w') as orig:
-                        orig.write(rh.analyzer_stderr)
-                if (len(rh.analyzer_stdout) > 0):
-                    with open(err_file + ".stdout", 'w') as orig:
-                        orig.write(rh.analyzer_stdout)
-                LOG.error('Analyzing ' + source_file_name + ' with ' +
-                          action.analyzer_type + ' failed.')
+                LOG.debug("Writing error debugging to '" + failed_dir + "'")
+
+                result_file =\
+                    os.path.basename(rh.analyzer_result_file) + '.zip'
+                with zipfile.ZipFile(os.path.join(failed_dir, result_file),
+                                     'w') as archive:
+                    if len(rh.analyzer_stdout) > 0:
+                        LOG.debug("[ZIP] Writing analyzer STDOUT to /stdout")
+                        archive.writestr("stdout", rh.analyzer_stdout)
+
+                    if len(rh.analyzer_stderr) > 0:
+                        LOG.debug("[ZIP] Writing analyzer STDERR to /stderr")
+                        archive.writestr("stderr", rh.analyzer_stderr)
+
+                    LOG.debug("Generating and writing dependent headers...")
+                    try:
+                        dependencies = set(create_dependencies(rh.buildaction))
+                    except Exception as ex:
+                        LOG.debug("Couldn't create dependencies:")
+                        LOG.debug(ex.message)
+                        archive.writestr("no-sources", ex.message)
+                        dependencies = set()
+
+                    for dependent_source in dependencies:
+                        LOG.debug("[ZIP] Writing '" + dependent_source + "' "
+                                  "to the archive.")
+                        archive.write(
+                            dependent_source,
+                            os.path.join("sources-root",
+                                         dependent_source.lstrip('/')),
+                            zipfile.ZIP_DEFLATED)
+
+                    LOG.debug("[ZIP] Writing extra information...")
+
+                    archive.writestr("build-action",
+                                     rh.buildaction.original_command)
+                    archive.writestr("analyzer-command",
+                                     ' '.join(rh.analyzer_cmd))
+                    archive.writestr("return-code",
+                                     str(rh.analyzer_returncode))
+
+                LOG.debug("ZIP file written at '" +
+                          os.path.join(failed_dir, result_file) + "'")
+                LOG.error("Analyzing '" + source_file_name + "' with " +
+                          action.analyzer_type + " failed.")
                 if rh.analyzer_stdout != '':
                     LOG.error(rh.analyzer_stdout)
                 if rh.analyzer_stderr != '':


### PR DESCRIPTION
A ZIP file is created instead of the `[plist_name].error` file which contains the following data:

 - The original `build-command` and `analyzer-command`
 - The `return-code` of the analyzer
 - The `stdout` and `stderr` output (if was present)
 - Every file that was `#include`d into the analysed file (along with the source file, of course) in the `source-root` folder, with *full* path.
   - If this "dependency" generation fails, a `no-sources` file containing the error reason.

Closes #736.