### PR TITLE
Severity statistics and csv export

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -571,6 +571,17 @@ def handle_list_result_types(args):
     resolved_checkers = get_statistics(client, run_ids, 'detectionStatus',
                                        [ttypes.DetectionStatus.RESOLVED])
 
+    # Get severity counts
+    report_filter = ttypes.ReportFilter()
+    report_filter.isUnique = True
+    sev_count = client.getSeverityCounts(run_ids, report_filter, None)
+    severities = []
+    for key, count in sorted(sev_count.items(),
+                             reverse=True):
+        severities.append(dict(
+            severity=ttypes.Severity._VALUES_TO_NAMES[key],
+            reports=count))
+
     all_results = []
     for key, checker_data in sorted(all_checkers_dict.items(),
                                     key=lambda x: x[1].severity,
@@ -588,6 +599,7 @@ def handle_list_result_types(args):
 
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(all_results))
+        print(CmdLineOutputEncoder().encode(severities))
     else:
         header = ['Checker', 'Severity', 'All reports', 'Resolved',
                   'Unreviewed', 'Confirmed', 'False positive', "Intentional"]
@@ -602,6 +614,16 @@ def handle_list_result_types(args):
                          str(stat['confirmed']),
                          str(stat['false_positive']),
                          str(stat['intentional'])))
+
+        print(twodim_to_str(args.output_format, header, rows))
+
+        # Print severity counts
+        header = ['Severity', 'All reports']
+
+        rows = []
+        for stat in severities:
+            rows.append((stat['severity'],
+                         str(stat['reports'])))
 
         print(twodim_to_str(args.output_format, header, rows))
 

--- a/www/scripts/codecheckerviewer/util.js
+++ b/www/scripts/codecheckerviewer/util.js
@@ -359,6 +359,21 @@ function (locale, dom, style, json) {
         date.getUTCMinutes(),
         date.getUTCSeconds(),
         date.getUTCMilliseconds());
+    },
+
+    exportToCSV : function (filename, content) {
+      var csvContent = 'data:text/csv;charset=utf-8,';
+      content.forEach(function (c) {
+        csvContent += c.join(',') + '\r\n';
+      });
+
+      var link = dom.create('a', {
+        href : encodeURI(csvContent),
+        download : filename
+      }, document.body);
+
+      link.click();
+      document.body.removeChild(link);
     }
   };
 });

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -1221,20 +1221,6 @@ span[class*="severity-"] {
   display: flex;
 }
 
-.checker-statistics {
-  display: flex;
-  flex-direction: column;
-}
-
-.checker-statistics-filter {
-  display: block;
-  overflow: hidden;
-}
-
-.checker-statistics-list {
-  flex-grow: 1;
-}
-
 .run-count-wrapper {
   padding: 10px;
 }
@@ -1279,4 +1265,38 @@ span[class*="severity-"] {
 /* Removes orange border from focus */
 .dijitTooltipBelow {
   outline: none;
+}
+
+.severity-statistics-list {
+  width: 300px;
+}
+
+.statistic-header-wrapper {
+  font-weight: 600;
+  font-size: 1.5em;
+  padding: 10px;
+  color: #3680a9;
+}
+
+.statistic-header-wrapper .title {
+  vertical-align: middle;
+}
+
+.export-to {
+  padding: 4px;
+  margin: 0 5px;
+  font-weight: 600;
+  font-size: small;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+.export-to:hover {
+  text-decoration: underline;
+}
+
+.export-to-csv {
+  background-color: #d9e4ee;
+  color: #357ea7;
+  border: 1px solid #cad2da;
 }


### PR DESCRIPTION
- Showing severity report count at the statistics page.
- Statistics can be exported to CSV.

![cc_sev_statistics](https://user-images.githubusercontent.com/6695818/32664219-e459c59e-c630-11e7-90c1-3089a5ea26fe.png)

Closes #1104