### PR TITLE
Share the run's "undergoing storage" lock between servers through the database

### DIFF
--- a/db_migrate/versions/dd9c97ead24_share_the_locking_of_runs.py
+++ b/db_migrate/versions/dd9c97ead24_share_the_locking_of_runs.py
@@ -1,0 +1,35 @@
+"""Share the locking of runs across servers via database
+
+Revision ID: dd9c97ead24
+Revises: 4b38fa14c27b
+Create Date: 2017-11-17 15:44:07.810579
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dd9c97ead24'
+down_revision = '4b38fa14c27b'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+from libcodechecker.server.database.run_db_model import Run
+
+
+def upgrade():
+    op.add_column('runs', sa.Column('lock_timestamp', sa.DateTime(),
+                                    nullable=True))
+
+
+def downgrade():
+    op.drop_column('runs', 'lock_timestamp')
+
+    # If there are runs who are in the database with '-2' duration, they
+    # must be removed as these rows signify runs which store operation didn't
+    # conclude.
+    connection = op.get_bind()
+    session = Session(bind=connection)
+    session.query(Run).filter(Run.duration == -2).delete()
+    session.commit()

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -38,18 +38,6 @@ LOG = logger.get_logger('system')
 MAX_UPLOAD_SIZE = 1 * 1024 * 1024 * 1024  # 1GiB
 
 
-def full_traceback(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
-            raise type(e)(msg)
-    return wrapper
-
-
 def get_argparser_ctor_args():
     """
     This method returns a dict containing the kwargs for constructing an

--- a/libcodechecker/server/database/db_cleanup.py
+++ b/libcodechecker/server/database/db_cleanup.py
@@ -1,9 +1,33 @@
-from codeCheckerDBAccess_v6.ttypes import*
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Perform automatic cleanup routines on the database.
+"""
+
+from datetime import datetime, timedelta
+
+from codeCheckerDBAccess_v6.ttypes import *
 
 from libcodechecker.logger import get_logger
 from libcodechecker.server.database.run_db_model import *
 
 LOG = get_logger('server')
+
+
+def remove_stale_runs(session):
+    LOG.debug("Pruning of stale runs whose storage went away started...")
+
+    locks_expired_at = datetime.now() - timedelta(minutes=30)
+
+    session.query(Run) \
+        .filter(and_(Run.duration == -2,
+                     Run.lock_timestamp < locks_expired_at)) \
+        .delete(synchronize_session=False)
+
+    LOG.info("Pruning of stale runs whose storage went away finished.")
 
 
 def remove_unused_files(session):

--- a/libcodechecker/server/database/session_context.py
+++ b/libcodechecker/server/database/session_context.py
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Provides a context manager over a database sessionmaker.
+"""
+
+
+class DBSession(object):
+    """
+    Requires a session maker object and creates one session which can be used
+    in the context.
+
+    The session will be automatically closed, but committing must be done
+    inside the context.
+    """
+    def __init__(self, session_maker):
+        self.__session = None
+        self.__session_maker = session_maker
+
+    def __enter__(self):
+        # create new session
+        self.__session = self.__session_maker()
+        return self.__session
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.__session:
+            self.__session.close()

--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -641,6 +641,7 @@ class Product(object):
         with database.DBContext(prod_db) as db:
             try:
                 db_cleanup.remove_unused_files(db.session)
+                db_cleanup.remove_stale_runs(db.session)
                 db.session.commit()
                 return True
             except Exception as ex:


### PR DESCRIPTION
> Closes #1138.

To allow using a shared database from multiple CodeChecker servers, the fact that a run is currently undergoing a storage is to be shared through the database instead of it being purely in the server's memory.

----

`runs` table will get a new `lock_timestamp` column that stamps when a store operation begins into that particular run. (This update happens every time the store operation accesses the database.) The `lock_timestamp` is written independently from the transaction that handles storing the *actual* data for the run, and is always up-to-date in the database.

`runs.duration` will have a new extreme value, `-2` for runs which the current ongoing store is their **first**. `duration` already had `-1` as a value for "store ongoing", but this value never appeared in the database, because a run either was successfully stored (in this case, `duration` was a positive number), or not (in this case, the row did not appear in the database). Currently, the record for the lock itself must be present in the database. This special value was chosen to prevent having an extra field, e.g. `first_store_succeeded` which, in 99.9999999% of the cases will always be `TRUE`, as discussed with @gyorb.

If a run is being updated, the database will contain the lock value, but all the actual data change will be in a transaction buffer. If it succeeds, the lock is taken off, if fails, the lock will eventually expire (just like how the internal `StorageSession` buffer expires after a while).

To prevent extra queries to the database, if the particular server instance knows about the lock in its memory, it will report it directly.

If a run is having its first store operation, the row immediately appears in the database &ndash; so that other servers are notified that this run-name and ID is locked. In case a **lock expires** from this special, `-2` duration run, the clients will not be notified of this run's existence (it won't be shown on the Web GUI or the command-line output), and the next subsequent store to the run-name will be able to properly start storing again. This is because technically, this run never *actually* happened, as only a lock operation was ever committed to the database.

The automatic "database cleanup" routine will prune all such "empty" lock records at server start.

This patch fixes a very special case of session timeouts and such, and thus, I see no actual way to reliably set up an environment for testing this, hence why the tests are missing.