### PR TITLE
HTML format bug report for local compare

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -51,8 +51,8 @@ def get_checker_name(diagnostic, path=""):
     """
     checker_name = diagnostic.get('check_name')
     if not checker_name:
-        LOG.info("Check name wasn't found in the plist file '%s'. "
-                 "Read the user guide!" % path)
+        LOG.warning("Check name wasn't found in the plist file '%s'. "
+                    % path)
         checker_name = "unknown"
     return checker_name
 
@@ -120,7 +120,7 @@ def parse_plist(path, source_root=None):
 
             bug_path_items = [item for item in diag['path']]
 
-            report = Report(main_section, bug_path_items)
+            report = Report(main_section, bug_path_items, files)
             reports.append(report)
 
         if diag_changed:

--- a/libcodechecker/report.py
+++ b/libcodechecker/report.py
@@ -152,7 +152,7 @@ class Report(object):
     from the path section for easier skip/suppression handling
     and result processing.
     """
-    def __init__(self, main, bugpath):
+    def __init__(self, main, bugpath, files):
         # Dictionary containing checker name, report hash,
         # main report position, report message ...
         self.__main = main
@@ -160,6 +160,9 @@ class Report(object):
         # Dictionary containing bug path related data
         # with control, event ... sections.
         self.__bug_path = bugpath
+
+        # Dictionary fileid to filepath that bugpath events refer to
+        self.__files = files
 
     @property
     def main(self):
@@ -169,6 +172,11 @@ class Report(object):
     def bug_path(self):
         return self.__bug_path
 
+    @property
+    def files(self):
+        return self.__files
+
     def __str__(self):
         msg = json.dumps(self.__main, sort_keys=True, indent=2)
+        msg += str(self.__files)
         return msg


### PR DESCRIPTION
"CodeChecker cmd diff" command can generate HTML output
even if the new report set is a local report directory.

Fixes #1277 