### PR TITLE
fix pep8 and broken comment test because of uniqueing

### DIFF
--- a/libcodechecker/server/client_db_access_handler.py
+++ b/libcodechecker/server/client_db_access_handler.py
@@ -689,11 +689,11 @@ class ThriftRequestHandler(object):
             # initial ORDER BY expressions problem.
             if is_unique:
                 q = q.order_by(Report.bug_id,
-                           Report.checker_id,
-                           Report.checker_message,
-                           Report.severity,
-                           File.filename,
-                           ReviewStatus.status)
+                               Report.checker_id,
+                               Report.checker_message,
+                               Report.severity,
+                               File.filename,
+                               ReviewStatus.status)
 
             if cmp_data:
                 q = q.filter(Report.bug_id.in_(diff_hashes))

--- a/tests/functional/comment/test_comment.py
+++ b/tests/functional/comment/test_comment.py
@@ -93,8 +93,12 @@ class TestComment(unittest.TestCase):
         self.assertTrue(success)
         logging.debug('Bug commented successfully')
 
-        # Add new comment for the second bug
-        bug2 = run_results[1]
+        # Add new comment for a second bug with a different hash!
+        bug2 = None
+        for b in run_results:
+            if b.bugHash != bug.bugHash:
+                bug2 = b
+
         comment3 = CommentData(author='anybody', message='Third msg')
         success = self._cc_client.addComment(bug2.reportId, comment3)
         self.assertTrue(success)


### PR DESCRIPTION
Comments are added based on report hash. There were
no bugs with the same hash in the test suite, with the
newly added test files this changed and the comment tests
needed to be updated.