### PR TITLE
Auto-detect compiler target and add it to the analyze command.

### DIFF
--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -88,9 +88,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd = [config.analyzer_binary]
 
-            analyzer_cmd.extend(self.buildaction.compiler_defines)
-            analyzer_cmd.extend(self.buildaction.compiler_includes)
-
             if len(config.compiler_resource_dir) > 0:
                 analyzer_cmd.extend(['-resource-dir',
                                      config.compiler_resource_dir,
@@ -163,6 +160,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.append(config.analyzer_extra_arguments)
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
+
+            analyzer_cmd.extend(self.buildaction.compiler_includes)
 
             analyzer_cmd.append(self.source_file)
 

--- a/libcodechecker/analyze/analyzers/ctu_triple_arch.py
+++ b/libcodechecker/analyze/analyzers/ctu_triple_arch.py
@@ -17,7 +17,6 @@ def get_compile_command(action, config, source='', output=''):
     for other operations. """
 
     cmd = [config.analyzer_binary]
-    cmd.extend(action.compiler_defines)
     cmd.extend(action.compiler_includes)
     if len(config.compiler_resource_dir) > 0:
         cmd.extend(['-resource-dir', config.compiler_resource_dir,

--- a/libcodechecker/log/build_action.py
+++ b/libcodechecker/log/build_action.py
@@ -13,7 +13,6 @@ class BuildAction(object):
         self._id = build_action_id
         self._analyzer_options = []
         self._compiler_includes = []
-        self._compiler_defines = []
         self._analyzer_type = -1
         self._original_command = ''
         self._directory = ''
@@ -60,14 +59,6 @@ class BuildAction(object):
     @compiler_includes.setter
     def compiler_includes(self, value):
         self._compiler_includes = value
-
-    @property
-    def compiler_defines(self):
-        return self._compiler_defines
-
-    @compiler_defines.setter
-    def compiler_defines(self, value):
-        self._compiler_defines = value
 
     @property
     def analyzer_options(self):


### PR DESCRIPTION
Inclusion of target-specific defines is disabled.