### PR TITLE
Fixing root.user file deletion exception

### DIFF
--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -426,9 +426,13 @@ def main(args):
         GenericSuppressHandler(None, False)
 
     if 'reset_root' in args:
-        os.remove(os.path.join(args.config_directory, 'root.user'))
-        LOG.info("Master superuser (root) credentials invalidated and "
-                 "deleted. New ones will be generated...")
+        try:
+            os.remove(os.path.join(args.config_directory, 'root.user'))
+            LOG.info("Master superuser (root) credentials invalidated and "
+                     "deleted. New ones will be generated...")
+        except OSError:
+            # File doesn't exist.
+            pass
 
     if 'force_auth' in args:
         LOG.info("'--force-authentication' was passed as a command-line "


### PR DESCRIPTION
Initially `root.user` file doesn't exist. If the server is started with
`--reset-root` flag then this file is removed which produces an
exception if the file doesn't exist.