### PR TITLE
Find basenamed binary in PATH if present, instead of versioned one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
       env: DATABASE=psql_pg8000
 
 before_install:
+    # Download macOS specific extra dependencies.
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm --branch master --single-branch --depth 1; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz -O; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;               fi
@@ -50,6 +51,14 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PYTHONPATH=~/llvm/tools/scan-build-py/; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/llvm/tools/scan-build-py/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build; fi
+
+    # Set the proper Clang versions early in the PATH.
+    - export PATH=$HOME:$PATH
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which clang-3.8; ln -s $(which clang-3.8) $HOME/clang; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which clang-tidy-3.8; ln -s $(which clang-tidy-3.8) $HOME/clang-tidy; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which clang; ln -s $(which clang) $HOME/clang; fi
+
+    # PostgreSQL is not started automatically on macOS.
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PG_DATA=$(brew --prefix)/var/postgres; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -w start -l postgres.log --pgdata ${PG_DATA}; cat postgres.log; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi

--- a/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
@@ -157,7 +157,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             return False
 
         # clang-tidy, clang-tidy-5.0, ...
-        clangtidy = get_binary_in_path(r'^clang-tidy(-\d+(\.\d+){0,2})?$', env)
+        clangtidy = get_binary_in_path(['clang-tidy'],
+                                       r'^clang-tidy(-\d+(\.\d+){0,2})?$',
+                                       env)
 
         LOG.debug("Using '" + clangtidy + "' for ClangSA!")
         return clangtidy

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -219,7 +219,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             return False
 
         # clang, clang-5.0, clang++, clang++-5.1, ...
-        clang = get_binary_in_path(r'^clang(\+\+)?(-\d+(\.\d+){0,2})?$', env)
+        clang = get_binary_in_path(['clang', 'clang++'],
+                                   r'^clang(\+\+)?(-\d+(\.\d+){0,2})?$',
+                                   env)
 
         LOG.debug("Using '" + clang + "' for ClangSA!")
         return clang

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -170,13 +170,13 @@ def find_by_regex_in_envpath(pattern, environment):
     return binaries
 
 
-def get_binary_in_path(pattern, env):
+def get_binary_in_path(basename_list, versioning_pattern, env):
     """
     Select the most matching binary for the given pattern in the given
     environment. Works well for binaries that contain versioning.
     """
 
-    binaries = find_by_regex_in_envpath(pattern, env)
+    binaries = find_by_regex_in_envpath(versioning_pattern, env)
 
     if len(binaries) == 0:
         return False
@@ -185,10 +185,20 @@ def get_binary_in_path(pattern, env):
         # found binary name group.
         return binaries.values()[0][0]
     else:
-        # Select the "newest" available clang version if there are multiple.
         keys = list(binaries.keys())
         keys.sort()
-        files = binaries[keys[-1]]
+
+        # If one of the base names match, select that version.
+        for base_key in basename_list:
+            # Cannot use set here as it would destroy precendence.
+            if base_key in keys:
+                files = binaries[base_key]
+                break
+
+        if not files:
+            # Select the "newest" available version if there are multiple and
+            # none of the base names matched.
+            files = binaries[keys[-1]]
 
         # Return the one earliest in PATH.
         return files[0]


### PR DESCRIPTION
There was an issue that if the user had `clang-tidy-3.5` installed whereas `clang-tidy` in the PATH was a newer one, we still used the `-3.5` version.

This has been changed so that the **automatic detection** favours the "non-versioned" binary names, and if one is found, uses the earliest of such in the PATH.

----

Travis need to be changed back so that the custom-installed `clang-3.8` is used instead of `clang` (which is a `clang-3.5` automatically installed by the system). The symbolic link in the home folder takes care of that.