### PR TITLE
Fix a storage bug

### DIFF
--- a/libcodechecker/analyze/store_handler.py
+++ b/libcodechecker/analyze/store_handler.py
@@ -53,9 +53,17 @@ def metadata_info(metadata_file):
     return check_commands, check_durations, skip_handlers
 
 
-def collect_paths_events(report, file_ids):
-    files = file_ids.keys()
+def collect_paths_events(report, file_ids, files):
+    """
+    This function creates the BugPathPos and BugPathEvent objects which belong
+    to a report.
 
+    report -- A report object from the parsed plist file.
+    file_ids -- A dictionary which maps the file paths to file IDs in the
+                database.
+    files -- A list containing the file paths from the parsed plist file. The
+             order of this list must be the same as in the plist file.
+    """
     bug_paths = []
     bug_events = []
 

--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -10,7 +10,6 @@ Handle Thrift requests.
 import base64
 import codecs
 from collections import defaultdict
-from collections import OrderedDict
 import datetime
 import json
 import os
@@ -2335,7 +2334,7 @@ class ThriftRequestHandler(object):
                 LOG.error('Parsing the plist failed: ' + str(ex))
                 continue
 
-            file_ids = OrderedDict()
+            file_ids = {}
             # Store content of file to the server if needed.
             for file_name in files:
                 file_ids[file_name] = file_path_to_id[file_name]
@@ -2352,7 +2351,7 @@ class ThriftRequestHandler(object):
                     shared.ttypes.Severity._NAMES_TO_VALUES[severity_name]
 
                 bug_paths, bug_events = \
-                    store_handler.collect_paths_events(report, file_ids)
+                    store_handler.collect_paths_events(report, file_ids, files)
 
                 LOG.debug("Storing report")
                 report_id = store_handler.addReport(


### PR DESCRIPTION
Fixes #878
In the CTU parsing there happened to be a path which goes threw a file
twice, including another file between these two. In the previous
implementation we had a dictionary which contained the files as keys,
but according to the precondition of `collect_path_events()` function
the keys of this dictionary have to be the file list in the same order
as in the plist file including multiple occurrences.