### PR TITLE
Storage on remote server (non localhost) is fixed. Source files are t…

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -306,9 +306,9 @@ service codeCheckerDBAccess {
   // database. If it is, then it is not necessary to send it in the ZIP file
   // with massStoreRun() function. This function requires a list of file hashes
   // (sha256) and returns the ones which are not stored yet.
-  list<string> necessaryFileContents(
-                                     1: list<string> file_hashes)
-                                     throws (1: shared.RequestFailed requestError),
+  list<string> getMissingContentHashes(
+                                       1: list<string> file_hashes)
+                                       throws (1: shared.RequestFailed requestError),
 
   // This function stores an entire run encapsulated and sent in a ZIP file.
   // The ZIP file has to be compressed and sent as a base64 encoded string. The
@@ -316,7 +316,7 @@ service codeCheckerDBAccess {
   // The former one is the output of 'CodeChecker analyze' command and the
   // latter one contains the source files on absolute paths starting as if
   // "root" was the "/" directory. The source files are not necessary to be
-  // wrapped in the ZIP file (see necessaryFileContents() function).
+  // wrapped in the ZIP file (see getMissingContentHashes() function).
   //
   // The "version" parameter is the used CodeChecker version which checked this
   // run.

--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -106,7 +106,7 @@ def create_dependencies(action):
 
         if option_index:
             arg_vect = arg_vect[0:option_index] + \
-                       arg_vect[option_index + num_args + 1:]
+                arg_vect[option_index + num_args + 1:]
 
         return arg_vect
 

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -136,7 +136,7 @@ class ThriftClientHelper(object):
     # STORAGE RELATED API CALLS
 
     @ThriftClientCall
-    def necessaryFileContents(self, file_hashes):
+    def getMissingContentHashes(self, file_hashes):
         pass
 
     @ThriftClientCall

--- a/tests/libtest/codechecker.py
+++ b/tests/libtest/codechecker.py
@@ -199,6 +199,7 @@ def serv_cmd(codechecker_cfg, test_config):
                        '--port',
                        str(codechecker_cfg['viewer_port'])
                        ])
+    # server_cmd.extend(['--verbose', 'debug'])
 
     psql_cfg = codechecker_cfg.get('pg_db_config')
     if psql_cfg:


### PR DESCRIPTION
…aken

from the ZIP file instead of the directories on the server.
content_hashes.json file is now generated and sent over by the store command.
This file contains the content hashes of all source files that are referred to from the plist.
So the server can now find the correct file versions for the source files when storing the reports.

Fixed a bug which caused source files not being put into the ZIP file when their content hashes were the same.

Renamed necessaryFileContents to getMissingContentHashes to better express its functionality.