### PR TITLE
run database operations in the proper environment

### DIFF
--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -456,12 +456,15 @@ def check_product_db_status(cfg_sql_server, context):
                  DBStatus.SCHEMA_INIT_ERROR,
                  DBStatus.SCHEMA_MISSING]
 
+    cc_env = analyzer_env.get_check_env(context.path_env_extra,
+                                        context.ld_lib_path_extra)
     prod_status = {}
     for pd in products:
         db = database.SQLServer.from_connection_string(pd.connection,
                                                        RUN_META,
                                                        migration_root,
-                                                       interactive=False)
+                                                       interactive=False,
+                                                       env=cc_env)
         db_location = db.get_db_location()
         ret = db.connect()
         s_ver = db.get_schema_version()
@@ -530,6 +533,9 @@ def __db_migration(cfg_sql_server, context, product_to_upgrade='all'):
                 "to start the server")
     LOG.warning("It is advised to make a full backup of your "
                 "run databases.")
+
+    cc_env = analyzer_env.get_check_env(context.path_env_extra,
+                                        context.ld_lib_path_extra)
     for prod in prod_to_upgrade:
         LOG.info("========================")
         LOG.info("Checking: " + prod)
@@ -542,7 +548,8 @@ def __db_migration(cfg_sql_server, context, product_to_upgrade='all'):
         db = database.SQLServer.from_connection_string(product.connection,
                                                        RUN_META,
                                                        migration_root,
-                                                       interactive=False)
+                                                       interactive=False,
+                                                       env=cc_env)
 
         db_status = db.connect()
 

--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -634,10 +634,12 @@ class Product(object):
         Cleanup the run database wich belongs to this product.
         """
         connection_str = self.__connection_string
-        prod_db = database.SQLServer.from_connection_string(connection_str,
-                                                            RUN_META,
-                                                            None,
-                                                            interactive=False)
+        prod_db = \
+            database.SQLServer.from_connection_string(connection_str,
+                                                      RUN_META,
+                                                      None,
+                                                      interactive=False,
+                                                      env=self.__check_env)
         with database.DBContext(prod_db) as db:
             try:
                 db_cleanup.remove_unused_files(db.session)


### PR DESCRIPTION
If not the proper environment is set it is possible that not all
of the database operations are run in the same environment.
This can cause cause version mismatches (not the same psql command
version is used in all cases).

Resolves #1251 