### PR TITLE
Preserve asserts. Fixes #380.

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -178,7 +178,10 @@ UNKNOWN_OPTIONS_MAP_REGEX = {
     '^-mupdate$': 0,
     '^-fno-merge-const-bfstores$': 0,
     '^-fno-ipa-sra$': 0,
-    '^-mno-thumb-interwork$': 0
+    '^-mno-thumb-interwork$': 0,
+    # This is not unknown but we want to preserve asserts to improve the
+    # quality of analysis.
+    '^-DNDEBUG$': 0
 }
 
 


### PR DESCRIPTION
Preserving asserts will improve the quality of the analysis. Fixes #380.