### PR TITLE
Do not limit run count for server by default

### DIFF
--- a/config/server_config.json
+++ b/config/server_config.json
@@ -1,5 +1,5 @@
 {
-  "max_run_count": 200,
+  "max_run_count": null,
   "authentication": {
     "enabled" : false,
     "realm_name" : "CodeChecker Privileged server",


### PR DESCRIPTION
Do not limit the number of runs which can be stored on the server for a product by default.