### PR TITLE
Fix run_test target in Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,7 +59,7 @@ run_test: package venv_dev
 	$(ACTIVATE_DEV_VENV) && \
 		$(REPO_ROOT) $(CLANG_VERSION) $(TEST_PROJECT) \
 		nosetests $(NOSECFG) ${TEST} \
-		&& ${EXIT_HAPPY} || ${EXIT_ERROR}
+		&& { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
 
 test_unit: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)


### PR DESCRIPTION
In a prevous commit a Makefile variable was removed but a usage was left
in the code. This made an error at `run_test` make target usage.