### PR TITLE
Product connection backward compatibility fix

### DIFF
--- a/api/v6/products.thrift
+++ b/api/v6/products.thrift
@@ -35,8 +35,8 @@ struct Product {
   2: string            endpoint,
   3: string            displayedName_b64,
   4: string            description_b64,
-  5: bool              connected,         // !DEPRECATED FLAG it will be always False.
-                                          // databaseStatus is used to get the status of the database.
+  5: bool              connected,         // True only if database status is OK.
+                                          // !DEPRECATED FLAG databaseStatus is used to get the status of the database.
   6: bool              accessible,        // Indicates whether the current user can access this product.
   7: bool              administrating     // Indicates that the current user can administrate the product.
   8: shared.DBStatus   databaseStatus     // Indicates the database backend status.

--- a/libcodechecker/server/api/product_server.py
+++ b/libcodechecker/server/api/product_server.py
@@ -166,7 +166,7 @@ class ThriftProductHandler(object):
                     endpoint=prod.endpoint,
                     displayedName_b64=name,
                     description_b64=descr,
-                    connected=False,  # DEPRECATED use databaseStatus instead.
+                    connected=db_status == shared.ttypes.DBStatus.OK,
                     accessible=product_access,
                     administrating=product_admin,
                     databaseStatus=db_status))
@@ -228,12 +228,13 @@ class ThriftProductHandler(object):
             # Update the database status.
             server_product.connect()
 
+            connected = server_product.db_status == shared.ttypes.DBStatus.OK
             return ttypes.Product(
                 id=prod.id,
                 endpoint=prod.endpoint,
                 displayedName_b64=name,
                 description_b64=descr,
-                connected=False,  # DEPRECATED use databaseStatus instead.
+                connected=connected,
                 accessible=product_access,
                 administrating=product_admin,
                 databaseStatus=server_product.db_status)

--- a/tests/functional/products/test_products.py
+++ b/tests/functional/products/test_products.py
@@ -15,6 +15,7 @@ import os
 import unittest
 
 from shared.ttypes import RequestFailed
+from shared.ttypes import DBStatus
 from ProductManagement_v6.ttypes import ProductConfiguration
 from ProductManagement_v6.ttypes import DatabaseConnection
 
@@ -139,12 +140,10 @@ class TestProducts(unittest.TestCase):
                          "The product's endpoint is improper.")
         self.assertTrue(pr_data.id > 0, "Product didn't have valid ID")
 
-        # The connected attribute of a product will be always False.
-        # There is a new databaseStatus attribute which can be used
-        # to check the status of the databases.
-        self.assertFalse(pr_data.connected,
-                         "Deprecated value will take always False."
-                         "Use databaseStatus instead.")
+        # The connected attribute of a product will be always True if
+        # database status is OK.
+        connected = pr_data.databaseStatus == DBStatus.OK
+        self.assertEqual(pr_data.connected, connected)
 
         # Now get the SERVERSPACE (configuration) for the product.
         # TODO: These things usually should only work for superusers!


### PR DESCRIPTION
Product `connected` field should be set for backward compatibility reason.