### PR TITLE
Update analyzer mentioned files

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -359,6 +359,9 @@ def check(check_data):
 
                     LOG.debug("Writing dependent files to archive.")
                     for dependent_source in dependencies:
+                        if not os.path.isabs(dependent_source):
+                            dependent_source = \
+                                os.path.abspath(dependent_source)
                         LOG.debug("[ZIP] Writing '" + dependent_source + "' "
                                   "to the archive.")
                         archive_path = dependent_source.lstrip('/')

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -128,15 +128,13 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                          '-Xclang', checker_name])
 
             if config.ctu_dir:
-                env = analyzer_env.get_check_env(config.path_env_extra,
-                                                 config.ld_lib_path_extra)
-                triple_arch = ctu_triple_arch.get_triple_arch(self.buildaction,
-                                                              self.source_file,
-                                                              config, env)
                 analyzer_cmd.extend(['-Xclang', '-analyzer-config',
                                      '-Xclang',
-                                     'xtu-dir=' + os.path.join(config.ctu_dir,
-                                                               triple_arch)])
+                                     'xtu-dir=' + self.get_xtu_dir(),
+                                     ])
+                if config.ctu_has_analyzer_display_ctu_progress:
+                    analyzer_cmd.extend(['-Xclang',
+                                         '-analyzer-display-ctu-progress'])
                 if config.ctu_in_memory:
                     analyzer_cmd.extend(['-Xclang', '-analyzer-config',
                                          '-Xclang',
@@ -160,35 +158,38 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             LOG.error(ex)
             return []
 
+    def get_xtu_dir(self):
+        """
+        Returns the path of the xtu directory (containing the triple).
+        """
+        config = self.config_handler
+        env = analyzer_env.get_check_env(config.path_env_extra,
+                                         config.ld_lib_path_extra)
+        triple_arch = ctu_triple_arch.get_triple_arch(self.buildaction,
+                                                      self.source_file,
+                                                      config, env)
+        xtu_dir = os.path.join(config.ctu_dir, triple_arch)
+        return xtu_dir
+
     def get_analyzer_mentioned_files(self, output):
         """
         Parse ClangSA's output to generate a list of files that were mentioned
         in the standard output or standard error.
         """
 
-        # A line mentioning a file in ClangSA's output looks like this:
-        # /home/.../.cpp:L:C: warning: foobar.
-        regex = re.compile(
-            # File path followed by a ':'.
-            '^(?P<path>[\S ]+?):'
-            # Line number followed by a ':'.
-            '(?P<line>\d+?):'
-            # Column number followed by a ':' and a space.
-            # This is optional, as lines beginning with
-            # "In file included from" don't have a column number.
-            '((?P<column>\d+?):\ )?')
+        regex_for_ctu_ast_load = re.compile(
+            "ANALYZE \(CTU loaded AST for source file\): (.*)")
 
         paths = []
 
-        for line in output.splitlines():
-            # Files can also be referenced in a line that
-            # begins as "In file included from /home/...".
-            if line[0] == 'I':
-                line = line.replace("In file included from ", "", 1)
+        xtu_ast_dir = os.path.join(self.get_xtu_dir(), "ast")
 
-            match = re.match(regex, line)
+        for line in output.splitlines():
+            match = re.match(regex_for_ctu_ast_load, line)
             if match:
-                paths.append(match.group('path'))
+                path = match.group(1)
+                if xtu_ast_dir in path:
+                    paths.append(path[len(xtu_ast_dir):])
 
         return set(paths)
 

--- a/libcodechecker/analyze/analyzers/analyzer_types.py
+++ b/libcodechecker/analyze/analyzers/analyzer_types.py
@@ -281,6 +281,10 @@ def __build_clangsa_config_handler(args, context):
         config_handler.ctu_dir = os.path.join(args.output_path,
                                               args.ctu_dir)
         config_handler.ctu_in_memory = 'ctu_in_memory' in args
+        config_handler.ctu_has_analyzer_display_ctu_progress = \
+            host_check.has_analyzer_feature(
+                context.analyzer_binaries.get(CLANG_SA),
+                '-analyzer-display-ctu-progress')
         config_handler.log_file = args.logfile
         config_handler.path_env_extra = context.path_env_extra
         config_handler.ld_lib_path_extra = context.ld_lib_path_extra

--- a/tests/functional/ctu/ctu_failure/__init__.py
+++ b/tests/functional/ctu/ctu_failure/__init__.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Setup for the test package ctu."""
+
+import os
+import shutil
+
+from libtest import env
+
+# Test workspace should be initialized in this module.
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for testing ctu."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('ctu_failure')
+
+    # Set the TEST_WORKSPACE used by the tests.
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+
+def teardown_package():
+    """Delete workspace."""
+
+    global TEST_WORKSPACE
+
+    print('Removing: ' + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/tests/functional/ctu/ctu_failure/test_ctu_failure.py
+++ b/tests/functional/ctu/ctu_failure/test_ctu_failure.py
@@ -1,0 +1,176 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+""" CTU function test."""
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+import zipfile
+
+from libtest import env
+from libtest import project
+
+from libcodechecker.analyze import host_check
+
+NO_CTU_MESSAGE = "CTU is not supported"
+NO_DISPLAY_CTU_PROGRESS = "-analyzer-display-ctu-progress is not supported"
+
+
+class TestCtu(unittest.TestCase):
+    """ Test CTU functionality. """
+
+    def setUp(self):
+        """ Set up workspace."""
+
+        # TEST_WORKSPACE is automatically set by test package __init__.py .
+        self.test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self.test_workspace)
+
+        # Get the CodeChecker cmd if needed for the tests.
+        self._codechecker_cmd = env.codechecker_cmd()
+        self.env = env.codechecker_env()
+        self.report_dir = os.path.join(self.test_workspace, 'reports')
+        os.makedirs(self.report_dir)
+
+        self.test_dir = project.path('ctu_failure')
+
+        # Get if clang is CTU-capable or not.
+        cmd = [self._codechecker_cmd, 'analyze', '-h']
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         cwd=self.test_dir, env=self.env)
+        self.ctu_capable = '--ctu-' in output
+        print("'analyze' reported CTU-compatibility? " + str(self.ctu_capable))
+
+        self.ctu_has_analyzer_display_ctu_progress = \
+            host_check.has_analyzer_feature(self.__getClangSaPath(),
+                                            '-analyzer-display-ctu-progress')
+        print("Has -analyzer-display-ctu-progress? " + str(self.ctu_capable))
+
+        # Fix the "template" build JSONs to contain a proper directory
+        # so the tests work.
+        raw_buildlog = os.path.join(self.test_dir, 'buildlog.json')
+        with open(raw_buildlog) as log_file:
+            build_json = json.load(log_file)
+            for command in build_json:
+                command['directory'] = self.test_dir
+
+        os.chdir(self.test_workspace)
+        self.buildlog = os.path.join(self.test_workspace, 'buildlog.json')
+        with open(self.buildlog, 'w') as log_file:
+            json.dump(build_json, log_file)
+
+    def tearDown(self):
+        """ Tear down workspace."""
+
+        shutil.rmtree(self.report_dir, ignore_errors=True)
+
+    def test_ctu_logs_ast_import(self):
+        """ Test that Clang indeed logs the AST import events.
+        """
+        if not self.ctu_capable:
+            self.skipTest(NO_CTU_MESSAGE)
+        if not self.ctu_has_analyzer_display_ctu_progress:
+            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
+
+        output = self.__do_ctu_all(reparse=False,
+                                   extra_args=["--verbose", "debug"])
+        self.assertIn("ANALYZE (CTU loaded AST for source file)", output)
+
+    def test_ctu_failure_zip(self):
+        """ Test the failure zip contains the source of imported TU
+        """
+
+        if not self.ctu_capable:
+            self.skipTest(NO_CTU_MESSAGE)
+        if not self.ctu_has_analyzer_display_ctu_progress:
+            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
+
+        output = self.__do_ctu_all(reparse=False,
+                                   extra_args=[
+                                       "--verbose", "debug",
+                                       # The below special checker crashes when
+                                       # a function with a specified name is
+                                       # analyzed.
+                                       "-e", "debug.ExprInspection"
+                                   ])
+
+        # lib.c should be logged as its AST is loaded by Clang
+        self.assertRegexpMatches(
+                output,
+                "ANALYZE \(CTU loaded AST for source file\): .*lib\.c")
+
+        # We expect a failure archive to be in the failed directory.
+        failed_dir = os.path.join(self.report_dir, "failed")
+        failed_files = os.listdir(failed_dir)
+        self.assertEquals(len(failed_files), 1)
+        # Ctu should fail during analysis of main.c
+        self.assertIn("main.c", failed_files[0])
+
+        fail_zip = os.path.join(failed_dir, failed_files[0])
+
+        with zipfile.ZipFile(fail_zip, 'r') as archive:
+            files = archive.namelist()
+
+            self.assertIn("build-action", files)
+            self.assertIn("analyzer-command", files)
+
+            def check_source_in_archive(source_in_archive):
+                source_file = os.path.join(self.test_dir, source_in_archive)
+                source_in_archive = os.path.join("sources-root",
+                                                 source_file.lstrip('/'))
+                self.assertIn(source_in_archive, files)
+                # Check file content.
+                with archive.open(source_in_archive, 'r') as archived_code:
+                    with open(source_file, 'r') as source_code:
+                        self.assertEqual(archived_code.read(),
+                                         source_code.read())
+
+            check_source_in_archive("main.c")
+            check_source_in_archive("lib.c")
+
+    def __do_ctu_all(self, reparse, extra_args=None):
+        """
+        Execute a full CTU run.
+        @param extra_args: list of additional arguments
+        """
+
+        cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
+               '--analyzers', 'clangsa', '--ctu-all']
+        if reparse:
+            cmd.append('--ctu-on-the-fly')
+        if extra_args is not None:
+            cmd.extend(extra_args)
+        cmd.append(self.buildlog)
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         cwd=self.test_dir, env=self.env)
+        return output
+
+    def __do_ctu_analyze(self, reparse):
+        """ Execute CTU analyze phase. """
+
+        cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
+               '--analyzers', 'clangsa', '--ctu-analyze']
+        if reparse:
+            cmd.append('--ctu-on-the-fly')
+        cmd.append(self.buildlog)
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         cwd=self.test_dir, env=self.env)
+        return output
+
+    def __getClangSaPath(self):
+        cmd = [self._codechecker_cmd, 'analyzers', '--details', '-o', 'json']
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         cwd=self.test_dir, env=self.env)
+        json_data = json.loads(output)
+        if json_data[0]["name"] == "clangsa":
+            return json_data[0]["path"]
+        if json_data[1]["name"] == "clangsa":
+            return json_data[1]["path"]

--- a/tests/functional/ctu/test_ctu.py
+++ b/tests/functional/ctu/test_ctu.py
@@ -52,7 +52,6 @@ class TestCtu(unittest.TestCase):
             for command in build_json:
                 command['directory'] = self.test_dir
 
-        self.__old_pwd = os.getcwd()
         os.chdir(self.test_workspace)
         self.buildlog = os.path.join(self.test_workspace, 'buildlog.json')
         with open(self.buildlog, 'w') as log_file:
@@ -61,7 +60,6 @@ class TestCtu(unittest.TestCase):
     def tearDown(self):
         """ Tear down workspace."""
 
-        os.chdir(self.__old_pwd)
         shutil.rmtree(self.report_dir, ignore_errors=True)
 
     def test_ctu_all_no_reparse(self):

--- a/tests/functional/host_check/__init__.py
+++ b/tests/functional/host_check/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+
+def setup_package():
+    pass
+
+
+def teardown_package():
+    pass

--- a/tests/functional/host_check/test_host_check.py
+++ b/tests/functional/host_check/test_host_check.py
@@ -1,0 +1,22 @@
+import unittest
+
+import libcodechecker.analyze.host_check as hc
+
+
+class Test_has_analyzer_feature(unittest.TestCase):
+    def test_existing_feature(self):
+        self.assertEqual(
+            hc.has_analyzer_feature("clang",
+                                    "-analyzer-display-progress"),
+            True)
+
+    def test_non_existing_feature(self):
+        self.assertEqual(
+            hc.has_analyzer_feature("clang",
+                                    "-non-existent-feature"),
+            False)
+
+    def test_non_existent_binary_throws(self):
+        with self.assertRaises(OSError):
+            hc.has_analyzer_feature("non-existent-binary-Yg4pEna5P7",
+                                    "")

--- a/tests/projects/ctu_failure/buildlog.json
+++ b/tests/projects/ctu_failure/buildlog.json
@@ -1,0 +1,13 @@
+[
+  {
+    "directory": ".",
+    "command": "gcc -c lib.c -o lib.o",
+    "file": "lib.c"
+  },
+  {
+    "directory": ".",
+    "command": "gcc -c main.c -o main.o",
+    "file": "main.c"
+  }
+]
+

--- a/tests/projects/ctu_failure/lib.c
+++ b/tests/projects/ctu_failure/lib.c
@@ -1,0 +1,5 @@
+int foo(int i)
+{
+    return i * i;
+}
+

--- a/tests/projects/ctu_failure/main.c
+++ b/tests/projects/ctu_failure/main.c
@@ -1,0 +1,10 @@
+int clang_analyzer_crash(int * i);
+int foo(int);
+
+void test()
+{
+    int * ptr = 0;
+    foo(3); // This CallExpr will trigger the load of lib.c's AST
+    clang_analyzer_crash(ptr); // The analyzer will crash at this CallExpr
+}
+


### PR DESCRIPTION
* Since https://github.com/Ericsson/clang/pull/199/files we can track which source files corresponding AST had been loaded before a crash.
Therefore, it is no longer needed to have complex regex matching in `get_analyzer_mentioned_files`.
* We put absolute paths into the failed zip under sources-root, because all analyzer runs are using absolute paths.