### PR TITLE
Fix typo of argument name resulting in name error

### DIFF
--- a/libcodechecker/server/api/store_handler.py
+++ b/libcodechecker/server/api/store_handler.py
@@ -261,7 +261,7 @@ def finishCheckerRun(session, run_id):
         return False
 
 
-def setRunDuration(session, run_id, check_durations):
+def setRunDuration(session, run_id, duration):
     """
     """
     try:


### PR DESCRIPTION
Fix typo of argument name introduced in #1286.