### PR TITLE
Lock runs through the database that are undergoing a store operation

### DIFF
--- a/db_migrate/versions/dd9c97ead24_share_the_locking_of_runs.py
+++ b/db_migrate/versions/dd9c97ead24_share_the_locking_of_runs.py
@@ -1,0 +1,29 @@
+"""Share the locking of runs across servers via database
+
+Revision ID: dd9c97ead24
+Revises: 4b38fa14c27b
+Create Date: 2017-11-17 15:44:07.810579
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dd9c97ead24'
+down_revision = '4b38fa14c27b'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('run_locks',
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('locked_at', sa.DateTime(), nullable=False),
+        sa.Column('username', sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint('name', name=op.f('pk_run_locks'))
+    )
+
+
+def downgrade():
+    op.drop_table('run_locks')

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -11,13 +11,11 @@ database.
 import argparse
 import base64
 import errno
-import functools
 from hashlib import sha256
 import json
 import os
 import sys
 import tempfile
-import traceback
 import zipfile
 import zlib
 
@@ -36,18 +34,6 @@ from libcodechecker.util import split_product_url
 LOG = logger.get_logger('system')
 
 MAX_UPLOAD_SIZE = 1 * 1024 * 1024 * 1024  # 1GiB
-
-
-def full_traceback(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
-            raise type(e)(msg)
-    return wrapper
 
 
 def get_argparser_ctor_args():

--- a/libcodechecker/server/api/store_handler.py
+++ b/libcodechecker/server/api/store_handler.py
@@ -261,7 +261,7 @@ def finishCheckerRun(session, run_id):
         return False
 
 
-def setRunDuration(session, run_id, check_durations):
+def setRunDuration(session, run_id, duration):
     """
     """
     try:

--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -640,12 +640,13 @@ class Product(object):
                                                       env=self.__check_env)
         with database.DBContext(prod_db) as db:
             try:
+                db_cleanup.remove_expired_run_locks(db.session)
                 db_cleanup.remove_unused_files(db.session)
                 db.session.commit()
                 return True
             except Exception as ex:
                 db.session.rollback()
-                LOG.error("File cleanup failed.")
+                LOG.error("Database cleanup failed.")
                 LOG.error(ex)
                 return False
 


### PR DESCRIPTION
> Retry of #1147. Closes #1138.

Instead of using the run table and "shadow" records for the lock, use a proper lock table that locks individual run names.

Instead of wrapping one session into another, deliberately put the lock at the beginning of `massStoreRun`, and remove it at the end of this function. This way, the lock operations are **completely** independent of the transaction buffer that collects the data of the run getting stored, and the *tables* that are accessed by this buffer.

Otherwise, same as #1147.