### PR TITLE
Remove the default log level

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -296,7 +296,7 @@ common arguments:
                         connect to. (default: localhost)
   -p PORT, --port PORT  The port the server is running on. (default: 8001)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 The user can log in onto the server by issuing the command `CodeChecker cmd

--- a/docs/products.md
+++ b/docs/products.md
@@ -81,7 +81,7 @@ common arguments:
   --url SERVER_URL      The URL of the server to access, in the format of
                         '[http[s]://]host:port'. (default: localhost:8001)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 
 Most of these commands require authentication and appropriate access rights.
 Please see 'CodeChecker cmd login' to authenticate.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -315,7 +315,7 @@ optional arguments:
   -q, --quiet           Do not print the output of the build tool into the
                         output of this command.
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 Please note, that only the files that are used in the given `--build` argument
@@ -426,7 +426,7 @@ optional arguments:
   -n NAME, --name NAME  Annotate the run analysis with a custom name in the
                         created metadata file.
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 ### <a name="skip"></a> _Skip_ file
@@ -723,7 +723,7 @@ optional arguments:
   --print-steps         Print the steps the analyzers took in finding the
                         reported defect.
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 
 export arguments:
   -e {html}, --export {html}
@@ -842,7 +842,7 @@ optional arguments:
                         incrementally update defect reports for source files
                         that were analysed.)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 
 server arguments:
   Specifies a 'CodeChecker server' instance which will be used to store the
@@ -919,7 +919,7 @@ optional arguments:
                         The format to list the applicable checkers as.
                         (default: rows)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 The list provided by default is formatted for easy machine and human
@@ -963,7 +963,7 @@ optional arguments:
   -o {rows,table,csv,json}, --output {rows,table,csv,json}
                         Specify the format of the output list. (default: rows)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 A detailed view of the available analyzers is available via `--details`. In the
@@ -1024,7 +1024,7 @@ optional arguments:
   --skip-db-cleanup     Skip performing cleanup jobs on the database like
                         removing unused files.
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 
 configuration database arguments:
   --sqlite SQLITE_FILE  Path of the SQLite database file to use. (default:
@@ -1248,7 +1248,7 @@ common arguments:
                         The output format to use in showing the data.
                         (default: plaintext)
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 ### <a name="cmd-runs"></a> List runs (`runs`)
@@ -1487,7 +1487,7 @@ optional arguments:
 
 common arguments:
   --verbose {info,debug,debug_analyzer}
-                        Set verbosity level. (default: info)
+                        Set verbosity level.
 ~~~~~~~~~~~~~~~~~~~~~
 
 If a server [requires privileged access](authentication.md), you must

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -124,7 +124,7 @@ def add_filter_conditions(report_filter, filter_str):
 
 def handle_list_runs(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     client = setup_client(args.product_url)
     runs = client.getRunData(None)
@@ -145,8 +145,7 @@ def handle_list_runs(args):
 
 
 def handle_list_results(args):
-
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     client = setup_client(args.product_url)
 
@@ -195,7 +194,7 @@ def handle_list_results(args):
 
 def handle_diff_results(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     context = generic_package_context.get_context()
 
@@ -591,7 +590,7 @@ def handle_diff_results(args):
 
 def handle_list_result_types(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     def get_statistics(client, run_ids, field, values):
         report_filter = ttypes.ReportFilter()
@@ -718,7 +717,7 @@ def handle_list_result_types(args):
 
 def handle_remove_run_results(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     client = setup_client(args.product_url)
 
@@ -768,7 +767,7 @@ def handle_remove_run_results(args):
 
 def handle_suppress(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     def bug_hash_filter(bug_id, filepath):
         filepath = '%' + filepath
@@ -799,7 +798,7 @@ def handle_suppress(args):
 
 def handle_login(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     protocol, host, port = split_server_url(args.server_url)
     handle_auth(protocol, host, port, args.username,

--- a/libcodechecker/cmd/product_client.py
+++ b/libcodechecker/cmd/product_client.py
@@ -32,7 +32,7 @@ def init_logger(level, logger_name='system'):
 
 def handle_list_products(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)
@@ -67,7 +67,7 @@ def handle_list_products(args):
 
 def handle_add_product(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)
@@ -119,7 +119,7 @@ def handle_add_product(args):
 
 def handle_del_product(args):
 
-    init_logger(args.verbose)
+    init_logger(args.verbose if 'verbose' in args else None)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -359,7 +359,7 @@ def main(args):
     Perform analysis on the given logfiles and store the results in a machine-
     readable format.
     """
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     if len(args.logfile) != 1:
         LOG.warning("Only one log file can be processed right now!")

--- a/libcodechecker/libhandlers/analyzers.py
+++ b/libcodechecker/libhandlers/analyzers.py
@@ -75,7 +75,7 @@ def main(args):
     """
     List the analyzers' basic information supported by CodeChecker.
     """
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     context = generic_package_context.get_context()
     working, errored = \

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -373,7 +373,7 @@ def main(args):
     Execute a wrapper over log-analyze-parse, aka 'check'.
     """
 
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     def __load_module(name):
         """Loads the given subcommand's definition from the libs."""

--- a/libcodechecker/libhandlers/checkers.py
+++ b/libcodechecker/libhandlers/checkers.py
@@ -112,7 +112,7 @@ def main(args):
     alongside with their description or enabled status in various formats.
     """
 
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     # If nothing is set, list checkers for all supported analyzers.
     analyzers = args.analyzers \

--- a/libcodechecker/libhandlers/log.py
+++ b/libcodechecker/libhandlers/log.py
@@ -86,7 +86,7 @@ def main(args):
     Generates a build log by running the original build command.
     No analysis is done.
     """
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     args.logfile = os.path.realpath(args.logfile)
     if os.path.exists(args.logfile):

--- a/libcodechecker/libhandlers/parse.py
+++ b/libcodechecker/libhandlers/parse.py
@@ -194,7 +194,7 @@ def main(args):
     stdout in a human-readable format.
     """
 
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     context = generic_package_context.get_context()
 

--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -860,5 +860,5 @@ def main(args):
     Setup a logger server based on the configuration and
     manage the CodeChecker server.
     """
-    with logger.LOG_CFG_SERVER(args.verbose):
+    with logger.LOG_CFG_SERVER(args.verbose if 'verbose' in args else None):
         server_init_start(args)

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -251,7 +251,7 @@ def main(args):
     Store the defect results in the specified input list as bug reports in the
     database.
     """
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     if not host_check.check_zlib():
         raise Exception("zlib is not available on the system!")

--- a/libcodechecker/libhandlers/version.py
+++ b/libcodechecker/libhandlers/version.py
@@ -57,7 +57,7 @@ def main(args):
     Get and print the version information from the version config
     file and Thrift API definition.
     """
-    logger.setup_logger(args.verbose)
+    logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     context = generic_package_context.get_context()
 

--- a/libcodechecker/logger.py
+++ b/libcodechecker/logger.py
@@ -6,6 +6,7 @@
 """
 """
 
+import argparse
 import json
 import logging
 from logging import config
@@ -91,7 +92,7 @@ def add_verbose_arguments(parser):
     """
     parser.add_argument('--verbose', type=str, dest='verbose',
                         choices=CMDLINE_LOG_LEVELS,
-                        default='info',
+                        default=argparse.SUPPRESS,
                         help='Set verbosity level.')
 
 


### PR DESCRIPTION
Remove the default log level from command line arguments because it had always overridden the log level which came from the logger configuration file.
This way if the log level is not specified in the command line it will come from the configuration file. If the log level is specified in the command line it will set the log level of handlers and loggers to this.