### PR TITLE
Improve plist-to-html's Makefile for multijob and no redundant downloads

### DIFF
--- a/vendor/plist_to_html/Makefile
+++ b/vendor/plist_to_html/Makefile
@@ -10,6 +10,8 @@ BUILD_DIR = build
 BIN_DIR = $(BUILD_DIR)/bin
 DIST_DIR = $(BUILD_DIR)/dist
 
+default: all
+
 all: package
 
 package: dep
@@ -19,12 +21,39 @@ package: dep
 	cp plist_to_html/dist/js/bugviewer.js $(DIST_DIR)
 	cp plist_to_html/PlistToHtml.py $(BIN_DIR)/plist-to-html
 
-dep:
+dist_dir:
 	mkdir -p $(DIST_DIR)
-	curl -sSfLk --get $(CODEMIRROR)/codemirror.min.js -z $(DIST_DIR)/codemirror.min.js -o $(DIST_DIR)/codemirror.min.js
-	curl -sSfLk --get $(CODEMIRROR)/codemirror.min.css -z $(DIST_DIR)/codemirror.min.css -o $(DIST_DIR)/codemirror.min.css
-	curl -sSfLk --get $(CODEMIRROR)/mode/clike/clike.min.js -z $(DIST_DIR)/clike.min.js -o $(DIST_DIR)/clike.min.js
-	curl -sSfLk --get https://raw.githubusercontent.com/codemirror/CodeMirror/master/LICENSE -z $(DIST_DIR)/codemirror.LICENSE -o $(DIST_DIR)/codemirror.LICENSE
+
+dep: codemirror
+
+codemirror: $(DIST_DIR)/codemirror.min.js
+codemirror: $(DIST_DIR)/codemirror.min.css
+codemirror: $(DIST_DIR)/codemirror.LICENSE
+codemirror: $(DIST_DIR)/clike.min.js
+
+$(DIST_DIR)/codemirror.min.js: dist_dir
+	[ -f $(DIST_DIR)/codemirror.min.js ] && : || \
+	curl -sSfLk --get $(CODEMIRROR)/codemirror.min.js \
+			 -z $(DIST_DIR)/codemirror.min.js \
+			 -o $(DIST_DIR)/codemirror.min.js
+
+$(DIST_DIR)/codemirror.min.css: dist_dir
+	[ -f $(DIST_DIR)/codemirror.min.css ] && : || \
+	curl -sSfLk --get $(CODEMIRROR)/codemirror.min.css \
+			 -z $(DIST_DIR)/codemirror.min.css \
+			 -o $(DIST_DIR)/codemirror.min.css
+
+$(DIST_DIR)/codemirror.LICENSE: dist_dir
+	[ -f $(DIST_DIR)/codemirror.LICENSE ] && : || \
+	curl -sSfLk --get https://raw.githubusercontent.com/codemirror/CodeMirror/master/LICENSE \
+			 -z $(DIST_DIR)/codemirror.LICENSE \
+			 -o $(DIST_DIR)/codemirror.LICENSE
+
+$(DIST_DIR)/clike.min.js: dist_dir
+	[ -f $(DIST_DIR)/clike.min.js ] && : || \
+	curl -sSfLk --get $(CODEMIRROR)/mode/clike/clike.min.js \
+			 -z $(DIST_DIR)/clike.min.js \
+			 -o $(DIST_DIR)/clike.min.js
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
Instead of executing the `curl` calls all the time, act like how `Makefile`s usually behave: if the "built" files already exist, don't rebuild them. This makes quickly rebuilding CodeChecker a lot faster, and, if more job threads are given, the `curl` calls will also be multithreaded.