### PR TITLE
Garbage file collection at server startup

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -988,6 +988,8 @@ optional arguments:
                         locally, but to everyone, who can access the server
                         over the Internet. (Equivalent to specifying '--host
                         ""'.) (default: False)
+  --skip-db-cleanup     Skip performing cleanup jobs on the database like
+                        removing unused files.
   --verbose {info,debug,debug_analyzer}
                         Set verbosity level. (default: info)
 

--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -117,6 +117,14 @@ def add_arguments_to_parser(parser):
                              "can access the server over the Internet. "
                              "(Equivalent to specifying '--host \"\"'.)")
 
+    parser.add_argument('--skip-db-cleanup',
+                        dest="skip_db_cleanup",
+                        action='store_true',
+                        default=argparse.SUPPRESS,
+                        required=False,
+                        help="Skip performing cleanup jobs on the database "
+                             "like removing unused files.")
+
     dbmodes = parser.add_argument_group("configuration database arguments")
 
     dbmodes = dbmodes.add_mutually_exclusive_group(required=False)
@@ -495,6 +503,7 @@ def main(args):
                             suppress_handler,
                             args.listen_address,
                             'force_auth' in args,
+                            'skip_db_cleanup' not in args,
                             context,
                             check_env)
     except socket.error as err:

--- a/libcodechecker/server/db_cleanup.py
+++ b/libcodechecker/server/db_cleanup.py
@@ -1,0 +1,42 @@
+from codeCheckerDBAccess_v6.ttypes import*
+
+from libcodechecker.logger import LoggerFactory
+from libcodechecker.server.database.run_db_model import *
+
+LOG = LoggerFactory.get_new_logger('DB CLEANUP')
+
+
+def remove_unused_files(session):
+    LOG.info("Garbage collection of dangling files started...")
+
+    bpe_files = session.query(BugPathEvent.file_id) \
+        .group_by(BugPathEvent.file_id) \
+        .subquery()
+    brp_files = session.query(BugReportPoint.file_id) \
+        .group_by(BugReportPoint.file_id) \
+        .subquery()
+
+    session.query(File) \
+        .filter(File.id.notin_(bpe_files),
+                File.id.notin_(brp_files)) \
+        .delete(synchronize_session=False)
+
+    files = session.query(File.content_hash) \
+        .group_by(File.content_hash) \
+        .subquery()
+
+    session.query(FileContent) \
+        .filter(FileContent.content_hash.notin_(files)) \
+        .delete(synchronize_session=False)
+
+    session.commit()
+
+    LOG.info("Garbage collection of dangling files finished.")
+
+
+def run_cleanup_jobs(session):
+    sess = session()
+
+    remove_unused_files(sess)
+
+    sess.close()

--- a/tests/functional/db_cleanup/__init__.py
+++ b/tests/functional/db_cleanup/__init__.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import os
+import shutil
+
+from libtest import env
+
+
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for testing db_cleanup."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('db_cleanup')
+
+    # Set the TEST_WORKSPACE used by the tests.
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+    # Create a basic CodeChecker config for the tests, this should
+    # be imported by the tests and they should only depend on these
+    # configuration options.
+    codechecker_cfg = {
+        'suppress_file': None,
+        'skip_list_file': None,
+        'check_env': env.test_env(TEST_WORKSPACE),
+        'workspace': TEST_WORKSPACE,
+        'checkers': [],
+        'viewer_host': 'localhost',
+        'viewer_product': 'db_cleanup'
+    }
+
+    env.export_test_cfg(TEST_WORKSPACE, {'codechecker_cfg': codechecker_cfg})
+
+
+def teardown_package():
+    """Clean up after the test."""
+
+    global TEST_WORKSPACE
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/tests/functional/db_cleanup/test_db_cleanup.py
@@ -1,0 +1,158 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import json
+import multiprocessing
+import os
+import unittest
+import time
+
+from codeCheckerDBAccess_v6.ttypes import *
+
+from libtest import codechecker
+from libtest import env
+
+
+class TestDbCleanup(unittest.TestCase):
+
+    def setUp(self):
+        self.test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self.test_workspace)
+
+        self.codechecker_cfg = env.import_codechecker_cfg(self.test_workspace)
+        self.test_dir = os.path.join(self.test_workspace, 'test_files')
+
+        try:
+            os.makedirs(self.test_dir)
+        except os.error:
+            # Directory already exists.
+            pass
+
+    def __create_test_dir(self):
+        makefile = "all:\n\t$(CXX) -c a/main.cpp -o /dev/null\n"
+        project_info = {
+            "name": "hello",
+            "clean_cmd": "",
+            "build_cmd": "make"
+        }
+        source_main = """
+// Test file for db_cleanup
+#include "f.h"
+int main() { f(0); }
+"""
+        source_f = """
+// Test file for db_cleanup
+int f(int x) { return 1 / x; }
+"""
+
+        os.makedirs(os.path.join(self.test_dir, 'a'))
+
+        with open(os.path.join(self.test_dir, 'Makefile'), 'w') as f:
+            f.write(makefile)
+        with open(os.path.join(self.test_dir, 'project_info.json'), 'w') as f:
+            json.dump(project_info, f)
+        with open(os.path.join(self.test_dir, 'a', 'main.cpp'), 'w') as f:
+            f.write(source_main)
+        with open(os.path.join(self.test_dir, 'a', 'f.h'), 'w') as f:
+            f.write(source_f)
+
+    def __rename_project_dir(self):
+        os.rename(os.path.join(self.test_dir, 'a'),
+                  os.path.join(self.test_dir, 'b'))
+
+        makefile = "all:\n\t$(CXX) -c b/main.cpp -o /dev/null\n"
+
+        with open(os.path.join(self.test_dir, 'Makefile'), 'w') as f:
+            f.write(makefile)
+
+    def __get_files_in_report(self):
+        run_filter = RunFilter()
+        run_filter.names = ['db_cleanup_test']
+        run_filter.exactMatch = True
+
+        codechecker.check(self.codechecker_cfg,
+                          'db_cleanup_test',
+                          self.test_dir)
+
+        runs = self._cc_client.getRunData(run_filter)
+        run_id = runs[0].runId
+
+        reports \
+            = self._cc_client.getRunResults([run_id], 10, 0, [], None, None)
+
+        details = self._cc_client.getReportDetails(reports[0].reportId)
+
+        files = set()
+        files.update(map(lambda bp: bp.fileId, details.pathEvents))
+        files.update(map(lambda bp: bp.fileId, details.executionPath))
+
+        file_ids = set()
+        for file_id in files:
+            file_data = self._cc_client.getSourceFileData(file_id, False, None)
+            if file_data.fileId is not None:
+                file_ids.add(file_data.fileId)
+
+        return file_ids
+
+    def test_garbage_file_collection(self):
+        event = multiprocessing.Event()
+        event.clear()
+
+        self.codechecker_cfg['viewer_port'] = env.get_free_port()
+        env.export_test_cfg(self.test_workspace,
+                            {'codechecker_cfg': self.codechecker_cfg})
+
+        env.enable_auth(self.test_workspace)
+
+        server_access = codechecker.start_server(self.codechecker_cfg, event)
+        server_access['viewer_port'] \
+            = self.codechecker_cfg['viewer_port']
+        server_access['viewer_product'] \
+            = self.codechecker_cfg['viewer_product']
+
+        codechecker.add_test_package_product(server_access,
+                                             self.test_workspace)
+
+        self._cc_client = env.setup_viewer_client(self.test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        self.__create_test_dir()
+        files_in_report_before = self.__get_files_in_report()
+
+        self.__rename_project_dir()
+
+        files_in_report_after = self.__get_files_in_report()
+
+        event.set()
+        time.sleep(5)
+
+        event.clear()
+        self.codechecker_cfg['viewer_port'] = env.get_free_port()
+        env.export_test_cfg(self.test_workspace,
+                            {'codechecker_cfg': self.codechecker_cfg})
+
+        codechecker.start_server(self.codechecker_cfg,
+                                 event)
+        codechecker.login(self.codechecker_cfg,
+                          self.test_workspace,
+                          'cc',
+                          'test')
+
+        self._cc_client = env.setup_viewer_client(self.test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        self.assertEqual(len(files_in_report_before & files_in_report_after),
+                         0)
+
+        for file_id in files_in_report_before:
+            f = self._cc_client.getSourceFileData(file_id, False, None)
+            self.assertIsNone(f.fileId)
+
+        event.set()
+        time.sleep(5)

--- a/tests/functional/instance_manager/__init__.py
+++ b/tests/functional/instance_manager/__init__.py
@@ -87,34 +87,3 @@ def teardown_package():
 
     print("Removing: " + TEST_WORKSPACE)
     shutil.rmtree(TEST_WORKSPACE)
-
-
-# This server uses multiple custom servers, which are brought up here
-# and torn down by the package itself --- it does not connect to the
-# test run's "master" server.
-def start_server(codechecker_cfg, event):
-    """Start the CodeChecker server."""
-    def start_server_proc(event, server_cmd, checking_env):
-        """Target function for starting the CodeChecker server."""
-        proc = subprocess.Popen(server_cmd, env=checking_env)
-
-        # Blocking termination until event is set.
-        event.wait()
-
-        # If proc is still running, stop it.
-        if proc.poll() is None:
-            proc.terminate()
-
-    server_cmd = codechecker.serv_cmd(codechecker_cfg['workspace'],
-                                      str(codechecker_cfg['viewer_port']),
-                                      None)
-
-    server_proc = multiprocessing.Process(
-        name='server',
-        target=start_server_proc,
-        args=(event, server_cmd, codechecker_cfg['check_env']))
-
-    server_proc.start()
-
-    # Wait for server to start and connect to database.
-    time.sleep(5)

--- a/tests/functional/instance_manager/test_instances.py
+++ b/tests/functional/instance_manager/test_instances.py
@@ -15,8 +15,8 @@ import unittest
 from libcodechecker.server import instance_manager
 
 from libtest import env
+from libtest.codechecker import start_server
 from . import EVENT_1, EVENT_2
-from . import start_server
 
 
 class TestInstances(unittest.TestCase):


### PR DESCRIPTION
When starting server with `--db_cleanup` flag a garbage collection is
run which collects dangling files (i.e. the ones which don't belong to
a bug path any more).

Fixes #785