### PR TITLE
fix Default product config modification

### DIFF
--- a/libcodechecker/libhandlers/server.py
+++ b/libcodechecker/libhandlers/server.py
@@ -755,8 +755,8 @@ def server_init_start(args):
 
     # Create the main database link from the arguments passed over the
     # command line.
-    default_product_path = os.path.join(args.config_directory,
-                                        'Default.sqlite')
+    cfg_dir = os.path.abspath(args.config_directory)
+    default_product_path = os.path.join(cfg_dir, 'Default.sqlite')
     create_default_product = 'sqlite' in args and \
                              not os.path.exists(default_product_path)
 


### PR DESCRIPTION
The sqlite database path for the Default product was set up and stored
as a relative path. Any config modification on the UI caused an error.
The sqlite db path is converter to absolute path every time a change
is requested but it did not match the relative path stored in the database.