### PR TITLE
Deduplicate files between runs.

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -363,12 +363,12 @@ service codeCheckerDBAccess {
                  throws (1: shared.RequestFailed requestError),
 
   NeedFileResult needFileContent(
-                                 1: i64 run_id,
-                                 2: string filepath)
+                                 1: string filepath,
+                                 2: string content_hash)
                                  throws (1: shared.RequestFailed requestError),
 
   bool addFileContent(
-                      1: i64 file_id,
+                      1: string content_hash,
                       2: string file_content,
                       3: optional Encoding encoding)
                       throws (1: shared.RequestFailed requestError),

--- a/config/version.json
+++ b/config/version.json
@@ -5,7 +5,7 @@
         "revision" : "0"
     },
     "db_version":{
-        "major" : "5",
+        "major" : "6",
         "minor" : "0"
     }
 }

--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_db.py
@@ -8,12 +8,11 @@ from abc import ABCMeta
 import base64
 import codecs
 import os
-import traceback
+from hashlib import sha256
 
 import shared
 from codeCheckerDBAccess.ttypes import Encoding
 
-from libcodechecker import logger
 from libcodechecker import suppress_handler
 from libcodechecker.analyze import plist_parser
 from libcodechecker.analyze.analyzers.result_handler_base import ResultHandler
@@ -38,30 +37,32 @@ class PlistToDB(ResultHandler):
         file_ids = {}
         # Send content of file to the server if needed.
         for file_name in files:
-            file_descriptor = client.needFileContent(self.__run_id,
-                                                     file_name)
-            file_ids[file_name] = file_descriptor.fileId
-
             # Sometimes the file doesn't exist, e.g. when the input of the
             # analysis is pure plist files.
             if not os.path.isfile(file_name):
                 LOG.debug(file_name + ' not found, and will not be stored.')
                 continue
 
-            if file_descriptor.needed:
-                with codecs.open(file_name, 'r', 'UTF-8') as source_file:
-                    file_content = source_file.read()
-                    # WARN the right content encoding is needed for thrift!
-                    source = codecs.encode(file_content, 'utf-8')
-                    # TODO: we may not use the file content in the end
-                    # depending on skippaths.
+            with codecs.open(file_name, 'r', 'UTF-8') as source_file:
+                file_content = source_file.read()
+                # WARN the right content encoding is needed for thrift!
+                # TODO: we may not use the file content in the end
+                # depending on skippaths.
+                source = codecs.encode(file_content, 'utf-8')
 
-                    source64 = base64.b64encode(source)
-                    res = client.addFileContent(file_descriptor.fileId,
-                                                source64,
-                                                Encoding.BASE64)
-                    if not res:
-                        LOG.debug("Failed to store file content")
+            hasher = sha256()
+            hasher.update(source)
+            content_hash = hasher.digest()
+            file_descriptor = client.needFileContent(file_name, content_hash)
+            file_ids[file_name] = file_descriptor.fileId
+
+            if file_descriptor.needed:
+                source64 = base64.b64encode(source)
+                res = client.addFileContent(content_hash,
+                                            source64,
+                                            Encoding.BASE64)
+                if not res:
+                    LOG.debug("Failed to store file content")
 
         # Skipping reports in header files handled here.
         report_ids = []

--- a/libcodechecker/libclient/client.py
+++ b/libcodechecker/libclient/client.py
@@ -20,7 +20,7 @@ from libcodechecker.logger import LoggerFactory
 import shared
 
 LOG = LoggerFactory.get_new_logger('CLIENT')
-SUPPORTED_VERSION = '5.0'
+SUPPORTED_VERSION = '6.0'
 
 
 def check_api_version(client):

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -161,11 +161,11 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def needFileContent(self, run_id, filepath):
+    def needFileContent(self, filepath, content_hash):
         pass
 
     @ThriftClientCall
-    def addFileContent(self, file_id, file_content, encoding):
+    def addFileContent(self, content_hash, content, encoding):
         pass
 
     @ThriftClientCall

--- a/libcodechecker/orm_model.py
+++ b/libcodechecker/orm_model.py
@@ -89,25 +89,25 @@ class Config(Base):
         self.checker_name, self.run_id = checker_name, run_id
 
 
+class FileContent(Base):
+    __tablename__ = 'file_content'
+
+    content_hash = Column(String, primary_key=True)
+    content = Column(Binary)
+
+
 class File(Base):
     __tablename__ = 'files'
 
     id = Column(Integer, autoincrement=True, primary_key=True)
-    run_id = Column(Integer,
-                    ForeignKey('runs.id', deferrable=True,
-                               initially="DEFERRED",
-                               ondelete='CASCADE')
-                    )
     filepath = Column(String)
-    content = Column(Binary)
-    inc_count = Column(Integer)
+    content_hash = Column(String,
+                          ForeignKey('file_content.content_hash',
+                                     deferrable=True,
+                                     initially="DEFERRED", ondelete='CASCADE'))
 
-    def __init__(self, run_id, filepath):
-        self.run_id, self.filepath = run_id, filepath
-        self.inc_count = 0
-
-    def addContent(self, content):
-        self.content = content
+    def __init__(self, filepath, content_hash):
+        self.filepath, self.content_hash = filepath, content_hash
 
 
 class BugPathEvent(Base):
@@ -282,6 +282,7 @@ class Comment(Base):
         self.author = author
         self.message = message
         self.created_at = created_at
+
 
 # End of ORM classes.
 

--- a/libcodechecker/orm_model.py
+++ b/libcodechecker/orm_model.py
@@ -29,8 +29,6 @@ CC_META = MetaData(naming_convention={
 Base = declarative_base(metadata=CC_META)
 
 
-# Start of ORM classes.
-
 class DBVersion(Base):
     __tablename__ = 'db_version'
     # TODO: constraint, only one line in this table
@@ -282,9 +280,6 @@ class Comment(Base):
         self.author = author
         self.message = message
         self.created_at = created_at
-
-
-# End of ORM classes.
 
 
 def CreateSchema(engine):

--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -1559,12 +1559,13 @@ class ThriftRequestHandler():
                 shared.ttypes.ErrorCode.GENERAL,
                 str(ex))
 
+        needed = self.__session.query(FileContent).get(content_hash) is None
+
         if not f:
             f = File(filepath, content_hash)
             self.__session.add(f)
             self.__session.commit()
-            return NeedFileResult(True, f.id)
-        return NeedFileResult(False, f.id)
+        return NeedFileResult(needed, f.id)
 
     @timeit
     def addFileContent(self, content_hash, content, encoding):
@@ -1574,10 +1575,10 @@ class ThriftRequestHandler():
             content = base64.b64decode(content)
 
         try:
-            f = self.__session.query(FileContent).get(content_hash)
             compressed_content = zlib.compress(content,
-                                                zlib.Z_BEST_COMPRESSION)
-            f.content = compressed_content
+                                               zlib.Z_BEST_COMPRESSION)
+            file_content = FileContent(content_hash, compressed_content)
+            self.__session.add(file_content)
             self.__session.commit()
             return True
 


### PR DESCRIPTION
If two file has the same SHA256, store the content only once. The chance of hash collision is very small, so we do not handle that case.

Since several runs might share files with the same content this update should reduce the database size significantly. 

Closes #728.