### PR TITLE
Exclude cppcoreguidelines-pro-type-vararg from all profiles

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -110,7 +110,6 @@
         "cppcoreguidelines-pro-type-member-init" : ["extreme"],
         "cppcoreguidelines-pro-type-reinterpret-cast" : ["sensitive", "extreme"],
         "cppcoreguidelines-pro-type-static-cast-downcast" : ["sensitive", "extreme"],
-        "cppcoreguidelines-pro-type-vararg" : ["sensitive", "extreme"],
         "cppcoreguidelines-slicing" : ["sensitive", "extreme"],
         "cppcoreguidelines-special-member-functions" : ["default", "sensitive", "extreme"],
         "google-build-explicit-make-pair" : ["sensitive", "extreme"],


### PR DESCRIPTION
Enabling cert-err34-c and cppcoreguidelines-pro-type-vararg together
causes an infinite loop. Until this issue is solved, the vararg checker
is removed from all profiles so that it needs to be individually enabled
and thus less likely to trigger the problem.

Fixes #1080.