### PR TITLE
Handle long file path at the editor header UI.

### DIFF
--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -115,7 +115,10 @@ function (declare, domClass, dom, style, fx, Toggler, on, query, Memory,
       var that = this;
 
       this.header = dom.create('div', { class : 'editorHeader' }, this.domNode);
-      this.filepath = dom.create('div', { class : 'filepath' }, this.header);
+      this.filepath = dom.create('div', {
+        class : 'filepath compact'
+      }, this.header);
+
       this.sameReportSelectorWrapper = dom.create('div', {
         class : 'same-report-selector-wrapper'
       }, this.header);

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -201,16 +201,24 @@ html, body {
 }
 
 .editorHeader {
-  padding: 5px;
   border-bottom: 1px solid lightgrey;
   font-family: monospace;
+  width: 100%;
+  white-space: nowrap;
+  display: flex;
+  justify-content: space-between;
+  height: 26px;
+}
+
+.editorHeader .filepath {
+  display: inline-block;
+  padding: 4px;
 }
 
 .editorHeader .same-report-selector-wrapper {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin: 2px;
+  white-space: nowrap;
+  display: inline-block;
+  padding: 2px 2px 2px 10px;
 }
 
 .editorHeader .same-report-selector-label {


### PR DESCRIPTION
If the file path is too long and there is not enough space in the editor header
it is being truncated.

![cc_filepath_truncate](https://user-images.githubusercontent.com/6695818/30910393-e2b7c908-a384-11e7-9607-36954a134865.png)
