### PR TITLE
Improve result query performance

### DIFF
--- a/api/report_server.thrift
+++ b/api/report_server.thrift
@@ -58,11 +58,11 @@ struct ReportData{
   4: string              checkerMsg,      // description of the bug report
   5: i64                 reportId,        // id of the report in the current run in the db
   6: i64                 fileId,          // unique id of the file the report refers to
-  7: shared.BugPathEvent lastBugPosition  // This contains the range and message of the last item in the symbolic
-                                          // execution step list.
-  8: shared.Severity     severity         // checker severity
-  9: ReviewData          review           // bug review status informations.
-  10: shared.DetectionStatus detectionStatus  // state of the bug (see the enum constant values)
+  7: i64                 line,            // line number or the reports main section (not part of the path)
+  8: i64                 column,          // column number of the report main section (not part of the path)
+  9: shared.Severity     severity         // checker severity
+  10: ReviewData          review           // bug review status informations.
+  11: shared.DetectionStatus detectionStatus  // state of the bug (see the enum constant values)
 }
 typedef list<ReportData> ReportDataList
 

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -165,7 +165,7 @@ def handle_list_results(args):
 
         rows = []
         for res in all_results:
-            bug_line = res.lastBugPosition.startLine
+            bug_line = res.line
             checked_file = res.checkedFile + ' @ ' + str(bug_line)
             sev = shared.ttypes.Severity._VALUES_TO_NAMES[res.severity]
 
@@ -312,8 +312,8 @@ def handle_diff_results(args):
                     getLineFromFile(report.main['location']['file_name'],
                                     bug_line)
             else:
-                bug_line = report.lastBugPosition.startLine
-                bug_col = report.lastBugPosition.startCol
+                bug_line = report.line
+                bug_col = report.column
                 sev = \
                     shared.ttypes.Severity._VALUES_TO_NAMES[report.severity]
                 checked_file = report.checkedFile + ':' + str(bug_line) +\

--- a/libcodechecker/orm_model.py
+++ b/libcodechecker/orm_model.py
@@ -186,6 +186,8 @@ class Report(Base):
     checker_cat = Column(String)
     bug_type = Column(String)
     severity = Column(Integer)
+    line = Column(Integer)
+    column = Column(Integer)
 
     # TODO: multiple messages to multiple source locations?
     checker_message = Column(String)
@@ -203,7 +205,8 @@ class Report(Base):
 
     # Priority/severity etc...
     def __init__(self, run_id, bug_id, file_id, checker_message, checker_id,
-                 checker_cat, bug_type, severity, detection_status):
+                 checker_cat, bug_type, line, column, severity,
+                 detection_status):
         self.run_id = run_id
         self.file_id = file_id
         self.bug_id = bug_id
@@ -213,6 +216,8 @@ class Report(Base):
         self.checker_cat = checker_cat
         self.bug_type = bug_type
         self.detection_status = detection_status
+        self.line = line
+        self.column = column
 
 
 class SkipPath(Base):

--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -359,36 +359,6 @@ class ThriftRequestHandler(object):
         self.__Session = Session
         self.__storage_session = StorageSession()
 
-    def __lastBugEventPos(self, report_id):
-        """
-        This function returns the last BugPathEvent object position which
-        belongs to the given report. If no such event is found then None
-        returns.
-        """
-        try:
-            session = self.__Session()
-
-            last = session.query(BugPathEvent) \
-                .filter(BugPathEvent.report_id == report_id) \
-                .order_by(BugPathEvent.order.desc()) \
-                .limit(1).one_or_none()
-
-            if not last:
-                return None
-
-            bpe = bugpathevent_db_to_api(last)
-            bpe.filePath = session.query(File).get(bpe.fileId).filepath
-
-            return bpe
-        except sqlalchemy.exc.SQLAlchemyError as ex:
-            msg = str(ex)
-            LOG.error(msg)
-            raise shared.ttypes.RequestFailed(
-                shared.ttypes.ErrorCode.DATABASE,
-                msg)
-        finally:
-            session.close()
-
     def __sortResultsQuery(self, query, sort_types=None):
         """
         Helper method for __queryDiffResults and queryResults to apply sorting.
@@ -511,7 +481,8 @@ class ThriftRequestHandler(object):
                 checkerMsg=report.checker_message,
                 reportId=report.id,
                 fileId=source_file.id,
-                lastBugPosition=self.__lastBugEventPos(report.id),
+                line=report.line,
+                column=report.column,
                 checkerId=report.checker_id,
                 severity=report.severity,
                 review=review_data,
@@ -574,8 +545,8 @@ class ThriftRequestHandler(object):
                                checkerMsg=report.checker_message,
                                reportId=report.id,
                                fileId=source_file.id,
-                               lastBugPosition=self.__lastBugEventPos(
-                                   report.id),
+                               line=report.line,
+                               column=report.column,
                                checkerId=report.checker_id,
                                severity=report.severity,
                                review=review_data,
@@ -655,8 +626,8 @@ class ThriftRequestHandler(object):
                                checkerMsg=report.checker_message,
                                reportId=report.id,
                                fileId=source_file.id,
-                               lastBugPosition=self.__lastBugEventPos(
-                                   report.id),
+                               line=report.line,
+                               column=report.column,
                                checkerId=report.checker_id,
                                severity=report.severity,
                                review=review_data,
@@ -1590,7 +1561,8 @@ class ThriftRequestHandler(object):
                     checkerMsg=report.checker_message,
                     reportId=report.id,
                     fileId=source_file.id,
-                    lastBugPosition=self.__lastBugEventPos(report.id),
+                    line=report.line,
+                    column=report.column,
                     checkerId=report.checker_id,
                     severity=report.severity,
                     review=review_data,
@@ -1663,7 +1635,8 @@ class ThriftRequestHandler(object):
                     checkerMsg=report.checker_message,
                     reportId=report.id,
                     fileId=source_file.id,
-                    lastBugPosition=self.__lastBugEventPos(report.id),
+                    line=report.line,
+                    column=report.column,
                     checkerId=report.checker_id,
                     severity=report.severity,
                     review=review_data))
@@ -2205,13 +2178,10 @@ class ThriftRequestHandler(object):
                     self.__storage_session,
                     run_id,
                     file_ids[files[report.main['location']['file']]],
-                    report.main['issue_hash_content_of_line_in_context'],
-                    report.main['description'],
+                    report.main,
                     bug_paths,
                     bug_events,
                     checker_name,
-                    report.main['category'],
-                    report.main['type'],
                     severity)
 
                 LOG.debug("Storing done for report " + str(report_id))

--- a/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/tests/functional/report_viewer_api/test_get_run_results.py
@@ -206,6 +206,6 @@ class RunResults(unittest.TestCase):
             bug2 = run_results[i + 1]
             self.assertTrue(bug1.checkedFile <= bug2.checkedFile)
             self.assertTrue((bug1.checkedFile != bug2.checkedFile) or
-                            (bug1.lastBugPosition.startLine <=
-                             bug2.lastBugPosition.startLine) or
+                            (bug1.line <=
+                             bug2.line) or
                             (bug1.checkerId <= bug2.checkerId))

--- a/tests/libtest/result_compare.py
+++ b/tests/libtest/result_compare.py
@@ -15,7 +15,7 @@ def compare_res_with_bug(run_res, bug):
     """
     same = False
     same = run_res.checkedFile.endswith(bug['file']) and \
-        run_res.lastBugPosition.startLine == bug['line'] and \
+        run_res.line == bug['line'] and \
         run_res.checkerId == bug['checker'] and \
         run_res.bugHash == bug['hash']
     return same

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -91,7 +91,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
     _formatItems : function (reportDataList) {
       reportDataList.forEach(function (reportData) {
         reportData.checkedFile = reportData.checkedFile +
-          ' @ Line ' + reportData.lastBugPosition.startLine;
+          ' @ Line ' + reportData.line;
 
         //--- Review status ---//
         var review = reportData.review;


### PR DESCRIPTION
To get the last bug events is a costly query just to view the line number on the UI.
The Report table is extended with the line and column data for faster query.
The api to get the reports was changed to get the report events only if they really needed.

Resolves #816 