### PR TITLE
Bug path is not shown on the UI

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -418,9 +418,6 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
         if (sender && sender !== that._grid)
           return;
 
-        if (!that.runData && !that.baseline && !reportHash && !that.allReportView)
-          return;
-
         if (reportData !== null && !(reportData instanceof CC_OBJECTS.ReportData))
           reportData = CC_SERVICE.getReport(reportData);
 
@@ -436,8 +433,8 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
           reportFilter.reportHash = [reportHash];
           reportFilter.isUnique = false;
 
-          reports = CC_SERVICE.getRunResults(null, CC_OBJECTS.MAX_QUERY_SIZE,
-            0, null, reportFilter, null);
+          reports = CC_SERVICE.getRunResults(runResultParam.runIds,
+            CC_OBJECTS.MAX_QUERY_SIZE,  0, null, reportFilter, null);
           reportData = reports[0];
         } else {
           runResultParam.runIds = [reportData.runId];


### PR DESCRIPTION
If I select a report, all of the reports in the current file are shown, on the bug tree view. The report steps are closed for all of the reports, for the currently selected one too. This commit resolves this problem.

Closes #1033