### PR TITLE
Load only the current tab data.

### DIFF
--- a/www/scripts/codecheckerviewer/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/BugFilterView.js
@@ -1442,6 +1442,10 @@ function (declare, Deferred, dom, domClass, all, topic, Standby, Button,
 
       this._clearAllButton.set('filters', this._filters);
 
+      this._subscribeTopics();
+    },
+
+    initLoad : function () {
       //--- Select items from the current url state ---//
 
       var state = hashHelper.getState();
@@ -1464,8 +1468,6 @@ function (declare, Deferred, dom, domClass, all, topic, Standby, Button,
       }
 
       this.refreshFilters(state, true);
-
-      this._subscribeTopics();
     },
 
     clearAll : function () {

--- a/www/scripts/codecheckerviewer/CheckerStatistics.js
+++ b/www/scripts/codecheckerviewer/CheckerStatistics.js
@@ -14,11 +14,12 @@ define([
   'dojo/topic',
   'dojox/form/CheckedMultiSelect',
   'dojox/grid/DataGrid',
+  'dojox/widget/Standby',
   'dijit/layout/ContentPane',
   'codechecker/hashHelper',
   'codechecker/util'],
 function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
-  topic, CheckedMultiSelect, DataGrid, ContentPane, hashHelper, util) {
+  topic, CheckedMultiSelect, DataGrid, Standby, ContentPane, hashHelper, util) {
 
   function severityFormatter(severity) {
     var severity = util.severityFromCodeToString(severity);
@@ -97,10 +98,7 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
         this.selectedRuns = state.run instanceof Array
           ? state.run.map(function (run) { return run; })
           : [state.run];
-
-      this.loadRunStoreData();
     },
-
 
     loadRunStoreData : function () {
       var that = this;
@@ -233,6 +231,8 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
     refreshGrid : function (runIds) {
       var that = this;
 
+      this.standBy.show();
+
       this.store.fetch({
         onComplete : function (runs) {
           runs.forEach(function (run) {
@@ -291,16 +291,23 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
           });
         });
         that.sort();
+        that.standBy.hide();
       });
     }
   });
 
   return declare(ContentPane, {
-    constructor : function (args) {
-      dojo.safeMixin(this, args);
+    postCreate : function () {
+      this._standBy = new Standby({
+        color : '#ffffff',
+        target : this.domNode,
+        duration : 0
+      });
+      this.addChild(this._standBy);
 
       this._checkerStatistics = new CheckerStatistics({
-        bugFilterView : this.listOfAllReports._bugFilterView
+        bugFilterView : this.listOfAllReports._bugFilterView,
+        standBy : this._standBy
       });
 
       this._filterPane = new FilterPane({
@@ -308,11 +315,21 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
       });
 
       this._checkerStatistics.set('filterPane', this._filterPane);
-    },
 
-    postCreate : function () {
       this.addChild(this._filterPane);
       this.addChild(this._checkerStatistics);
+    },
+
+    onShow : function () {
+      if (!this.initalized) {
+        this.initalized = true;
+
+        this._filterPane.loadRunStoreData();
+      }
+      hashHelper.resetStateValues({
+        'tab' : 'statistics',
+        'run' : this._filterPane.selectedRuns
+      });
     }
   });
 });

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -149,9 +149,6 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
           }
         });
 
-      deferred.total = CC_SERVICE.getRunResultCount(runResultParam.runIds,
-        query.reportFilters, runResultParam.cmpData);
-
       return deferred;
     },
 
@@ -388,7 +385,6 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
       var that = this;
 
       this._bugOverview.addChild(this._bugFilterView);
-      this._grid.refreshGrid(that._bugFilterView.getReportFilters());
 
       this._bugOverview.addChild(this._grid);
       this.addChild(this._bugOverview);
@@ -504,6 +500,9 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
 
       if (!this.initalized) {
         this.initalized = true;
+
+        this._bugFilterView.initLoad();
+        this._grid.refreshGrid(this._bugFilterView.getReportFilters());
 
         var urlState = hashHelper.getState();
         if (urlState.tab === state.tab)

--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -199,13 +199,7 @@ function (declare, topic, domConstruct, Dialog, Button,
 
     var checkerStatisticsTab = new CheckerStatistics({
       title : 'Checker statistics',
-      listOfAllReports : listOfAllReports,
-      onShow : function () {
-        hashHelper.resetStateValues({
-          'tab' : 'statistics',
-          'run' : this._filterPane.selectedRuns
-        });
-      }
+      listOfAllReports : listOfAllReports
     });
     runsTab.addChild(checkerStatisticsTab);
     runsTab.addChild(listOfAllReports);


### PR DESCRIPTION
Initially, load only the current tab data for some performance reason. For example load checker statistics data if the user opens the relevant tab.

Closes #1019