### PR TITLE
fix unicode value on thrift api

### DIFF
--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -322,7 +322,7 @@ def main(args):
 
         client.massStoreRun(args.name,
                             args.tag if 'tag' in args else None,
-                            context.version,
+                            str(context.version),
                             b64zip,
                             'force' in args)
 


### PR DESCRIPTION
context.version is read as a unicode value which can not be sent through thrift string type in python2.
The unicode value should be converted to string.

Resolves #1005