### PR TITLE
New report storage method

### DIFF
--- a/tests/functional/detection_status/test_detection_status.py
+++ b/tests/functional/detection_status/test_detection_status.py
@@ -64,6 +64,10 @@ class TestDetectionStatus(unittest.TestCase):
 int main()
 {
   int i = 1 / 0;
+
+  sizeof(42);
+  sizeof(42);
+  sizeof(42);
 }""", """
 int main()
 {
@@ -72,6 +76,10 @@ int main()
   int* p = 0;
 
   i = *p + 42;
+
+  sizeof(42);
+  sizeof(42);
+  sizeof(42);
 }""", """
 int main()
 {
@@ -80,6 +88,10 @@ int main()
   int* p = 0;
 
   i = *p + 42;
+
+  sizeof(42);
+  sizeof(42);
+  sizeof(42);
 }""", """
 
 
@@ -90,6 +102,9 @@ int main()
   int* p = 0;
 
   i = *p + 42;
+
+  sizeof(42);
+  sizeof(42);
 }"""]
 
     def tearDown(self):
@@ -122,8 +137,8 @@ int main()
                                                 [],
                                                 None,
                                                 None)
-        print(reports)
-        self.assertEqual(len(reports), 2)
+
+        self.assertEqual(len(reports), 5)
         self.assertTrue(all(map(
             lambda r: r.detectionStatus == DetectionStatus.NEW,
             reports)))
@@ -139,7 +154,8 @@ int main()
         for report in reports:
             if report.detectionStatus == DetectionStatus.UNRESOLVED:
                 self.assertIn(report.bugHash,
-                              ['209be2f6905590d99853ce01d52a78e0',
+                              ['e248e7441c15bcf0e47b5a3ad03df243',
+                               '209be2f6905590d99853ce01d52a78e0',
                                'e8f47588c8095f02a53e338984ce52ba'])
             elif report.detectionStatus == DetectionStatus.NEW:
                 self.assertIn(report.bugHash,
@@ -176,7 +192,8 @@ int main()
                               ['ac147b31a745d91be093bd70bbc5567c'])
             elif report.detectionStatus == DetectionStatus.UNRESOLVED:
                 self.assertIn(report.bugHash,
-                              ['cbd629ba2ee25c41cdbf5e2e336b1b1c'])
+                              ['e248e7441c15bcf0e47b5a3ad03df243',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
 
                 file_content = self._cc_client.getSourceFileData(
                     report.fileId,
@@ -203,7 +220,8 @@ int main()
         for report in reports:
             if report.detectionStatus == DetectionStatus.UNRESOLVED:
                 self.assertIn(report.bugHash,
-                              ['cbd629ba2ee25c41cdbf5e2e336b1b1c'])
+                              ['e248e7441c15bcf0e47b5a3ad03df243',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
             elif report.detectionStatus == DetectionStatus.REOPENED:
                 self.assertIn(report.bugHash,
                               ['209be2f6905590d99853ce01d52a78e0',
@@ -225,7 +243,8 @@ int main()
                 self.assertIn(report.bugHash,
                               ['209be2f6905590d99853ce01d52a78e0',
                                'e8f47588c8095f02a53e338984ce52ba',
-                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c',
+                               'e248e7441c15bcf0e47b5a3ad03df243'])
 
                 file_content = self._cc_client.getSourceFileData(
                     report.fileId,
@@ -274,4 +293,4 @@ int main()
                                                 None,
                                                 None)
 
-        self.assertEqual(len(reports), 4)
+        self.assertEqual(len(reports), 6)

--- a/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/tests/functional/report_viewer_api/test_hash_clash.py
@@ -102,11 +102,11 @@ class HashClash(unittest.TestCase):
         # The PList file contains six bugs:
         # 1. A normal bug
         # 2. Same as the first one (no new report generated)
-        # 3. Same as the first one except for line numbers (no new report
+        # 3. Same as the first one except for line numbers (new report
         #    generated)
         # 4. Same as the first one except for column numbers (new report
         #    generated)
-        # 5. Same as the first one except for the file name (no new report
+        # 5. Same as the first one except for the file name (new report
         #    generated)
         # 6. Same as the first one except for the checker message (new report
         #    generated)
@@ -128,12 +128,12 @@ class HashClash(unittest.TestCase):
         for report in reports:
             by_file[report.fileId] += 1
 
-        self.assertEqual(by_file[fileid1], 3)
+        self.assertEqual(by_file[fileid1], 5)
         self.assertEqual(by_file[fileid2], 1)
 
         by_checker_message = defaultdict(int)
         for report in reports:
             by_checker_message[report.checkerMsg] += 1
 
-        self.assertEqual(by_checker_message['checker message'], 3)
+        self.assertEqual(by_checker_message['checker message'], 5)
         self.assertEqual(by_checker_message['checker message 2'], 1)

--- a/tests/libtest/codechecker.py
+++ b/tests/libtest/codechecker.py
@@ -169,7 +169,6 @@ def check(codechecker_cfg, test_project_name, test_project_path):
     check_cmd = ['CodeChecker', 'check',
                  '-o', output_dir,
                  '-b', "'" + build_cmd + "'",
-                 '--analyzers', 'clangsa',
                  '--quiet',
                  '--verbose', 'debug']
 

--- a/tests/libtest/codechecker.py
+++ b/tests/libtest/codechecker.py
@@ -169,8 +169,7 @@ def check(codechecker_cfg, test_project_name, test_project_path):
     check_cmd = ['CodeChecker', 'check',
                  '-o', output_dir,
                  '-b', "'" + build_cmd + "'",
-                 '--quiet',
-                 '--verbose', 'debug']
+                 '--quiet']
 
     suppress_file = codechecker_cfg.get('suppress_file')
     if suppress_file:
@@ -199,8 +198,7 @@ def check(codechecker_cfg, test_project_name, test_project_path):
 
     store_cmd = ['CodeChecker', 'store', '-n', test_project_name,
                  output_dir,
-                 '--url', env.parts_to_url(codechecker_cfg),
-                 '--verbose', 'debug']
+                 '--url', env.parts_to_url(codechecker_cfg)]
 
     tag = codechecker_cfg.get('tag')
     if tag:


### PR DESCRIPTION
Instead of path updates in a storage session we remove all reports with
the given bug hash unless those are set to resolved.