### PR TITLE
use pycodestyle instead of pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
 
 install:
-    - pip install nose pep8
+    - pip install nose pycodestyle
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cat postgres.log; fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,13 @@ Contribution guidelines
 
 Python style
 ------------
-In CodeChecker, we use the [PEP-8](https://www.python.org/dev/peps/pep-0008)
-rules in our coding style. _PEP-8_ is enforced by the test infrastructure
-&ndash; if you write a new module outside the current directory structure,
+In CodeChecker, we use [pycodestyle](https://pypi.python.org/pypi/pycodestyle/)
+to automatically check our coding style. `pycodestyle` is enforced by the test
+infrastructure &ndash; if you write a new module outside the current directory structure,
 make sure to add its path to [`tests/Makefile`](`tests/Makefile`) under the
-`pep8` target.
+`pycodestyle` target.
 
-In addition to the general rules of _PEP-8_, please keep the following rules
+In addition to the general rules of `pycodestyle`, please keep the following rules
 while writing your code:
 
   * Comments must be whole sentences, beginning with a capital letter and

--- a/libcodechecker/analyze/analyzer_env.py
+++ b/libcodechecker/analyze/analyzer_env.py
@@ -28,7 +28,7 @@ def get_log_env(logfile, context, original_env):
         original_ld_library_path = new_env['LD_LIBRARY_PATH']
         new_env['LD_LIBRARY_PATH'] = context.path_logger_lib + ':' + \
             original_ld_library_path
-    except:
+    except KeyError:
         new_env['LD_LIBRARY_PATH'] = context.path_logger_lib
 
     # Set ld logger logfile.
@@ -52,7 +52,7 @@ def get_check_env(path_env_extra, ld_lib_path_extra):
 
         try:
             new_env['PATH'] = extra_path + ':' + new_env['PATH']
-        except:
+        except KeyError:
             new_env['PATH'] = extra_path
 
     if len(ld_lib_path_extra) > 0:
@@ -64,7 +64,7 @@ def get_check_env(path_env_extra, ld_lib_path_extra):
             original_ld_library_path = new_env['LD_LIBRARY_PATH']
             new_env['LD_LIBRARY_PATH'] = \
                 extra_lib + ':' + original_ld_library_path
-        except:
+        except KeyError:
             new_env['LD_LIBRARY_PATH'] = extra_lib
 
     return new_env

--- a/libcodechecker/libauth/cc_ldap.py
+++ b/libcodechecker/libauth/cc_ldap.py
@@ -226,7 +226,7 @@ class LDAPConnection(object):
                     LOG.debug(who)
                     res = self.connection.simple_bind_s(who, cred)
                     LOG.debug(res)
-        except:
+        except Exception:
             LOG.debug("Server bind failed.")
             if self.connection is not None:
                 self.connection.unbind()
@@ -397,6 +397,6 @@ def get_groups(ldap_config, username, credentials):
             LOG.debug("groups:")
             LOG.debug(groups)
             return groups
-        except:
+        except Exception:
             LOG.error("Cannot get ldap groups for user: " + username)
             return []

--- a/libcodechecker/libclient/client.py
+++ b/libcodechecker/libclient/client.py
@@ -72,7 +72,7 @@ def setup_auth_client_from_url(product_url, session_token=None):
     try:
         protocol, host, port, _ = split_product_url(product_url)
         return setup_auth_client(protocol, host, port, session_token)
-    except:
+    except ValueError:
         LOG.error("Malformed product URL was provided. A valid product URL "
                   "looks like this: 'http://my.server.com:80/ProductName'.")
         sys.exit(2)  # 2 for argument error.
@@ -236,7 +236,7 @@ def setup_client(product_url, product_client=False):
 
     try:
         protocol, host, port, product_name = split_product_url(product_url)
-    except:
+    except ValueError:
         LOG.error("Malformed product URL was provided. A valid product URL "
                   "looks like this: 'http://my.server.com:80/ProductName'.")
         sys.exit(2)  # 2 for argument error.

--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -627,7 +627,7 @@ def __instance_management(args):
                 LOG.info("Stopped CodeChecker server running on port {0} "
                          "in workspace {1} (PID: {2})".
                          format(i['port'], i['workspace'], i['pid']))
-            except:
+            except Exception:
                 # Let the exception come out if the commands fail
                 LOG.error("Couldn't stop process PID #" + str(i['pid']))
                 raise

--- a/libcodechecker/logger.py
+++ b/libcodechecker/logger.py
@@ -38,6 +38,7 @@ def add_verbose_arguments(parser):
                         default='info',
                         help='Set verbosity level.')
 
+
 DEBUG_ANALYZER = logging.DEBUG_ANALYZER = 15
 logging.addLevelName(DEBUG_ANALYZER, 'DEBUG_ANALYZER')
 

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -261,7 +261,7 @@ def unzip(b64zip, output_dir):
         with zipfile.ZipFile(zip_file, 'r', allowZip64=True) as zipf:
             try:
                 zipf.extractall(output_dir)
-            except:
+            except Exception:
                 LOG.error("Failed to extract received ZIP.")
                 import traceback
                 traceback.print_exc()

--- a/libcodechecker/server/database/config_db_model.py
+++ b/libcodechecker/server/database/config_db_model.py
@@ -106,6 +106,7 @@ class ProductPermission(Base):
         self.name = name
         self.is_group = is_group
 
+
 IDENTIFIER = {
     'identifier': "ConfigDatabase",
     'orm_meta': CC_META,

--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -879,7 +879,7 @@ def start_server(config_directory, package_data, port, db_conn_string,
             with open(root_file, 'r') as f:
                 root_sha = f.read()
             LOG.debug("Root digest is '{0}'".format(root_sha))
-        except:
+        except IOError:
             LOG.info("Cannot open root file '{0}' even though it exists"
                      .format(root_file))
             root_sha = __make_root_file(root_file)

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -250,7 +250,7 @@ def split_server_url(url):
         else:
             raise ValueError("The server's address is not in a valid "
                              "'host:port' format!")
-    except:
+    except Exception:
         raise ValueError("The specified server URL is invalid.")
 
     LOG.debug("Result: With '{0}' on server '{1}:{2}'"
@@ -317,7 +317,7 @@ def split_product_url(url):
                                  "'host:port' format!")
         else:
             raise ValueError("Product URL can not contain extra '/' chars.")
-    except:
+    except Exception:
         raise ValueError("The specified product URL is invalid.")
 
     LOG.debug("Result: With '{0}' on server '{1}:{2}', product '{3}'"

--- a/scripts/create_new_subcommand.py
+++ b/scripts/create_new_subcommand.py
@@ -91,5 +91,6 @@ def main():
     print("  * " + handler_file)
     print("  * " + os.path.join(lib_dir, lib_name))
 
+
 if __name__ == "__main__":
     main()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,12 +20,12 @@ CLEAR_WORKSPACE_CMD = rm -rf $(BUILD_DIR)/workspace
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: pep8 test_unit test_functional test_build_logger
+test: pycodestyle test_unit test_functional test_build_logger
 
-test_novenv: pep8 test_unit_novenv test_functional_novenv
+test_novenv: pycodestyle test_unit_novenv test_functional_novenv
 
-pep8:
-	pep8 bin libcodechecker scripts tests vendor/plist_to_html
+pycodestyle:
+	pycodestyle bin libcodechecker scripts tests vendor/plist_to_html
 
 UNIT_TEST_CMD = nosetests $(NOSECFG) tests/unit
 
@@ -112,13 +112,13 @@ test_clean:
 
 # Use the proper requirement file for the given test configuration
 test_matrix_sqlite: VENV_DEV_REQ_FILE = .ci/basic_python_requirements
-test_matrix_sqlite: pep8 test_unit test_sqlite
+test_matrix_sqlite: pycodestyle test_unit test_sqlite
 
 test_matrix_psql_psycopg2: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_psycopg2
-test_matrix_psql_psycopg2: pep8 test_unit test_psql_psycopg2
+test_matrix_psql_psycopg2: pycodestyle test_unit test_psql_psycopg2
 
 test_matrix_psql_pg8000: VENV_DEV_REQ_FILE = .ci/python_requirements_psql_pg8000
-test_matrix_psql_pg8000: pep8 test_unit test_psql_pg8000
+test_matrix_psql_pg8000: pycodestyle test_unit test_psql_pg8000
 
 clean_travis:
 	# Clean CodeChecker config files stored in the users home directory.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 nose
+pycodestyle


### PR DESCRIPTION
pep8 is deprecated, pycodestyle should be used instead of pep8
There can be an overlap in the changes with #1236

Resolves #1188