### PR TITLE
Skipping and replacing non-utf8 characters from source files.

### DIFF
--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -1487,7 +1487,8 @@ class ThriftRequestHandler(object):
                     LOG.debug(file_name + ' not found or already stored.')
                     continue
 
-                with codecs.open(zip_file_name, 'r', 'UTF-8') as source_file:
+                with codecs.open(zip_file_name, 'r',
+                                 'UTF-8', 'replace') as source_file:
                     file_content = source_file.read()
                     # TODO: we may not use the file content in the end
                     # depending on skippaths.

--- a/libcodechecker/server/client_db_access_server.py
+++ b/libcodechecker/server/client_db_access_server.py
@@ -222,6 +222,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
             return
 
         except Exception as exn:
+            import traceback
+            traceback.print_exc()
             LOG.error(str(exn))
             self.send_error(404, "Request failed.")
             return


### PR DESCRIPTION
Fixing utf8 parsing errors at store (which makes the storage fail) and showing Exception stack trace when processing thrift POST calls. Will be useful for debugging production environment... 

Fixes #820