### PR TITLE
Handle run database connection failure while server is running

### DIFF
--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -531,9 +531,19 @@ class Product(object):
             return
 
         self.__engine.dispose()
-
         self.__session = None
         self.__engine = None
+        self.__connected = False
+
+    def mark_failed(self, reason):
+        """
+        Disposes the database connection to the product's backend, and also
+        saves the given :reason as reason for the connection dropped.
+        """
+        LOG.error("The database connection for product '{0}' failed. "
+                  "Reason: {1}".format(self.endpoint, reason))
+        self.teardown()
+        self.__last_connect_attempt = (datetime.datetime.now(), reason)
 
 
 class CCSimpleHttpServer(HTTPServer):


### PR DESCRIPTION
Previously, the server only checked the availability of run databases at server start time. If the database was unavailable, an error was given, and if users tried to connect to the product which database was offline even after a retry, access was prohibited.

But if the server thought a database connection was valid and it, for any reason, terminated, the only indication of this was from the users' perspective, when, at issuing a query, they got an exception back on Thrift.

```
$ CodeChecker cmd runs
Database error on server
(psycopg2.OperationalError) could not connect to server: Connection refused
        Is the server running on host "localhost" (::1) and accepting
        TCP/IP connections on port 6250?
could not connect to server: Connection refused
        Is the server running on host "localhost" (127.0.0.1) and accepting
        TCP/IP connections on port 6250?

[16:17] - Server error.
```

This patch changes the behaviour so these errors are properly caught and put the product in particular back to "connection failed" state.

**NOTE!** This status check is not preemptive! An actual database operation must fail due to connection issues for this status change to be registered.

But this means that if the database dies, the first user trying to do anything to it will get an exception, but  any subsequent queries will, instead of the same exception, get a message that the product's database is missing.

> Image taken after starting a CodeChecker server and terminating the database server behind `pp`.

![error message](https://user-images.githubusercontent.com/1969470/32667175-3ca7cfb2-c63a-11e7-8ad1-cacf19b2ddd6.png)

Of course, an "unconnected" database is, after this, subject to the same rules as if the database wasn't connected at server start. Once every 5 minutes (I think this is the grace period configured) a connection attempt can be made, when users query the product list.