### PR TITLE
Fix logging with nonexistant G++ on macOS

### DIFF
--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -330,7 +330,7 @@ def main(args):
     if len(actions) == 0:
         LOG.info("None of the specified build log files contained "
                  "valid compilation commands. No analysis needed...")
-        return
+        sys.exit(1)
 
     if 'enable_all' in args:
         LOG.info("'--enable-all' was supplied for this analysis.")

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -502,7 +502,6 @@ def main(args):
         # database. When changing this behavior, the workspace argument should
         # be removed from here.
         store_args = argparse.Namespace(
-            workspace=args.workspace,
             input=[report_dir],
             input_format='plist',
             jobs=args.jobs,

--- a/tests/projects/simple/Makefile
+++ b/tests/projects/simple/Makefile
@@ -1,0 +1,4 @@
+all:
+	$(CXX) -c main.cpp -o /dev/null
+clean:
+	echo "clean"

--- a/tests/projects/simple/project_info.json
+++ b/tests/projects/simple/project_info.json
@@ -1,5 +1,5 @@
 {
     "name": "simple",
-    "clean_cmd": "rm a.out",
-    "build_cmd": "g++ main.cpp"
+    "clean_cmd": "make clean",
+    "build_cmd": "make"
 }


### PR DESCRIPTION
Due to this mishap, tests were already running in a bad fashion on macOS: https://travis-ci.org/whisperity/CodeChecker/jobs/266089412#L1806. But it didn't cause a functional problem, as the stored empty run could be deleted, and only `delete_runs` used this project.

(With #724, this behaviour will change, which surfaced the issue of `store` using an empty folder for storage.)

The change involves using the environmental variable `CXX` (just like in the test project `cpp`) for building.

To help better using the test and log output, the logger has been changed so that `INFO`s and `ERROR`s in **`--verbose debug`** are also a lot more verbose.
Previously, even in `debug` printing, `INFO` and `ERROR` logs did **not** contain otherwise useful information, such as the code location where the log output was issued.
This was especially an issue in understanding long outputs where multiple CodeCheckers were logging to the same output stream, such as on Travis.

As an added bonus, `CodeChecker analyze` will now properly return with `exit 1` if none of the build JSONs given to it contain a valid build command. (So build logging issues are better visible later on.)