### PR TITLE
Login window instead of WWW-Authenticate

### DIFF
--- a/api/v6/authentication.thrift
+++ b/api/v6/authentication.thrift
@@ -10,8 +10,8 @@ namespace py Authentication_v6
 namespace js codeCheckerAuthentication_v6
 
 struct HandshakeInformation {
-  1: bool requiresAuthentication,       // true if the server has a privileged zone --- the state of having a valid access is not considered here
-  2: bool sessionStillActive            // whether the session in which the HandshakeInformation is returned is a valid one
+  1: bool requiresAuthentication,       // True if the server has a privileged zone.
+  2: bool sessionStillActive            // Whether the session in which the HandshakeInformation is returned is a live one
 }
 
 struct AuthorisationList {
@@ -36,24 +36,25 @@ service codeCheckerAuthentication {
                        throws (1: shared.RequestFailed requestError),
 
   // ============= Authentication and session handling =============
-  // get basic authentication information from the server
+  // Get basic authentication information from the server.
   HandshakeInformation getAuthParameters(),
 
 
-  // retrieves a list of accepted authentication methods from the server
+  // Retrieves a list of accepted authentication methods from the server.
   list<string> getAcceptedAuthMethods(),
 
-  // handles creating a session token for the user
+  // Handles creating a session token for the user.
   string performLogin(1: string authMethod,
                       2: string authString)
                       throws (1: shared.RequestFailed requestError),
 
-  // performs logout action for the user (must be called from the corresponding valid session)
+  // Performs logout action for the user. Must be called from the
+  // corresponding valid session which is to be destroyed.
   bool destroySession()
                       throws (1: shared.RequestFailed requestError),
 
-  // returns currently logged in user within the active session
-  // returns empty string if the session is not active
+  // Returns the currently logged in user within the active session, or empty
+  // string if no authenticated session is active.
   string getLoggedInUser()
                          throws (1: shared.RequestFailed requestError),
 

--- a/libcodechecker/libclient/client.py
+++ b/libcodechecker/libclient/client.py
@@ -124,7 +124,7 @@ def handle_auth(protocol, host, port, username, login=False):
             pwd = saved_auth.split(":")[1]
         else:
             LOG.info("Logging in using credentials from command line...")
-            pwd = getpass.getpass("Please provide password for user '{0}'"
+            pwd = getpass.getpass("Please provide password for user '{0}': "
                                   .format(username))
 
         LOG.debug("Trying to login as {0} to {1}:{2}"

--- a/libcodechecker/server/routing.py
+++ b/libcodechecker/server/routing.py
@@ -14,8 +14,9 @@ from libcodechecker.version import SUPPORTED_VERSIONS
 
 # A list of top-level path elements under the webserver root
 # which should not be considered as a product route.
-NON_PRODUCT_ENDPOINTS = ['products.html',
-                         'index.html',
+NON_PRODUCT_ENDPOINTS = ['index.html',
+                         'login.html',
+                         'products.html',
                          'fonts',
                          'images',
                          'scripts',
@@ -29,6 +30,13 @@ NON_PRODUCT_ENDPOINTS += ['Authentication',
                           'Products',
                           'CodeCheckerService'
                           ]
+
+
+# A list of top-level path elements under the webserver root which should
+# be protected by authentication requirement when accessing the server.
+PROTECTED_ENTRY_POINTS = ['',  # Empty string in a request is 'index.html'.
+                          'index.html',
+                          'products.html']
 
 
 def is_valid_product_endpoint(uripart):
@@ -122,3 +130,11 @@ def split_client_POST_request(path):
         remainder = split_path[2]
 
         return None, version_tag, remainder
+
+
+def is_protected_GET_entrypoint(path):
+    """
+    Returns if the given GET request's PATH enters the server through an
+    entry point which is considered protected by authentication requirements.
+    """
+    return path in PROTECTED_ENTRY_POINTS

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -10,7 +10,7 @@ and client, related to API and other version-specific information.
 
 # The name of the cookie which contains the user's authentication session's
 # token.
-SESSION_COOKIE_NAME = "__ccPrivilegedAccessToken"
+SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.

--- a/www/login.html
+++ b/www/login.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CodeChecker</title>
+
+  <meta charset="UTF-8">
+
+  <link rel="shortcut icon" href="images/favicon.ico" />
+
+  <!-- CSS -->
+
+  <link type="text/css" rel="stylesheet" href="scripts/plugins/dojo/dijit/themes/claro/claro.css" />
+  <link type="text/css" rel="stylesheet" href="style/codecheckerviewer.css" />
+  <link type="text/css" rel="stylesheet" href="style/login.css" />
+  <link type="text/css" rel="stylesheet" href="style/productlist.css" />
+
+  <!-- Third party libraries -->
+
+  <script type="text/javascript" src="scripts/plugins/jsplumb/external/jquery-1.9.0-min.js"></script>
+  <script type="text/javascript" src="scripts/plugins/thrift/thrift.js"></script>
+
+  <!-- Services -->
+
+  <script type="text/javascript" src="scripts/codechecker-api/shared_types.js"></script>
+  <script type="text/javascript" src="scripts/codechecker-api/authentication_types.js"></script>
+  <script type="text/javascript" src="scripts/codechecker-api/codeCheckerAuthentication.js"></script>
+
+  <script type="text/javascript" src="scripts/version.js"></script>
+  <script type="text/javascript" src="scripts/browsersupport.js"></script>
+
+  <!-- Configure Dojo -->
+
+  <script>
+    var dojoConfig = {
+      baseUrl : '',
+      async : true,
+      packages : [
+        { name : 'dojo',  location : 'scripts/plugins/dojo/dojo'  },
+        { name : 'dijit', location : 'scripts/plugins/dojo/dijit' },
+        { name : 'dojox', location : 'scripts/plugins/dojo/dojox' },
+        { name : 'codechecker', location : 'scripts/codecheckerviewer' },
+        { name : 'login', location : 'scripts/login' }
+      ]
+    };
+  </script>
+
+  <script type="text/javascript" src="scripts/plugins/dojo/dojo/dojo.js"></script>
+
+  <!-- End loading custom scripts -->
+</head>
+<body class="claro">
+  <script>
+    if (!browserCompatible)
+      setNonCompatibleBrowserMessage();
+    else
+      require([
+        'login/login'],
+      function (loginPage) {
+        loginPage();
+      });
+  </script>
+</body>
+</html>

--- a/www/scripts/codecheckerviewer/HeaderPane.js
+++ b/www/scripts/codecheckerviewer/HeaderPane.js
@@ -6,16 +6,18 @@
 
 define([
   'dojo/_base/declare',
-  'dojo/topic',
+  'dojo/cookie',
   'dojo/dom-construct',
+  'dojo/topic',
+  'dijit/form/Button',
   'dijit/layout/ContentPane',
   'dijit/popup',
   'dijit/TooltipDialog',
   'codechecker/hashHelper',
   'codechecker/HeaderMenu',
   'codechecker/util'],
-function (declare, topic, dom, ContentPane, popup, TooltipDialog, hashHelper,
-  HeaderMenu, util) {
+function (declare, cookie, dom, topic, Button, ContentPane, popup,
+  TooltipDialog, hashHelper, HeaderMenu, util) {
   return declare(ContentPane, {
     postCreate : function () {
       this.inherited(arguments);
@@ -61,6 +63,29 @@ function (declare, topic, dom, ContentPane, popup, TooltipDialog, hashHelper,
           innerHTML : 'Logged in as '
         }, profileMenu);
         dom.create('span', { class : 'user-name', innerHTML : user}, header);
+
+        var logoutButton = new Button({
+          class   : 'logout-btn',
+          label   : 'Log out',
+          onClick : function () {
+            try {
+              var logoutResult = CC_AUTH_SERVICE.destroySession();
+
+              if (logoutResult) {
+                cookie(CC_AUTH_COOKIE_NAME, 'LOGGED_OUT',
+                       { path : '/', expires : -1 });
+
+                // Redirect the user to the homepage after a successful logout.
+                window.location.reload(true);
+              } else {
+                console.warn("Server rejected logout.");
+              }
+            } catch (exc) {
+              console.error("Logout failed.", exc);
+            }
+          }
+        });
+        dom.place(logoutButton.domNode, profileMenu);
 
         //--- Permissions ---//
 
@@ -133,7 +158,7 @@ function (declare, topic, dom, ContentPane, popup, TooltipDialog, hashHelper,
 
       var headerMenuButton = new HeaderMenu({
         class : 'main-menu-button',
-        iconClass : 'dijitIconFunction',
+        iconClass : 'dijitIconFunction'
       });
       dom.place(headerMenuButton.domNode, this._headerMenu);
 

--- a/www/scripts/login/login.js
+++ b/www/scripts/login/login.js
@@ -1,0 +1,239 @@
+// -------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -------------------------------------------------------------------------
+
+define([
+  'dojo/_base/declare',
+  'dojo/cookie',
+  'dojo/dom',
+  'dojo/dom-construct',
+  'dojo/dom-class',
+  'dojo/keys',
+  'dojo/on',
+  'dijit/form/Button',
+  'dijit/form/TextBox',
+  'dijit/layout/BorderContainer',
+  'dijit/layout/ContentPane',
+  'dojox/widget/Standby',
+  'codechecker/MessagePane',
+  'codechecker/hashHelper'],
+function (declare, cookie, dom, domConstruct, domClass, keys, on, Button,
+  TextBox, BorderContainer, ContentPane, Standby, MessagePane, hash) {
+
+  // A stripped-down version of the "normal" CodeChecker GUI header, tailored
+  // for a lightweight login window.
+  var HeaderPane = declare(ContentPane, {
+    postCreate : function () {
+      this.inherited(arguments);
+
+      //--- Logo ---//
+
+      var logoContainer = domConstruct.create('div', {
+        id : 'logo-container'
+      }, this.domNode);
+
+      var logo = domConstruct.create('span', { id : 'logo' }, logoContainer);
+
+      var logoText = domConstruct.create('div', {
+        id : 'logo-text',
+        innerHTML : 'CodeChecker'
+      }, logoContainer);
+    }
+  });
+
+  var LoginPane = declare(ContentPane, {
+    _doLogin : function() {
+      var that = this;
+
+      this.set('isAlreadyLoggingIn', true);
+      this._standBy.show();
+
+      CC_AUTH_SERVICE.performLogin(
+        'Username:Password', this.txtUser.value + ':' + this.txtPass.value,
+        function (sessionToken) {
+          domClass.add(that._mbox.domNode, 'mbox-success');
+          that._mbox.show("Successfully logged in!", '');
+
+          // Set the cookie in the browser.
+          cookie(CC_AUTH_COOKIE_NAME, sessionToken, { path : '/' });
+
+          var returnTo = hash.getState('returnto') || '';
+          window.location = window.location.origin + '/' + returnTo;
+        }).error(function (jsReq, status, exc) {
+          if (status === "parsererror") {
+            that._standBy.hide();
+            domClass.add(that._mbox.domNode, 'mbox-error');
+            that._mbox.show("Failed to log in!", exc.message);
+
+            that.txtPass.set('value', '');
+            that.txtPass.focus();
+            that.set('isAlreadyLoggingIn', false);
+          }
+        });
+    },
+
+    constructor : function() {
+      this._mbox = new MessagePane({
+        class   : 'mbox'
+      });
+
+      this.txtUser = new TextBox({
+        class : 'form-input',
+        name  : 'username'
+      });
+
+      this.txtPass = new TextBox({
+        class : 'form-input',
+        name  : 'password',
+        type  : 'password'
+      });
+
+      var that = this;
+      this.btnSubmit = new Button({
+        label   : "Login",
+        onClick : function () {
+          if (!that.get('isAlreadyLoggingIn'))
+            that._doLogin();
+        }
+      });
+    },
+
+    postCreate : function() {
+      this.set('isAlreadyLoggingIn', false);
+
+      this.addChild(this._mbox);
+      this._mbox.hide();
+
+      this._standBy = new Standby({
+        color : '#ffffff',
+        target : this.domNode,
+        duration : 0
+      });
+      this.addChild(this._standBy);
+
+      var authParams = CC_AUTH_SERVICE.getAuthParameters();
+
+      if (!authParams.requiresAuthentication || authParams.sessionStillActive) {
+        domClass.add(this._mbox.domNode, 'mbox-success');
+
+        var message = '';
+        if (!authParams.requiresAuthentication)
+          message = "This server allows anonymous access.";
+        else if (authParams.sessionStillActive)
+          message = "You are already logged in.";
+        this._mbox.show("No authentication required.", message);
+
+        var returnTo = hash.getState('returnto') || '';
+        window.location = window.location.origin + '/' + returnTo;
+      } else {
+        var authMethods = CC_AUTH_SERVICE.getAcceptedAuthMethods();
+        if (!authMethods.includes('Username:Password')) {
+          domClass.add(this._mbox.domNode, 'mbox-error');
+          this._mbox.show("Server rejects username-password authentication!",
+                          "This login form cannot be used.");
+        } else {
+          var cntPrompt = domConstruct.create('div', {
+            class : 'formElement'
+          }, this.containerNode);
+          var lblPrompt = domConstruct.create('span', {
+            class     : 'login-prompt',
+            style     : 'width: 100%',
+            innerHTML : this.loginPrompt
+          }, cntPrompt);
+
+          // Render the login dialog's controls.
+
+          var cntUser = domConstruct.create('div', {
+            class : 'formElement'
+          }, this.containerNode);
+          var lblUser = domConstruct.create('label', {
+            class     : 'formLabel bold',
+            innerHTML : "Username: ",
+            for       : 'username'
+          }, cntUser);
+          domConstruct.place(this.txtUser.domNode, cntUser);
+
+          var cntPass = domConstruct.create('div', {
+            class : 'formElement'
+          }, this.containerNode);
+          var lblPass = domConstruct.create('label', {
+            class     : 'formLabel bold',
+            innerHTML : "Password: ",
+            for       : 'password'
+          }, cntPass);
+          domConstruct.place(this.txtPass.domNode, cntPass);
+
+          var cntLogin = domConstruct.create('div', {
+            class : 'formElement'
+          }, this.containerNode);
+          domConstruct.place(this.btnSubmit.domNode, cntLogin);
+
+          var that = this;
+          function keypressHandler(evt) {
+            if (!that.get('isAlreadyLoggingIn') &&
+                evt.keyCode === keys.ENTER) {
+              that.btnSubmit.focus();
+              that._doLogin();
+            }
+          }
+          on(this.txtUser.domNode, 'keypress', keypressHandler);
+          on(this.txtPass.domNode, 'keypress', keypressHandler);
+          on(this.btnSubmit.domNode, 'keypress', keypressHandler);
+        }
+      }
+    }
+  });
+
+  return function () {
+
+    //---------------------------- Global objects ----------------------------//
+
+    CC_AUTH_SERVICE =
+      new codeCheckerAuthentication_v6.codeCheckerAuthenticationClient(
+        new Thrift.TJSONProtocol(
+          new Thrift.Transport("/v" + CC_API_VERSION + "/Authentication")));
+
+    CC_AUTH_OBJECTS = codeCheckerAuthentication_v6;
+
+    //----------------------------- Main layout ------------------------------//
+
+    var layout = new BorderContainer({ id : 'mainLayout' });
+
+    var headerPane = new HeaderPane({
+      id : 'headerPane',
+      region : 'top'
+    });
+    layout.addChild(headerPane);
+
+    //--- Center panel ---//
+
+    var that = this;
+
+    this.loginPane = new LoginPane({
+      region      : 'center',
+
+      // TODO: Extend the API so that custom messages can be shown here.
+      loginPrompt : "Accessing this CodeChecker server requires authentication!"
+    });
+
+    var loginContainer = new ContentPane({
+      region : 'center',
+      postCreate : function () {
+         var smallerContainer = domConstruct.create('div', {
+           id : 'login-form'
+         }, this.containerNode);
+
+         domConstruct.place(that.loginPane.domNode, smallerContainer);
+      }
+    });
+
+    layout.addChild(loginContainer);
+
+    //--- Init page ---//
+
+    document.body.appendChild(layout.domNode);
+    layout.startup();
+  };
+});

--- a/www/scripts/version.js
+++ b/www/scripts/version.js
@@ -1,1 +1,2 @@
 CC_API_VERSION = '6.6';
+CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -86,7 +86,6 @@ html, body {
 }
 
 #profile-menu .header {
-  border-bottom: 1px solid #b5bcc7;
   padding-bottom: 5px;
 }
 
@@ -95,7 +94,17 @@ html, body {
   color: #357ea7;
 }
 
+#profile-menu .logout-btn {
+  padding-bottom: 5px;
+}
+
+/** Remove orange outline from tooltip button. **/
+#profile-menu .logout-btn .dijitButtonContents {
+  outline: none;
+}
+
 #profile-menu .permission-title {
+  border-top: 1px solid #b5bcc7;
   padding: 5px 0px;
 }
 

--- a/www/style/login.css
+++ b/www/style/login.css
@@ -1,0 +1,26 @@
+#login-form {
+  display: block;
+  position: relative;
+  top: 25%;
+  margin: 0 auto;
+  width: 20%;
+  background-color: #edf4fa;
+  border: 1px solid;
+  border-color: #e5e6e9 #dfe0e4 #d0d1d5;
+  border-radius: 5px;
+}
+
+#login-form .mbox.mbox-error {
+  background-color: white;
+}
+
+#login-form .login-prompt {
+  font-weight: bold;
+  font-size: 12pt;
+  display: inline-block;
+  margin-bottom: 18px;
+}
+
+#login-form .formElement .form-input {
+    width: 100%;
+}


### PR DESCRIPTION
> Closes #1220.

Instead of prompting the user for `WWW-Authenticate` (the normal browser popup window authentication), use a facade put together in Dojo to ask for user credentials. This way, it is the Thrift API that handles the login of the user, the same way the command-line client does it.

Browsers cache the credentials of a `Authenticate` header which is very hacky to remove. Thanks to dropping that whole functionality, we can now introduce a *Log out* feature, which this patch also does.