### PR TITLE
Fix tests being broken due to working directory change

### DIFF
--- a/tests/functional/ctu/test_ctu.py
+++ b/tests/functional/ctu/test_ctu.py
@@ -51,6 +51,7 @@ class TestCtu(unittest.TestCase):
             for command in build_json:
                 command['directory'] = self.test_dir
 
+        self.__old_pwd = os.getcwd()
         os.chdir(self.test_workspace)
         self.buildlog = os.path.join(self.test_workspace, 'buildlog.json')
         with open(self.buildlog, 'w') as log_file:
@@ -60,6 +61,7 @@ class TestCtu(unittest.TestCase):
         """ Tear down workspace."""
 
         shutil.rmtree(self.report_dir, ignore_errors=True)
+        os.chdir(self.__old_pwd)
 
     def test_ctu_all_no_reparse(self):
         """ Test full CTU without reparse. """

--- a/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/tests/functional/ctu_failure/test_ctu_failure.py
@@ -62,6 +62,7 @@ class TestCtuFailure(unittest.TestCase):
             for command in build_json:
                 command['directory'] = self.test_dir
 
+        self.__old_pwd = os.getcwd()
         os.chdir(self.test_workspace)
         self.buildlog = os.path.join(self.test_workspace, 'buildlog.json')
         with open(self.buildlog, 'w') as log_file:
@@ -71,6 +72,7 @@ class TestCtuFailure(unittest.TestCase):
         """ Tear down workspace."""
 
         shutil.rmtree(self.report_dir, ignore_errors=True)
+        os.chdir(self.__old_pwd)
 
     def test_ctu_logs_ast_import(self):
         """ Test that Clang indeed logs the AST import events.


### PR DESCRIPTION
#1303 broke the build because an undefended `os.chdir()` code was moved to an upper folder in the hierarchy.

**No `os.chdir()` calls should be unguarded in the test suite because the working folder is global state!** Having the working folder removed means that subsequent folder changes kill the tests.