### PR TITLE
Fix clicking on a uniqued bug

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -465,6 +465,9 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           reportFilter.reportHash = [reportHash];
           reportFilter.isUnique = false;
 
+          if (reportData)
+            reportFilter.filepath = ['*' + reportData.checkedFile];
+
           reports = CC_SERVICE.getRunResults(runResultParam.runIds,
             CC_OBJECTS.MAX_QUERY_SIZE,  0, null, reportFilter,
             runResultParam.cmpData);


### PR DESCRIPTION
If a bug can be found on different files, uniquing will show only one file. If the user clicks on this bug, we should get the report by setting the file path filter.