### PR TITLE
Show detection status icon in the report tree

### DIFF
--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -550,8 +550,11 @@ function (declare, domClass, dom, style, fx, Toggler, on, query, Memory,
           case 'severity':
             return "icon-severity icon-severity-" + item.id;
           case 'bugpath':
-            return (opened ? "customIcon pathOpened"
-                           : "customIcon pathClosed");
+            var status =
+              util.detectionStatusFromCodeToString(item.report.detectionStatus);
+
+            return 'customIcon detection-status-' + status.toLowerCase() + ' '
+              + (opened ? 'pathOpened' : 'pathClosed');
           default:
             return (opened ? "dijitFolderOpened" : "dijitFolderClosed");
         }

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -338,12 +338,8 @@ span[class*="severity-"] {
 
 /* -- */
 
-.customIcon.pathClosed:before {
-  content: "\e003";
-}
-
-.customIcon.pathOpened:before {
-  content: "\e004";
+.customIcon.pathOpened {
+  opacity: 0.7;
 }
 
 .customIcon.result:before {


### PR DESCRIPTION
I changed the report tree to show the actual Detection Status icon instead of list icon.

Old:
![bugtree_old](https://user-images.githubusercontent.com/6695818/29623047-64fb5b3a-8825-11e7-95af-2dba9485cd4e.png)

New:
![bugtree_detection_status](https://user-images.githubusercontent.com/6695818/29623049-69493842-8825-11e7-8309-9823831d7ec5.png)

What do you think about this?