### PR TITLE
Set sqlalchemy pool size

### DIFF
--- a/libcodechecker/server/database/database.py
+++ b/libcodechecker/server/database/database.py
@@ -19,6 +19,7 @@ import sqlalchemy
 from sqlalchemy import event
 from sqlalchemy.engine.url import URL, make_url
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 
 from libcodechecker import host_check
 from libcodechecker import pgpass
@@ -338,10 +339,13 @@ class SQLServer(object):
             # FIXME: workaround for locking errors
             engine = sqlalchemy.create_engine(self.get_connection_string(),
                                               encoding='utf8',
-                                              connect_args={'timeout': 600})
+                                              connect_args={'timeout': 600},
+                                              poolclass=NullPool)
         else:
             engine = sqlalchemy.create_engine(self.get_connection_string(),
-                                              encoding='utf8')
+                                              encoding='utf8',
+                                              pool_size=2,
+                                              pool_recycle=3600)
 
         self._register_engine_hooks(engine)
         return engine


### PR DESCRIPTION
* For PostgreSQL the default allowed max connection is **100**. If we have to many products and multiple servers then we can reach this limit very easily because we create 5 pool for each product by default.
E.g.: **2 servers** (load balanced) with a _shared database_ which contains **10 products** and **1 config database** will create maximum (10 + 1) * 5 * 2 = **110** pool. In this case we can reach the default connection limit and PostgreSQL will not allow more connections.
* For SQlite we use the NullPool which doesnt pool connections.