### PR TITLE
ldap hardening and tests

### DIFF
--- a/libcodechecker/libauth/cc_ldap.py
+++ b/libcodechecker/libauth/cc_ldap.py
@@ -190,9 +190,10 @@ class LDAPConnection(object):
         None if initialization failed.
         """
 
-        ldap_server = ldap_config['connection_url']
+        ldap_server = ldap_config.get('connection_url')
         if ldap_server is None:
             LOG.error('Server address is missing from the configuration')
+            self.connection = None
             return
 
         referals = ldap_config.get('referals', False)
@@ -273,6 +274,9 @@ def auth_user(ldap_config, username=None, credentials=None):
     """
     Authenticate a user.
     """
+    if not username or not credentials:
+        LOG.error('No username or credential is provided for authentication.')
+        return False
 
     account_base = ldap_config.get('accountBase')
     if account_base is None:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
+mockldap
 nose
 pycodestyle

--- a/tests/unit/test_ccldap.py
+++ b/tests/unit/test_ccldap.py
@@ -1,0 +1,147 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+
+import unittest
+
+from mockldap import MockLdap
+
+from libcodechecker.libauth import cc_ldap
+
+
+class CCLDAPTest(unittest.TestCase):
+
+    top = ('o=test', {'o': ['test']})
+    example = ('ou=example,o=test', {'ou': ['example']})
+    other = ('ou=other,o=test', {'ou': ['other']})
+    service_user = ('cn=service_user,ou=example,o=test',
+                    {'cn': ['service_user'], 'userPassword': ['servicepw']})
+    user2 = ('cn=user2,ou=other,o=test',
+             {'cn': ['user2'], 'userPassword': ['user2pw']})
+
+    # This is the content of our mock LDAP directory.
+    # It takes the form {dn: {attr: [value, ...], ...}, ...}.
+    directory = dict([top, example, other, service_user, user2])
+
+    # service_user is used as a service user in the configuration.
+    ldap_config = {"connection_url": "ldap://localhost/",
+                   "username": "cn=service_user,ou=example,o=test",
+                   "password": "servicepw",
+                   "referrals": False,
+                   "deref": "always",
+                   "accountBase": "ou=other,o=test",
+                   "accountScope": "subtree",
+                   "accountPattern": "(cn=$USN$)",
+                   "groupBase": "o=test",
+                   "groupScope": "subtree",
+                   "groupPattern": "",
+                   "groupNameAttr": ""
+                   }
+
+    @classmethod
+    def setup_class(cls):
+        cls.mockldap = MockLdap(cls.directory)
+
+    def setUp(self):
+        # Patch ldap.initialize
+        self.mockldap.start()
+        self.ldapobj = self.mockldap['ldap://localhost/']
+
+    def tearDown(self):
+        # Stop patching ldap.initialize and reset state.
+        self.mockldap.stop()
+        del self.ldapobj
+
+    def test_empty_config(self):
+        """
+        At least a connection_url is required in the ldap config.
+        Without it no connection can be initialized.
+        """
+        with cc_ldap.LDAPConnection({}, None, None) as connection:
+            self.assertIsNone(connection)
+
+    def test_anonymous_bind(self):
+        """
+        Anonymous bind, without username and credentials.
+        """
+        with cc_ldap.LDAPConnection(self.ldap_config) as connection:
+            self.assertIsNotNone(connection)
+
+    def test_ldap_conn_context_bind_with_cred(self):
+        """
+        Bind to LDAP server with username and credentials.
+        """
+        ldap_config = {"connection_url": "ldap://localhost/"}
+
+        with cc_ldap.LDAPConnection(ldap_config,
+                                    'cn=service_user,ou=example,o=test',
+                                    'servicepw') as connection:
+            self.assertIsNotNone(connection)
+
+    def test_ldap_conn_context_anonym_no_pass_bind(self):
+        """
+        Username and credentials are missing from the ldap config
+        but username is provided at context initialization.
+        """
+        ldap_config = {"connection_url": "ldap://localhost/"}
+        with cc_ldap.LDAPConnection(ldap_config,
+                                    'cn=service_user,ou=example,o=test',
+                                    '') as connection:
+            self.assertIsNone(connection)
+
+    def test_ldap_conn_context_anonym_empty_pass_bind(self):
+        """
+        Username and credentials are missing from the ldap config
+        but username and credentials provided context initialization.
+        """
+        ldap_config = {"connection_url": "ldap://localhost/"}
+        with cc_ldap.LDAPConnection(ldap_config,
+                                    'cn=service_user,ou=example,o=test',
+                                    'servicepw') as connection:
+            self.assertIsNotNone(connection)
+
+    def test_get_user_dn(self):
+        """
+        Search for the full user DN.
+        """
+        ldap_config = {"connection_url": "ldap://localhost/"}
+        with cc_ldap.LDAPConnection(ldap_config,
+                                    'cn=service_user,ou=example,o=test') \
+                as connection:
+            self.assertIsNotNone(connection)
+
+            ret = cc_ldap.get_user_dn(connection,
+                                      'ou=other,o=test',
+                                      '(cn=user2)')
+
+            self.assertEqual(ret, 'cn=user2,ou=other,o=test')
+
+    def test_successful_auth(self):
+        """
+        Successful user authentication.
+        """
+        self.assertTrue(cc_ldap.auth_user(self.ldap_config,
+                                          'user2',
+                                          'user2pw'))
+
+    def test_wrong_pwd(self):
+        """
+        Wrong password is provided, authentication should fail.
+        """
+        self.assertFalse(cc_ldap.auth_user(self.ldap_config,
+                                           'user2',
+                                           'wrong_password'))
+
+    def test_missing_pwd(self):
+        """
+        Password is missing when auth_user function is called.
+        """
+        self.assertFalse(cc_ldap.auth_user(self.ldap_config, 'user2'))
+
+    def test_empty_pwd(self):
+        """
+        Try to authenticate with empty password.
+        """
+        self.assertFalse(cc_ldap.auth_user(self.ldap_config, 'user2', ''))


### PR DESCRIPTION
* better error handling in case of
  - wrong ldap config
  - username or credentials are missing
* add ldap authentication test