### PR TITLE
Add bug path length column to Bug overview

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -68,7 +68,8 @@ enum SortType {
   CHECKER_NAME,
   SEVERITY,
   REVIEW_STATUS,
-  DETECTION_STATUS
+  DETECTION_STATUS,
+  BUG_PATH_LENGTH,
 }
 
 
@@ -161,6 +162,7 @@ struct ReportData {
   12: DetectionStatus detectionStatus, // State of the bug (see the enum constant values).
   13: string          detectedAt,      // Detection date of the report.
   14: string          fixedAt          // Date when the report was fixed.
+  15: i64             bugPathLength,   // Length of the bug path.
 }
 typedef list<ReportData> ReportDataList
 

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -12,7 +12,7 @@ accepts.
 # This dict object stores for each MAJOR version (key) the largest MINOR
 # version (value) supported by the build.
 SUPPORTED_VERSIONS = {
-    6: 5
+    6: 6
 }
 
 # This value is automatically generated to represent the highest version

--- a/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/tests/functional/report_viewer_api/test_get_run_results.py
@@ -51,6 +51,25 @@ class RunResults(unittest.TestCase):
 
         self._runid = test_runs[0].runId
 
+    def __check_bug_path_order(self, run_results, order):
+        """
+        Checks the bug path length order of the run results.
+        :param run_results: Run results.
+        :param order: If it is a negative value, it checks that bug path length
+        of the results order is descending otherwise ascending.
+        """
+        prev = None
+        for res in run_results:
+            self.assertGreater(res.bugPathLength, 0)
+
+            if not prev:
+                prev = res
+                continue
+            if order == Order.ASC:
+                self.assertGreaterEqual(res.bugPathLength, prev.bugPathLength)
+            else:
+                self.assertLessEqual(res.bugPathLength, prev.bugPathLength)
+
     def test_get_run_results_no_filter(self):
         """ Get all the run results without any filtering. """
         runid = self._runid
@@ -219,3 +238,26 @@ class RunResults(unittest.TestCase):
                             (bug1.line <=
                              bug2.line) or
                             (bug1.checkerId <= bug2.checkerId))
+
+    def test_bug_path_length(self):
+        runid = self._runid
+        sortMode1 = SortMode(SortType.BUG_PATH_LENGTH, Order.ASC)
+        sortMode2 = SortMode(SortType.BUG_PATH_LENGTH, Order.DESC)
+        simple_filter = ReportFilter()
+        unique_filter = ReportFilter(isUnique=True)
+
+        run_results = self._cc_client.getRunResults([runid],
+                                                    100,
+                                                    0,
+                                                    [sortMode1],
+                                                    simple_filter,
+                                                    None)
+        self.__check_bug_path_order(run_results, Order.ASC)
+
+        run_results = self._cc_client.getRunResults([runid],
+                                                    100,
+                                                    0,
+                                                    [sortMode2],
+                                                    unique_filter,
+                                                    None)
+        self.__check_bug_path_order(run_results, Order.DESC)

--- a/www/scripts/codecheckerviewer/util.js
+++ b/www/scripts/codecheckerviewer/util.js
@@ -96,6 +96,14 @@ function (locale, dom, style, json) {
       return dojo.blendColors(baseColour, new dojo.Color(blendColour), ratio);
     },
 
+    generateRedGreenGradientColor : function (value, max, opacity) {
+      var red   = (255 * value) / max;
+      var green = (255 * (max - value)) / max;
+      var blue  = 0;
+      return 'rgba(' + parseInt(red) + ',' + parseInt(green) + ',' + blue
+       + ',' + opacity + ')';
+    },
+
     /**
      * Converts the given number of seconds into a more human-readable
      * 'hh:mm:ss' format.

--- a/www/scripts/version.js
+++ b/www/scripts/version.js
@@ -1,1 +1,1 @@
-CC_API_VERSION = '6.5';
+CC_API_VERSION = '6.6';

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -1304,3 +1304,12 @@ span[class*="severity-"] {
   color: #357ea7;
   border: 1px solid #cad2da;
 }
+
+.bug-path-length {
+  position: relative;
+}
+
+.bug-path-length .length {
+  display: block;
+  text-align: center;
+}


### PR DESCRIPTION
> Closes #1160

Add bug path length column to `Bug overview` table to indicate how long the report path is.

Screenshot:
![cc_bug_path_length](https://user-images.githubusercontent.com/6695818/33555447-b6bd1af4-d900-11e7-8cb2-e741220453e0.png)

