### PR TITLE
Remove default report directory from parse command

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -692,7 +692,7 @@ usage: CodeChecker parse [-h] [-t {plist}] [--export {html}]
                          [-o OUTPUT_PATH] [-c] [--suppress SUPPRESS]
                          [--export-source-suppress] [--print-steps]
                          [--verbose {info,debug,debug_analyzer}]
-                         [file/folder [file/folder ...]]
+                         file/folder [file/folder ...]
 
 Parse and pretty-print the summary and results from one or more 'codechecker-
 analyze' result files.
@@ -700,7 +700,6 @@ analyze' result files.
 positional arguments:
   file/folder           The analysis result files and/or folders containing
                         analysis results which should be parsed and printed.
-                        (default: /home/<username>/.codechecker/reports)
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/libcodechecker/libhandlers/parse.py
+++ b/libcodechecker/libhandlers/parse.py
@@ -56,10 +56,8 @@ def add_arguments_to_parser(parser):
 
     parser.add_argument('input',
                         type=str,
-                        nargs='*',
+                        nargs='+',
                         metavar='file/folder',
-                        default=os.path.join(util.get_default_workspace(),
-                                             'reports'),
                         help="The analysis result files and/or folders "
                              "containing analysis results which should be "
                              "parsed and printed.")


### PR DESCRIPTION
> Closes #1343

Do not accept 0 positional arguments for parse command as it can lead misleading behavior as it will not find reports as neither `CodeChecker analyze` or `CodeChekcer check` has default output report directory.

