### PR TITLE
remove linecache usage

### DIFF
--- a/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
+++ b/libcodechecker/analyze/analyzers/result_handler_plist_to_stdout.py
@@ -6,12 +6,12 @@
 
 from abc import ABCMeta
 from collections import defaultdict
-import linecache
 import math
 import os
 import sys
 
 from libcodechecker import suppress_handler
+from libcodechecker import util
 from libcodechecker.analyze import plist_parser
 from libcodechecker.analyze.analyzers.result_handler_base import ResultHandler
 from libcodechecker.logger import LoggerFactory
@@ -51,7 +51,7 @@ class PlistToStdout(ResultHandler):
     @staticmethod
     def __format_location(event, source_file):
         loc = event['location']
-        line = linecache.getline(source_file, loc['line'])
+        line = util.get_line(source_file, loc['line'])
         if line == '':
             return line
 

--- a/libcodechecker/suppress_handler.py
+++ b/libcodechecker/suppress_handler.py
@@ -8,10 +8,10 @@ Suppress handling.
 """
 
 import abc
-import linecache
 import os
 import re
 
+from libcodechecker import util
 from libcodechecker.logger import LoggerFactory
 
 LOG = LoggerFactory.get_new_logger('SUPPRESS HANDLER')
@@ -148,7 +148,7 @@ class SourceSuppressHandler(object):
             collected_lines = []
 
             while not marker_found and comment_line:
-                source_line = linecache.getline(source_file, previous_line_num)
+                source_line = util.get_line(source_file, previous_line_num)
                 if self.__check_if_comment(source_line):
                     # It is a comment.
                     if self.suppress_marker in source_line:


### PR DESCRIPTION
There were issues with the caching property of linecache which
caused errors when source file contents were read. The
already cached source file content was returned instead of the
changed new content.