### PR TITLE
Fix analysis duration display in GUI

### DIFF
--- a/libcodechecker/analyze/store_handler.py
+++ b/libcodechecker/analyze/store_handler.py
@@ -239,8 +239,8 @@ def addCheckerRun(session, storage_session, command, name, tag, username,
         elif run:
             # There is already a run, update the results.
             run.date = datetime.now()
-            # Increment update counter and the command.
             run.command = command
+            run.duration = -1
             session.flush()
             run_id = run.id
         else:

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -231,6 +231,8 @@ def assemble_zip(inputs, zip_file, client):
                         LOG.warning("Skipping '{0}' because it contains "
                                     "a missing source file."
                                     .format(plist_file))
+                elif f == 'metadata.json':
+                    zipf.write(plist_file, os.path.join('reports', f))
 
         necessary_hashes = client.getMissingContentHashes(hash_to_file.keys())
         for f, h in file_to_hash.items():

--- a/libcodechecker/server/run_db_model.py
+++ b/libcodechecker/server/run_db_model.py
@@ -64,7 +64,8 @@ class Run(Base):
         self.duration = -1
 
     def mark_finished(self):
-        self.duration = ceil((datetime.now() - self.date).total_seconds())
+        if self.duration == -1:
+            self.duration = ceil((datetime.now() - self.date).total_seconds())
 
 
 class RunHistory(Base):


### PR DESCRIPTION
The metadata.json was not copied to the .zip file so the duration
information was not sent to the server. Moreover even if this
information is sent, it was always overwritten by the duration of
storage session.
Fixes #883