### PR TITLE
Fix non existing field for superuser

### DIFF
--- a/libcodechecker/server/permissions.py
+++ b/libcodechecker/server/permissions.py
@@ -79,7 +79,8 @@ class Permission(object):
                 managed_by = [SUPERUSER] + managed_by
 
             self.inherited_from = inherited_from
-            self.managed_by = managed_by
+
+        self.managed_by = managed_by
 
     # Contains the list of arguments required by __call__ to initialise a
     # permission handler.


### PR DESCRIPTION
`managed_by` field is not set properly for `superuser` which causes an error when user tries to edit global permissions. The bug happened in #1403

