### PR TITLE
fix if workspace is removed before server stop

### DIFF
--- a/tests/functional/comment/__init__.py
+++ b/tests/functional/comment/__init__.py
@@ -116,7 +116,7 @@ def teardown_package():
     global TEST_WORKSPACE
 
     print("Removing: " + TEST_WORKSPACE)
-    shutil.rmtree(TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE, ignore_errors=True)
 
 
 def _start_server(codechecker_cfg, test_config, auth=False):

--- a/tests/functional/comment_unauth/__init__.py
+++ b/tests/functional/comment_unauth/__init__.py
@@ -112,7 +112,7 @@ def teardown_package():
     global TEST_WORKSPACE
 
     print("Removing: " + TEST_WORKSPACE)
-    shutil.rmtree(TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE, ignore_errors=True)
 
 
 def _start_server(codechecker_cfg, test_config, auth=False):


### PR DESCRIPTION
It is possible that the workspace was removed before the
server was stopped in that case an IOError was thrown
by the instance manager during the rewriting the configuration
files.

If stopping the server takes more time in the comment tests
the cleanup fails beacause there are files used by the server.