### PR TITLE
Print number of failed actions even if reanalized

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -40,9 +40,10 @@ def worker_result_handler(results, metadata, output_path):
     for res, skipped, reanalyzed, analyzer_type, _ in results:
         if skipped:
             skipped_num += 1
-        elif reanalyzed:
-            reanalyzed_num += 1
         else:
+            if reanalyzed:
+                reanalyzed_num += 1
+
             if res == 0:
                 successful_analysis[analyzer_type] += 1
             else:


### PR DESCRIPTION
The number of failed build actions should be printed even if it was a
reanalized action.
Fixes #1043