### PR TITLE
Remove alpha.cpluscplus.IteratorRange from all profiles

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -26,7 +26,7 @@
         "alpha.core.SizeofPtr" : ["sensitive", "extreme"],
         "alpha.core.TestAfterDivZero" : ["sensitive", "extreme"],
         "alpha.cplusplus.DeleteWithNonVirtualDtor" : ["sensitive", "extreme"],
-        "alpha.cplusplus.IteratorRange" : ["sensitive", "extreme"],
+        "alpha.cplusplus.IteratorRange" : [],
         "alpha.cplusplus.MisusedMovedObject" : ["sensitive", "extreme"],
         "alpha.security.ArrayBound" : ["extreme"],
         "alpha.security.ArrayBoundV2" : ["extreme"],


### PR DESCRIPTION
This is the first step of a complex checker, it does not do any useful in its current state.