### PR TITLE
Automatically create configuration database for both Postgres tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ matrix:
       dist: trusty
       python: "2.7"
       env: DATABASE=psql_psycopg2
+    - os: linux
+      sudo: required
+      dist: trusty
+      python: "2.7"
+      env: DATABASE=psql_pg8000
     - os: osx
       osx_image: xcode8
       sudo: false
@@ -26,6 +31,11 @@ matrix:
       sudo: false
       language: generic
       env: DATABASE=psql_psycopg2
+    - os: osx
+      osx_image: xcode8
+      sudo: false
+      language: generic
+      env: DATABASE=psql_pg8000
 
 before_install:
     # Download macOS specific extra dependencies.
@@ -56,7 +66,6 @@ before_install:
 install:
     - pip install nose pep8
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
-    - psql -c 'create database codechecker_config;' -U postgres
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
 
 addons:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@
 # Database settings can be overwritten by local
 # Makefile
 PSQL ?= TEST_USE_POSTGRESQL=true
-PG800 ?= CODECHECKER_DB_DRIVER=pg8000
+PG8000 ?= CODECHECKER_DB_DRIVER=pg8000
 PSYCOPG2 ?= CODECHECKER_DB_DRIVER=psycopg2
 DBPORT ?= TEST_DBPORT=5432
 DBUNAME ?= TEST_DBUSERNAME=postgres
@@ -13,6 +13,9 @@ CLANG_VERSION ?= TEST_CLANG_VERSION=stable
 TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
+WORKSPACE = $(BUILD_DIR)/workspace
+
+CLEAR_WORKSPACE_CMD = rm -rf $(BUILD_DIR)/workspace
 
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
@@ -28,21 +31,29 @@ UNIT_TEST_CMD = nosetests $(NOSECFG) tests/unit
 
 CODECHECKER_CMD = $(BUILD_DIR)/CodeChecker/bin/CodeChecker
 SHUTDOWN_SERVER_CMD = echo "Shutting down server..."; \
-    HOME="$(BUILD_DIR)/workspace" ${CODECHECKER_CMD} server -l; \
-    HOME="$(BUILD_DIR)/workspace" ${CODECHECKER_CMD} server \
-			--config-directory $(BUILD_DIR)/workspace \
-	    --port `cat "$(BUILD_DIR)/workspace/serverport"` --stop; \
-    rm -f "$(BUILD_DIR)/workspace/serverport"; \
-    HOME="$(BUILD_DIR)/workspace" ${CODECHECKER_CMD} server -l
+    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server -l; \
+    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server \
+			--config-directory $(WORKSPACE) \
+	    --port `cat "$(WORKSPACE)/serverport"` --stop; \
+    rm -f "$(WORKSPACE)/serverport"; \
+    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server -l
 
-# Preserve the error or no error status of the previous command but always
-# be able to shut down servers.
-EXIT_HAPPY = { ${SHUTDOWN_SERVER_CMD}; exit 0; }
+# Preserve the error status of the previous command but always be able to
+# shut down servers.
 EXIT_ERROR = { ${SHUTDOWN_SERVER_CMD}; exit 1; }
 
-FUNCTIONAL_TEST_CMD = $(REPO_ROOT) $(CLANG_VERSION) $(TEST_PROJECT) \
+FUNCTIONAL_TEST_CMD = $(CLEAR_WORKSPACE_CMD) && \
+		$(REPO_ROOT) $(CLANG_VERSION) $(TEST_PROJECT) \
 		nosetests $(NOSECFG) tests/functional \
-		&& ${EXIT_HAPPY} || ${EXIT_ERROR}
+		&& { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+
+MAKE_DB_CMD = bash -c 'psql -h localhost \
+		-p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
+		-c "CREATE DATABASE codechecker_config_$${CODECHECKER_DB_DRIVER}"'
+
+DROP_DB_CMD = bash -c 'psql -h localhost \
+		-p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
+		-c "DROP DATABASE codechecker_config_$${CODECHECKER_DB_DRIVER}"'
 
 run_test: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
@@ -66,27 +77,35 @@ test_sqlite: package venv_dev
 test_sqlite_novenv: package
 		$(FUNCTIONAL_TEST_CMD)
 
-test_psql: test_psql_psycopg2
+test_psql: test_psql_psycopg2 test_psql_pg8000
 
-test_psql_novenv: test_psql_psycopg2_novenv
+test_psql_novenv: test_psql_psycopg2_novenv test_psql_pg8000_novenv
 
 test_psql_psycopg2: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
+		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
 		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
-		$(FUNCTIONAL_TEST_CMD)
+		$(FUNCTIONAL_TEST_CMD) && \
+		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD)
 
 test_psql_psycopg2_novenv: package
+		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
 		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
-		$(FUNCTIONAL_TEST_CMD)
+		$(FUNCTIONAL_TEST_CMD) && \
+		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD)
 
 test_psql_pg8000: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PG800) \
-		$(FUNCTIONAL_TEST_CMD)
+		$(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
+		$(PSQL) $(DBUNAME) $(DBPORT) $(PG8000) \
+		$(FUNCTIONAL_TEST_CMD) && \
+		$(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD)
 
 test_psql_pg8000_novenv: package
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PG800) \
-		$(FUNCTIONAL_TEST_CMD)
+		$(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
+		$(PSQL) $(DBUNAME) $(DBPORT) $(PG8000) \
+		$(FUNCTIONAL_TEST_CMD) && \
+		$(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD)
 
 test_clean:
 	rm -rf build/workspace
@@ -97,6 +116,9 @@ test_matrix_sqlite: pep8 test_unit test_sqlite
 
 test_matrix_psql_psycopg2: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_psycopg2
 test_matrix_psql_psycopg2: pep8 test_unit test_psql_psycopg2
+
+test_matrix_psql_pg8000: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_pg8000
+test_matrix_psql_pg8000: pep8 test_unit test_psql_pg8000
 
 clean_travis:
 	# Clean CodeChecker config files stored in the users home directory.

--- a/tests/libtest/env.py
+++ b/tests/libtest/env.py
@@ -45,7 +45,8 @@ def get_postgresql_cfg():
     if use_postgresql:
         pg_db_config = {'dbaddress': 'localhost',
                         'dbport': os.environ.get('TEST_DBPORT'),
-                        'dbname': 'codechecker_config'
+                        'dbname': 'codechecker_config_' +
+                                  os.environ['CODECHECKER_DB_DRIVER']
                         }
         if os.environ.get('TEST_DBUSERNAME', False):
             pg_db_config['dbusername'] = os.environ['TEST_DBUSERNAME']


### PR DESCRIPTION
Closes #984.

The test scripts will automatically create (and in case of a successful test, clean up) configuration databases. This way both PSQL tests can be run without user intervention.

They also use a separate database, postfixed with the DB driver's name.