### PR TITLE
Tidy hash generation bugfixes

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -56,7 +56,7 @@ def get_checker_name(diagnostic):
     return checker_name
 
 
-def get_report_hash(diagnostic, files):
+def get_report_hash(diagnostic, source_file):
     """
     Check if checker name is available in the report.
     Checker hash was not available in older clang versions before 3.8.
@@ -65,8 +65,10 @@ def get_report_hash(diagnostic, files):
     report_hash = diagnostic.get('issue_hash_content_of_line_in_context')
     if not report_hash:
         # Generate hash value if it is missing from the report.
-        report_hash = generate_report_hash(diagnostic['path'], files,
-                                           get_checker_name(diagnostic))
+        report_hash \
+            = generate_report_hash(diagnostic['path'],
+                                   source_file,
+                                   get_checker_name(diagnostic))
     return report_hash
 
 
@@ -101,7 +103,7 @@ def parse_plist(path):
             # We need to extend information for plist files generated
             # by older clang version (before 3.8).
             main_section['issue_hash_content_of_line_in_context'] = \
-                get_report_hash(diag, files)
+                get_report_hash(diag, files[diag['location']['file']])
 
             bug_path_items = [item for item in diag['path']]
 

--- a/libcodechecker/analyze/store_handler.py
+++ b/libcodechecker/analyze/store_handler.py
@@ -359,15 +359,23 @@ def addReport(storage_session,
                         report.detection_status == 'unresolved' or \
                         report.detection_status == 'reopened':
                     new_status = 'unresolved'
+
                     report.file_id = file_id
+                    report.line = line_num
+                    report.column = column
+
                     change_path_and_events(session,
                                            report.id,
                                            bugpath,
                                            events)
                 elif report.detection_status == 'resolved':
                     new_status = 'reopened'
+
                     report.file_id = file_id
+                    report.line = line_num
+                    report.column = column
                     report.fixed_at = None
+
                     change_path_and_events(session,
                                            report.id,
                                            bugpath,

--- a/libcodechecker/report.py
+++ b/libcodechecker/report.py
@@ -13,15 +13,15 @@ All hash generation algorithms should be documented and implemented here.
 """
 import hashlib
 import json
-import linecache
 import os
 
 from libcodechecker.logger import LoggerFactory
+from libcodechecker.util import get_line
 
 LOG = LoggerFactory.get_new_logger('REPORT')
 
 
-def generate_report_hash(path, files, check_name):
+def generate_report_hash(path, source_file, check_name):
     """
     !!! Compatible with the old hash before v6.0
 
@@ -78,17 +78,16 @@ def generate_report_hash(path, files, check_name):
         main_section = path[-1]
 
         m_loc = main_section.get('location')
-        source_file = files[m_loc.get('file')]
         source_line = m_loc.get('line')
 
         from_col = m_loc.get('col')
         until_col = m_loc.get('col')
 
-        line_content = linecache.getline(source_file, source_line)
+        line_content = get_line(source_file, source_line)
 
         if line_content == '' and not os.path.isfile(source_file):
-            LOG.debug("Failed to generate report hash.")
-            LOG.debug('%s does not exists!' % source_file)
+            LOG.error("Failed to generate report hash.")
+            LOG.error('%s does not exists!' % source_file)
 
         file_name = os.path.basename(source_file)
         msg = main_section.get('message')

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -1882,7 +1882,6 @@ class ThriftRequestHandler(object):
                 continue
 
             file_ids = {}
-            # Store content of file to the server if needed.
             for file_name in files:
                 file_ids[file_name] = file_path_to_id[file_name]
 

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -320,3 +320,21 @@ def escape_like(string, escape_char='*'):
     return string.replace(escape_char, escape_char * 2) \
                  .replace('%', escape_char + '%') \
                  .replace('_', escape_char + '_')
+
+
+def get_line(file_name, line_no):
+    """
+    Return the given line from the file. If line_no is larger than the number
+    of lines in the file then empty string returns.
+    If the file can't be opened for read, the function also returns empty
+    string.
+    """
+    try:
+        with open(file_name) as f:
+            for line in f:
+                line_no -= 1
+                if line_no == 0:
+                    return line
+            return ''
+    except IOError:
+        return ''

--- a/tests/unit/tidy_output_test_files/tidy1.plist
+++ b/tests/unit/tidy_output_test_files/tidy1.plist
@@ -11,6 +11,8 @@
 			<string>clang-analyzer-core.DivideZero</string>
 			<key>description</key>
 			<string>Division by zero</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>79cc349883cacbd7d2a4301ddb79bc68</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -67,6 +69,8 @@
 			<string>clang-diagnostic-division-by-zero</string>
 			<key>description</key>
 			<string>remainder by zero is undefined</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>9785900b66c87f89edcc9daaab59647a</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>

--- a/tests/unit/tidy_output_test_files/tidy2.plist
+++ b/tests/unit/tidy_output_test_files/tidy2.plist
@@ -11,6 +11,8 @@
 			<string>clang-diagnostic-unused-variable</string>
 			<key>description</key>
 			<string>unused variable 'y'</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>0afd6d1f5bf7f1856d9f01e4ac92534e</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -50,6 +52,8 @@
 			<string>clang-analyzer-core.DivideZero</string>
 			<key>description</key>
 			<string>Division by zero</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>7cc9ef198741b4dff762b1a8578b4546</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -227,6 +231,8 @@
 			<string>clang-diagnostic-division-by-zero</string>
 			<key>description</key>
 			<string>remainder by zero is undefined</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>cac9b3630bea66ab98dfefacc2a8f6d0</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>

--- a/tests/unit/tidy_output_test_files/tidy3.plist
+++ b/tests/unit/tidy_output_test_files/tidy3.plist
@@ -11,6 +11,8 @@
 			<string>modernize-use-nullptr</string>
 			<key>description</key>
 			<string>use nullptr</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>881bd0b5111814b3eaab59f4229eccba</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -67,6 +69,8 @@
 			<string>clang-analyzer-core.NullDereference</string>
 			<key>description</key>
 			<string>Dereference of null pointer (loaded from variable 'x')</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>42a599e2e32611711ec3ffce39cd61ce</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>


### PR DESCRIPTION
On server side the linecache Python module cached the files from which
it returned a given line. If the file changed and the file was queried
from the cache then the given line returned from the old file version.

In case of ClangTidy the bug hash is generated by CodeChecker. Because
of the previous bug a false bug hash was generated if the line number of
the bug event changed. So now the bug hash is computed on client side
and is written to the .plist file. Server will use this hash instead of
generating it again.

When a bug path changed because it is shifted a few lines downer then
the corresponding line number was only updated in BagPathEvent and
BugReportPoint tables, but not in Report table. This caused a GUI
glitch, i.e. it didn't jump to the correct position when a report was
opened.

Fixes #1106