### PR TITLE
Fix bug event numbering restarts when the bug path changes file

### DIFF
--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -161,6 +161,10 @@ function (declare, domClass, dom, style, fx, Toggler, on, query, Memory,
       var reportDetails = CC_SERVICE.getReportDetails(this.reportData.reportId);
 
       var points = reportDetails.executionPath.filter(filterFunction);
+      reportDetails.pathEvents.map(function (evt, index) {
+        evt.bugEventNumber = index + 1;
+      });
+
       var bubbles = reportDetails.pathEvents.filter(filterFunction);
 
       // This is needed because CodeChecker gives different positions.
@@ -185,7 +189,9 @@ function (declare, domClass, dom, style, fx, Toggler, on, query, Memory,
             ? 'error' : bubble.msg.indexOf(' (fixit)') > -1
             ? 'fixit' : 'info';
 
-          var enumeration = createBugStepEnumeration(i + 1, enumType).outerHTML;
+          var enumeration =
+            createBugStepEnumeration(bubble.bugEventNumber, enumType).outerHTML;
+
           var element = dom.create('div', {
             style : 'margin-left: ' + left,
             class : 'check-msg ' + enumType,


### PR DESCRIPTION
Closes #829 

![cc_bugevent_numbering](https://user-images.githubusercontent.com/6695818/29617531-830e7888-8815-11e7-8fa2-cb4f7b18a0ad.png)
