### PR TITLE
Fix run history tag count query

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -1657,7 +1657,7 @@ class ThriftRequestHandler(object):
 
             tag_q = tag_q.subquery()
 
-            q = session.query(tag_q.c.run_id,
+            q = session.query(tag_q.c.run_history_id,
                               func.max(Run.name).label('run_name'),
                               func.max(RunHistory.id),
                               func.max(RunHistory.time),


### PR DESCRIPTION
Select run history id instead of run id when getting run history tag count.