### PR TITLE
Foreign key bugfix

### DIFF
--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -2265,6 +2265,7 @@ class ThriftRequestHandler(object):
             for file_name in files:
                 source_file_name = os.path.join(source_root,
                                                 file_name.strip("/"))
+                source_file_name = os.path.realpath(source_file_name)
                 LOG.debug("Storing source file:"+source_file_name)
 
                 if not os.path.isfile(source_file_name):


### PR DESCRIPTION
At storage the file path has to be normalized in case it contains '..'
part (e.g. a/b/../c/d).