### PR TITLE
Fix automatically starting PostgreSQL server in tests

### DIFF
--- a/libcodechecker/database_handler.py
+++ b/libcodechecker/database_handler.py
@@ -178,10 +178,10 @@ class SQLServer(object):
             # responsibility. Until then, use the default folder now
             # for the new commands who no longer define workspace.
             if 'dbdatadir' in args:
-                workspace = args.dbdatadir
+                data_url = args.dbdatadir
             else:
-                workspace = util.get_default_workspace()
-            data_url = os.path.join(workspace, 'pgsql_data')
+                data_url = os.path.join(util.get_default_workspace(),
+                                        'pgsql_data')
             return PostgreSQLServer(data_url,
                                     migration_root,
                                     args.dbaddress,
@@ -302,10 +302,18 @@ class PostgreSQLServer(SQLServer):
 
         LOG.debug('Initializing database at ' + self.path)
 
-        init_db = ['initdb', '-U', self.user, '-D', self.path, '-E SQL_ASCII']
+        init_db = ['initdb',
+                   '-U', self.user,
+                   '-D', self.path,
+                   '-E', 'SQL_ASCII']
 
         err, code = util.call_command(init_db, self.run_env)
-        # logger -> print error
+
+        if code != 0:
+            LOG.error("Couldn't initialize database. Call to 'initdb' "
+                      "returned {0}.".format(code))
+            LOG.error(err)
+
         return code == 0
 
     def _get_connection_string(self, database):

--- a/tests/functional/analyze/test_analyze.py
+++ b/tests/functional/analyze/test_analyze.py
@@ -36,7 +36,12 @@ class TestAnalyze(unittest.TestCase):
         os.makedirs(self.report_dir)
         self.test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
         # Change working dir to testfile dir so CodeChecker can be run easily.
+        self.__old_pwd = os.getcwd()
         os.chdir(self.test_dir)
+
+    def tearDown(self):
+        """Restore environment after tests have ran."""
+        os.chdir(self.__old_pwd)
 
     def test_failure(self):
         """

--- a/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -38,7 +38,13 @@ class AnalyzeParseTestCase(unittest.TestCase):
             os.path.dirname(__file__), 'test_files')
 
         # Change working dir to testfile dir so CodeChecker can be run easily.
+        cls.__old_pwd = os.getcwd()
         os.chdir(cls.test_dir)
+
+    @classmethod
+    def teardown_class(cls):
+        """Restore environment after tests have ran."""
+        os.chdir(cls.__old_pwd)
 
     def __check_one_file(self, path, mode):
         """

--- a/tests/functional/ctu/test_ctu.py
+++ b/tests/functional/ctu/test_ctu.py
@@ -42,6 +42,7 @@ class TestCtu(unittest.TestCase):
             for command in build_json:
                 command['directory'] = self.test_dir
         self.ctu_capable = self.__is_ctu_capable()
+        self.__old_pwd = os.getcwd()
         os.chdir(self.test_workspace)
         self.buildlog = os.path.join(self.test_workspace, 'buildlog.json')
         with open(self.buildlog, 'w') as log_file:
@@ -50,6 +51,7 @@ class TestCtu(unittest.TestCase):
     def tearDown(self):
         """ Tear down workspace."""
 
+        os.chdir(self.__old_pwd)
         shutil.rmtree(self.report_dir, ignore_errors=True)
 
     def test_help(self):

--- a/tests/unit/test_tidy_output_converter.py
+++ b/tests/unit/test_tidy_output_converter.py
@@ -20,9 +20,13 @@ except ImportError:
 
 import libcodechecker.analyze.tidy_output_converter as tidy_out_conv
 
+OLD_PWD = None
+
 
 def setup_module():
     """Setup the test tidy reprs for the test classes in the module."""
+    global OLD_PWD
+    OLD_PWD = os.getcwd()
     os.chdir(os.path.join(os.path.dirname(__file__), 'tidy_output_test_files'))
 
     # tidy1.out Message/Note representation
@@ -129,6 +133,12 @@ def setup_module():
     TidyPListConverterTestCase.tidy1_repr = tidy1_repr
     TidyPListConverterTestCase.tidy2_repr = tidy2_repr
     TidyPListConverterTestCase.tidy3_repr = tidy3_repr
+
+
+def teardown_module():
+    """Restore environment after tests have ran."""
+    global OLD_PWD
+    os.chdir(OLD_PWD)
 
 
 class TidyOutputParserTestCase(unittest.TestCase):


### PR DESCRIPTION
#772 or #781 broke the "postgresql local auto-start" feature in the database handler **under SLES!**, due to a working directory change. This patch fixes said issue.

There also has been a mistake in #743 resulting in the automatically created postgresql server reside under `<WORKSPACE>/pgsql_data/pgsql_data`. This has been properly fixed, so the postgres gets created and started under `<WORKSPACE>/pgsql_data`.