### PR TITLE
check source file content change before store/parse/plistToHtml

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -566,6 +566,12 @@ def check(check_data):
                          (progress_checked_num.value, progress_actions.value,
                           action.analyzer_type, source_file_name))
 
+                if skip_handler:
+                    # We need to check the plist content because skipping
+                    # reports in headers can be done only this way.
+                    plist_parser.skip_report_from_plist(result_file,
+                                                        skip_handler)
+
             else:
                 LOG.error("Analyzing '" + source_file_name + "' with " +
                           action.analyzer_type +

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -533,3 +533,20 @@ def load_json_or_empty(path, default=None, kind=None):
                     .format(kind if kind else 'json', path))
 
     return ret
+
+
+def get_file_content_hash(file_path):
+    """
+    Return the file content hash for a file.
+    """
+    with open(file_path) as content:
+        hasher = hashlib.sha256()
+        hasher.update(content.read())
+        return hasher.hexdigest()
+
+
+def get_last_mod_time(file_path):
+    """
+    Return the last modification time of a file.
+    """
+    return os.stat(file_path)[9]

--- a/tests/functional/source_change/__init__.py
+++ b/tests/functional/source_change/__init__.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Setup for the package tests."""
+
+import os
+import shutil
+import sys
+import uuid
+
+from libtest import codechecker
+from libtest import env
+from libtest import project
+
+
+# Test workspace used for source change tests
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for testing source_change."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('source_change')
+
+    # Set the TEST_WORKSPACE used by the tests.
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+    test_config = {}
+
+    test_project = 'cpp'
+
+    project_info = project.get_info(test_project)
+
+    # Copy the test project to the workspace. The tests should
+    # work only on this test project.
+    test_proj_path = os.path.join(TEST_WORKSPACE, "test_proj")
+    shutil.copytree(project.path(test_project), test_proj_path)
+
+    project_info['project_path'] = test_proj_path
+
+    # Generate a unique name for this test run.
+    test_project_name = project_info['name'] + '_' + uuid.uuid4().hex
+
+    test_config['test_project'] = project_info
+
+    # Get an environment which should be used by the tests.
+    test_env = env.test_env(TEST_WORKSPACE)
+
+    # Create a basic CodeChecker config for the tests, this should
+    # be imported by the tests and they should only depend on these
+    # configuration options.
+    codechecker_cfg = {
+        'check_env': test_env,
+        'workspace': TEST_WORKSPACE,
+        'reportdir': os.path.join(TEST_WORKSPACE, 'reports'),
+        'checkers': []
+    }
+
+    # Start or connect to the running CodeChecker server and get connection
+    # details.
+    print("This test uses a CodeChecker server... connecting...")
+    server_access = codechecker.start_or_get_server()
+    server_access['viewer_product'] = 'source_change'
+    codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
+
+    # Extend the checker configuration with the server access.
+    codechecker_cfg.update(server_access)
+
+    # Clean the test project, if needed by the tests.
+    ret = project.clean(test_project)
+    if ret:
+        sys.exit(ret)
+
+    # Save the run names in the configuration.
+    codechecker_cfg['run_names'] = [test_project_name]
+
+    test_config['codechecker_cfg'] = codechecker_cfg
+
+    # Export the test configuration to the workspace.
+    env.export_test_cfg(TEST_WORKSPACE, test_config)
+
+
+def teardown_package():
+    """Clean up after the test."""
+
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
+    global TEST_WORKSPACE
+
+    check_env = env.import_test_cfg(TEST_WORKSPACE)[
+        'codechecker_cfg']['check_env']
+    codechecker.remove_test_package_product(TEST_WORKSPACE, check_env)
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/tests/functional/source_change/test_source_change.py
+++ b/tests/functional/source_change/test_source_change.py
@@ -1,0 +1,118 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""
+Tests for source file changes
+"""
+import os
+import time
+import unittest
+
+from libtest import codechecker
+from libtest import env
+
+
+def touch(fname, times=None):
+    """
+    Modify the update and last modification times for a file.
+    """
+    with open(fname, 'a'):
+        os.utime(fname, times)
+
+
+class TestSkeleton(unittest.TestCase):
+
+    _ccClient = None
+
+    def setUp(self):
+
+        # TEST_WORKSPACE is automatically set by test package __init__.py .
+        self.test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self.test_workspace)
+
+        # Get the test project configuration from the prepared test workspace.
+        self._testproject_data = env.setup_test_proj_cfg(self.test_workspace)
+        self.assertIsNotNone(self._testproject_data)
+
+        # Setup a viewer client to test viewer API calls.
+        self._cc_client = env.setup_viewer_client(self.test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        # Get the CodeChecker cmd if needed for the tests.
+        self._codechecker_cmd = env.codechecker_cmd()
+        self._codechecker_cfg = env.import_codechecker_cfg(self.test_workspace)
+
+        self.env = env.codechecker_env()
+
+    def test_parse(self):
+        """
+        Test if parse there are skip messages in the output of the parse if
+        the source files did change between the analysis and the parse.
+        """
+
+        test_proj_path = self._testproject_data['project_path']
+
+        test_proj_files = os.listdir(test_proj_path)
+        print(test_proj_files)
+
+        null_deref_file = os.path.join(test_proj_path, 'null_dereference.cpp')
+
+        codechecker.analyze(self._codechecker_cfg,
+                            'hash_change',
+                            test_proj_path)
+
+        ret, out, _ = codechecker.parse(self._codechecker_cfg)
+        self.assertEqual(ret, 0)
+
+        # Need to wait a little before updating the last modification time.
+        # If we do not wait, not enough time will be past
+        # between the analysis and the parse in the test.
+        time.sleep(2)
+        touch(null_deref_file)
+
+        ret, out, _ = codechecker.parse(self._codechecker_cfg)
+        self.assertEqual(ret, 0)
+        print(out)
+
+        msg = 'did change since the last analysis.'
+        self.assertTrue(msg in out,
+                        '"' + msg + '" was not found in the parse output')
+
+    def test_store(self):
+        """
+        Store should fail if the source files were modified since the
+        last analysis.
+        """
+
+        test_proj = os.path.join(self.test_workspace, 'test_proj')
+
+        ret = codechecker.check(self._codechecker_cfg,
+                                'test_proj',
+                                test_proj)
+
+        self.assertEqual(ret, 0)
+
+        ret = codechecker.store(self._codechecker_cfg,
+                                'test_proj',
+                                self._codechecker_cfg['reportdir'])
+        self.assertEqual(ret, 0)
+
+        test_proj_path = self._testproject_data['project_path']
+
+        test_proj_files = os.listdir(test_proj_path)
+        print(test_proj_files)
+
+        null_deref_file = os.path.join(test_proj_path, 'null_dereference.cpp')
+
+        touch(null_deref_file)
+
+        ret = codechecker.store(self._codechecker_cfg,
+                                'test_proj',
+                                self._codechecker_cfg['reportdir'])
+        self.assertEqual(ret, 1)

--- a/tests/libtest/codechecker.py
+++ b/tests/libtest/codechecker.py
@@ -268,6 +268,30 @@ def analyze(codechecker_cfg, test_project_name, test_project_path):
         return cerr.returncode
 
 
+def parse(codechecker_cfg):
+    """
+    Parse the results of the analysis and return the output.
+    """
+
+    parse_cmd = ['CodeChecker', 'parse', codechecker_cfg['reportdir']]
+
+    try:
+        print("LOG:")
+        proc = subprocess.Popen(shlex.split(' '.join(parse_cmd)),
+                                cwd=codechecker_cfg['workspace'],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                env=codechecker_cfg['check_env'])
+        out, err = proc.communicate()
+        print(out)
+        print(err)
+
+        return proc.returncode, out, err
+    except CalledProcessError as cerr:
+        print("Failed to call:\n" + ' '.join(cerr.cmd))
+        return 1, '', ''
+
+
 def store(codechecker_cfg, test_project_name, report_path):
     """
     Store results from a report dir.


### PR DESCRIPTION
> Closes #1320

If the source file content changes between the analysis and the store
the results will not be shown properly after store or parse.

File content changes are checked before:
* store (store will fail if there is a change)
* parse (reports with a source file change will not be printed and
         will not count into the statistics)
* plistToHtml (html files will only be generated for the reports where
               the source files did not change)