### PR TITLE
Fix sort problem of product listing page

### DIFF
--- a/www/scripts/productlist/ListOfProducts.js
+++ b/www/scripts/productlist/ListOfProducts.js
@@ -252,8 +252,6 @@ function (declare, domClass, domConstruct, ItemFileWriteStore, topic,
 
       CC_PROD_SERVICE.getProducts(null, productNameFilter,
       function (productList) {
-        that.onLoaded(productList);
-
         productList.forEach(function (item) {
           that._addProductData(item);
         });
@@ -312,8 +310,10 @@ function (declare, domClass, domConstruct, ItemFileWriteStore, topic,
     },
 
     onLoaded : function (productDataList) {
+      var that = this;
+
       this.toggleAdminButtons(this.adminLevel);
-      this.sort();
+      setTimeout(function () { that.sort(); }, 0);
     }
   });
 


### PR DESCRIPTION
The DataGrid sort method was throwing an error message because some item wasn't rendered properly.

I have also removed the first `onLoaded` call from the `_populateProducts` function because it is enough to call it after the items are added to the store.

Closes #1101 