### PR TITLE
Check at the beginning of store if another is ongoing

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -1719,6 +1719,15 @@ class ThriftRequestHandler(object):
     def massStoreRun(self, name, tag, version, b64zip, force):
         self.__require_store()
 
+        try:
+            session = self.__Session()
+            run = session.query(Run).filter(Run.name == name).one_or_none()
+
+            if run and self.__storage_session.has_ongoing_run(run.id):
+                raise Exception('Storage of ' + name + ' is already going!')
+        finally:
+            session.close()
+
         # Unzip sent data.
         zip_dir = unzip(b64zip)
 


### PR DESCRIPTION
We shouldn't wait for file storage to notice that another storage with
the same name is already going.
Fixes #1013