### PR TITLE
Skip linking build actions

### DIFF
--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -357,7 +357,7 @@ def main(args):
             continue
 
         actions += log_parser.parse_log(log_file, args.output_path,
-                                        'add_compiler_defaults' in args)
+                                        'ctu_phases' in args)
     if len(actions) == 0:
         LOG.info("None of the specified build log files contained "
                  "valid compilation commands. No analysis needed...")

--- a/tests/unit/logparser_test_files/link_actions.json
+++ b/tests/unit/logparser_test_files/link_actions.json
@@ -1,0 +1,12 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	},
+	{
+		"directory": "/tmp",
+		"command": "g++ /tmp/c.cpp /tmp/b.o -o /tmp/a.out",
+		"file": "/tmp/b.o"
+	}
+]

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -137,3 +137,14 @@ class LogParserTest(unittest.TestCase):
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
+
+    def test_omitting_link_actions(self):
+        """
+        Test whether plist parser omits build actions which belong to a linking
+        action, i.e. those of which the imput file is a .o or .so.
+        """
+        logfile = os.path.join(self.__test_files, "link_actions.json")
+
+        build_actions = log_parser.parse_log(logfile)
+
+        self.assertEqual(len(build_actions), 1)


### PR DESCRIPTION
CodeChecker analyze should skip the linking actions unless CTU is used.

Fixes #1037