### PR TITLE
Remove soft session lifetime completely

### DIFF
--- a/config/server_config.json
+++ b/config/server_config.json
@@ -4,7 +4,6 @@
     "enabled" : false,
     "realm_name" : "CodeChecker Privileged server",
     "realm_error" : "Access requires valid credentials.",
-    "soft_expire" : 60,
     "session_lifetime" : 300,
     "logins_until_cleanup" : 30,
     "method_dictionary": {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,14 +45,6 @@ is handled.
 
     After this many login attempts made towards the server, it will perform an
     automatic cleanup of old, expired sessions.
- * `soft_expire`
-
-    (in seconds) When a user is authenticated, a session is created for them
-    and this session identifies the user's access. This configuration variable
-    sets how long the session considered "valid" before the user is needed
-    to reauthenticate again &mdash; if this time expires, the session will
-    be *hibernated*: the next access will be denied, but if the user presents
-    a valid login, they will get their session reused.
  * `session_lifetime`
 
     (in seconds) The lifetime of the session sets that after this many seconds

--- a/libcodechecker/server/api/authentication.py
+++ b/libcodechecker/server/api/authentication.py
@@ -45,13 +45,9 @@ class ThriftAuthHandler(object):
 
     @timeit
     def getAuthParameters(self):
-        token = None
-        if self.__auth_session:
-            token = self.__auth_session.token
-        return HandshakeInformation(self.__manager.is_enabled,
-                                    self.__manager.is_valid(
-                                        token,
-                                        True))
+        alive = self.__auth_session.is_alive if self.__auth_session \
+                else False
+        return HandshakeInformation(self.__manager.is_enabled, alive)
 
     @timeit
     def getLoggedInUser(self):


### PR DESCRIPTION
#1301's removal of `WWW-Authenticate` broke the session handling logic that enabled us to have a soft and a hard life-time. (If the user had a session that soft-expired but didn't hard expire, the login window was infintiely looping.) Due to the server not storing anything user session specific within the session itself (it is just only used to allow privileged access), the soft lifetime's reason *"with a login the user could get back settings stored for their session"* is moot.

`soft_expire` has been removed completely from usage. If `soft_expire` is found in the server configuration, it is ignored. The previous logic of `session_expire` being a hard expire now becomes the *only* expire countdown. If this expires, the user has to log in again no matter what.

If soft-expire is ever to be introduced again, the logic on when and exactly how the user needs to be redirected need be revised.