### PR TITLE
Fix checker statistics performance

### DIFF
--- a/www/scripts/codecheckerviewer/CheckerStatistics.js
+++ b/www/scripts/codecheckerviewer/CheckerStatistics.js
@@ -62,7 +62,6 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
       this._runStore = new Observable(new Memory({}));
 
       this._runFilter = new RunFilter({
-        store     : this._runStore,
         labelAttr : 'label',
         label     : "Get statistics only for runs...",
         multiple  : true,
@@ -116,6 +115,8 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
             value : run.runId
           });
         });
+
+        that._runFilter.set('store', that._runStore);
 
         if (that.selectedRuns)
           that._runFilter.set('value', that.selectedRuns);
@@ -306,11 +307,13 @@ function (declare, ItemFileWriteStore, Deferred, all, Memory, Observable,
       this.addChild(this._standBy);
 
       this._checkerStatistics = new CheckerStatistics({
+        class : 'checker-statistics-list',
         bugFilterView : this.listOfAllReports._bugFilterView,
         standBy : this._standBy
       });
 
       this._filterPane = new FilterPane({
+        class : 'checker-statistics-filter',
         dataGrid : this._checkerStatistics
       });
 

--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -198,6 +198,7 @@ function (declare, topic, domConstruct, Dialog, Button,
     //--- Check static tab ---//
 
     var checkerStatisticsTab = new CheckerStatistics({
+      class : 'checker-statistics',
       title : 'Checker statistics',
       listOfAllReports : listOfAllReports
     });

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -1171,3 +1171,23 @@ span[class*="severity-"] {
 .doxgen .image {
   text-align: center;
 }
+
+/* Checker statistics */
+.dojoxCheckedMultiSelectMenu {
+  max-height: 200px;
+  display: flex;
+}
+
+.checker-statistics {
+  display: flex;
+  flex-direction: column;
+}
+
+.checker-statistics-filter {
+  display: block;
+  overflow: hidden;
+}
+
+.checker-statistics-list {
+  flex-grow: 1;
+}


### PR DESCRIPTION
If I am initializing a dojo CheckedMultiSelect with a store and adding multiple (~500) item to it, it behaves slowly. For performance reason we set the store of the CheckedMultiSelect after items are added to it.

This commit also set the maximum height of the CheckedMultiSelect and resolves the height of the checker statistics tab.