### PR TITLE
Fix to select the actual report in unique mode

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -734,7 +734,7 @@ class ThriftRequestHandler(object):
                     get_sort_map(sort_types, True)
 
                 selects = [func.max(Report.id).label('id'),
-                           func.max(path_len_q.c.path_length)
+                           func.min(path_len_q.c.path_length)
                                .label('bug_path_length')]
                 for sort in sort_types:
                     sorttypes = sort_type_map.get(sort.type)

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -468,8 +468,14 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           if (reportData)
             reportFilter.filepath = ['*' + reportData.checkedFile];
 
+          // We set a sort option to select a report which has the shortest
+          // bug path length.
+          var sortMode = new CC_OBJECTS.SortMode();
+          sortMode.type = CC_OBJECTS.SortType.BUG_PATH_LENGTH;
+          sortMode.ord = CC_OBJECTS.Order.ASC;
+
           reports = CC_SERVICE.getRunResults(runResultParam.runIds,
-            CC_OBJECTS.MAX_QUERY_SIZE,  0, null, reportFilter,
+            CC_OBJECTS.MAX_QUERY_SIZE,  0, [sortMode], reportFilter,
             runResultParam.cmpData);
           reportData = reports[0];
         } else {


### PR DESCRIPTION
When clicking to the bug report show the report instance with this shortest path among the many similar ones.

Closes #1365