### PR TITLE
CTU test cannot be ran if clang-func-mapping's location is edited in the built package

### DIFF
--- a/tests/functional/ctu/__init__.py
+++ b/tests/functional/ctu/__init__.py
@@ -29,6 +29,8 @@ def setup_package():
 def teardown_package():
     """Delete workspace."""
 
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
     global TEST_WORKSPACE
 
     print('Removing: ' + TEST_WORKSPACE)


### PR DESCRIPTION
Test infrastructure cannot read configuration file. If `package_layout.json` is written **only in the package made**, (so the one in the source code directory is intact), the test can't reliably load the modified `clang-func-mapping` path.

Instead, for now, we believe that `analyze` can accurately detect if the binary exists, and run the test accordingly.