### PR TITLE
Compilation target is registered per build action.

### DIFF
--- a/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
@@ -102,6 +102,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             # Set language.
             analyzer_cmd.extend(['-x', self.buildaction.lang])
 
+            if self.buildaction.target != "":
+                analyzer_cmd.append("--target=" + self.buildaction.target)
+
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
             analyzer_cmd.extend(self.buildaction.compiler_includes)

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -143,6 +143,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             # Set language.
             analyzer_cmd.extend(['-x', self.buildaction.lang])
+            if self.buildaction.target != "":
+                analyzer_cmd.append("--target=" + self.buildaction.target)
 
             analyzer_cmd.append(config.analyzer_extra_arguments)
 

--- a/libcodechecker/analyze/log_parser.py
+++ b/libcodechecker/analyze/log_parser.py
@@ -173,7 +173,7 @@ def parse_compile_commands_json(logfile, output_path=None,
     data = json.load(logfile)
 
     compiler_includes = {}
-    compiler_target = ''
+    compiler_target = {}
 
     counter = 0
     for entry in data:
@@ -233,13 +233,12 @@ def parse_compile_commands_json(logfile, output_path=None,
                                           results.compile_opts, output_path,
                                           extra_opts)
 
-                compiler_target = get_compiler_target(results.compiler,
-                                                      output_path)
+            if not (results.compiler in compiler_target):
+                compiler_target[results.compiler] = \
+                    get_compiler_target(results.compiler, output_path)
 
             action.compiler_includes = compiler_includes[results.compiler]
-
-            if compiler_target != "":
-                action.analyzer_options.append("--target=" + compiler_target)
+            action.target = compiler_target[results.compiler]
 
         if results.action == option_parser.ActionType.COMPILE or \
            results.action == option_parser.ActionType.LINK:

--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -225,6 +225,7 @@ class OptionParserResult(object):
         self._link_opts = []
         self._files = []
         self._arch = ''
+        self._target = ''
         self._lang = None
         self._output = ''
         self._compiler = None
@@ -288,6 +289,14 @@ class OptionParserResult(object):
     @arch.setter
     def arch(self, value):
         self._arch = value
+
+    @property
+    def target(self):
+        return self._target
+
+    @target.setter
+    def target(self, value):
+        self._target = value
 
     @property
     def lang(self):

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -52,7 +52,7 @@ class LogParserTest(unittest.TestCase):
 
         self.assertEqual(' '.join(results.files),
                          r'"-DVARIABLE="some value"" /tmp/a.cpp')
-        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertEqual(len(build_action.analyzer_options), 0)
 
     def test_new_ldlogger(self):
         """
@@ -70,7 +70,8 @@ class LogParserTest(unittest.TestCase):
         build_action = log_parser.parse_log(logfile)[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
-        self.assertEqual(len(build_action.analyzer_options), 2)
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
                          r'-DVARIABLE="\"some value"\"')
 
@@ -96,7 +97,8 @@ class LogParserTest(unittest.TestCase):
         build_action = log_parser.parse_log(logfile)[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
-        self.assertEqual(len(build_action.analyzer_options), 2)
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
                          r'-DVARIABLE="\"some value"\"')
 
@@ -126,7 +128,8 @@ class LogParserTest(unittest.TestCase):
         build_action = log_parser.parse_log(logfile)[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
-        self.assertEqual(len(build_action.analyzer_options), 2)
+        self.assertEqual(len(build_action.analyzer_options), 1)
+        self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
                          r'-DVARIABLE="\"some value"\"')
 


### PR DESCRIPTION
This fixes a bug where if a compilation db contained multiple
different compilation targets, only one of them was used for
all files.