### PR TITLE
bug event and point to report id index

### DIFF
--- a/db_migrate/versions/101a9cb747de_add_bug_event_and_point_report_index.py
+++ b/db_migrate/versions/101a9cb747de_add_bug_event_and_point_report_index.py
@@ -1,0 +1,24 @@
+"""add bug event and point report index
+
+Revision ID: 101a9cb747de
+Revises: dd9c97ead24
+Create Date: 2018-02-15 15:30:59.966552
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '101a9cb747de'
+down_revision = 'dd9c97ead24'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+def upgrade():
+    op.create_index(op.f('ix_bug_path_events_report_id'), 'bug_path_events', ['report_id'], unique=False)
+    op.create_index(op.f('ix_bug_report_points_report_id'), 'bug_report_points', ['report_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_bug_path_events_report_id'), table_name='bug_path_events')
+    op.drop_index(op.f('ix_bug_report_points_report_id'), table_name='bug_report_points')

--- a/libcodechecker/server/database/run_db_model.py
+++ b/libcodechecker/server/database/run_db_model.py
@@ -172,6 +172,7 @@ class BugPathEvent(Base):
     report_id = Column(Integer, ForeignKey('reports.id', deferrable=True,
                                            initially="DEFERRED",
                                            ondelete='CASCADE'),
+                       index=True,
                        primary_key=True)
 
     def __init__(self, line_begin, col_begin, line_end, col_end,
@@ -201,6 +202,7 @@ class BugReportPoint(Base):
     report_id = Column(Integer, ForeignKey('reports.id', deferrable=True,
                                            initially="DEFERRED",
                                            ondelete='CASCADE'),
+                       index=True,
                        primary_key=True)
 
     def __init__(self, line_begin, col_begin, line_end, col_end,


### PR DESCRIPTION
With the new indexes deleting the reports should be much faster.
Storing the reports in update mode (using the same run name) and
deleting a run should be much faster.