### PR TITLE
Ignore unused arguments for tidy. Remove redundant argument from SA.

### DIFF
--- a/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
@@ -90,6 +90,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.append("--")
 
+            analyzer_cmd.append('-Qunused-arguments')
+
             # Options before the analyzer options.
             if len(config.compiler_resource_dir) > 0:
                 analyzer_cmd.extend(['-resource-dir',

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -94,9 +94,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                      '-isystem',
                                      config.compiler_resource_dir])
 
-            # Compiling is enough.
-            analyzer_cmd.append('-c')
-
             # Do not warn about the unused gcc/g++ arguments.
             analyzer_cmd.append('-Qunused-arguments')
 


### PR DESCRIPTION
When we run the clang static analyzer there will be no compilation, so there is no point passing `-c`.