### PR TITLE
Do not limit checker name filter options

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -86,7 +86,8 @@ def process_report_filter_v2(report_filter, count_filter=None):
               for cm in report_filter.checkerMsg]
         AND.append(or_(*OR))
 
-    if report_filter.checkerName is not None:
+    if report_filter.checkerName is not None and \
+       count_filter != CountFilter.CHECKER_NAME:
         OR = [Report.checker_id.ilike(conv(cn))
               for cn in report_filter.checkerName]
         AND.append(or_(*OR))

--- a/www/scripts/codecheckerviewer/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/BugFilterView.js
@@ -1493,21 +1493,15 @@ function (declare, Deferred, dom, domClass, all, topic, Standby, Button,
         title : 'Checker name',
         parent   : this,
         enableSearch : true,
-        serverSideSearch : true,
         filterLabel : 'Search for checker names...',
         getItems : function (filter, limit) {
           var deferred = new Deferred();
 
           var runs = that.getRunIds();
-          var searchData = this.createSearchData(filter, limit);
+          var reportFilter = that.getReportFilters();
 
-          if (!searchData.limit) {
-            deferred.resolve([]);
-            return deferred;
-          }
-
-          CC_SERVICE.getCheckerCounts(runs.baseline, searchData.reportFilter,
-            runs.newcheck, searchData.limit, 0, function (res) {
+          CC_SERVICE.getCheckerCounts(runs.baseline, reportFilter,
+          runs.newcheck, null, 0, function (res) {
             deferred.resolve(res.map(function (checker) {
               return {
                 label : checker.name,


### PR DESCRIPTION
The checker name filter options should not be limited, because there is no full overview about the number of issues found by the checkers.

Closes #1153