### PR TITLE
Set check command dialog maximum width

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -95,7 +95,10 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
       this.escapeHTMLInData = false;
       this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
 
-      this._dialog = new Dialog({ title : 'Check command' });
+      this._dialog = new Dialog({
+        title : 'Check command',
+        style : 'max-width: 75%;'
+      });
     },
 
     postCreate : function () {


### PR DESCRIPTION
If the check command is too long the popup window of the check command sticks to right. This commit fixes this problem.

Closes #1393