### PR TITLE
Use the same naming convention at CodeChecker javascript services

### DIFF
--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -33,16 +33,16 @@ function (declare, topic, domConstruct, Dialog, DropDownMenu, MenuItem,
 
     CC_OBJECTS = codeCheckerDBAccess;
 
-    AUTH_SERVICE =
+    CC_AUTH_SERVICE =
       new codeCheckerAuthentication.codeCheckerAuthenticationClient(
         new Thrift.TJSONProtocol(
           new Thrift.Transport("/Authentication")));
 
-    PROD_SERVICE =
+    CC_PROD_SERVICE =
       new codeCheckerProductManagement.codeCheckerProductServiceClient(
         new Thrift.Protocol(new Thrift.Transport("Products")));
 
-    PROD_OBJECTS = codeCheckerProductManagement;
+    CC_PROD_OBJECTS = codeCheckerProductManagement;
 
     //----------------------------- Main layout ------------------------------//
 
@@ -56,7 +56,7 @@ function (declare, topic, domConstruct, Dialog, DropDownMenu, MenuItem,
 
     //--- Logo ---//
 
-    var currentProduct = PROD_SERVICE.getCurrentProduct();
+    var currentProduct = CC_PROD_SERVICE.getCurrentProduct();
     var currentProductName = util.atou(currentProduct.displayedName_b64);
     document.title = currentProductName + ' - CodeChecker';
 
@@ -76,7 +76,7 @@ function (declare, topic, domConstruct, Dialog, DropDownMenu, MenuItem,
       innerHTML : CC_SERVICE.getPackageVersion()
     }, logoText);
 
-    var user = AUTH_SERVICE.getLoggedInUser();
+    var user = CC_AUTH_SERVICE.getLoggedInUser();
     var loginUserSpan = null;
     if (user.length > 0) {
       loginUserSpan = domConstruct.create('span', {

--- a/www/scripts/productlist/ListOfProducts.js
+++ b/www/scripts/productlist/ListOfProducts.js
@@ -117,7 +117,8 @@ function (declare, domConstruct, ItemFileWriteStore, topic, Button,
     _populateProducts : function (productNameFilter) {
       var that = this;
 
-      PROD_SERVICE.getProducts(null, productNameFilter, function (productList) {
+      CC_PROD_SERVICE.getProducts(null, productNameFilter,
+      function (productList) {
         that.onLoaded(productList);
 
         productList.forEach(function (item) {
@@ -142,7 +143,8 @@ function (declare, domConstruct, ItemFileWriteStore, topic, Button,
         }
       });
 
-      PROD_SERVICE.getProducts(null, productNameFilter, function (productDataList) {
+      CC_PROD_SERVICE.getProducts(null, productNameFilter,
+      function (productDataList) {
         productDataList.forEach(function (item) {
           that._addProductData(item);
         });

--- a/www/scripts/productlist/productlist.js
+++ b/www/scripts/productlist/productlist.js
@@ -19,13 +19,13 @@ function (declare, topic, domConstruct, Button, BorderContainer,
 
     //---------------------------- Global objects ----------------------------//
 
-    PROD_SERVICE =
+    CC_PROD_SERVICE =
       new codeCheckerProductManagement.codeCheckerProductServiceClient(
         new Thrift.Protocol(new Thrift.Transport("Products")));
 
-    PROD_OBJECTS = codeCheckerProductManagement;
+    CC_PROD_OBJECTS = codeCheckerProductManagement;
 
-    AUTH_SERVICE =
+    CC_AUTH_SERVICE =
       new codeCheckerAuthentication.codeCheckerAuthenticationClient(
         new Thrift.TJSONProtocol(
           new Thrift.Transport("/Authentication")));
@@ -55,10 +55,10 @@ function (declare, topic, domConstruct, Button, BorderContainer,
 
     var version = domConstruct.create('span', {
       id : 'logo-version',
-      innerHTML : PROD_SERVICE.getPackageVersion()
+      innerHTML : CC_PROD_SERVICE.getPackageVersion()
     }, logoText);
 
-    var user = AUTH_SERVICE.getLoggedInUser();
+    var user = CC_AUTH_SERVICE.getLoggedInUser();
     var loginUserSpan = null;
     if (user.length > 0) {
       loginUserSpan = domConstruct.create('span', {


### PR DESCRIPTION
The #773 pull request has broken the commenting and the review status feature,  because it renamed the CC_AUTH_SERVICE to AUTH_SERVICE but in some file it didn't.

We should use the same naming convention in javascript files for CodeChecker services (`CC_` prefix).