### PR TITLE
Trim leading path from stored results

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -474,11 +474,12 @@ service codeCheckerDBAccess {
   // run.
   // The "force" parameter removes existing analysis results for a run.
   // PERMISSION: PRODUCT_STORE
-  i64 massStoreRun(1: string runName,
-                   2: string tag,
-                   3: string version,
-                   4: string zipfile,
-                   5: bool   force)
+  i64 massStoreRun(1: string       runName,
+                   2: string       tag,
+                   3: string       version,
+                   4: string       zipfile,
+                   5: bool         force,
+                   6: list<string> trimPathPrefixes)
                    throws (1: shared.RequestFailed requestError),
 
 }

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -837,6 +837,12 @@ optional arguments:
                         used, if exists.
   --tag TAG             A unique identifier for this individual store of results
                         in the run's history.
+  --trim-path-prefix [TRIM_PATH_PREFIX [TRIM_PATH_PREFIX ...]]
+                        Removes leading path from files which will be stored.
+                        So if you have /a/b/c/x.cpp and /a/b/c/y.cpp then by
+                        removing "/a/b/" prefix will store files like c/x.cpp
+                        and c/y.cpp. If multiple prefix is given, the longest
+                        match will be removed.
   -f, --force           Delete analysis results stored in the database for the
                         current analysis run's name and store only the results
                         reported in the 'input' files. (By default,

--- a/libcodechecker/libclient/thrift_helper.py
+++ b/libcodechecker/libclient/thrift_helper.py
@@ -129,5 +129,6 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def massStoreRun(self, name, tag, version, zipdir, force):
+    def massStoreRun(self, name, tag, version, zipdir, force,
+                     trim_path_prefixes):
         pass

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -101,6 +101,19 @@ def add_arguments_to_parser(parser):
                         help="A uniques identifier for this individual store "
                              "of results in the run's history.")
 
+    parser.add_argument('--trim-path-prefix',
+                        type=str,
+                        nargs='*',
+                        dest="trim_path_prefix",
+                        required=False,
+                        default=argparse.SUPPRESS,
+                        help="Removes leading path from files which will be "
+                             "stored. So if you have /a/b/c/x.cpp and "
+                             "/a/b/c/y.cpp then by removing \"/a/b/\" prefix "
+                             "will store files like c/x.cpp and c/y.cpp. "
+                             "If multiple prefix is given, the longest match "
+                             "will be removed.")
+
     parser.add_argument('-f', '--force',
                         dest="force",
                         default=argparse.SUPPRESS,
@@ -337,11 +350,15 @@ def main(args):
 
         context = generic_package_context.get_context()
 
+        trim_path_prefixes = args.trim_path_prefix if \
+            'trim_path_prefix' in args else None
+
         client.massStoreRun(args.name,
                             args.tag if 'tag' in args else None,
                             str(context.version),
                             b64zip,
-                            'force' in args)
+                            'force' in args,
+                            trim_path_prefixes)
 
         LOG.info("Storage finished successfully.")
     except Exception as ex:

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -555,3 +555,30 @@ def get_last_mod_time(file_path):
         LOG.debug(oerr)
         LOG.debug("File is missing")
         return None
+
+
+def trim_path_prefixes(path, prefixes):
+    """
+    Removes the longest matching leading path from the file path.
+    """
+
+    # If no prefixes are specified.
+    if not prefixes:
+        return path
+
+    # Find the longest matching prefix in the path.
+    longest_matching_prefix = None
+    for prefix in prefixes:
+        if not prefix.endswith('/'):
+            prefix += '/'
+
+        if path.startswith(prefix) and (not longest_matching_prefix or
+                                        longest_matching_prefix < prefix):
+            longest_matching_prefix = prefix
+
+    # If no prefix found or the longest prefix is the root do not trim the
+    # path.
+    if not longest_matching_prefix or longest_matching_prefix == '/':
+        return path
+
+    return path[len(longest_matching_prefix):]

--- a/tests/unit/test_trim_path_prefix.py
+++ b/tests/unit/test_trim_path_prefix.py
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Test cases to trim a path by using prefixes. """
+
+import unittest
+
+from libcodechecker.util import trim_path_prefixes
+
+
+class TrimPathPrefixTestCase(unittest.TestCase):
+    """
+    Test cases to trim a path by using prefixes.
+    """
+
+    def test_no_prefix(self):
+        test_path = '/a/b/c'
+        self.assertEqual(test_path, trim_path_prefixes(test_path, None))
+        self.assertEqual(test_path, trim_path_prefixes(test_path, []))
+        self.assertEqual(test_path, trim_path_prefixes(test_path, ['x']))
+
+    def test_only_root_matches(self):
+        test_path = '/a/b/c'
+        self.assertEqual(test_path, trim_path_prefixes(test_path, ['/']))
+        self.assertEqual(test_path, trim_path_prefixes(test_path, ['/x']))
+
+    def test_one_matches(self):
+        test_path = '/a/b/c'
+        self.assertEqual('b/c', trim_path_prefixes(test_path, ['/a']))
+        self.assertEqual('c', trim_path_prefixes(test_path, ['/a/b']))
+
+    def test_longest_matches(self):
+        test_path = '/a/b/c'
+        self.assertEqual('b/c', trim_path_prefixes(test_path, ['/a']))
+        self.assertEqual('c', trim_path_prefixes(test_path, ['/a', '/a/b']))
+
+    def test_file_path(self):
+        test_path = '/a/b/c/foo.txt'
+        self.assertEqual('foo.txt', trim_path_prefixes(test_path, ['/a/b/c']))
+
+    def test_prefix_in_dir_name(self):
+        test_path = '/a/b/common/foo.txt'
+        self.assertEqual(test_path, trim_path_prefixes(test_path, ['/a/b/c']))
+        self.assertEqual('foo.txt',
+                         trim_path_prefixes(test_path, ['/a/b/common']))
+
+    def test_prefix_in_filename(self):
+        test_path = '/a/b/common.txt'
+        self.assertEqual(test_path, trim_path_prefixes(test_path, ['/a/b/c']))
+        self.assertEqual(test_path,
+                         trim_path_prefixes(test_path, ['/a/b/common']))
+        self.assertEqual('common.txt',
+                         trim_path_prefixes(test_path, ['/a/b/']))


### PR DESCRIPTION
> Closes #1411

Removes leading path from files which will be stored. If multiple prefix is given, the longest match will be removed.