### PR TITLE
Show reports in bug tree when viewing diff view

### DIFF
--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -579,7 +579,7 @@ function (declare, domClass, dom, style, fx, Toggler, on, query, Memory,
         0,
         null,
         fileFilter,
-        this.runResultParam.cmpData,
+        null,
         function (result) {
           result.forEach(function (report) { that._addReport(report); });
 


### PR DESCRIPTION
> Closes #1275

Do not use ComperData object when getting reports for bug tree. Get bug tree reports only by the report run id and file.