### PR TITLE
Fix invalid subcommand choice printing ustring to commandline

### DIFF
--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -150,7 +150,7 @@ output.
                 LOG.debug("Creating arg parser for subcommand " + subcommand)
 
                 try:
-                    libhandlers.add_subcommand(subparsers, subcommand)
+                    libhandlers.add_subcommand(subparsers, str(subcommand))
                 except (IOError, ImportError):
                     LOG.warning("Couldn't import module for subcommand '" +
                                 subcommand + "'... ignoring.")


### PR DESCRIPTION
Due to the available subcommands being read from file, the option string for the subcommand is considered an Unicode string. Defining true unicode subcommands will definitely not be a case in the long run because CodeChecker is an English system.

The only effect of this fix is that if the user typos the command to use or types in a subcommand that does not exist, the error message will look instead of this:

```
$ CodeChecker whisperity
usage: CodeChecker [-h]
                   {checkers,analyze,analyzers,check,cmd,log,parse,plist,quickcheck,
                   server,store,version}
                   ...
CodeChecker: error: invalid choice: 'whisperity' (choose from 'checkers',
u'analyze', u'analyzers', u'check', u'cmd', u'log', u'parse', u'plist', u'quickcheck',
u'server', u'store', u'version')
```

like this:

```
$ CodeChecker whisperity
usage: CodeChecker [-h]
                   {checkers,analyze,analyzers,check,cmd,log,parse,plist,quickcheck,
                   server,store,version}
                   ...
CodeChecker: error: invalid choice: 'whisperity' (choose from 'checkers',
'analyze', 'analyzers', 'check', 'cmd', 'log', 'parse', 'plist', 'quickcheck',
'server', 'store', 'version')
```

(Note the `u` in front of every possible choice, except `checkers`, as it is defined in the source code, see #634 for why.)