### PR TITLE
Multiple run name by using regex at cmd

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1250,7 +1250,12 @@ usage: CodeChecker cmd results [-h] RUN_NAME [-s] [--filter FILTER]
 Show the individual analysis reports' summary.
 
 positional arguments:
-  RUN_NAME              Name of the analysis run to show result summaries of.
+  RUN_NAME              Names of the analysis runs to show result summaries of.
+                        This has the following format:
+                        <run_name_1>:<run_name_2>:<run_name_3> where run names
+                        can be a Python regex expression. So if you have
+                        run_1_a_name, run_2_b_name, run_2_c_name, run_3_d_name
+                        then "run_2*:run_3_d_name" selects the last three runs.
                         Use 'CodeChecker cmd runs' to get the available runs.
 
 optional arguments:
@@ -1348,7 +1353,12 @@ optional arguments:
   -h, --help            show this help message and exit
   -n RUN_NAME [RUN_NAME ...], --name RUN_NAME [RUN_NAME ...]
                         Names of the analysis runs to show result count
-                        breakdown for.
+                        breakdown for. This has the following format:
+                        <run_name_1>:<run_name_2>:<run_name_3> where run names
+                        can be a Python regex expression. So if you have
+                        run_1_a_name, run_2_b_name, run_2_c_name, run_3_d_name
+                        then "run_2*:run_3_d_name" selects the last three runs.
+                        Use 'CodeChecker cmd runs' to get the available runs.
   -a, --all             Show breakdown for all analysis runs.
   -s, --suppressed      Filter results to only show suppressed entries.
                         (default: False)

--- a/libcodechecker/libhandlers/cmd.py
+++ b/libcodechecker/libhandlers/cmd.py
@@ -158,10 +158,16 @@ def __register_results(parser):
 
     parser.add_argument(type=str,
                         dest="name",
-                        metavar='RUN_NAME',
-                        help="Name of the analysis run to show result "
-                             "summaries of. Use 'CodeChecker cmd runs' to "
-                             "get the available runs.")
+                        metavar='RUN_NAMES',
+                        help="Names of the analysis runs to show result "
+                             "summaries of. This has the following format: "
+                             "<run_name_1>:<run_name_2>:<run_name_3> "
+                             "where run names can be a Python regex "
+                             "expression. So if you have run_1_a_name, "
+                             "run_2_b_name, run_2_c_name, run_3_d_name then"
+                             "\"run_2*:run_3_d_name\" selects the last three"
+                             "runs. Use 'CodeChecker cmd runs' to get the "
+                             "available runs.")
 
     __add_filtering_arguments(parser)
 
@@ -255,7 +261,15 @@ def __register_sum(parser):
                             metavar='RUN_NAME',
                             default=argparse.SUPPRESS,
                             help="Names of the analysis runs to show result "
-                                 "count breakdown for.")
+                                 "count breakdown for. This has the following "
+                                 "format: <run_name_1>:<run_name_2>:"
+                                 "<run_name_3> where run names can be a "
+                                 "Python regex expression. So if you have "
+                                 "run_1_a_name, run_2_b_name, run_2_c_name, "
+                                 "run_3_d_name then \"run_2*:run_3_d_name\""
+                                 "selects the last three runs. Use "
+                                 "'CodeChecker cmd runs' to get the available "
+                                 "runs.")
 
     name_group.add_argument('-a', '--all',
                             dest="all_results",

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -531,9 +531,9 @@ class ThriftRequestHandler(object):
                     if run_filter.exactMatch:
                         q = q.filter(Run.name.in_(run_filter.names))
                     else:
-                        OR = [Run.name.ilike('%{0}%'.format(
-                                  util.escape_like(name)), escape='*') for
-                              name in run_filter.names]
+                        OR = [Run.name.ilike('{0}'.format(conv(
+                            util.escape_like(name, '\\'))), escape='\\') for
+                            name in run_filter.names]
                         q = q.filter(or_(*OR))
 
             q = q.outerjoin(stmt, Run.id == stmt.c.run_id) \

--- a/tests/functional/report_viewer_api/__init__.py
+++ b/tests/functional/report_viewer_api/__init__.py
@@ -98,6 +98,17 @@ def setup_package():
         sys.exit(1)
     print("Second analysis of the test project was successful.")
 
+    test_project_name_third = project_info['name'] + uuid.uuid4().hex
+
+    # Let's run the third analysis.
+    ret = codechecker.check(codechecker_cfg,
+                            test_project_name_third,
+                            project.path(test_project))
+
+    if ret:
+        sys.exit(1)
+    print("Third analysis of the test project was successful.")
+
     codechecker_cfg['run_names'] = [test_project_name,
                                     test_project_name_new]
 

--- a/tests/functional/report_viewer_api/test_run_data.py
+++ b/tests/functional/report_viewer_api/test_run_data.py
@@ -48,26 +48,26 @@ class TestRunData(unittest.TestCase):
                          "There should be two runs for this test.")
 
         # Filter runs which name starts with `test_files_`.
-        test_runs = self.__get_runs('test_files_')
+        test_runs = self.__get_runs('test_files_*')
         self.assertEqual(len(test_runs), 1,
                          "There should be one run for this test.")
 
         # Run name filter is case insensitive.
-        test_runs = self.__get_runs('Test_Files_')
+        test_runs = self.__get_runs('Test_Files_*')
         self.assertEqual(len(test_runs), 1,
                          "There should be one run for this test.")
 
         # Filter runs which name contains `files_`.
-        test_runs = self.__get_runs('files_')
+        test_runs = self.__get_runs('*files_*')
         self.assertEqual(len(test_runs), 1,
                          "There should be one run for this test.")
 
         # Filter runs which name contains `test_files*`.
         test_runs = self.__get_runs('test_files*')
-        self.assertEqual(len(test_runs), 1,
-                         "There should be one run for this test.")
+        self.assertEqual(len(test_runs), 2,
+                         "There should be two runs for this test.")
 
-        test_runs = self.__get_runs('_')
+        test_runs = self.__get_runs('*_*')
         self.assertEqual(len(test_runs), 2,
                          "There should be two runs for this test.")
 
@@ -75,13 +75,9 @@ class TestRunData(unittest.TestCase):
         self.assertEqual(len(test_runs), 2,
                          "There should be two runs for this test.")
 
-        test_runs = self.__get_runs('**')
-        self.assertEqual(len(test_runs), 1,
-                         "There should be one run for this test.")
-
         test_runs = self.__get_runs('%')
-        self.assertEqual(len(test_runs), 1,
-                         "There should be one run for this test.")
+        self.assertEqual(len(test_runs), 0,
+                         "There should be no run for this test.")
 
         # Filter non existing run.
         test_runs = self.__get_runs('non_existing_run_name')


### PR DESCRIPTION
User can get command line results for multiple runs by using Python regex expression.