### PR TITLE
Show number of unique reports in the run list page

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -128,7 +128,7 @@ def process_report_filter_v2(report_filter, count_filter=None):
 
         OR = []
         if detection_status is not None and len(detection_status) == 1 and \
-           shared.ttypes.DetectionStatus.RESOLVED in detection_status:
+           ttypes.DetectionStatus.RESOLVED in detection_status:
             OR.append(Report.fixed_at >= date)
         else:
             OR.append(Report.detected_at >= date)
@@ -139,7 +139,7 @@ def process_report_filter_v2(report_filter, count_filter=None):
 
         OR = []
         if detection_status is not None and len(detection_status) == 1 and \
-           shared.ttypes.DetectionStatus.RESOLVED in detection_status:
+           ttypes.DetectionStatus.RESOLVED in detection_status:
             OR.append(Report.fixed_at < date)
         else:
             OR.append(Report.detected_at < date)
@@ -518,8 +518,8 @@ class ThriftRequestHandler(object):
 
             # Count the reports subquery.
             stmt = session.query(Report.run_id,
-                                 func.count(literal_column('*')).label(
-                                     'report_count')) \
+                                 func.count(Report.bug_id.distinct())
+                                 .label('report_count')) \
                 .group_by(Report.run_id) \
                 .subquery()
 
@@ -559,8 +559,7 @@ class ThriftRequestHandler(object):
 
             status_q = session.query(Report.run_id,
                                      Report.detection_status,
-                                     func.count(literal_column('*'))
-                                         .label('status_count')) \
+                                     func.count(Report.bug_id.distinct())) \
                 .group_by(Report.run_id, Report.detection_status)
 
             status_sum = defaultdict(defaultdict)

--- a/tests/functional/report_viewer_api/test_run_data.py
+++ b/tests/functional/report_viewer_api/test_run_data.py
@@ -10,10 +10,11 @@ import unittest
 
 from libtest import env
 
+from codeCheckerDBAccess_v6.ttypes import ReportFilter
 from codeCheckerDBAccess_v6.ttypes import RunFilter
 
 
-class TestRunFilter(unittest.TestCase):
+class TestRunData(unittest.TestCase):
 
     _ccClient = None
 
@@ -86,3 +87,17 @@ class TestRunFilter(unittest.TestCase):
         test_runs = self.__get_runs('non_existing_run_name')
         self.assertEqual(len(test_runs), 0,
                          "There should be no run for this test.")
+
+    def test_number_of_unique_reports(self):
+        """
+        Tests that resultCount field value in runData is equal with the
+        number of unique reports in the run.
+        """
+        test_runs = self.__get_runs()
+
+        unique_filter = ReportFilter(isUnique=True)
+        for run in test_runs:
+            run_count = self._cc_client.getRunResultCount([run.runId],
+                                                          unique_filter,
+                                                          None)
+            self.assertEqual(run.resultCount, run_count)


### PR DESCRIPTION
> Closes #1202

Show number of unique reports in the run list page.

This commit also fixes non existing type reference to DetectStatus because it has been moved to the report server types from shared.

