### PR TITLE
Fix dependency gen problem in xerces

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -153,6 +153,9 @@ def create_dependencies(action):
         # Build out custom invocation for dependency generation.
         command = [command[0], '-E', '-M', '-MT', '__dummy'] + command[1:]
 
+        # Remove empty arguments
+        command = [i for i in command if i]
+
         LOG.debug("Crafting build dependencies from GCC or Clang!")
 
         output, rc = util.call_command(command,


### PR DESCRIPTION
There are empty arguments in the executed command, which are handled by the compiler as positional arguments, i.e. it tries to find files with the name which is equal to the empty string.
Hence the strange errors `c++: error: : No such file or directory`.
This is how the command looks like in one case:
```
[u'g++', '-E', '-M', '-MT', '__dummy', u'', u'-DHAVE_CONFIG_H=1', u'-DXERCES_BUILDING_LIBRARY=1', u'-D_FILE_OFFSET_BITS=64', u'-D_THREAD_SAFE=1', u'-Dxerces_c_EXPORTS', u'-I.', u'-I../src', u'-Isrc', u'-isystem', u'/usr/include/x86_64-linux-gnu', u'', u'', u'-Wall', u'-Wcast-align', u'-Wcast-qual', u'-Wctor-dtor-privacy', u'-Wextra', u'-Wformat=2', u'-Wmissing-declarations', u'-Wno-long-long', u'-Woverlength-strings', u'-Woverloaded-virtual', u'-Wredundant-decls', u'-Wreorder', u'-Wswitch-default', u'-Wunused-variable', u'-Wwrite-strings', u'-Wno-variadic-macros', u'-fstrict-aliasing', u'-msse2', u'-fPIC', u'', u'', u'-pthread', u'-std=gnu++14', u'-c', u'/home/egbomrt/WORK/CodeCheckerProjects/xerces-c-3.2.0/src/xercesc/util/XMLString.cpp']

Solution is to remove empty arguments.