### PR TITLE
Compiler info from file

### DIFF
--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -121,6 +121,22 @@ def add_arguments_to_parser(parser):
                         default=argparse.SUPPRESS,
                         help="Store the analysis output in the given folder.")
 
+    parser.add_argument('--compiler-includes-file',
+                        dest="compiler_includes_file",
+                        required=False,
+                        default=None,
+                        help="Read the compiler includes from the specified "
+                             "file rather than invoke the compiler "
+                             "executable.")
+
+    parser.add_argument('--compiler-target-file',
+                        dest="compiler_target_file",
+                        required=False,
+                        default=None,
+                        help="Read the compiler target from the specified "
+                             "file rather than invoke the compiler "
+                             "executable.")
+
     parser.add_argument('-t', '--type', '--output-format',
                         dest="output_format",
                         required=False,
@@ -310,6 +326,22 @@ def add_arguments_to_parser(parser):
     parser.set_defaults(func=main)
 
 
+class ParseLogOptions:
+    " Options for log parsing. "
+
+    def __init__(self, args=None):
+        if (args is None):
+            self.output_path = None
+            self.compiler_includes_file = None
+            self.compiler_target_file = None
+        else:
+            self.output_path = getattr(args, 'output_path', None)
+            self.compiler_includes_file =\
+                getattr(args, 'compiler_includes_file', None)
+            self.compiler_target_file =\
+                getattr(args, 'compiler_target_file', None)
+
+
 def main(args):
     """
     Perform analysis on the given logfiles and store the results in a machine-
@@ -346,6 +378,7 @@ def main(args):
     if not os.path.exists(args.output_path):
         os.makedirs(args.output_path)
 
+    LOG.debug("args: " + str(args))
     LOG.debug("Output will be stored to: '" + args.output_path + "'")
 
     # Parse the JSON CCDBs and retrieve the compile commands.
@@ -356,8 +389,8 @@ def main(args):
                       "exist!")
             continue
 
-        actions += log_parser.parse_log(log_file, args.output_path,
-                                        'add_compiler_defaults' in args)
+        parseLogOptions = ParseLogOptions(args)
+        actions += log_parser.parse_log(log_file, parseLogOptions)
     if len(actions) == 0:
         LOG.info("None of the specified build log files contained "
                  "valid compilation commands. No analysis needed...")

--- a/tests/unit/test_buildcmd_escaping.py
+++ b/tests/unit/test_buildcmd_escaping.py
@@ -21,6 +21,7 @@ except ImportError:
 from libcodechecker.log import build_manager
 from libcodechecker.analyze import log_parser
 from libcodechecker.analyze.analyzers import analyzer_base
+from libcodechecker.libhandlers.analyze import ParseLogOptions
 
 
 class BuildCmdTestNose(unittest.TestCase):
@@ -81,7 +82,9 @@ class BuildCmdTestNose(unittest.TestCase):
         comp_cmd_json = self.__get_cmp_json(compile_cmd)
         with closing(StringIO()) as text:
             text.write(comp_cmd_json)
-            return log_parser.parse_compile_commands_json(text)
+
+            return log_parser.parse_compile_commands_json(text,
+                                                          ParseLogOptions())
 
     def test_buildmgr(self):
         """

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -11,6 +11,7 @@ import unittest
 
 from libcodechecker.analyze import log_parser
 from libcodechecker.log import option_parser
+from libcodechecker.libhandlers.analyze import ParseLogOptions
 
 
 class LogParserTest(unittest.TestCase):
@@ -47,7 +48,7 @@ class LogParserTest(unittest.TestCase):
         # option_parser, so here we aim for a non-failing stalemate of the
         # define being considered a file and ignored, for now.
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
         results = option_parser.parse_options(build_action.original_command)
 
         self.assertEqual(' '.join(results.files),
@@ -67,7 +68,7 @@ class LogParserTest(unittest.TestCase):
         # Logfile contains -DVARIABLE="some value"
         # and --target=x86_64-linux-gnu.
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -78,7 +79,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -94,7 +95,7 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -105,7 +106,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -125,7 +126,7 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -136,7 +137,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
-        build_action = log_parser.parse_log(logfile)[0]
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(list(build_action.sources)[0], r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')


### PR DESCRIPTION
Make it possible to load the compiler system includes and target info from a file.
This is good for two reasons:
* We can ctu collect the content of a failed report, since the system includes are stored in `sources-root` dir
* We can analyze independently anytime after a build log. If for some reason the compiler is not available, we can just simply feed the previously saved compiler includes and target files (this is the case with the investigation of a fail zip as well)