### PR TITLE
Make Travis faster by only downloading shallow LLVM on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       env: DATABASE=psql_pg8000
 
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm --branch master --single-branch --depth 1; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz -O; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;               fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/thrift090;                fi
@@ -50,33 +50,31 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PYTHONPATH=~/llvm/tools/scan-build-py/; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/llvm/tools/scan-build-py/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build; fi
-
-install:
-    - pip install nose pep8
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PG_DATA=$(brew --prefix)/var/postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}; cat postgres.log; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
+
+install:
+    - pip install nose pep8
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
-
 
 addons:
     apt:
         sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
             - llvm-toolchain-precise
+            - llvm-toolchain-precise-3.8
+            - ubuntu-toolchain-r-test
         packages:
-            - doxygen
-            - libpq-dev
             - clang-3.8
             - clang-tidy-3.8
-            - libc6-dev-i386
+            - doxygen
             - gcc-multilib
+            - libc6-dev-i386
+            - libpq-dev
             - thrift-compiler
-
     postgresql: "9.3"
 
 script:


### PR DESCRIPTION
There is no need to download the full Clang history for the macOS tests. This speeds up from 10 minutes to 1 minute to fetch `scan-build-py`, as only ~40k objects need to be downloaded instead of ~700k.
It will also make the macOS cases more resilient against timeouts.