### PR TITLE
Show only relevant bugs in the bug tree

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -455,9 +455,9 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
             runResultParam.cmpData);
           reportData = reports[0];
         } else {
-          runResultParam.runIds = [reportData.runId];
           runResultParam.cmpData = null;
         }
+        runResultParam.runIds = [reportData.runId];
 
         if (that.reportData &&
             that.reportData.reportId === reportData.reportId) {


### PR DESCRIPTION
If file is opened from the All reports tab, bugs are shown from all runs.
This commit solves the problem to open only those bugs, which is valid for that opened specific run.

Closes #1117