### PR TITLE
fix token remove KeyError

### DIFF
--- a/libcodechecker/libclient/credential_manager.py
+++ b/libcodechecker/libclient/credential_manager.py
@@ -81,7 +81,7 @@ class UserCredentials:
 
     def save_token(self, host, port, token, destroy=False):
         if destroy:
-            del self.__tokens['{0}:{1}'.format(host, port)]
+            self.__tokens.pop('{0}:{1}'.format(host, port), None)
         else:
             self.__tokens['{0}:{1}'.format(host, port)] = token
 


### PR DESCRIPTION
KeyError exception was thrown if there was no token for the
given host:port.
Handling removal more gracefully.