### PR TITLE
Fix diff command fails (sqlite)

### DIFF
--- a/tests/functional/diff/test_diff.py
+++ b/tests/functional/diff/test_diff.py
@@ -612,3 +612,15 @@ class Diff(unittest.TestCase):
         self.assertEqual(count, 5)
         count = len(re.findall(r'\[unix\.Malloc\]', out))
         self.assertEqual(count, 1)
+
+    def test_max_compound_select(self):
+        """
+        Test the maximum number of compound select query.
+        """
+        base_run_id = self._base_runid
+
+        report_hashes = [str(i) for i in range(0, 10000)]
+        diff_res = self._cc_client.getDiffResultsHash([base_run_id],
+                                                      report_hashes,
+                                                      DiffType.NEW)
+        self.assertEqual(len(diff_res), len(report_hashes))


### PR DESCRIPTION
> Closes: #1281

The maximum number of compound select in sqlite is 500 by default. We tried to increase SQLITE_MAX_COMPOUND_SELECT limit but when the number of compound select was larger than 8435 sqlite threw a `Segmentation fault` error. For this reason we create queries with chunks.