### PR TITLE
fix skip for header files

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -17,6 +17,7 @@ import zipfile
 
 from libcodechecker import util
 from libcodechecker.analyze import analyzer_env
+from libcodechecker.analyze import plist_parser
 from libcodechecker.analyze.analyzers import analyzer_types
 from libcodechecker.logger import LoggerFactory
 
@@ -295,6 +296,13 @@ def check(check_data):
                     err_file = os.path.join(failed_dir, result_base + '.zip')
                     if os.path.exists(err_file):
                         os.remove(err_file)
+
+                if skip_handler:
+                    # We need to check the plist content because skipping
+                    # reports in headers can be done only this way.
+                    plist_parser.skip_report_from_plist(result_file,
+                                                        skip_handler)
+
             else:
                 # If the analysis has failed, we help debugging.
                 if not os.path.exists(failed_dir):
@@ -399,7 +407,7 @@ def check(check_data):
     except Exception as e:
         LOG.debug_analyzer(str(e))
         traceback.print_exc(file=sys.stdout)
-        return 1, skipped, reanalyzed, action, None
+        return 1, skipped, reanalyzed, action.analyzer_type, None
 
 
 def start_workers(actions, context, analyzer_config_map,

--- a/tests/functional/diff/test_diff.py
+++ b/tests/functional/diff/test_diff.py
@@ -159,7 +159,7 @@ class Diff(unittest.TestCase):
                                                     [],
                                                     None,
                                                     cmp_data)
-        self.assertEqual(len(diff_res), 18)
+        self.assertEqual(len(diff_res), 20)
 
     def test_get_diff_res_count_resolved(self):
         """
@@ -211,14 +211,14 @@ class Diff(unittest.TestCase):
                                                         None,
                                                         cmp_data)
 
-        self.assertEqual(diff_res, 18)
+        self.assertEqual(diff_res, 20)
 
     def test_get_diff_res_count_unresolved_filter(self):
         base_run_id = self._base_runid
         new_run_id = self._new_runid
 
         filter_severity_levels = [{"MEDIUM": 1}, {"LOW": 5},
-                                  {"HIGH": 12}, {"STYLE": 0},
+                                  {"HIGH": 14}, {"STYLE": 0},
                                   {"UNSPECIFIED": 0}, {"CRITICAL": 0}]
 
         cmp_data = CompareData(run_ids=[new_run_id],
@@ -300,7 +300,7 @@ class Diff(unittest.TestCase):
                                                     report_filter,
                                                     cmp_data)
         # Unresolved core checkers.
-        test_res = {'core.NullDereference': 4, 'core.DivideZero': 3}
+        test_res = {'core.NullDereference': 4, 'core.DivideZero': 5}
         self.assertDictContainsSubset(test_res, diff_res)
 
     def test_get_diff_checker_counts_all_unresolved(self):
@@ -317,7 +317,7 @@ class Diff(unittest.TestCase):
                                                     None,
                                                     cmp_data)
         # All unresolved checkers.
-        test_res = {'core.DivideZero': 3,
+        test_res = {'core.DivideZero': 5,
                     'core.NullDereference': 4,
                     'cplusplus.NewDelete': 5,
                     'deadcode.DeadStores': 5,
@@ -338,7 +338,7 @@ class Diff(unittest.TestCase):
         sev_res = self._cc_client.getSeverityCounts([base_run_id],
                                                     None,
                                                     cmp_data)
-        test_res = {shared.ttypes.Severity.HIGH: 12,
+        test_res = {shared.ttypes.Severity.HIGH: 14,
                     shared.ttypes.Severity.LOW: 5,
                     shared.ttypes.Severity.MEDIUM: 1}
         self.assertDictEqual(sev_res, test_res)
@@ -390,7 +390,7 @@ class Diff(unittest.TestCase):
                                                     None,
                                                     cmp_data)
 
-        test_res = {shared.ttypes.ReviewStatus.UNREVIEWED: 18}
+        test_res = {shared.ttypes.ReviewStatus.UNREVIEWED: 20}
         self.assertDictEqual(res, test_res)
 
     def test_get_diff_res_review_status_counts(self):
@@ -449,7 +449,7 @@ class Diff(unittest.TestCase):
                     'deadcode.DeadStores': 5,
                     'unix.Malloc': 1,
                     'core.NullDereference': 4,
-                    'core.DivideZero': 3}
+                    'core.DivideZero': 5}
         self.assertDictEqual(diff_res, test_res)
 
     def test_get_diff_res_types_unresolved_filter(self):
@@ -540,7 +540,7 @@ class Diff(unittest.TestCase):
 
         # # 3 disappeared core.StackAddressEscape issues
         count = len(re.findall(r'\[core\.DivideZero\]', out))
-        self.assertEqual(count, 3)
+        self.assertEqual(count, 5)
         count = len(re.findall(r'\[deadcode\.DeadStores\]', out))
         self.assertEqual(count, 5)
         count = len(re.findall(r'\[core\.NullDereference\]', out))
@@ -549,5 +549,3 @@ class Diff(unittest.TestCase):
         self.assertEqual(count, 5)
         count = len(re.findall(r'\[unix\.Malloc\]', out))
         self.assertEqual(count, 1)
-        count = len(re.findall(r'\[core.DivideZero\]', out))
-        self.assertEqual(count, 3)

--- a/tests/functional/diff/test_regression_diff.py
+++ b/tests/functional/diff/test_regression_diff.py
@@ -129,14 +129,14 @@ class Diff(unittest.TestCase):
                                                       DiffType.UNRESOLVED,
                                                       [])
 
-        self.assertEqual(diff_res, 18)
+        self.assertEqual(diff_res, 20)
 
     def test_get_diff_res_count_unresolved_filter(self):
         base_run_id = self._base_runid
         new_run_id = self._new_runid
 
         filter_severity_levels = [{"MEDIUM": 1}, {"LOW": 5},
-                                  {"HIGH": 12}, {"STYLE": 0},
+                                  {"HIGH": 14}, {"STYLE": 0},
                                   {"UNSPECIFIED": 0}, {"CRITICAL": 0}]
 
         for level in filter_severity_levels:
@@ -212,7 +212,7 @@ class Diff(unittest.TestCase):
 
     def test_get_diff_res_types_unresolved_filter(self):
         """
-        Test diff result types for unresolved results with checker name filter
+        test diff result types for unresolved results with checker name filter
         on the api.
         """
         base_run_id = self._base_runid
@@ -305,7 +305,7 @@ class Diff(unittest.TestCase):
 
         # # 3 disappeared core.StackAddressEscape issues
         count = len(re.findall(r'\[core\.DivideZero\]', out))
-        self.assertEqual(count, 3)
+        self.assertEqual(count, 5)
         count = len(re.findall(r'\[deadcode\.DeadStores\]', out))
         self.assertEqual(count, 5)
         count = len(re.findall(r'\[core\.NullDereference\]', out))
@@ -314,5 +314,3 @@ class Diff(unittest.TestCase):
         self.assertEqual(count, 5)
         count = len(re.findall(r'\[unix\.Malloc\]', out))
         self.assertEqual(count, 1)
-        count = len(re.findall(r'\[core.DivideZero\]', out))
-        self.assertEqual(count, 3)

--- a/tests/functional/report_viewer_api/test_report_counting.py
+++ b/tests/functional/report_viewer_api/test_report_counting.py
@@ -58,7 +58,7 @@ class TestReportFilter(unittest.TestCase):
 
         self.run1_checkers = \
             {'core.CallAndMessage': 5,
-             'core.DivideZero': 3,
+             'core.DivideZero': 5,
              'core.NullDereference': 4,
              'core.StackAddressEscape': 3,
              'cplusplus.NewDelete': 5,
@@ -67,7 +67,7 @@ class TestReportFilter(unittest.TestCase):
 
         self.run2_checkers = \
             {'core.CallAndMessage': 5,
-             'core.DivideZero': 3,
+             'core.DivideZero': 5,
              'core.NullDereference': 4,
              'cplusplus.NewDelete': 5,
              'deadcode.DeadStores': 5,
@@ -75,17 +75,17 @@ class TestReportFilter(unittest.TestCase):
 
         self.run1_sev_counts = {Severity.MEDIUM: 1,
                                 Severity.LOW: 5,
-                                Severity.HIGH: 20}
+                                Severity.HIGH: 22}
 
         self.run2_sev_counts = {Severity.MEDIUM: 1,
                                 Severity.LOW: 5,
-                                Severity.HIGH: 17}
+                                Severity.HIGH: 19}
 
         self.run1_detection_counts = \
-            {DetectionStatus.NEW: 26}
+            {DetectionStatus.NEW: 28}
 
         self.run2_detection_counts = \
-            {DetectionStatus.NEW: 23}
+            {DetectionStatus.NEW: 25}
 
         self.run1_files = \
             {'file_to_be_skipped.cpp': 2,
@@ -94,7 +94,9 @@ class TestReportFilter(unittest.TestCase):
              'stack_address_escape.cpp': 3,
              'call_and_message.cpp': 5,
              'divide_zero.cpp': 4,
-             'has a space.cpp': 1
+             'has a space.cpp': 1,
+             'skip_header.cpp': 1,
+             'skip.h': 1
              }
 
         self.run2_files = \
@@ -103,7 +105,9 @@ class TestReportFilter(unittest.TestCase):
              'divide_zero.cpp': 4,
              'null_dereference.cpp': 5,
              'file_to_be_skipped.cpp': 2,
-             'has a space.cpp': 1
+             'has a space.cpp': 1,
+             'skip_header.cpp': 1,
+             'skip.h': 1
              }
 
     def test_run1_all_checkers(self):
@@ -346,7 +350,7 @@ class TestReportFilter(unittest.TestCase):
 
         # Unset statuses cout as unreviewed.
         review_status = {ReviewStatus.CONFIRMED: 5,
-                         ReviewStatus.UNREVIEWED: 11,
+                         ReviewStatus.UNREVIEWED: 13,
                          ReviewStatus.FALSE_POSITIVE: 5,
                          ReviewStatus.WONT_FIX: 5}
 
@@ -457,7 +461,7 @@ class TestReportFilter(unittest.TestCase):
                'core.StackAddressEscape': 3,
                'cplusplus.NewDelete': 5,
                'core.NullDereference': 4,
-               'core.DivideZero': 3,
+               'core.DivideZero': 5,
                'deadcode.DeadStores': 5,
                'unix.Malloc': 1}
         self.assertDictEqual(new, new_reports)

--- a/tests/functional/report_viewer_api/test_report_filter.py
+++ b/tests/functional/report_viewer_api/test_report_filter.py
@@ -185,7 +185,7 @@ class TestReportFilter(unittest.TestCase):
 
         run_result_count = self._cc_client.getRunResultCount(self._runids, [])
 
-        self.assertEqual(run_result_count, 49)
+        self.assertEqual(run_result_count, 53)
 
         run_results = self._cc_client.getRunResults(
             self._runids, run_result_count, 0, [], [])

--- a/tests/functional/report_viewer_api/test_report_filter_v2.py
+++ b/tests/functional/report_viewer_api/test_report_filter_v2.py
@@ -190,7 +190,7 @@ class TestReportFilter(unittest.TestCase):
                                                                 None,
                                                                 None)
 
-        self.assertEqual(run_result_count, 49)
+        self.assertEqual(run_result_count, 53)
 
         run_results = self._cc_client.getRunResults_v2(
             self._runids, run_result_count, 0, [], None, None)

--- a/tests/functional/skip/__init__.py
+++ b/tests/functional/skip/__init__.py
@@ -108,7 +108,8 @@ def _generate_skip_list_file(skip_list_file):
     """
     skip_list_content = ["-*randtable.c", "-*blocksort.c", "-*huffman.c",
                          "-*decompress.c", "-*crctable.c",
-                         "-*file_to_be_skipped.cpp"]
+                         "-*file_to_be_skipped.cpp",
+                         "-*skip.h"]
     print('Skip list file content: ' + skip_list_file)
     print('\n'.join(skip_list_content))
 

--- a/tests/functional/skip/test_skip.py
+++ b/tests/functional/skip/test_skip.py
@@ -61,23 +61,22 @@ class TestSkip(unittest.TestCase):
         run_results = get_all_run_results(self._cc_client, runid)
         self.assertIsNotNone(run_results)
 
-        skipped_file = "file_to_be_skipped.cpp"
+        skipped_files = ["file_to_be_skipped.cpp", "skip.h"]
 
         test_proj_res = self._testproject_data[self._clang_to_test]['bugs']
-        skipped = [x for x in test_proj_res if x['file'] == skipped_file]
+        skipped = [x for x in test_proj_res if x['file'] in skipped_files]
+
         print("Analysis:")
         for res in run_results:
             print(res)
 
-        print("Test config results:")
+        print("\nTest config results:")
         for res in test_proj_res:
             print(res)
 
-        print("Test config skipped results:")
+        print("\nTest config skipped results:")
         for res in skipped:
             print(res)
-
-        self.assertEqual(len(run_results), len(test_proj_res) - len(skipped))
 
         missing_results = find_all(run_results, test_proj_res)
 
@@ -89,8 +88,10 @@ class TestSkip(unittest.TestCase):
 
         if missing_results:
             for bug in missing_results:
-                self.assertEqual(bug['file'], skipped_file)
+                self.assertIn(bug['file'], skipped_files)
         else:
             self.assertTrue(True,
                             "There should be missing results because"
                             "using skip")
+
+        self.assertEqual(len(run_results), len(test_proj_res) - len(skipped))

--- a/tests/projects/cpp/Makefile
+++ b/tests/projects/cpp/Makefile
@@ -6,6 +6,7 @@ all:
 	$(CXX) -c new_delete.cpp
 	$(CXX) -c null_dereference.cpp
 	$(CXX) -c stack_address_escape.cpp
+	$(CXX) -c skip_header.cpp
 clean:
 	rm -f call_and_message.o
 	rm -f divide_zero.o

--- a/tests/projects/cpp/project_info.json
+++ b/tests/projects/cpp/project_info.json
@@ -29,13 +29,15 @@
             { "file": "null_dereference.cpp", "line": 29, "checker": "deadcode.DeadStores", "hash": "98db15ea41ba255ba5e98d5ed35b5037" },
             { "file": "stack_address_escape.cpp", "line": 15, "checker": "core.StackAddressEscape", "hash": "a785826f20c20d703c98eacb6f014bc0" },
             { "file": "stack_address_escape.cpp", "line": 18, "checker": "core.StackAddressEscape", "hash": "79838e6f63246dda474910da1d37ae32" },
-            { "file": "stack_address_escape.cpp", "line": 25, "checker": "core.StackAddressEscape", "hash": "d8284a4775702c394deb2b9f6ae7c2fd" }
+            { "file": "stack_address_escape.cpp", "line": 25, "checker": "core.StackAddressEscape", "hash": "d8284a4775702c394deb2b9f6ae7c2fd" },
+            { "file": "skip_header.cpp", "line": 15, "checker": "core.DivideZero", "hash": "6323bb2b22ffeff5c265eb14ae402d29" },
+            { "file": "skip.h", "line": 8, "checker": "core.DivideZero", "hash": "269d82a20d38f23bbf730a2cf1d1668b" }
         ],
-        "filter_severity_levels": [{"MEDIUM": 1}, {"LOW": 5}, {"HIGH": 20}, {"STYLE": 0}, {"UNSPECIFIED": 0}, {"CRITICAL": 0}],
-        "filter_checker_id": [{"*unix*": 1}, {"core*": 15}, {"*DeadStores": 5}],
+        "filter_severity_levels": [{"MEDIUM": 1}, {"LOW": 5}, {"HIGH": 22}, {"STYLE": 0}, {"UNSPECIFIED": 0}, {"CRITICAL": 0}],
+        "filter_checker_id": [{"*unix*": 1}, {"core*": 17}, {"*DeadStores": 5}],
         "filter_filepath": [{"*null*": 5}],
         "filter_filepath_case_insensitive": [{"*null*": 5}, {"*nULl*": 5}, {"*NULL*": 5}, {"*Null*": 5}],
-        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 26}, {"FALSE_POSITIVE": 0}, {"WONT_FIX": 0}],
+        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 28}, {"FALSE_POSITIVE": 0}, {"WONT_FIX": 0}],
         "diff_res_types_filter": [{"deadcode.DeadStores": 5},  {"cplusplus.NewDelete": 5}, {"unix.Malloc": 1}]
     }
 }

--- a/tests/projects/cpp/skip.h
+++ b/tests/projects/cpp/skip.h
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+int null_div(int z) {
+    int x = z / 0; // warn
+    return x;
+}
+

--- a/tests/projects/cpp/skip_header.cpp
+++ b/tests/projects/cpp/skip_header.cpp
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+#include "skip.h"
+
+int test() {
+    int x = null_div(42);
+    return x;
+}
+
+int test1(int i) {
+    int y = i / 0; // warn
+    return y;
+}
+

--- a/tests/projects/cpp/skip_list
+++ b/tests/projects/cpp/skip_list
@@ -1,1 +1,0 @@
--*file_to_be_skipped.cpp


### PR DESCRIPTION
Skipping reports in header files included by a c/cpp
file can be done only after the analysis is done and the
plist output is generated.

With this modification if there is a skip file with headers
in it, the reports from the header will be removed from the
generated plist file.

resolves #812