### PR TITLE
Switch tab fails on run history selection

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -376,6 +376,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
             'tab' : state.tab,
             'subtab' : 'runHistory'
           });
+          that.subtab = 'runHistory';
         }
       });
 
@@ -412,7 +413,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
       this._hashChangeTopic = topic.subscribe('/dojo/hashchange',
       function (url) {
         var state = hashHelper.getState();
-        if (state.subtab !== that.subtab)
+        if (state.tab === that.tab && state.subtab !== that.subtab)
           initByUrl(that._grid, that.tab);
       });
 

--- a/www/scripts/codecheckerviewer/RunHistory.js
+++ b/www/scripts/codecheckerviewer/RunHistory.js
@@ -74,8 +74,7 @@ function (declare, dom, topic, ContentPane, util) {
 
               topic.publish('filterchange', {
                 parent : that.bugOverView,
-                changed : state,
-                subtab : null
+                changed : state
               });
             }
           }, content);


### PR DESCRIPTION
If someone clicks on one of the elements in the run history tab the view does not switch on the Bug Overview tab. The filters are updated at the Bug Overview tab.

Closes #1017