### PR TITLE
Disable plist update on plist parsing unit tests

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -73,7 +73,7 @@ def get_report_hash(diagnostic, source_file):
     return report_hash
 
 
-def parse_plist(path, source_root=None):
+def parse_plist(path, source_root=None, allow_plist_update=True):
     """
     Parse the reports from a plist file.
     One plist file can contain multiple reports.
@@ -123,7 +123,7 @@ def parse_plist(path, source_root=None):
             report = Report(main_section, bug_path_items, files)
             reports.append(report)
 
-        if diag_changed:
+        if diag_changed and allow_plist_update:
             # If the diagnostic section has changed we update the plist file.
             # This way the client will always send a plist file where the
             # report hash field is filled.

--- a/tests/unit/test_plist_parser.py
+++ b/tests/unit/test_plist_parser.py
@@ -233,7 +233,7 @@ class PlistParserTestCaseNose(unittest.TestCase):
     def test_empty_file(self):
         """Plist file is empty."""
         empty_plist = os.path.join(self.__plist_test_files, 'empty_file')
-        files, reports = plist_parser.parse_plist(empty_plist)
+        files, reports = plist_parser.parse_plist(empty_plist, None, False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -241,7 +241,7 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """There was no bug in the checked file."""
         no_bug_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7-noerror.plist')
-        files, reports = plist_parser.parse_plist(no_bug_plist)
+        files, reports = plist_parser.parse_plist(no_bug_plist, None, False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -252,7 +252,7 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang37_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7.plist')
-        files, reports = plist_parser.parse_plist(clang37_plist)
+        files, reports = plist_parser.parse_plist(clang37_plist, None, False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -266,7 +266,7 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang38_plist = os.path.join(
             self.__plist_test_files, 'clang-3.8-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang38_plist)
+        files, reports = plist_parser.parse_plist(clang38_plist, None, False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -294,7 +294,7 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang40_plist = os.path.join(
             self.__plist_test_files, 'clang-4.0.plist')
-        files, reports = plist_parser.parse_plist(clang40_plist)
+        files, reports = plist_parser.parse_plist(clang40_plist, None, False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -324,7 +324,8 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang50_trunk_plist)
+        files, reports = plist_parser.parse_plist(clang50_trunk_plist, None,
+                                                  False)
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
 


### PR DESCRIPTION
Create a new parameter for plist parsing function to allow the caller to disable plist file update.

> Note: if I ran the unit tests (`make test_unit`), plist parser updated `tests/unit/plist_test_files/clang-3.7.plist` file. I disabled these updates for this unit test.