### PR TITLE
Fix store using /tmp for ZIP paths

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -310,12 +310,12 @@ service codeCheckerDBAccess {
 
   // This function stores an entire run encapsulated and sent in a ZIP file.
   // The ZIP file has to be compressed and sent as a base64 encoded string. The
-  // ZIP file must contain exactly one directory which has a "reports" and an
-  // optional "root" sub-folder. The former one is the output of "CodeChecker
-  // analyze" command and the latter one contains the source files on absolute
-  // paths starting as if "root" was the "/" directory. The source files are
-  // not necessary to be wrapped in the ZIP file (see necessaryFileContents()
-  // function).
+  // ZIP file must contain a "reports" and an optional "root" sub-folder.
+  // The former one is the output of 'CodeChecker analyze' command and the
+  // latter one contains the source files on absolute paths starting as if
+  // "root" was the "/" directory. The source files are not necessary to be
+  // wrapped in the ZIP file (see necessaryFileContents() function).
+  //
   // The "version" parameter is the used CodeChecker version which checked this
   // run.
   // The "force" parameter removes existing analysis results for a run.

--- a/libcodechecker/analyze/store_handler.py
+++ b/libcodechecker/analyze/store_handler.py
@@ -4,6 +4,7 @@
 #   License. See LICENSE.TXT for details.
 # -------------------------------------------------------------------------
 
+import base64
 from hashlib import sha256
 import json
 import os

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -340,7 +340,7 @@ def main(args):
     if len(actions) == 0:
         LOG.info("None of the specified build log files contained "
                  "valid compilation commands. No analysis needed...")
-        return
+        sys.exit(1)
 
     if 'enable_all' in args:
         LOG.info("'--enable-all' was supplied for this analysis.")

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -488,7 +488,6 @@ def main(args):
         # database. When changing this behavior, the workspace argument should
         # be removed from here.
         store_args = argparse.Namespace(
-            workspace=args.workspace,
             input=[report_dir],
             input_format='plist',
             force=args.force,

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -469,8 +469,6 @@ def main(args):
             __update_if_key_exists(args, analyze_args, key)
         if args.force:
             setattr(analyze_args, 'clean', True)
-
-        analyze_module = __load_module("analyze")
         __update_if_key_exists(args, analyze_args, "verbose")
 
         analyze_module = __load_module("analyze")

--- a/libcodechecker/libhandlers/quickcheck.py
+++ b/libcodechecker/libhandlers/quickcheck.py
@@ -350,8 +350,6 @@ def main(args):
             input_format='plist',
             print_steps=args.print_steps
         )
-
-        parse_module = __load_module("parse")
         __update_if_key_exists(args, parse_args, "verbose")
 
         parse_module = __load_module("parse")

--- a/tests/functional/detection_status/test_detection_status.py
+++ b/tests/functional/detection_status/test_detection_status.py
@@ -48,12 +48,15 @@ class TestDetectionStatus(unittest.TestCase):
         self._source_file = "main.cpp"
 
         # Init project dir.
+        makefile = "all:\n\t$(CXX) -c main.cpp -o /dev/null\n"
         project_info = {
             "name": "hello",
             "clean_cmd": "",
-            "build_cmd": "g++ main.cpp"
+            "build_cmd": "make"
         }
 
+        with open(os.path.join(self._test_dir, 'Makefile'), 'w') as f:
+            f.write(makefile)
         with open(os.path.join(self._test_dir, 'project_info.json'), 'w') as f:
             json.dump(project_info, f)
 
@@ -117,7 +120,7 @@ int main()
         # Check the first file version
         self._create_source_file(1)
 
-        runs = self._cc_client.getRunData("")
+        runs = self._cc_client.getRunData(None)
         run_id = max(map(lambda run: run.runId, runs))
 
         reports = self._cc_client.getRunResults(run_id, 100, 0, {}, {})

--- a/tests/functional/report_viewer_api/test_files/metadata.json
+++ b/tests/functional/report_viewer_api/test_files/metadata.json
@@ -57,10 +57,10 @@
     "clangsa": 1,
     "clang-tidy": 1},
   "command": [
-    "/home/etibbru/CodeChecker/CodeChecker/build/CodeChecker/cc_bin/CodeChecker.py",
+    "/home/user/CodeChecker/bin/CodeChecker.py",
     "analyze",
-    "asd.json"],
+    "test_hash_clash.json"],
   "failed": {},
-  "working_directory": "/home/etibbru/CodeCompass/projects/hello",
+  "working_directory": "$$$",
   "timestamps": {"begin": 1502964665.566252, "end": 1502964665.777198},
-  "output_path": "/home/etibbru/.codechecker/reports"}
+  "output_path": "$$$"}

--- a/tests/projects/simple/Makefile
+++ b/tests/projects/simple/Makefile
@@ -1,0 +1,4 @@
+all:
+	$(CXX) -c main.cpp -o /dev/null
+clean:
+	echo "clean"

--- a/tests/projects/simple/project_info.json
+++ b/tests/projects/simple/project_info.json
@@ -1,5 +1,5 @@
 {
     "name": "simple",
-    "clean_cmd": "rm a.out",
-    "build_cmd": "g++ main.cpp"
+    "clean_cmd": "make clean",
+    "build_cmd": "make"
 }


### PR DESCRIPTION
> Contains changes of #824 too, as those issues were made apparent on `version6` branch. The `(cherry-picked)` commit will be eliminated at the next rebase of `version6`.

On macOS, the temporary folder is in an entirely different location: `/var/folders/my/[some random string?]/T/tmp[random token]`. :exclamation:

Due to this, `/tmp` must not be hardcoded for the ZIP system. Also, there was some nasty hack of `store` assembling a structure over `/tmp/tmpXXXXX` and zipping it as `tmpXXXXX/reports/*.plist` and so on. On the server, it was saved to `/tmp/tmpYYYYY.zip` which was unzipped to `/tmp/tmpXXXXX` (even if it existed earlier!) and then this path was used later on to find the files.

Instead of this, Python module [`tempfile`](https://docs.python.org/2/library/tempfile.html) is used in this patch to properly generate valid, random temporary folders and ZIP files. (Thus, no state, such as the subfolder under `/tmp` is carried from `store` to `server`.)

----

Some minor fixes was also applied:
 * The ZIP creation and extraction process are now more verbosely logged in `debug` verbosity.
 * The tests introduced with #724 to `report_viewer_api` will now properly make the temporary files into the `build/workspace/[test-folder]` instead of the `/tests/functional/[test-folder]`, solving badly modified files reported by Git if someone executes tests from their local working directory.
 * Akin to #824, the `detection_status` test was changed to use `$(CXX)` instead of `g++` so this test produces a valid analysis output on macOS.
 * In some tests, `""` was used instead of the proper value `None` for `getRunData()` API call. These were fixed too.
