### PR TITLE
Get line content information for multiple files

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -225,6 +225,13 @@ struct CompareData {
   2: DiffType  diffType
 }
 
+// This type is used to get line content information for the given file at the
+// given positions.
+struct LinesInFilesRequested {
+  1: i64        fileId,
+  2: set<i64>   lines
+}
+typedef list<LinesInFilesRequested> LinesInFilesRequestedList
 
 service codeCheckerDBAccess {
 
@@ -294,6 +301,14 @@ service codeCheckerDBAccess {
                                    2: bool     fileContent,
                                    3: Encoding encoding)
                                    throws (1: shared.RequestFailed requestError),
+
+  // Get line content information for multiple files in different positions.
+  // The first key of the map is a file id, the second is a line number:
+  // (e.g.: lineContent = result[fileId][line])
+  // PERMISSION: PRODUCT_ACCESS
+  map<i64, map<i64, string>> getLinesInSourceFileContents(1: LinesInFilesRequestedList linesInFilesRequested,
+                                                          2: Encoding encoding)
+                                                          throws (1: shared.RequestFailed requestError),
 
   // change review status of a bug.
   // PERMISSION: PRODUCT_ACCESS or PRODUCT_STORE

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -113,6 +113,10 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
+    def getLinesInSourceFileContents(self, lines_in_files_requested, encoding):
+        pass
+
+    @ThriftClientCall
     def getDiffResultsHash(self, run_ids, report_hashes, diff_type):
         pass
 

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -1336,6 +1336,35 @@ class ThriftRequestHandler(object):
         finally:
             session.close()
 
+    @timeit
+    def getLinesInSourceFileContents(self, lines_in_files_requested, encoding):
+        self.__require_access()
+        try:
+            session = self.__Session()
+
+            res = defaultdict(lambda: defaultdict(str))
+            for lines_in_file in lines_in_files_requested:
+                sourcefile = session.query(File).get(lines_in_file.fileId)
+                cont = session.query(FileContent).get(sourcefile.content_hash)
+                lines = zlib.decompress(cont.content).split('\n')
+                for line in lines_in_file.lines:
+                    content = '' if len(lines) < line else lines[line - 1]
+                    if not encoding or encoding == Encoding.DEFAULT:
+                        content = codecs.decode(content, 'utf-8', 'replace')
+                    elif encoding == Encoding.BASE64:
+                        content = base64.b64encode(content)
+                    res[lines_in_file.fileId][line] = content
+
+            return res
+        except sqlalchemy.exc.SQLAlchemyError as alchemy_ex:
+            msg = str(alchemy_ex)
+            LOG.error(msg)
+            raise shared.ttypes.RequestFailed(shared.ttypes.ErrorCode.DATABASE,
+                                              msg)
+
+        finally:
+            session.close()
+
     def _cmp_helper(self, session, run_ids, cmp_data):
         """
         Get the report hashes for all of the runs.

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -12,7 +12,7 @@ accepts.
 # This dict object stores for each MAJOR version (key) the largest MINOR
 # version (value) supported by the build.
 SUPPORTED_VERSIONS = {
-    6: 3
+    6: 4
 }
 
 # This value is automatically generated to represent the highest version

--- a/tests/functional/report_viewer_api/test_get_lines_in_file.py
+++ b/tests/functional/report_viewer_api/test_get_lines_in_file.py
@@ -1,0 +1,119 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import base64
+import logging
+import os
+import unittest
+
+from libtest import env
+
+from codeCheckerDBAccess_v6.ttypes import Encoding
+from codeCheckerDBAccess_v6.ttypes import LinesInFilesRequested
+from codeCheckerDBAccess_v6.ttypes import ReportFilter
+
+
+class TestRunFilter(unittest.TestCase):
+
+    _ccClient = None
+
+    def setUp(self):
+        test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + test_workspace)
+
+        # Get the clang version which is tested.
+        self._clang_to_test = env.clang_to_test()
+
+        self._testproject_data = env.setup_test_proj_cfg(test_workspace)
+        self.assertIsNotNone(self._testproject_data)
+
+        self._cc_client = env.setup_viewer_client(test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        # Get the run names which belong to this test.
+        run_names = env.get_run_names(test_workspace)
+
+        runs = self._cc_client.getRunData(None)
+
+        test_runs = [run for run in runs if run.name in run_names]
+
+        self._runid = test_runs[0].runId
+        self._project_info = env.setup_test_proj_cfg(test_workspace)
+
+    def __get_file_id_for_path(self, run_id, file_path):
+        # Returns file id for the given file path in the given run.
+        file_filter = ReportFilter(filepath=[file_path])
+        run_results = self._cc_client.getRunResults(
+            [run_id], 1, 0, None, file_filter, None)
+
+        self.assertTrue(len(run_results))
+        return run_results[0].fileId
+
+    def __check_lines_in_source_file_contents(self, lines_in_files_requested,
+                                              encoding, expected):
+        """
+        Get line content information with the given encoding and check the
+        results.
+        """
+        file_to_lines_map = self._cc_client.getLinesInSourceFileContents(
+            lines_in_files_requested, encoding)
+        for file_id in expected:
+            for line in expected[file_id]:
+                source_line = file_to_lines_map[file_id][line]
+                if encoding == Encoding.BASE64:
+                    source_line = base64.b64decode(source_line)
+
+                self.assertEqual(source_line,
+                                 expected[file_id][line])
+
+    def __get_local_lines_in_source_file_contents(self, file_name, lines):
+        """
+        :param file_name File name under the project path.
+        :param lines Line number starting from 1.
+        Returns line content information for the given file located in the
+        project path.
+        """
+        file_path = os.path.join(self._project_info['project_path'], file_name)
+        with open(file_path, 'r') as f:
+            lines_in_file = f.read().split('\n')
+            return {line: '' if len(lines_in_file) < line else
+                    lines_in_file[line - 1] for line in lines}
+
+    def test_get_lines_in_source_file_contents(self):
+        """
+        Get line content information for multiple files in different positions.
+        """
+        runid = self._runid
+        logging.debug('Get line content information from the db for runid: ' +
+                      str(runid))
+
+        # Get reports by file to get a file id.
+        file_id_1 = self.__get_file_id_for_path(runid, "*call_and_message.cpp")
+        file_id_2 = self.__get_file_id_for_path(runid, "*divide_zero.cpp")
+
+        lines_in_files_requested = [
+            LinesInFilesRequested(fileId=file_id_1, lines=[15, 20]),
+            LinesInFilesRequested(fileId=file_id_2, lines=[12, 19])]
+
+        expected = {
+            file_id_1: self.__get_local_lines_in_source_file_contents(
+                'call_and_message.cpp', [15, 20]),
+            file_id_2: self.__get_local_lines_in_source_file_contents(
+                'divide_zero.cpp', [12, 19])
+        }
+
+        # Check results by using default encoding.
+        self.__check_lines_in_source_file_contents(lines_in_files_requested,
+                                                   Encoding.DEFAULT,
+                                                   expected)
+
+        # Check results by using base64 encoding.
+        self.__check_lines_in_source_file_contents(lines_in_files_requested,
+                                                   Encoding.BASE64,
+                                                   expected)

--- a/www/scripts/version.js
+++ b/www/scripts/version.js
@@ -1,1 +1,1 @@
-CC_API_VERSION = '6.3';
+CC_API_VERSION = '6.4';


### PR DESCRIPTION
This commit introduces new API function to get line content information for multiple files in different positions.
This way we do not make a lot of API call to get line content information when getting resolved bugs from the command line client.

Measurement:
- Old time: 1m17.498s
- New time: 0m1.568s

Closes #956