### PR TITLE
Fix regex search filter

### DIFF
--- a/www/scripts/codecheckerviewer/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/BugFilterView.js
@@ -136,7 +136,7 @@ function (declare, Deferred, dom, domClass, keys, all, topic, Standby, Button,
 
         if (that.reportFilter.serverSideSearch && query) {
           that._items.unshift({
-            label : query,
+            label : '&lrm;' + query + '&lrm;',
             value : query,
             isFilterByRegexItem : true
           });
@@ -225,7 +225,7 @@ function (declare, Deferred, dom, domClass, keys, all, topic, Standby, Button,
 
         hasItem = true;
 
-        var label = (item.isFilterByRegexItem ? 'Filter by this regex: ' : '') +
+        var label = (item.isFilterByRegexItem ? 'Filter by RegEx: ' : '') +
           item.label;
 
         var content = '<span class="customIcon selected"></span>'


### PR DESCRIPTION
Fix regex search if search string contains multiple stars.
E.g.: `*word*`

Closes #1352