### PR TITLE
Feature comparison of cmd and webgui

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Developer Documentation
   * [Package layout](docs/package_layout.md)
   * [Checker documentation](docs/checker_docs.md)
   * [Thrift interface](api/README.md)
+  * [Feature overview of command-line and Web
+    interface](docs/feature_comparison.md)
   * [Package and integration tests](tests/README.md)
   * [Database schema migration](docs/db_schema_guide.md)
   * A high-level overview about the infrastructure is available amongst the

--- a/docs/feature_comparison.md
+++ b/docs/feature_comparison.md
@@ -1,0 +1,100 @@
+Feature comparison
+==================
+
+CodeChecker includes two user interfaces, which support different actions. This
+comparison summary is intended to overview which feature is available through
+which interface.
+
+Table of Contents
+-----------------
+
+ * [Analysis invocation](#analysis-invocation)
+ * [Storage of reports to a server](#storage-of-reports-to-a-server)
+ * [Report navigation and visualisation](#report-navigation-and-visualisation)
+    * [Report management, triaging tools](#report-management-triaging-tools)
+    * [Statistics, summary views](#statistics-summary-views)
+ * [Run management](#run-management)
+ * [Server administration](#server-administration)
+    * [Starting a server](#starting-a-server)
+    * [Product management](#product-management)
+    * [Authentication and access control](#authentication-and-access-control)
+
+## Analysis invocation
+
+Analyzers can only be invoked through the command-line command,
+[`analyze`](/docs/user_guide.md#analyze).
+
+Analysis runs locally on the user's computer.
+
+Cross&ndash;Translation-Unit analysis supported if using a [Clang version
+which supports it](http://github.com/Ericsson/clang).
+
+## Storage of reports to a server
+
+Storage of reports can only be done through the command-line command,
+[`store`](/docs/user_guide.md#store).
+
+## Report navigation and visualisation
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Listing basic (file, check message, ...) report summary| ✓ | ✓ |
+| Listing advanced (detection status, review, ...) report summary | ✗ | ✓ |
+| Basic (file path, check name, ...) filtering of reports | ✓ | ✓ |
+| Advanced (detection status, detection date, ...) filtering | ✗ | ✓ |
+| Printing bug path for report | [Only for local output folder](/docs/user_guide.md#parse) | ✓ |
+| Visualisation of bug path in the code | [Only through exporting to HTML](/docs/user_guide.md#parse) | ✓ |
+| Listing reports in the same file | Only through filters | ✓ |
+| Listing all reports in a product | ✗ | ✓ |
+
+### Report management, triaging tools
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Showing comments for a particular report | ✗ | ✓ |
+| Commenting on reports | ✗ | ✓ |
+| Comment management (edit, delete) | ✗ | ✓ |
+| Showing review status of a report | ✗ | ✓ |
+| Changing review status of a report | ✗ | ✓ |
+| *(Legacy)* Importing [suppressions](/docs/user_guide.md#manage-suppressions) of `< 6.0` CodeChecker | ✓ | ✗ |
+| Difference of two runs | ✓ | ✓ |
+| Difference of a stored run to a local output folder | ✓ | ✗ |
+
+### Statistics, summary views
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Run overview | Basic (only report count and timestamp) | ✓ |
+| Breakdown of reports per run, per check | ✓ | ✓ |
+| Exporting report breakdown to CSV | ✓ | ✓ |
+
+## Run management
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Listing runs in a product | ✓ | ✓ |
+| Listing store actions to a run (history) | ✗ | ✓ |
+| Deleting runs | ✓ | ✓ |
+
+## Server administration
+
+### Starting a server
+
+The command-line command [`CodeChecker server`](/docs/user_guide.md#server) is
+used to start a CodeChecker server.
+
+This command is also responsible for handling schema upgrades.
+
+### [Product management](/docs/products.md)
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Listing products on a server | ✓ | ✓ |
+| Addition, modification and removal of products | ✓ | ✓ |
+
+### [Authentication](/docs/authentication.md) and [access control](/docs/permissions.md)
+
+| Feature name | [Command-line](/docs/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+|--------------|-----------------------------------------|----------------------------------------|
+| Configuration of authentication system | Through configuration file | ✗ |
+| Managing permissions granted to users | ✗ | ✓ |


### PR DESCRIPTION
This is something I intended to do for a long while now... A quick overview on what subfeatures of CodeChecker is available in the cmd and on the webgui. Seeing as, for example, @Xazax-hun recently messed up in mentioning suppression through cmd in the "False positives guide".