### PR TITLE
fix logger initialization

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -30,7 +30,14 @@ from libcodechecker.report import Report
 from libcodechecker.util import split_server_url
 
 
-LOG = logger.get_logger('system')
+# Needs to be set in the handler functions.
+LOG = None
+
+
+def init_logger(level, logger_name='system'):
+    logger.setup_logger(level)
+    global LOG
+    LOG = logger.get_logger(logger_name)
 
 
 class CmdLineOutputEncoder(json.JSONEncoder):
@@ -105,7 +112,8 @@ def add_filter_conditions(report_filter, filter_str):
 
 
 def handle_list_runs(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     client = setup_client(args.product_url)
     runs = client.getRunData(None)
@@ -126,7 +134,8 @@ def handle_list_runs(args):
 
 
 def handle_list_results(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     client = setup_client(args.product_url)
 
@@ -178,7 +187,7 @@ def handle_list_results(args):
 
 def handle_diff_results(args):
 
-    logger.setup_logger(args.verbose)
+    init_logger(args.verbose)
 
     context = generic_package_context.get_context()
 
@@ -573,7 +582,8 @@ def handle_diff_results(args):
 
 
 def handle_list_result_types(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     def get_statistics(client, run_ids, field, values):
         report_filter = ttypes.ReportFilter()
@@ -681,7 +691,7 @@ def handle_list_result_types(args):
 
 def handle_remove_run_results(args):
 
-    logger.setup_logger(args.verbose)
+    init_logger(args.verbose)
 
     client = setup_client(args.product_url)
 
@@ -731,7 +741,7 @@ def handle_remove_run_results(args):
 
 def handle_suppress(args):
 
-    logger.setup_logger(args.verbose)
+    init_logger(args.verbose)
 
     def bug_hash_filter(bug_id, filepath):
         filepath = '%' + filepath
@@ -762,7 +772,7 @@ def handle_suppress(args):
 
 def handle_login(args):
 
-    logger.setup_logger(args.verbose)
+    init_logger(args.verbose)
 
     protocol, host, port = split_server_url(args.server_url)
     handle_auth(protocol, host, port, args.username,

--- a/libcodechecker/cmd/product_client.py
+++ b/libcodechecker/cmd/product_client.py
@@ -20,12 +20,19 @@ from libcodechecker.util import split_server_url
 
 from cmd_line_client import CmdLineOutputEncoder
 
+# Needs to be set in the handler functions.
+LOG = None
 
-LOG = logger.get_logger('system')
+
+def init_logger(level, logger_name='system'):
+    logger.setup_logger(level)
+    global LOG
+    LOG = logger.get_logger(logger_name)
 
 
 def handle_list_products(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)
@@ -59,7 +66,8 @@ def handle_list_products(args):
 
 
 def handle_add_product(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)
@@ -110,7 +118,8 @@ def handle_add_product(args):
 
 
 def handle_del_product(args):
-    logger.setup_logger(args.verbose)
+
+    init_logger(args.verbose)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)


### PR DESCRIPTION
The global LOG should be initialized only after the setup_logger
call which reads up the log config.

If the LOG is initialized at module import time it will use the
default Python logging config. By default this will print the
messages to the standard output which might not be a problem.

Some log messages might go to the wrong place (stdout) before the
logging config is read up in setup_logger if the default setting
in the log config forwards the log messages not to the stdout.