### PR TITLE
Fix ordering by File in Unique reports mode

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -312,7 +312,8 @@ def filter_report_filter(q, filter_expression, run_ids=None, cmp_data=None,
 def get_sort_map(sort_types, is_unique=False):
     # Get a list of sort_types which will be a nested ORDER BY.
     sort_type_map = {
-        SortType.FILENAME: [(File.filepath, 'filepath')],
+        SortType.FILENAME: [(File.filepath, 'filepath'),
+                            (Report.line, 'line')],
         SortType.CHECKER_NAME: [(Report.checker_id, 'checker_id')],
         SortType.SEVERITY: [(Report.severity, 'severity')],
         SortType.REVIEW_STATUS: [(ReviewStatus.status, 'rw_status')],
@@ -791,6 +792,13 @@ class ThriftRequestHandler(object):
                     .outerjoin(sorted_reports,
                                sorted_reports.c.id == Report.id) \
                     .filter(sorted_reports.c.id.isnot(None))
+
+                # We have to sort the results again because an ORDER BY in a
+                # subtable is broken by the JOIN.
+                q = sort_results_query(q,
+                                       sort_types,
+                                       sort_type_map,
+                                       order_type_map)
 
                 for report_id, bug_id, checker_msg, checker, severity, \
                     status, filename, path in \

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -175,7 +175,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
       var sortMode = new CC_OBJECTS.SortMode();
 
       sortMode.type
-        = sort.attribute === 'checkedFile'
+        = sort.attribute === 'file'
         ? CC_OBJECTS.SortType.FILENAME
         : sort.attribute === 'checkerId'
         ? CC_OBJECTS.SortType.CHECKER_NAME
@@ -270,7 +270,7 @@ function (declare, dom, Deferred, ObjectStore, Store, QueryResults, topic,
     canSort : function (inSortInfo) {
       var cell = this.getCell(Math.abs(inSortInfo) - 1);
 
-      return cell.field === 'checkedFile' ||
+      return cell.field === 'file' ||
              cell.field === 'checkerId'   ||
              cell.field === 'severity'    ||
              cell.field === 'reviewStatus' ||


### PR DESCRIPTION
Ordering by File when Unique reports are enabled should give an alphabetical order.

Closes #1198