### PR TITLE
fix command line json output

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -660,7 +660,6 @@ def handle_list_result_types(args):
 
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(all_results))
-        print(CmdLineOutputEncoder().encode(severities))
     else:
         header = ['Checker', 'Severity', 'All reports', 'Resolved',
                   'Unreviewed', 'Confirmed', 'False positive', "Intentional"]


### PR DESCRIPTION
When using the commmand line to get results only one json should
be returned which can be parsed by other tools.