### PR TITLE
Minor fix for server --stop-all

### DIFF
--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -378,14 +378,15 @@ def __instance_management(args):
         print(output_formatters.twodim_to_str('table', head, rows))
     elif 'stop' in args or 'stop_all' in args:
         for i in instance_manager.list():
+            if i['hostname'] != socket.gethostname():
+                continue
+
             # A STOP only stops the server associated with the given workspace
             # and view-port.
-            if i['hostname'] != socket.gethostname() or (
-                        args.stop and not (i['port'] == args.view_port and
-                                           os.path.abspath(
-                                           i['workspace']) ==
-                                           os.path.abspath(
-                                               args.config_directory))):
+            if 'stop' in args and \
+                not (i['port'] == args.view_port and
+                     os.path.abspath(i['workspace']) ==
+                     os.path.abspath(args.config_directory)):
                 continue
 
             try:

--- a/tests/functional/instance_manager/__init__.py
+++ b/tests/functional/instance_manager/__init__.py
@@ -27,7 +27,6 @@ from libtest import env
 # Stopping events for CodeChecker servers.
 EVENT_1 = multiprocessing.Event()
 EVENT_2 = multiprocessing.Event()
-EVENT_3 = multiprocessing.Event()
 
 # Test workspace initialized at setup for authentication tests.
 TEST_WORKSPACE = None
@@ -83,7 +82,6 @@ def teardown_package():
     # Let the remaining CodeChecker servers die.
     EVENT_1.set()
     EVENT_2.set()
-    EVENT_3.set()
 
     # TODO If environment variable is set keep the workspace
     # and print out the path.


### PR DESCRIPTION
The refactoring in #655 introduced a crash if `codechecker-server --stop-all` was called due to `--stop` and `--stop-all` being an `argparse.SUPPRESS` argument and thus raising a `KeyError` if `args.stop` would be used when `--stop` was **not** given.

I've also refactored the ugly long conditional to two early returns.