### PR TITLE
Fix get diff hashes for new bugs

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -677,6 +677,9 @@ class ThriftRequestHandler(object):
         try:
             session = self.__Session()
             if diff_type == DiffType.NEW:
+                if not report_hashes:
+                    return []
+
                 # In postgresql we can select multiple rows filled with
                 # constants by using `unnest` function. In sqlite we have to
                 # use multiple UNION ALL.


### PR DESCRIPTION
If the user tries to get diff hashes for new bugs, where no bugs found in the plist files gets an error message in case of pgsql because empty array is given to the pgsql `unnest` function. This commit solves this problem by returning an empty list.