### PR TITLE
Fix product editing

### DIFF
--- a/libcodechecker/server/api/product_server.py
+++ b/libcodechecker/server/api/product_server.py
@@ -493,10 +493,10 @@ class ThriftProductHandler(object):
                         product.connection)
                 if dbc.password_b64 and dbc.password_b64 != '':
                     dbpass = base64.b64decode(dbc.password_b64)
-                elif 'dbpass' in old_connection_args:
+                elif 'dbpassword' in old_connection_args:
                     # The password was not changed. Retrieving from old
                     # configuration -- if the old configuration contained such!
-                    dbpass = old_connection_args['dbpass']
+                    dbpass = old_connection_args['dbpassword']
                 else:
                     dbpass = None
 


### PR DESCRIPTION
`dbpass` key is non exist in database connection string. This way the old connection string and the new connection string was different and the server tried to reconnect the product. If the user does not have superuser access, the server throws a `not authorized` exception.