### PR TITLE
Improve dependency generation at failed analyses

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -322,7 +322,7 @@ def check(check_data):
     except Exception as e:
         LOG.debug_analyzer(str(e))
         traceback.print_exc(file=sys.stdout)
-        return 1, skipped, action.analyzer_type, None
+        return 1, skipped, action, None
 
 
 def start_workers(actions, context, analyzer_config_map,

--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -278,7 +278,7 @@ def check(check_data):
                         LOG.debug("[ZIP] Writing analyzer STDERR to /stderr")
                         archive.writestr("stderr", rh.analyzer_stderr)
 
-                    LOG.debug("Generating and writing dependent headers...")
+                    LOG.debug("Generating dependent headers via compiler...")
                     try:
                         dependencies = set(create_dependencies(rh.buildaction))
                     except Exception as ex:
@@ -287,6 +287,28 @@ def check(check_data):
                         archive.writestr("no-sources", str(ex))
                         dependencies = set()
 
+                    LOG.debug("Fetching other dependent files from analyzer "
+                              "output...")
+                    try:
+                        other_files = set()
+                        if len(rh.analyzer_stdout) > 0:
+                            other_files.update(
+                                source_analyzer.get_analyzer_mentioned_files(
+                                    rh.analyzer_stdout))
+
+                        if len(rh.analyzer_stderr) > 0:
+                            other_files.update(
+                                source_analyzer.get_analyzer_mentioned_files(
+                                    rh.analyzer_stderr))
+                    except Exception as ex:
+                        LOG.debug("Couldn't generate list of other files "
+                                  "from analyzer output:")
+                        LOG.debug(str(ex))
+                        other_files = set()
+
+                    dependencies.update(other_files)
+
+                    LOG.debug("Writing dependent files to archive.")
                     for dependent_source in dependencies:
                         LOG.debug("[ZIP] Writing '" + dependent_source + "' "
                                   "to the archive.")

--- a/libcodechecker/analyze/analyzers/analyzer_base.py
+++ b/libcodechecker/analyze/analyzers/analyzer_base.py
@@ -69,6 +69,15 @@ class SourceAnalyzer(object):
         """
         pass
 
+    @abstractmethod
+    def get_analyzer_mentioned_files(self, output):
+        """
+        Return a collection of files that were mentioned by the analyzer in
+        its standard outputs, which should be analyzer_stdout or
+        analyzer_stderr from a result handler.
+        """
+        pass
+
     def analyze(self, res_handler, env=None):
         """
         Run the analyzer.

--- a/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
@@ -117,6 +117,31 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             LOG.error(ex)
             return []
 
+    def get_analyzer_mentioned_files(self, output):
+        """
+        Parse Clang-Tidy's output to generate a list of files that were
+        mentioned in the standard output or standard error.
+        """
+
+        # A line mentioning a file in Clang-Tidy's output looks like this:
+        # /home/.../.cpp:L:C: warning: foobar.
+        regex = re.compile(
+            # File path followed by a ':'.
+            '^(?P<path>[\S ]+?):'
+            # Line number followed by a ':'.
+            '(?P<line>\d+?):'
+            # Column number followed by a ':' and a space.
+            '(?P<column>\d+?):\ ')
+
+        paths = []
+
+        for line in output.splitlines():
+            match = re.match(regex, line)
+            if match:
+                paths.append(match.group('path'))
+
+        return set(paths)
+
     @classmethod
     def resolve_missing_binary(cls, configured_binary, env):
         """

--- a/libcodechecker/analyze/tidy_output_converter.py
+++ b/libcodechecker/analyze/tidy_output_converter.py
@@ -74,11 +74,11 @@ class OutputParser(object):
     # Regex for parsing a clang-tidy message.
     message_line_re = re.compile(
         # File path followed by a ':'.
-        '^(?P<path>[\S]+):'
+        '^(?P<path>[\S ]+?):'
         # Line number followed by a ':'.
-        '(?P<line>\d+):'
+        '(?P<line>\d+?):'
         # Column number followed by a ':' and a space.
-        '(?P<column>\d+):\ '
+        '(?P<column>\d+?):\ '
         # Severity followed by a ':'.
         '(?P<severity>\w+):'
         # Checker message.
@@ -89,11 +89,11 @@ class OutputParser(object):
     # Matches a note.
     note_line_re = re.compile(
         # File path followed by a ':'.
-        '^(?P<path>[\S]+):'
+        '^(?P<path>[\S ]+?):'
         # Line number followed by a ':'.
-        '(?P<line>\d+):'
+        '(?P<line>\d+?):'
         # Column number followed by a ':' and a space.
-        '(?P<column>\d+):\ '
+        '(?P<column>\d+?):\ '
         # Severity == note.
         'note:'
         # Checker message.

--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -107,7 +107,14 @@ REPLACE_OPTIONS_MAP = {
 
 IGNORED_OPTION_MAP = {
     '-MT': 1,
+    '-MQ': 1,
     '-MF': 1,
+    '-MJ': 1,
+    '-MM': 0,
+    '-MP': 0,
+    '-MD': 0,
+    '-MV': 0,
+    '-MMD': 0,
     '-fsyntax-only': 0,
     '-save-temps': 0,
     '-install_name': 1,
@@ -123,6 +130,10 @@ IGNORED_OPTION_MAP = {
     '--param': 1,
     '-u': 1,
     '--serialize-diagnostics': 1
+}
+
+IGNORED_OPTION_MAP_REGEX = {
+    '^-g(.+)?$': 0,
 }
 
 # Unknown options by clang, will be skipped.
@@ -435,6 +446,7 @@ def arg_check(it, result):
         append_merged_to_list(LINK_OPTION_MAP_MERGED, result.link_opts),
         skip(LINKER_OPTION_MAP),
         skip(IGNORED_OPTION_MAP),
+        skip(IGNORED_OPTION_MAP_REGEX, True),
         append_to_list_from_file('-filelist', result.files),
         append_to_list({'^[^-].+': 0}, result.files, True)]
 

--- a/tests/functional/analyze/__init__.py
+++ b/tests/functional/analyze/__init__.py
@@ -27,6 +27,9 @@ def setup_package():
     global TEST_WORKSPACE
     TEST_WORKSPACE = env.get_workspace('analyze')
 
+    report_dir = os.path.join(TEST_WORKSPACE, 'reports')
+    os.makedirs(report_dir)
+
     os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
 
 


### PR DESCRIPTION
> Closes #793.

# Enhancements
 - Certain build systems, such as that of Linux and Apache Xerces, make `make` make dependency files on the fly. These directives are recorded in the build action, and they derail our dependency list generation which would create the source files in the `failed.zip`.
 - If the crash happens in CTU, the dependency list only contains the files originally found by G++/Clang to be a dependency for the build action... Additional to this, we now parse the analyzer output with a regular expression matching lines that mention files, and add these files to the ZIP too.

# Fixes
 - A nonexistent dependency file reported by the compiler would crash the current analyzer call. This has been fixed in a way that we explicitly append to the archive, under `failed-sources-root/<filename>` the reason why it couldn't be added to the archive.
 - Python Exceptions in the analyzer invoker code (such as the one above) would result in the process pool crashing and the `analyze` call hanging indefinitely. This has been fixed too.