### PR TITLE
Workaround for wrong clang-tidy output

### DIFF
--- a/libcodechecker/analyze/tidy_output_converter.py
+++ b/libcodechecker/analyze/tidy_output_converter.py
@@ -160,7 +160,7 @@ class OutputParser(object):
 
             return message, line
         except StopIteration:
-            return message, line
+            return message, ''
 
     def _parse_code(self, message, titer, line):
         # Eat code line.

--- a/tests/unit/test_tidy_output_converter.py
+++ b/tests/unit/test_tidy_output_converter.py
@@ -190,6 +190,17 @@ class TidyOutputParserTestCase(unittest.TestCase):
         for message in messages:
             self.assertIn(message, self.tidy3_repr)
 
+    def test_tidy4(self):
+        """
+        Test the generated Messages of tidy4.out ClangTidy output file.
+        This is an uncomplete file which is equal with tidy1.out except it's
+        missing the last two lines.
+        """
+        messages = self.parser.parse_messages_from_file('tidy4.out')
+        self.assertEqual(len(messages), len(self.tidy1_repr))
+        for message in messages:
+            self.assertIn(message, self.tidy1_repr)
+
 
 class TidyPListConverterTestCase(unittest.TestCase):
     """

--- a/tests/unit/tidy_output_test_files/tidy4.out
+++ b/tests/unit/tidy_output_test_files/tidy4.out
@@ -1,0 +1,7 @@
+files/test.cpp:8:12: warning: Division by zero [clang-analyzer-core.DivideZero]
+  return x % 0;
+           ^
+files/test.cpp:8:12: note: Division by zero
+  return x % 0;
+           ^
+files/test.cpp:8:12: warning: remainder by zero is undefined [clang-diagnostic-division-by-zero]


### PR DESCRIPTION
Clang-tidy has an output of the following format:

/path/to/file:<line>:<col> message [checker-name]
code_fragment(42);
^~~~~~~~~~~~~

The output may contain an optional fixit. Several groups of these lines
may follow each other.
In case of bugprone-undefined-memory-manipulation checker it happened
that in the last group only the first line appeared. The tidy output
converter assumed that the following lines are also present. If not then
it was an infinite loop.
Fixes #1064