### PR TITLE
Fix ctu_failure test not removing its test folder

### DIFF
--- a/tests/functional/ctu_failure/__init__.py
+++ b/tests/functional/ctu_failure/__init__.py
@@ -29,6 +29,8 @@ def setup_package():
 def teardown_package():
     """Delete workspace."""
 
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
     global TEST_WORKSPACE
 
     print('Removing: ' + TEST_WORKSPACE)

--- a/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/tests/functional/ctu_failure/test_ctu_failure.py
@@ -22,7 +22,7 @@ NO_CTU_MESSAGE = "CTU is not supported"
 NO_DISPLAY_CTU_PROGRESS = "-analyzer-display-ctu-progress is not supported"
 
 
-class TestCtu(unittest.TestCase):
+class TestCtuFailure(unittest.TestCase):
     """ Test CTU functionality. """
 
     def setUp(self):


### PR DESCRIPTION
The test workspace has a lingering `ctu_failure` project folder due to test code layout error.

If you check the output with `nocapture=1` in the `.noserc` (and use the rename of the class in this patch), the following is printed:

```
Test the failure zip contains the source of imported TU ... Running TestCtuFailure tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
Has -analyzer-display-ctu-progress? False
SKIP: CTU is not supported
Test the failure zip contains the source of imported TU and all the ... Running TestCtuFailure tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_fail
ure-s7so2I
'analyze' reported CTU-compatibility? False
Has -analyzer-display-ctu-progress? False
SKIP: CTU is not supported
Test that Clang indeed logs the AST import events. ... Running TestCtuFailure tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
Has -analyzer-display-ctu-progress? False
SKIP: CTU is not supported
Removing: /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
Test full CTU without reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Test full CTU with reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Test CTU analyze phase without reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Test CTU analyze phase with reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Test CTU collect phase without reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Test CTU collect phase with reparse. ... Running TestCtu tests in /home/<username>/CodeChecker/codechecker/build/workspace/ctu_failure-s7so2I
'analyze' reported CTU-compatibility? False
SKIP: CTU is not supported
Removing: /home/<username>/CodeChecker/codechecker/build/workspace/ctu-haeeWw
```

This means that the `TestCtu` class is ran in the `ctu_failure` folder too, because of how the files are laid out. This results in the CTU-FAILURE folder being removed, but then created again.