### PR TITLE
Gracefully handle the addition and removal of products if Config DB is shared

### DIFF
--- a/libcodechecker/libclient/client.py
+++ b/libcodechecker/libclient/client.py
@@ -216,10 +216,10 @@ def setup_product_client(protocol, host, port, product_name=None):
             '/' + product_name + '/v' + CLIENT_API + '/Products',
             session_token)
 
-        # However, in this case, the specified product might not be existing,
-        # which makes subsequent calls to this API crash (server sends
-        # HTTP 500 Internal Server Error error page).
-        if not product_client.getPackageVersion():
+        # However, in this case, the specified product might not exist,
+        # which means we can't communicate with the server orderly.
+        if not product_client.getPackageVersion() or \
+                not product_client.getCurrentProduct():
             LOG.error("The product '{0}' cannot be communicated with. It "
                       "either doesn't exist, or the server's configuration "
                       "is bogus.".format(product_name))

--- a/tests/libtest/codechecker.py
+++ b/tests/libtest/codechecker.py
@@ -291,10 +291,11 @@ def store(codechecker_cfg, test_project_name, report_path):
         print(out)
         print(err)
 
-        return 0
-    except CalledProcessError as cerr:
-        print("Failed to call:\n" + ' '.join(cerr.cmd))
-        return cerr.returncode
+        return proc.returncode
+    except OSError as oserr:
+        print("Failed to call:\n" + ' '.join(store_cmd) +
+              "\n" + oserr.strerror)
+        return oserr.errno
 
 
 def serv_cmd(config_dir, port, pg_config=None, serv_args=None):


### PR DESCRIPTION
> Closes #876.

Previously, if (at least) two servers were started with the same configuration database, and a product was, through only one server

 * added: a warning was issued when the new product was accessed through the other server that even though it is in the database, no connection existed for it
 * removed: the user couldn't access the product anymore through neither servers, but the database connection was kept, dangling

This is solved in this patch. In case *any* access request is given to a product that exists in the database but the server has no connection to, the server will try to connect, instead of issuing a warning.

In case of deleted products, the user will be barred access through the "other" servers which no longer find the product in the configuration database but have a connection object towards them, and the server will also actively tear down these connections.

`len()` and `count()` are optimised operations, as every collection in Python stores their length as a variable, no traversal is needed, and returning full row count from the database is analogous to this.

We can expect in good faith that the cases fixed here are edge ones, as usually a server is configured and then is running with no brutal changes to the products mounted to it. But this little change can help the rare configuration cases easy, as there is no longer a need to essentially restart all servers using a particular config DB if the product list of that config DB changes.