### PR TITLE
Handle non existing session config file

### DIFF
--- a/libcodechecker/libclient/credential_manager.py
+++ b/libcodechecker/libclient/credential_manager.py
@@ -34,8 +34,10 @@ class UserCredentials:
                                         ".codechecker.passwords.json")
         LOG.debug(session_cfg_file)
 
-        scfg_dict = load_json_or_empty(session_cfg_file, {},
-                                       "user authentication")
+        scfg_dict = {}
+        if os.path.exists(session_cfg_file):
+            scfg_dict = load_json_or_empty(session_cfg_file, {},
+                                           "user authentication")
         if os.path.exists(session_cfg_file):
             check_file_owner_rw(session_cfg_file)
 


### PR DESCRIPTION
If the session config file does not exist in the home directory of the user, do not throw warning message.