### PR TITLE
Fixing the argument parsing gcc arguments

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -24,26 +24,30 @@ from libcodechecker.logger import LoggerFactory
 
 LOG = LoggerFactory.get_new_logger('OPTION PARSER')
 
-# Compiler options.
+# Compiler options in the following format
+# argument_name: number of parameters sepearated by space.
 
 COMPILE_OPTION_MAP = {
-    '-idirafter': 1,
-    '-imacros': 1,
-    '-include': 1,
-    '--include': 1,
-    '-iprefix': 1,
-    '-isysroot': 1,
-    '-isystem': 1,
-    '-iwithprefix': 1,
-    '-iwithprefixbefore': 1,
     '-nostdinc': 0,
-    '-sysroot': 1
+    '--sysroot': 1,
+    '--include': 1
 }
 
+# Compiler options which are followed by 1 parameter with or without
+# space in between e.g. "-I/include" "-I /include".
+# After parsing the parameter will be merged to the compiler option.
 COMPILE_OPTION_MAP_MERGED = [
     '^-iquote(.*)$',
     '^-[DIU](.*)$',
-    '^-F(.+)$'
+    '^-F(.+)$',
+    '^-idirafter(.*)$',
+    '^-isystem(.*)$',
+    '^-imacros(.*)$',
+    '^-include(.*)$',
+    '^-isysroot(.*)$',
+    '^-iprefix(.*)$',
+    '^-iwithprefix(.*)$',
+    '^-iwithprefixbefore(.*)$'
 ]
 
 
@@ -80,8 +84,7 @@ COMPILER_LINKER_OPTION_MAP = {
     '-rdynamic': 0,
     '-s': 0,
     '-stdlib': 0,
-    '-sysroot': 1,
-    '-target': 1,
+    '-target': 1,  # This is a clang compiler option!
     '-v': 0,
     '-write-strings': 0
 }

--- a/tests/unit/test_option_parser.py
+++ b/tests/unit/test_option_parser.py
@@ -127,9 +127,17 @@ class OptionParserTest(unittest.TestCase):
         for the analyzer too to search for headers.
         """
         source_files = ["main.cpp", "test.cpp"]
-        compiler_options = ["-sysroot", "/home/sysroot",
-                            "-isysroot", "/home/isysroot",
-                            "-I/home/test"]
+        compiler_options = ["-std=c++11",
+                            "-include/include/myheader.h",
+                            "-include /include/myheader2.h",
+                            "--include", "/include/myheader3.h",
+                            "--sysroot", "/home/sysroot",
+                            "--sysroot=/home/sysroot3",
+                            "-isysroot /home/isysroot",
+                            "-isysroot/home/isysroot2",
+                            "-I/home/test", "-I /home/test2",
+                            "-idirafter /dirafter1",
+                            "-idirafter/dirafter2"]
         linker_options = ["-L/home/test_lib", "-lm"]
         build_cmd = "g++ -o myapp " + \
                     ' '.join(compiler_options) + ' ' + \
@@ -138,8 +146,13 @@ class OptionParserTest(unittest.TestCase):
 
         res = option_parser.parse_options(build_cmd)
         print(res)
+        co_no_space = []
+        for c in compiler_options:
+            co_no_space.append(c.replace(" ", ""))
+        print(set(co_no_space))
+        print(set(res.compile_opts))
         self.assertTrue(set(source_files) == set(res.files))
-        self.assertTrue(set(compiler_options) == set(res.compile_opts))
+        self.assertTrue(set(co_no_space) == set(res.compile_opts))
         self.assertTrue(set(linker_options) == set(res.link_opts))
         self.assertEqual(ActionType.COMPILE, res.action)
 
@@ -159,8 +172,8 @@ class OptionParserTest(unittest.TestCase):
         object_files = ["foo.o",
                         "main.o",
                         "bar.o"]
-        compiler_options = ["-sysroot", "/home/sysroot",
-                            "-isysroot", "/home/isysroot",
+        compiler_options = ["--sysroot", "/home/sysroot",
+                            "-isysroot/home/isysroot",
                             "-I/home/test"]
         linker_options = ["-L/home/test_lib", "-lm"]
         build_cmd = "g++ -o fubar " + \


### PR DESCRIPTION
Some of the gcc compilation options that
accept files or directories
as arguments (-I,-idirafter, -include ...)
are accepted with and without space between the option
and the option argument. The handling of these
options corrected now.