### PR TITLE
Rename get lines function test class

### DIFF
--- a/tests/functional/report_viewer_api/test_get_lines_in_file.py
+++ b/tests/functional/report_viewer_api/test_get_lines_in_file.py
@@ -17,7 +17,7 @@ from codeCheckerDBAccess_v6.ttypes import LinesInFilesRequested
 from codeCheckerDBAccess_v6.ttypes import ReportFilter
 
 
-class TestRunFilter(unittest.TestCase):
+class TestGetLinesInFile(unittest.TestCase):
 
     _ccClient = None
 


### PR DESCRIPTION
Because of copy-and-paste class name was not renamed (#1177). This commit renames the copied class to a unique one.