### PR TITLE
Fix big screen bug

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -248,6 +248,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
       this.store = new ObjectStore({ objectStore : new BugStore() });
       this.escapeHTMLInData = false;
       this.selectionMode = 'single';
+      this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
       this._lastSelectedRow = 0;
     },
 

--- a/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -93,6 +93,7 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
       this.selectable = true;
       this.keepSelection = true;
       this.escapeHTMLInData = false;
+      this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
 
       this._dialog = new Dialog({ title : 'Check command' });
     },


### PR DESCRIPTION
When the browser window is too big then sometimes only a few results
appear. This was because of GUI table rendering issues.