### PR TITLE
POST errors to thrift exceptions in http server

### DIFF
--- a/libcodechecker/libclient/authentication_helper.py
+++ b/libcodechecker/libclient/authentication_helper.py
@@ -12,6 +12,7 @@ import socket
 from thrift.transport import THttpClient
 from thrift.protocol import TJSONProtocol
 from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TApplicationException
 
 import shared
 from Authentication_v6 import codeCheckerAuthentication
@@ -69,6 +70,10 @@ class ThriftAuthHelper():
                     print(str(reqfailure))
 
                 sys.exit(1)
+            except TApplicationException as ex:
+                print("Internal server error on {0}:{1}"
+                      .format(self.__host, self.__port))
+                print(ex.message)
             except TProtocolException as ex:
                 print("Connection failed to {0}:{1}"
                       .format(self.__host, self.__port))

--- a/libcodechecker/libclient/product_helper.py
+++ b/libcodechecker/libclient/product_helper.py
@@ -11,6 +11,7 @@ import socket
 from thrift.transport import THttpClient
 from thrift.protocol import TJSONProtocol
 from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TApplicationException
 
 import shared
 from ProductManagement_v6 import codeCheckerProductService
@@ -62,6 +63,10 @@ class ThriftProductHelper(object):
                 else:
                     print('Other error')
                     print(str(reqfailure))
+            except TApplicationException as ex:
+                print("Internal server error on {0}:{1}"
+                      .format(self.__host, self.__port))
+                print(ex.message)
             except TProtocolException as ex:
                 print("Connection failed to {0}:{1}"
                       .format(self.__host, self.__port))

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -11,6 +11,7 @@ import sys
 from thrift.transport import THttpClient
 from thrift.protocol import TJSONProtocol
 from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TApplicationException
 
 import shared
 from codeCheckerDBAccess_v6 import codeCheckerDBAccess
@@ -68,7 +69,10 @@ class ThriftClientHelper(object):
                     print(str(reqfailure))
 
                 raise
-
+            except TApplicationException as ex:
+                print("Internal server error on {0}:{1}"
+                      .format(self.__host, self.__port))
+                print(ex.message)
             except TProtocolException as ex:
                 if ex.type == TProtocolException.UNKNOWN:
                     LOG.debug('Unknown thrift error')


### PR DESCRIPTION
Internal errors in POST (used for thirft) requests were returned
as http errors which could not be parsed by thrift client
(results are expected in json format).
Convert the errors to TApplicationException which can be
processed by the thrift clients.