### PR TITLE
Upgrade codemirror to 5.25.0

### DIFF
--- a/vendor_projects.json
+++ b/vendor_projects.json
@@ -14,13 +14,26 @@
   {
     "name":"codemirror",
     "directory":"vendor/codemirror",
-    "version":"5.18.2",
+    "version":"5.25.0",
     "description":"codemirror",
     "homepage":"https://codemirror.net/",
     "repository":{
       "type":"git",
-      "git_tag":"5.18.2",
+      "git_tag":"5.25.0",
       "url":"https://github.com/codemirror/CodeMirror.git"
+    }
+  },
+  {
+    "name":"codemirror-dist",
+    "directory":"vendor/codemirror/dist",
+    "version":"5.25.0",
+    "description":"codemirror",
+    "homepage":"https://codemirror.net/",
+    "source_package":{
+      "download_cmd":"curl",
+      "url":"https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.0/codemirror.min.js",
+      "option":"-o",
+      "name":"codemirror.min.js"
     }
   },
   {

--- a/www/index.html
+++ b/www/index.html
@@ -23,7 +23,7 @@
   <script type="text/javascript" src="scripts/plugins/jsplumb/jquery.jsPlumb-1.7.6-min.js"></script>
   <script type="text/javascript" src="scripts/plugins/thrift/thrift.js"></script>
   <script type="text/javascript" src="scripts/plugins/marked/marked.min.js"></script>
-  <script type="text/javascript" src="scripts/plugins/codemirror/lib/codemirror.js"></script>
+  <script type="text/javascript" src="scripts/plugins/codemirror/dist/codemirror.min.js"></script>
   <script type="text/javascript" src="scripts/plugins/codemirror/mode/clike/clike.js"></script>
   <script type="text/javascript" src="scripts/plugins/codemirror/addon/dialog/dialog.js"></script>
   <script type="text/javascript" src="scripts/plugins/codemirror/addon/search/search.js"></script>


### PR DESCRIPTION
From version 5.20.0 a git checkout no longer contains a working `codemirror.js` so we download it from the cdn instead of building it with npm.

Closes #1355