### PR TITLE
Ignore -Werror

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -120,7 +120,6 @@ IGNORED_OPTION_MAP = {
     '-MD': 0,
     '-MV': 0,
     '-MMD': 0,
-    '-fsyntax-only': 0,
     '-save-temps': 0,
     '-install_name': 1,
     '-exported_symbols_list': 1,
@@ -134,7 +133,10 @@ IGNORED_OPTION_MAP = {
     '-sectorder': 3,
     '--param': 1,
     '-u': 1,
-    '--serialize-diagnostics': 1
+    '--serialize-diagnostics': 1,
+    # Clang gives different warnings than GCC. Thus if this flag is kept, the
+    # analysis with Clang can fail even if the compilation passes with GCC.
+    '-Werror': 0
 }
 
 IGNORED_OPTION_MAP_REGEX = {

--- a/tests/unit/test_option_parser.py
+++ b/tests/unit/test_option_parser.py
@@ -187,3 +187,9 @@ class OptionParserTest(unittest.TestCase):
         self.assertTrue(set(compiler_options) == set(res.compile_opts))
         self.assertTrue(set(linker_options) == set(res.link_opts))
         self.assertEqual(ActionType.LINK, res.action)
+
+    def test_ignore_flags(self):
+        ignore = ["-Werror", "-MT hello", "-M", "-fsyntax-only"]
+        build_cmd = "g++ {} main.cpp".format(' '.join(ignore))
+        res = option_parser.parse_options(build_cmd)
+        self.assertEqual(res.compile_opts, ["-fsyntax-only"])


### PR DESCRIPTION
In some cases Clang is stricter than GCC regarding the warning messages.
-Werror flag converts these to error messages which thus fail the
analysis. That's why -Werror will be ignored from now on.