### PR TITLE
Fix run tag

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -133,7 +133,9 @@ typedef list<RunHistoryData> RunHistoryDataList
 struct RunTagCount {
   1: string          time,   // Date time of the last run.
   2: string          name,   // Name of the tag.
-  3: i64             count   // Count of the reports.
+  3: i64             count,  // Count of the reports.
+  4: i64             id,     // Id of the run tag.
+  5: string          runName // Name of the run which the tag belongs to.
 }
 typedef list<RunTagCount> RunTagCounts
 
@@ -156,7 +158,9 @@ struct ReportData {
   9: i64              column,          // column number of the report main section (not part of the path).
   10: Severity        severity,        // Checker severity.
   11: ReviewData      reviewData,      // Bug review status information.
-  12: DetectionStatus detectionStatus  // State of the bug (see the enum constant values).
+  12: DetectionStatus detectionStatus, // State of the bug (see the enum constant values).
+  13: string          detectedAt,      // Detection date of the report.
+  14: string          fixedAt          // Date when the report was fixed.
 }
 typedef list<ReportData> ReportDataList
 
@@ -172,11 +176,12 @@ struct ReportFilter {
   5: list<Severity>        severity,
   6: list<ReviewStatus>    reviewStatus,
   7: list<DetectionStatus> detectionStatus,
-  8: list<string>          runHistoryTag,
+  8: list<string>          runHistoryTag,      // Date of the run tag. !Deprecated!
   9: optional i64          firstDetectionDate,
   10: optional i64         fixDate,
   11: optional bool        isUnique,
-  12: list<string>         runName
+  12: list<string>         runName,
+  13: list<i64>            runTag              // Ids of the run history tags.
 }
 
 struct RunReportCount {

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -12,7 +12,7 @@ accepts.
 # This dict object stores for each MAJOR version (key) the largest MINOR
 # version (value) supported by the build.
 SUPPORTED_VERSIONS = {
-    6: 4
+    6: 5
 }
 
 # This value is automatically generated to represent the highest version

--- a/tests/functional/report_viewer_api/test_report_counting.py
+++ b/tests/functional/report_viewer_api/test_report_counting.py
@@ -597,15 +597,3 @@ class TestReportFilter(unittest.TestCase):
             all_report_counts += rc.reportCount
 
         self.assertEqual(separate_report_counts, all_report_counts)
-
-    def test_run_history_tag_counts(self):
-        """
-        Count reports for all the runs.
-        There is only one tag
-        """
-        run = self._test_runs[0]
-        tag_reports = self._cc_client.getRunHistoryTagCounts(None,
-                                                             None,
-                                                             None)
-        self.assertEqual(len(tag_reports), 1)
-        self.assertEqual(tag_reports[0].name, run.name + ':v1.0')

--- a/tests/functional/run_tag/__init__.py
+++ b/tests/functional/run_tag/__init__.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Setup for the test package detection_status."""
+
+import os
+import shutil
+
+from libtest import codechecker
+from libtest import env
+
+# Test workspace should be initialized in this module.
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for testing detection_status."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('run_tag')
+
+    # Set the TEST_WORKSPACE used by the tests.
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+    # Configuration options.
+    codechecker_cfg = {
+        'suppress_file': None,
+        'skip_list_file': None,
+        'check_env': env.test_env(TEST_WORKSPACE),
+        'workspace': TEST_WORKSPACE,
+        'checkers': [],
+        'reportdir': os.path.join(TEST_WORKSPACE, 'reports'),
+        'test_project': 'test_run_tag'
+    }
+
+    # Start or connect to the running CodeChecker server and get connection
+    # details.
+    print("This test uses a CodeChecker server... connecting...")
+    server_access = codechecker.start_or_get_server()
+    server_access['viewer_product'] = 'run_tag'
+    codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
+
+    # Extend the checker configuration with the server access.
+    codechecker_cfg.update(server_access)
+
+    # Export the test configuration to the workspace.
+    env.export_test_cfg(TEST_WORKSPACE, {'codechecker_cfg': codechecker_cfg})
+
+
+def teardown_package():
+    """Clean up after the test."""
+
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
+    global TEST_WORKSPACE
+
+    check_env = env.import_test_cfg(TEST_WORKSPACE)[
+        'codechecker_cfg']['check_env']
+    codechecker.remove_test_package_product(TEST_WORKSPACE, check_env)
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/tests/functional/run_tag/test_run_tag.py
+++ b/tests/functional/run_tag/test_run_tag.py
@@ -1,0 +1,188 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+""" Run tag function test. """
+
+import json
+import os
+import unittest
+
+from codeCheckerDBAccess_v6.ttypes import ReportFilter
+
+from libtest import codechecker
+from libtest import env
+
+
+class TestRunTag(unittest.TestCase):
+
+    def setUp(self):
+        # TEST_WORKSPACE is automatically set by test package __init__.py .
+        self.test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self.test_workspace)
+
+        self._codechecker_cfg = env.import_codechecker_cfg(self.test_workspace)
+        self._test_dir = os.path.join(self.test_workspace, 'test_files')
+
+        try:
+            os.makedirs(self._test_dir)
+        except os.error:
+            # Directory already exists.
+            pass
+
+        # Setup a viewer client to test viewer API calls.
+        self._cc_client = env.setup_viewer_client(self.test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        # Change working dir to testfile dir so CodeChecker can be run easily.
+        self.__old_pwd = os.getcwd()
+        os.chdir(self._test_dir)
+
+        self._source_file = "main.cpp"
+
+        # Init project dir.
+        makefile = "all:\n\t$(CXX) -c main.cpp -o /dev/null\n"
+        project_info = {
+            "name": "test_run_tag",
+            "clean_cmd": "",
+            "build_cmd": "make"
+        }
+
+        with open(os.path.join(self._test_dir, 'Makefile'), 'w') as f:
+            f.write(makefile)
+        with open(os.path.join(self._test_dir, 'project_info.json'), 'w') as f:
+            json.dump(project_info, f)
+
+        self.sources = ["""
+int main()
+{
+  sizeof(42);
+  sizeof(43);
+}""", """
+int main()
+{
+  sizeof(43);
+  sizeof(44);
+  sizeof(45);
+}""", """
+int main()
+{
+  sizeof(45);
+}"""]
+        self.tags = ['v1.0', 'v1.1', 'v1.2']
+
+    def tearDown(self):
+        """Restore environment after tests have ran."""
+        os.chdir(self.__old_pwd)
+
+    def _create_source_file(self, version, run_name):
+        with open(os.path.join(self._test_dir, self._source_file), 'w') as f:
+            f.write(self.sources[version])
+
+        self._codechecker_cfg['tag'] = self.tags[version]
+        codechecker.check(self._codechecker_cfg, run_name, self._test_dir)
+
+    def __get_run_tag_counts(self, run_id):
+        """
+        Get run history tag for the given run.
+        """
+        test_run_tags = self._cc_client.getRunHistoryTagCounts([run_id],
+                                                               None, None)
+        self.assertGreater(len(test_run_tags), 0)
+
+        return test_run_tags
+
+    def __reports_by_tag(self, tag_ids):
+        report_filter = ReportFilter(runTag=tag_ids)
+        return self._cc_client.getRunResults(None, 100, 0, [],
+                                             report_filter, None)
+
+    def __check_reports(self, tag):
+        reports = self.__reports_by_tag([tag.id])
+        self.assertEqual(tag.count, len(reports))
+
+        for report in reports:
+            self.assertLessEqual(report.detectedAt, tag.time)
+
+    def test_file_change(self):
+        """
+        This tests the change of the detection status of bugs when the file
+        content changes.
+
+        CHECK 1 ----- CHECK 2 --------- CHECK 3 ---------- CHECK 4
+           |             |                 |                  |
+          42             |                 |                  |
+           |             |                 |                  |
+          43             |                 |                  |
+                         |                 |                  |
+                        42 ---------- [RESOLVED]              |
+                         |                 |                  |
+                        43 --------- [UNRESOLVED] ------- [RESOLVED]
+                                           |                  |
+                                          44 ------------ [RESOLVED]
+                                           |                  |
+                                          45 ----------- [UNRESOLVED]
+        """
+
+        # ######################## 1st check #################################
+
+        # Check the first file version.
+        self._create_source_file(0, 'test_run_tag')
+
+        # ######################## 2nd check #################################
+
+        # Check the first file versions again with different run name to see
+        # that set a run tag filter will filter the reports by the run id.
+        self._create_source_file(0, 'test_run_tag_update')
+
+        # Get the run names which belong to this test
+        runs = self._cc_client.getRunData(None)
+        test_run_ids = [run.runId for run in runs]
+
+        self.assertEqual(len(test_run_ids), 2)
+
+        run_id = test_run_ids[1]
+        test_run_tags = self.__get_run_tag_counts(run_id)
+        run_tags_v0 = [t for t in test_run_tags if t.name == self.tags[0]]
+
+        self.assertEqual(len(run_tags_v0), 1)
+        run_tags_v0 = run_tags_v0[0]
+
+        reports = self.__reports_by_tag([run_tags_v0.id])
+        self.assertEqual(run_tags_v0.count, len(reports))
+
+        # ######################## 3rd check #################################
+
+        # Check the second file version.
+        self._create_source_file(1, 'test_run_tag_update')
+
+        # We do not show future bugs for later tags.
+        reports = self.__reports_by_tag([run_tags_v0.id])
+        self.assertEqual(run_tags_v0.count, len(reports))
+
+        test_run_tags = self.__get_run_tag_counts(run_id)
+        run_tags_v1 = [t for t in test_run_tags if t.name == self.tags[1]]
+
+        self.assertEqual(len(run_tags_v1), 1)
+        run_tags_v1 = run_tags_v1[0]
+        self.__check_reports(run_tags_v1)
+
+        # ######################## 4th check #################################
+
+        # Check the third file version.
+        self._create_source_file(2, 'test_run_tag_update')
+
+        # We do not show future bugs for later tags.
+        reports = self.__reports_by_tag([run_tags_v0.id])
+        self.assertEqual(run_tags_v0.count, len(reports))
+
+        test_run_tags = self.__get_run_tag_counts(run_id)
+        run_tags_v2 = [t for t in test_run_tags if t.name == self.tags[2]]
+
+        self.assertEqual(len(run_tags_v2), 1)
+        run_tags_v2 = run_tags_v2[0]
+        self.__check_reports(run_tags_v2)

--- a/www/scripts/codecheckerviewer/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/BugFilterView.js
@@ -1372,19 +1372,20 @@ function (declare, Deferred, dom, domClass, all, topic, Standby, Button,
       //--- Run history tags filter ---//
 
       this._runHistoryTagFilter = new SelectFilter({
-        class : 'run-history-tag',
+        class : 'run-tag',
         title : 'Run tag',
         parent   : this,
         enableSearch : true,
         filterLabel : 'Search for run tags...',
         createItem : function (runHistoryTagCount) {
           return runHistoryTagCount.map(function (tag) {
+            var tagName = tag.runName + ':' + tag.name;
             return {
-              label : tag.name,
-              value : tag.time,
+              label : tagName,
+              value : tag.id,
               count : tag.count,
               iconClass : 'customIcon tag',
-              iconStyle : 'color: ' + util.strToColor(tag.name)
+              iconStyle : 'color: ' + util.strToColor(tagName)
             };
           });
         },

--- a/www/scripts/version.js
+++ b/www/scripts/version.js
@@ -1,1 +1,1 @@
-CC_API_VERSION = '6.4';
+CC_API_VERSION = '6.5';


### PR DESCRIPTION
If a report is fixed and the date of run tag is older than report's fixed at date, the report should not be shown when the tag is selected in the run history.

Closes #1264