### PR TITLE
Fix severity string crashing when a bug is loaded

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -183,11 +183,16 @@ function (declare, Deferred, ObjectStore, Store, QueryResults, topic,
     }
   });
 
-  function severityFormatter(id) {
-    var severityStr = util.severityFromCodeToString(id);
-    var title = severityStr.charAt(0).toUpperCase() + severityStr.slice(1);
+  function severityFormatter(severity) {
+    // When loaded from URL then report data is originally a number.
+    // When loaded by clicking on a table row, then severity is already
+    // changed to its string representation.
+    if (typeof severity === 'number')
+      severity = util.severityFromCodeToString(severity);
+
+    var title = severity.charAt(0).toUpperCase() + severity.slice(1);
     return '<span title="' + title  + '" class="icon-severity icon-severity-'
-      + severityStr + '"></span>';
+      + severity + '"></span>';
   }
 
   var ListOfBugsGrid = declare(DataGrid, {


### PR DESCRIPTION
#817 contained a minor oversight. While it fixed the severity field being unsortable, it did not take into account a crucial thing:

https://github.com/Ericsson/codechecker/blob/068c206a01d756b7870d0e1c6d737e9c276787e1/www/scripts/codecheckerviewer/BugViewer.js#L381-L386

When a bug was clicked on in the bug list, the code crashed in `ListOfBugs.js` because the new formatter function was called with the severity **string** (such as `low` or `high`) instead of the severity **enum value** (such as `30`).

I have appended this exact same routine to the changes of #817. 