### PR TITLE
Show severity of the report at parse command

### DIFF
--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
@@ -59,16 +59,17 @@ class PlistToStdout(ResultHandler):
         return '%s%s^' % (line.replace('\t', '  '), marker_line)
 
     @staticmethod
-    def __format_bug_event(name, event, source_file):
+    def __format_bug_event(name, severity, event, source_file):
 
         loc = event['location']
         fname = os.path.basename(source_file)
         if name:
-            return '%s:%d:%d: %s [%s]' % (fname,
-                                          loc['line'],
-                                          loc['col'],
-                                          event['message'],
-                                          name)
+            return '[%s] %s:%d:%d: %s [%s]' % (severity,
+                                               fname,
+                                               loc['line'],
+                                               loc['col'],
+                                               event['message'],
+                                               name)
         else:
             return '%s:%d:%d: %s' % (fname,
                                      loc['line'],
@@ -123,7 +124,11 @@ class PlistToStdout(ResultHandler):
 
                 continue
 
+            severity = self.severity_map.get(checker_name,
+                                             'UNSPECIFIED')
+
             self.__output.write(self.__format_bug_event(checker_name,
+                                                        severity,
                                                         last_report_event,
                                                         source_file))
             self.__output.write('\n')
@@ -135,7 +140,9 @@ class PlistToStdout(ResultHandler):
                 for index, event in enumerate(events):
                     self.__output.write(index_format % (index + 1))
                     source_file = files[event['location']['file']]
-                    self.__output.write(self.__format_bug_event(None, event,
+                    self.__output.write(self.__format_bug_event(None,
+                                                                None,
+                                                                event,
                                                                 source_file))
                     self.__output.write('\n')
             self.__output.write('\n')

--- a/tests/functional/analyze_and_parse/test_files/multi_error.en1.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error.en1.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
+[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   return &x;
   ^
 

--- a/tests/functional/analyze_and_parse/test_files/multi_error.en2.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error.en2.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
+[LOW] multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;
   ^
 

--- a/tests/functional/analyze_and_parse/test_files/multi_error.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error.output
@@ -17,11 +17,11 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
+[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   return &x;
   ^
 
-multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
+[LOW] multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;
   ^
 

--- a/tests/functional/analyze_and_parse/test_files/multi_error.steps.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error.steps.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
+[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   return &x;
   ^
   Steps:
@@ -25,7 +25,7 @@ multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' 
     2, multi_error.cpp:1:1: Entered call from 'main'
     3, multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller
 
-multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
+[LOW] multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;
   ^
   Steps:

--- a/tests/functional/analyze_and_parse/test_files/multi_error_suppress.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error_suppress.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make multi_error_suppress" --output $OUTPUT$ --
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-multi_error_suppress.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
+[HIGH] multi_error_suppress.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
   return &x;
   ^
 

--- a/tests/functional/analyze_and_parse/test_files/saargs_forward.output
+++ b/tests/functional/analyze_and_parse/test_files/saargs_forward.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make saargs_forward" --output $OUTPUT$ --quiet 
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-saargs_forward.cpp:11:10: Dereference of null pointer (loaded from variable 'ptr') [core.NullDereference]
+[HIGH] saargs_forward.cpp:11:10: Dereference of null pointer (loaded from variable 'ptr') [core.NullDereference]
   return *ptr;
          ^
 

--- a/tests/functional/analyze_and_parse/test_files/simple1.output
+++ b/tests/functional/analyze_and_parse/test_files/simple1.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make simple1" --output $OUTPUT$ --quiet --analy
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-simple1.cpp:18:15: Division by zero [core.DivideZero]
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero]
   return 2015 / x;
               ^
 

--- a/tests/functional/analyze_and_parse/test_files/simple1.steps.output
+++ b/tests/functional/analyze_and_parse/test_files/simple1.steps.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make simple1" --output $OUTPUT$ --quiet --analy
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-simple1.cpp:18:15: Division by zero [core.DivideZero]
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero]
   return 2015 / x;
               ^
   Steps:

--- a/tests/functional/analyze_and_parse/test_files/simple2.output
+++ b/tests/functional/analyze_and_parse/test_files/simple2.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make simple2" --output $OUTPUT$ --quiet --analy
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-simple2.cpp:17:14: Division by zero [core.DivideZero]
+[HIGH] simple2.cpp:17:14: Division by zero [core.DivideZero]
   return 2015 / x;
               ^
 

--- a/tests/functional/analyze_and_parse/test_files/simple2.steps.output
+++ b/tests/functional/analyze_and_parse/test_files/simple2.steps.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make simple2" --output $OUTPUT$ --quiet --analy
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-simple2.cpp:17:14: Division by zero [core.DivideZero]
+[HIGH] simple2.cpp:17:14: Division by zero [core.DivideZero]
   return 2015 / x;
               ^
   Steps:

--- a/tests/functional/analyze_and_parse/test_files/tidy_check.output
+++ b/tests/functional/analyze_and_parse/test_files/tidy_check.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make tidy_check" --output $OUTPUT$ --quiet --an
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-tidy_check.cpp:5:5: found assert() with side effect [misc-assert-side-effect]
+[MEDIUM] tidy_check.cpp:5:5: found assert() with side effect [misc-assert-side-effect]
     assert(++i);
     ^
 


### PR DESCRIPTION
In the parse command also show the severity of the bug like:
```bash
[HIGH] tinyxml.cpp:1884:12: Dereference of null pointer (loaded from variable 'something') [core.NullDereference]

int *something=new int;
```
Resolves #960