### PR TITLE
Add Clang include path in debug scripts

### DIFF
--- a/scripts/debug_tools/failure_lib.py
+++ b/scripts/debug_tools/failure_lib.py
@@ -5,6 +5,7 @@
 # -------------------------------------------------------------------------
 import json
 import os
+import subprocess
 
 
 def find_path_end(string, path_begin):
@@ -57,3 +58,25 @@ def load_json_file(filename):
     with open(filename, 'r') as f:
         data = json.load(f)
     return data
+
+
+def get_resource_dir(clang_bin):
+    """
+    Returns the resource_dir of Clang or None if the switch is not supported by
+    Clang.
+    """
+    cmd = [clang_bin, "-print-resource-dir"]
+    try:
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                )
+        out, err = proc.communicate()
+
+        if proc.returncode == 0:
+            return out.decode("utf-8").rstrip()
+        else:
+            return None
+    except OSError:
+        LOG.error('Failed to run: "' + ' '.join(cmd) + '"')
+        raise

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -64,7 +64,26 @@ class PathOptions:
 def prepare(analyzer_command_file, pathOptions):
     res = lib.change_paths(get_first_line_of_file(analyzer_command_file),
                            AnalyzerCommandPathModifier(pathOptions))
-    return res
+
+    if '-nobuiltininc' not in res:
+        return res
+
+    # Find Clang include path
+    clang_include_path = lib.get_resource_dir(pathOptions.clang) + '/include'
+
+    if clang_include_path is None:
+        clang_lib_path = os.path.dirname(pathOptions.clang) + '/../lib'
+        clang_include_path = ''
+        for path, _, files in os.walk(clang_lib_path):
+            if 'stddef.h' in files:
+                clang_include_path = path
+                break
+
+    if clang_include_path is None:
+        return res
+
+    return res.replace('-nobuiltininc',
+                       '-nobuiltininc -isystem ' + clang_include_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some standard header files should be present during the analysis from
the standard library. The location of these is now added to the prepared
analysis command.