### PR TITLE
Fix setup logger for command line

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -105,6 +105,8 @@ def add_filter_conditions(report_filter, filter_str):
 
 
 def handle_list_runs(args):
+    logger.setup_logger(args.verbose)
+
     client = setup_client(args.product_url)
     runs = client.getRunData(None)
 
@@ -571,6 +573,8 @@ def handle_diff_results(args):
 
 
 def handle_list_result_types(args):
+    logger.setup_logger(args.verbose)
+
     def get_statistics(client, run_ids, field, values):
         report_filter = ttypes.ReportFilter()
         report_filter.isUnique = True


### PR DESCRIPTION
`runs` and `sum` subcommands of the command line client has been forgotten to set up the correct logger. This way the user always got a `No handlers could be found for logger` error message on these command line options.