### PR TITLE
Add debug tools for ctu

### DIFF
--- a/scripts/debug_tools/README.md
+++ b/scripts/debug_tools/README.md
@@ -1,0 +1,37 @@
+Debug Tools
+===========
+
+These scripts may be used to aid debugging of clang crashes during analysis.
+The goal is to reproduce the crash locally, i.e. using the source files in the
+failure zip. During the process we take the original compile command database,
+compiler includes and compiler target files and we create the modified version
+of them (with `_DEBUG` postfix).  These modified files contain the paths
+prefixed with the root of the source directory which holds the dependent source
+files (`sources-root`).
+
+`prepare_analyzer_cmd.py` creates a new analyzer command which may be executed
+immediately, if cross translation unit (CTU) was disabled.  However, to debug
+CTU analysis related crashed in clang we have to synthetise the AST dump files
+too, so other phases are needed which are done in `prepare_all_cmd_for_ctu.py`.
+It executes `CodeChecker` with ctu-collect, therefore `CodeChecker` must be in
+the `PATH` and the proper venv must be set.
+
+Example session for debugging a clang crash:
+```sh
+$ export WS=/your_own_path
+$ cd reports/failed
+$ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
+$ $WS/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$ bash analyzer-command_DEBUG
+```
+
+Example session for debuggin a CTU clang crash:
+```sh
+$ export WS=/your_own_path
+$ export PATH=$WS/CodeChecker/build/CodeChecker/bin:$PATH
+$ source $WS/CodeChecker/venv_dev/bin/activate
+$ cd reports/failed
+$ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
+$ $WS/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$ bash analyzer-command_DEBUG
+```

--- a/scripts/debug_tools/README.md
+++ b/scripts/debug_tools/README.md
@@ -9,12 +9,13 @@ of them (with `_DEBUG` postfix).  These modified files contain the paths
 prefixed with the root of the source directory which holds the dependent source
 files (`sources-root`).
 
-`prepare_analyzer_cmd.py` creates a new analyzer command which may be executed
-immediately, if cross translation unit (CTU) was disabled.  However, to debug
-CTU analysis related crashed in clang we have to synthetise the AST dump files
-too, so other phases are needed which are done in `prepare_all_cmd_for_ctu.py`.
-It executes `CodeChecker` with ctu-collect, therefore `CodeChecker` must be in
-the `PATH` and the proper venv must be set.
+`prepare_analyzer_cmd.py` creates a new clang static analyzer command
+(`analyzer-command_DEBUG`) which may be executed immediately if cross
+translation unit (CTU) was disabled.  However, to debug CTU analysis related
+crashed in clang we have to synthetise the AST dump files too, so other phases
+are needed which are done in `prepare_all_cmd_for_ctu.py`.  It executes
+`CodeChecker` with ctu-collect, therefore `CodeChecker` must be in the `PATH`
+and the proper venv must be set.
 
 Example session for debugging a clang crash:
 ```sh

--- a/scripts/debug_tools/failure_lib.py
+++ b/scripts/debug_tools/failure_lib.py
@@ -1,0 +1,59 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import json
+import os
+
+
+def find_path_end(string, path_begin):
+    """
+    Find one path in string.
+    Returns the pair of the begin and end pos.
+    """
+    path_end = string.find(' ', path_begin)
+    if path_end == -1:
+        path_end = len(string)
+    path = string[path_begin:path_end]
+    return path, path_end
+
+
+def change_paths(string, pathModifierFun):
+    """
+    Scan through the string and possibly replace all found paths.
+    Returns the modified string.
+    """
+    result = []
+    i = 0
+    while i < len(string):
+        # Everything is a path wich starts with a '/' and there is a whitespace
+        # after that.
+        # Note, this supports only POSIX paths.
+        if string[i] == '/':
+            path, path_end = find_path_end(string, i)
+            path = pathModifierFun(path)
+            result += path
+            i = path_end - 1
+        else:
+            result.extend(string[i])
+        i = i + 1
+    return ''.join(result)
+
+
+class IncludePathModifier:
+    def __init__(self, sources_root):
+        self.sources_root = sources_root
+
+    def __call__(self, path):
+        return os.path.join(
+            self.sources_root,
+            os.path.normpath(
+                path.lstrip(
+                    os.path.sep)))
+
+
+def load_json_file(filename):
+    with open(filename, 'r') as f:
+        data = json.load(f)
+    return data

--- a/scripts/debug_tools/prepare_all_cmd_for_ctu.py
+++ b/scripts/debug_tools/prepare_all_cmd_for_ctu.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import argparse
+import json
+import os
+import subprocess
+
+import prepare_compile_cmd
+import prepare_compiler_includes
+import prepare_compiler_target
+import prepare_analyzer_cmd
+
+
+def execute(cmd):
+    print("Executing command: " + ' '.join(cmd))
+    try:
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        out, err = proc.communicate()
+
+        print("stdout:\n\n" + out.decode("utf-8"))
+        print("stderr:\n\n" + err.decode("utf-8"))
+
+        if proc.returncode != 0:
+            print('Unsuccessful run: "' + ' '.join(cmd) + '"')
+            raise Exception("Unsuccessful run of command.")
+        return out
+    except OSError:
+        print('Failed to run: "' + ' '.join(cmd) + '"')
+        raise
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Prepare all commands '
+        'to execute in local environmennt for debugging.')
+    parser.add_argument(
+        '--sources_root',
+        default='./sources-root',
+        help="Path of the source root.")
+    parser.add_argument(
+        '--report_dir',
+        default='..',
+        help="Path of the report dir.")
+    parser.add_argument(
+        '--clang',
+        required=True,
+        help="Path to the clang binary.")
+    parser.add_argument(
+        '--clang_plugin_name', default=None,
+        help="Name of the used clang plugin.")
+    parser.add_argument(
+        '--clang_plugin_path', default=None,
+        help="Path to the used clang plugin.")
+    args = parser.parse_args()
+
+    compile_cmd_debug = "compile_cmd_DEBUG.json"
+    with open(compile_cmd_debug, 'w') as f:
+        f.write(
+            json.dumps(
+                prepare_compile_cmd.prepare(
+                    os.path.join(args.report_dir, "compile_cmd.json"),
+                    args.sources_root),
+                indent=4))
+
+    compiler_includes_debug = "compiler_includes_DEBUG.json"
+    with open(compiler_includes_debug, 'w') as f:
+        f.write(
+            json.dumps(
+                prepare_compiler_includes.prepare(
+                    os.path.join(args.report_dir, "compiler_includes.json"),
+                    args.sources_root),
+                indent=4))
+
+    compiler_target_debug = "compiler_target_DEBUG.json"
+    with open(compiler_target_debug, 'wb') as f:
+        f.write(
+            json.dumps(
+                prepare_compiler_target.prepare(
+                    os.path.join(args.report_dir, "compiler_target.json"),
+                    args.sources_root),
+                indent=4))
+
+    # ctu-collect
+    out = execute(["CodeChecker", "analyze", "--ctu-collect",
+                   compile_cmd_debug,
+                   "--compiler-includes-file", compiler_includes_debug,
+                   "--compiler-target-file", compiler_target_debug,
+                   "-o", "report_debug",
+                   "--verbose", "debug"])
+
+    analyzer_command_debug = "analyzer-command_DEBUG"
+    with open(analyzer_command_debug, 'w') as f:
+        f.write(
+            prepare_analyzer_cmd.prepare(
+                "./analyzer-command",
+                prepare_analyzer_cmd.PathOptions(
+                    args.sources_root,
+                    args.clang,
+                    args.clang_plugin_name,
+                    args.clang_plugin_path,
+                    "./report_debug/ctu-dir/x86_64")))
+
+    print(
+        "Preparation of files for debugging is done. "
+        "Now you can execute the generated analyzer command. "
+        "E.g. $ bash % s" %
+        analyzer_command_debug)

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import argparse
+import re
+import failure_lib as lib
+import os
+import sys
+
+
+def getFirstLineOfFile(fname):
+    with open(fname) as f:
+        return f.readline()
+
+
+class AnalyzerCommandPathModifier:
+    def __init__(self, opts):
+        self.opts = opts
+
+    def __call__(self, path):
+
+        if re.search('clang$', path):
+            return self.opts.clang
+
+        if self.opts.clang_plugin_name is not None and\
+                re.search(self.opts.clang_plugin_name, path):
+            if self.opts.clang_plugin_path is None:
+                print("clang_plugin_name is in a path, "
+                      "but clang_plugin_path is not given in the options")
+                sys.exit(-1)
+            return self.opts.clang_plugin_path
+
+        if re.search('ctu-dir', path):
+            if self.opts.ctu_dir is None:
+                print('ctu-dir is in a path, but not in the options!')
+                sys.exit(-1)
+            return self.opts.ctu_dir
+
+        return os.path.join(
+            self.opts.sources_root,
+            os.path.normpath(
+                path.lstrip(
+                    os.path.sep)))
+
+
+class PathOptions:
+    def __init__(
+            self,
+            sources_root,
+            clang,
+            clang_plugin_name,
+            clang_plugin_path,
+            ctu_dir):
+        self.sources_root = sources_root
+        self.clang = clang
+        self.clang_plugin_name = clang_plugin_name
+        self.clang_plugin_path = clang_plugin_path
+        self.ctu_dir = ctu_dir
+
+
+def prepare(analyzer_command_file, pathOptions):
+    res = lib.change_paths(getFirstLineOfFile(analyzer_command_file),
+                           AnalyzerCommandPathModifier(pathOptions))
+    return res
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare analyzer-command '
+                                     'to execute in local environmennt.')
+    parser.add_argument(
+        'analyzer_command_file',
+        help="The stored analyzer command.")
+    parser.add_argument(
+        '--sources_root',
+        default='./sources-root',
+        help="Path of the source root.")
+    parser.add_argument(
+        '--ctu_dir',
+        default=None,
+        help="Path of the used ctu-dir.")
+    parser.add_argument(
+        '--clang',
+        required=True,
+        help="Path to the clang binary.")
+    parser.add_argument(
+        '--clang_plugin_name', default=None,
+        help="Name of the used clang plugin.")
+    parser.add_argument(
+        '--clang_plugin_path', default=None,
+        help="Path to the used clang plugin.")
+    args = parser.parse_args()
+
+    print(
+        prepare(
+            args.analyzer_command_file,
+            PathOptions(
+                args.sources_root,
+                args.clang,
+                args.clang_plugin_name,
+                args.clang_plugin_path,
+                args.ctu_dir)))

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 
-def getFirstLineOfFile(fname):
+def get_first_line_of_file(fname):
     with open(fname) as f:
         return f.readline()
 
@@ -62,7 +62,7 @@ class PathOptions:
 
 
 def prepare(analyzer_command_file, pathOptions):
-    res = lib.change_paths(getFirstLineOfFile(analyzer_command_file),
+    res = lib.change_paths(get_first_line_of_file(analyzer_command_file),
                            AnalyzerCommandPathModifier(pathOptions))
     return res
 

--- a/scripts/debug_tools/prepare_compile_cmd.py
+++ b/scripts/debug_tools/prepare_compile_cmd.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import argparse
+import json
+import os
+
+import failure_lib as lib
+
+
+def existsInSourcesRoot(entry, sources_root):
+    """
+    Returns true if the given file in the compile commands really available
+    in the sources-root dir
+    """
+    if os.path.isabs(entry['file']):
+        real_path = os.path.join(
+            sources_root,
+            entry['file'].lstrip(os.path.sep))
+        return os.path.exists(real_path)
+
+    real_path = os.path.join(
+        sources_root,
+        entry['directory'].lstrip(
+            os.path.sep),
+        entry['file'])
+    return os.path.exists(real_path)
+
+
+def prepare(compile_command_json, sources_root):
+    """
+    Read a compile cmd json file and change all paths with a prefix
+    (sources_root).  Returns the modified json data.
+    """
+    json_data = lib.load_json_file(compile_command_json)
+    result_json = []
+    sources_root_abs = os.path.abspath(sources_root)
+    for entry in json_data:
+        if not existsInSourcesRoot(entry, sources_root):
+            continue
+
+        entry['directory'] =\
+            lib.change_paths(entry['directory'],
+                             lib.IncludePathModifier(sources_root_abs))
+
+        cmd = entry['command']
+        compiler, compilerEnd = lib.find_path_end(cmd.lstrip(), 0)
+        entry['command'] = compiler +\
+            lib.change_paths(cmd[compilerEnd:],
+                             lib.IncludePathModifier(sources_root_abs))
+
+        entry['file'] =\
+            lib.change_paths(entry['file'],
+                             lib.IncludePathModifier(sources_root_abs))
+
+        result_json.append(entry)
+    return result_json
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare compile cmd json '
+                                     'to execute in local environmennt.')
+    parser.add_argument('compile_command_json')
+    parser.add_argument('--sources_root', default='./sources-root')
+    args = parser.parse_args()
+
+    print(
+        json.dumps(
+            prepare(
+                args.compile_command_json,
+                args.sources_root),
+            indent=4))

--- a/scripts/debug_tools/prepare_compiler_includes.py
+++ b/scripts/debug_tools/prepare_compiler_includes.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import argparse
+import json
+import os
+
+import failure_lib as lib
+
+
+def prepare(compiler_includes_file, sources_root):
+    json_data = lib.load_json_file(compiler_includes_file)
+    new_json_data = dict()
+    sources_root_abs = os.path.abspath(sources_root)
+    for key, value in json_data.items():
+        lines = value.split("\n")
+        changed_lines = []
+        for line in lines:
+            changed_lines.append(
+                lib.change_paths(line,
+                                 lib.IncludePathModifier(sources_root_abs)))
+        new_json_data[key] = "\n".join(changed_lines)
+    return new_json_data
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare compiler includes '
+                                     'json to execute in local environmennt.')
+    parser.add_argument('compiler_includes_file')
+    parser.add_argument('--sources_root', default='./sources-root')
+    args = parser.parse_args()
+
+    print(
+        json.dumps(
+            prepare(
+                args.compiler_includes_file,
+                args.sources_root)))

--- a/scripts/debug_tools/prepare_compiler_target.py
+++ b/scripts/debug_tools/prepare_compiler_target.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+import argparse
+import json
+
+import failure_lib as lib
+
+
+def prepare(compiler_target_file, sources_root):
+    json_data = lib.load_json_file(compiler_target_file)
+    return json_data
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare compiler target '
+                                     'json to execute in local environmennt.')
+    parser.add_argument('compiler_target_file')
+    parser.add_argument('--sources_root', default='./sources-root')
+    args = parser.parse_args()
+
+    print(
+        json.dumps(
+            prepare(
+                args.compiler_target_file,
+                args.sources_root)))


### PR DESCRIPTION
These scripts may be used to aid debugging of clang crashes during analysis.
The goal is to reproduce the crash locally, i.e. using the source files in the
failure zip. During the process we take the original compile command database,
compiler includes and compiler target files and we create the modified version
of them (with `_DEBUG` postfix).  These modified files contain the paths
prefixed with the root of the source directory which holds the dependent source
files (`sources-root`).

`prepare_analyzer_cmd.py` creates a new analyzer command which may be executed
immediately, if cross translation unit (CTU) was disabled.  However, to debug
CTU analysis related crashed in clang we have to synthetise the AST dump files
too, so other phases are needed which are done in `prepare_all_cmd_for_ctu.py`.
It executes `CodeChecker` with ctu-collect, therefore `CodeChecker` must be in
the `PATH` and the proper venv must be set.

Example session for debugging a clang crash:
```
$ cd reports/failed
$ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
$ ~w/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang ~w/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path ~w/codechecker_core_ws/build/debug/libericsson-checkers.so
$ bash analyzer-command_DEBUG
```

Example session for debuggin a CTU clang crash:
```
$ export PATH=~w/CodeChecker/build/CodeChecker/bin:$PATH
$ source ~w/CodeChecker/venv_dev/bin/activate
$ cd reports/failed
$ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
$ ~w/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang ~w/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path ~w/codechecker_core_ws/build/debug/libericsson-checkers.so
$ bash analyzer-command_DEBUG
```
