### PR TITLE
Handle thrift error with fail callback

### DIFF
--- a/www/scripts/login/login.js
+++ b/www/scripts/login/login.js
@@ -61,7 +61,7 @@ function (declare, cookie, dom, domConstruct, domClass, keys, on, Button,
 
           var returnTo = hash.getState('returnto') || '';
           window.location = window.location.origin + '/' + returnTo;
-        }).error(function (jsReq, status, exc) {
+        }).fail(function (jsReq, status, exc) {
           if (status === "parsererror") {
             that._standBy.hide();
             domClass.add(that._mbox.domNode, 'mbox-error');

--- a/www/scripts/productlist/ProductSettingsView.js
+++ b/www/scripts/productlist/ProductSettingsView.js
@@ -189,7 +189,7 @@ function (declare, domAttr, domClass, domConstruct, Dialog, Button,
               if (success)
                   if (that.successCallback !== undefined)
                     that.successCallback(success);
-            }).error(function (jsReq, status, exc) {
+            }).fail(function (jsReq, status, exc) {
               if (status === "parsererror")
                 that._showMessageBox('error',
                   "Adding the product failed!", exc.message);
@@ -204,7 +204,7 @@ function (declare, domAttr, domClass, domConstruct, Dialog, Button,
                   that._showMessageBox('success',
                     "Successfully edited the product settings!", "");
                 }
-            }).error(function (jsReq, status, exc) {
+            }).fail(function (jsReq, status, exc) {
               if (status === "parsererror")
                 that._showMessageBox('error',
                   "Saving new settings failed!", exc.message);


### PR DESCRIPTION
The `error` callback is deprecated since jQuery 1.8. We have to use the `fail` callback instead of this.