### PR TITLE
Update test project for Clang-3.9 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,22 +40,21 @@ matrix:
 before_install:
     # Download macOS specific extra dependencies.
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm --branch master --single-branch --depth 1; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz -O; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl http://releases.llvm.org/3.9.0/clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz -O; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;               fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/thrift090;                fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=/usr/local/Cellar/thrift@0.90/0.9.0/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which thrift;                fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install doxygen;               fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz -C ~/; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/clang+llvm-3.8.0-x86_64-apple-darwin/bin/:$PATH; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar xf clang+llvm-3.9.0-x86_64-apple-darwin.tar.xz -C ~/; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/clang+llvm-3.9.0-x86_64-apple-darwin/bin/:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PYTHONPATH=~/llvm/tools/scan-build-py/; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/llvm/tools/scan-build-py/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod a+x ~/llvm/tools/scan-build-py/bin/intercept-build; fi
 
     # Set the proper Clang versions early in the PATH.
     - export PATH=$HOME:$PATH
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which clang-3.8; ln -s $(which clang-3.8) $HOME/clang; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which clang-tidy-3.8; ln -s $(which clang-tidy-3.8) $HOME/clang-tidy; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which clang; which clang-tidy; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which clang; ln -s $(which clang) $HOME/clang; fi
 
     # PostgreSQL is not started automatically on macOS.
@@ -73,12 +72,8 @@ install:
 addons:
     apt:
         sources:
-            - llvm-toolchain-precise
-            - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
         packages:
-            - clang-3.8
-            - clang-tidy-3.8
             - doxygen
             - gcc-multilib
             - libc6-dev-i386

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -189,6 +189,7 @@ def get_binary_in_path(basename_list, versioning_pattern, env):
         keys.sort()
 
         # If one of the base names match, select that version.
+        files = None
         for base_key in basename_list:
             # Cannot use set here as it would destroy precendence.
             if base_key in keys:

--- a/tests/projects/cpp/project_info.json
+++ b/tests/projects/cpp/project_info.json
@@ -5,7 +5,7 @@
     "clang_stable": {
         "bugs": [
             { "file": "call_and_message.cpp", "line": 19, "checker": "core.CallAndMessage", "hash": "3fbecc0c445a2d45d94eab4ac921ff8b" },
-            { "file": "call_and_message.cpp", "line": 24, "checker": "core.CallAndMessage", "hash": "b867ce71d1acd1f107c74a60d3488630" },
+            { "file": "call_and_message.cpp", "line": 24, "checker": "core.CallAndMessage", "hash": "d2f5e4582550c02937c549aff599fe95" },
             { "file": "call_and_message.cpp", "line": 30, "checker": "core.CallAndMessage", "hash": "8d46ddba240e5dedcc46eb8d685f72c7" },
             { "file": "call_and_message.cpp", "line": 40, "checker": "core.CallAndMessage", "hash": "238003a99eb9995e520a5b67e81fea8d" },
             { "file": "call_and_message.cpp", "line": 45, "checker": "core.CallAndMessage", "hash": "c17c89738f50c7b8ae6833223354a855" },


### PR DESCRIPTION
As of 7 September, 2017, Travis has updated the Ubuntu Trusty (14.04) images (automatically loaded at every job start). [Travis news](https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/)

The only important change for us is that now, they automatically ship Clang `3.9` in the image.

This means that our test projects could be updated to use Clang-3.9 hashes, and there is no longer a need to manually install `clang-3.8` in the image. (This further speeds up Travis tests!)