### PR TITLE
Consistent report counting

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -115,7 +115,7 @@ struct RunData {
   2: string                    runDate,      // Date of the run last updated.
   3: string                    name,         // Human-given identifier.
   4: i64                       duration,     // Duration of the run (-1 if not finished).
-  5: i64                       resultCount,  // Number of results in the run.
+  5: i64                       resultCount,  // Number of unresolved results (review status is not FALSE_POSITIVE or INTENTIONAL) in the run.
   6: string                    runCmd,       // The used check command.
   7: map<DetectionStatus, i32> detectionStatusCount, // Number of reports with a particular detection status.
   8: string                    versionTag    // Version tag of the latest run.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1503,9 +1503,11 @@ https://docs.python.org/2/library/re.html#regular-expression-syntax.
 ### <a name="cmd-sum"></a> Show summarised count of results (`sum`)
 
 ~~~~~~~~~~~~~~~~~~~~~
-usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a) [-s]
-                           [--filter FILTER] [--url PRODUCT_URL]
-                           [-o {plaintext,rows,table,csv,json}]
+usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a)
+                           [--disable-unique] [-s] [--filter FILTER]
+                           [--url PRODUCT_URL]
+                           [-o {plaintext,html,rows,table,csv,json}]
+                           [-e EXPORT_DIR] [-c]
                            [--verbose {info,debug,debug_analyzer}]
 
 Show checker statistics for some analysis runs.
@@ -1521,6 +1523,10 @@ optional arguments:
                         then "run_2*:run_3_d_name" selects the last three runs.
                         Use 'CodeChecker cmd runs' to get the available runs.
   -a, --all             Show breakdown for all analysis runs.
+  --disable-unique      List all bugs even if these end up in the same bug
+                        location, but reached through different paths. By
+                        uniqueing the bugs a report will be appeared only once
+                        even if it is found on several paths.
   -s, --suppressed      Filter results to only show suppressed entries.
                         (default: False)
   --filter FILTER       Filter results. The filter string has the following

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -659,9 +659,11 @@ def handle_list_result_types(args):
 
     init_logger(args.verbose if 'verbose' in args else None)
 
+    is_unique = 'disable_unique' not in args
+
     def get_statistics(client, run_ids, field, values):
         report_filter = ttypes.ReportFilter()
-        report_filter.isUnique = True
+        report_filter.isUnique = is_unique
         add_filter_conditions(report_filter, args.filter)
         setattr(report_filter, field, values)
         checkers = client.getCheckerCounts(run_ids,
@@ -685,7 +687,7 @@ def handle_list_result_types(args):
             sys.exit(1)
 
     all_checkers_report_filter = ttypes.ReportFilter()
-    all_checkers_report_filter.isUnique = True
+    all_checkers_report_filter.isUnique = is_unique
     add_filter_conditions(all_checkers_report_filter, args.filter)
 
     all_checkers = client.getCheckerCounts(run_ids,
@@ -712,7 +714,7 @@ def handle_list_result_types(args):
 
     # Get severity counts
     report_filter = ttypes.ReportFilter()
-    report_filter.isUnique = True
+    report_filter.isUnique = is_unique
     add_filter_conditions(report_filter, args.filter)
 
     sev_count = client.getSeverityCounts(run_ids, report_filter, None)

--- a/libcodechecker/libhandlers/cmd.py
+++ b/libcodechecker/libhandlers/cmd.py
@@ -292,6 +292,16 @@ def __register_sum(parser):
                             default=argparse.SUPPRESS,
                             help="Show breakdown for all analysis runs.")
 
+    parser.add_argument('--disable-unique',
+                        dest="disable_unique",
+                        action='store_true',
+                        default=argparse.SUPPRESS,
+                        help="List all bugs even if these end up in the same "
+                             "bug location, but reached through different "
+                             "paths. By uniqueing the bugs a report will be "
+                             "appeared only once even if it is found on "
+                             "several paths.")
+
     __add_filtering_arguments(parser)
 
 

--- a/libcodechecker/source_code_comment_handler.py
+++ b/libcodechecker/source_code_comment_handler.py
@@ -16,18 +16,16 @@ from libcodechecker.logger import get_logger
 
 LOG = get_logger('system')
 
+# Note: codechecker_suppress source code comment will be also
+# marked as false_positive.
+SKIP_REVIEW_STATUSES = ['false_positive', 'intentional']
+
 
 def skip_suppress_status(status):
     """
     Returns True if the given status is in the skip list, otherwise False.
     """
-
-    # Note: codechecker_suppress source code comment will be also
-    # marked as false_positive.
-    skip_suppress_statuses = ['false_positive',
-                              'intentional']
-
-    return status in skip_suppress_statuses
+    return status in SKIP_REVIEW_STATUSES
 
 
 class BaseSourceCodeCommentHandler(object):

--- a/tests/functional/report_viewer_api/test_run_data.py
+++ b/tests/functional/report_viewer_api/test_run_data.py
@@ -10,8 +10,8 @@ import unittest
 
 from libtest import env
 
-from codeCheckerDBAccess_v6.ttypes import ReportFilter
-from codeCheckerDBAccess_v6.ttypes import RunFilter
+from codeCheckerDBAccess_v6.ttypes import ReportFilter, RunFilter, \
+    DetectionStatus
 
 
 class TestRunData(unittest.TestCase):
@@ -87,13 +87,17 @@ class TestRunData(unittest.TestCase):
     def test_number_of_unique_reports(self):
         """
         Tests that resultCount field value in runData is equal with the
-        number of unique reports in the run.
+        number of unfixed reports in the run.
         """
         test_runs = self.__get_runs()
 
-        unique_filter = ReportFilter(isUnique=True)
+        report_filter = ReportFilter()
+        report_filter.detectionStatus = [DetectionStatus.NEW,
+                                         DetectionStatus.UNRESOLVED,
+                                         DetectionStatus.REOPENED]
+
         for run in test_runs:
             run_count = self._cc_client.getRunResultCount([run.runId],
-                                                          unique_filter,
+                                                          report_filter,
                                                           None)
             self.assertEqual(run.resultCount, run_count)

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -349,7 +349,8 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
         style    : 'width: 300px; padding: 0px;',
         splitter : true,
         parent   : this,
-        diffView : this.newcheck
+        diffView : this.newcheck,
+        openedByUserEvent : this.openedByUserEvent
       });
       this._grid.set('bugFilterView', this._bugFilterView);
       this._bugFilterView.register(this._grid);
@@ -504,8 +505,13 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
       hashHelper.resetStateValues(state);
 
       // If the filter has not been initalized then we should initalize it.
-      if (!this._bugFilterView.isInitalized())
+      if (!this._bugFilterView.isInitalized()) {
+        if (this.baseline && !state.run)
+          state.run = this.baseline;
+        if (this.newcheck && !state.newcheck)
+          state.newcheck = this.newcheck;
         this._bugFilterView.initAll(state);
+      }
 
      //--- Call show method of the selected children ---//
 

--- a/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -16,11 +16,9 @@ define([
   'dijit/layout/BorderContainer',
   'dijit/layout/ContentPane',
   'dojox/grid/DataGrid',
-  'codechecker/hashHelper',
   'codechecker/util'],
 function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
-  RadioButton, TextBox, BorderContainer, ContentPane, DataGrid, hashHelper,
-  util) {
+  RadioButton, TextBox, BorderContainer, ContentPane, DataGrid, util) {
 
   /**
    * This function helps to format a data grid cell with two radio buttons.
@@ -80,7 +78,7 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
       this.structure = [
         { name : 'Diff', field : 'diff', styles : 'text-align: center;', formatter : diffBtnFormatter},
         { name : 'Name', field : 'name', styles : 'text-align: left;', width : '100%' },
-        { name : 'Number of reports', field : 'numberofbugs', styles : 'text-align: center;', width : '20%' },
+        { name : 'Number of unresolved reports', field : 'numberofbugs', styles : 'text-align: center;', width : '20%' },
         { name : 'Storage date', field : 'date', styles : 'text-align: center;', width : '30%' },
         { name : 'Analysis duration', field : 'duration', styles : 'text-align: center;' },
         { name : 'Check command', field : 'checkcmd', styles : 'text-align: center;' },
@@ -116,9 +114,11 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
           if (!evt.target.classList.contains('link'))
             return;
 
-          hashHelper.setStateValues({
-            'run' : item.runData[0].name,
-            'tab' : item.runData[0].name
+          var runName = item.runData[0].name;
+          topic.publish('openRun', {
+            baseline : runName,
+            tabId : runName,
+            openedByUserEvent : true
           });
           break;
 
@@ -259,11 +259,12 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
         class    : 'diff-btn',
         disabled : true,
         onClick  : function () {
-          hashHelper.setStateValues({
-            run : that.baseline.name,
+          var runName = that.baseline.name;
+          topic.publish('openRun', {
+            baseline : that.baseline.name,
             newcheck : that.newcheck.name,
-            difftype : util.diffTypeFromCodeToString(CC_OBJECTS.DiffType.NEW),
-            tab : that.baseline.name + '_diff_' + that.newcheck.name
+            tabId : that.baseline.name + '_diff_' + that.newcheck.name,
+            openedByUserEvent : true
           });
         }
       });

--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -64,16 +64,10 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
     if (newcheck && !(newcheck instanceof Array))
       newcheck = [newcheck];
 
-    var runs = state.tab.split('_diff_');
-    var title = runs.length == 2
-      ? 'Diff of ' + runs[0] + ' and ' + runs[1]
-      : runs[0];
-
     topic.publish('openRun', {
       baseline : baseline,
       newcheck : newcheck,
       tabId    : state.tab,
-      title    : title,
       difftype : state.difftype ? state.difftype : CC_OBJECTS.DiffType.NEW
     });
   }
@@ -155,11 +149,14 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
 
     runsTab.addChild(listOfRuns);
 
+    var state = hashHelper.getState();
+
     var listOfAllReports = new ListOfBugs({
       title : 'All reports',
       iconClass : 'customIcon all-reports',
       allReportView : true,
-      tab : 'allReports'
+      tab : 'allReports',
+      openedByUserEvent : state['tab'] !== 'allReports'
     });
 
     //--- Check static tab ---//
@@ -188,13 +185,19 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
       var newcheck = param.newcheck;
 
       if (!(tabId in runIdToTab)) {
+        var runs = tabId.split('_diff_');
+        var title = runs.length == 2
+          ? 'Diff of ' + runs[0] + ' and ' + runs[1]
+          : runs[0];
+
         runIdToTab[tabId] = new ListOfBugs({
           baseline : param.baseline,
           newcheck : param.newcheck,
-          title : param.title,
+          title : title,
           iconClass : 'customIcon reports',
           closable : true,
           tab : tabId,
+          openedByUserEvent : param.openedByUserEvent,
           onClose : function () {
             delete runIdToTab[tabId];
             return true;

--- a/www/scripts/codecheckerviewer/filter/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/filter/BugFilterView.js
@@ -218,6 +218,15 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
         stateDecoder : function (key) {
           return CC_OBJECTS.ReviewStatus[key.replace(' ', '_').toUpperCase()];
         },
+        defaultValues : function () {
+          var state = {};
+          state[this.class] = [
+            CC_OBJECTS.ReviewStatus.UNREVIEWED,
+            CC_OBJECTS.ReviewStatus.CONFIRMED
+          ].map(this.stateConverter);
+
+          return state;
+        },
         getIconClass : function (value) {
           var statusCode = this.stateDecoder(value);
           return 'customIcon ' + util.reviewStatusCssClass(statusCode);
@@ -260,6 +269,16 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
         },
         stateDecoder : function (key) {
           return CC_OBJECTS.DetectionStatus[key.toUpperCase()];
+        },
+        defaultValues : function () {
+          var state = {};
+          state[this.class] = [
+            CC_OBJECTS.DetectionStatus.NEW,
+            CC_OBJECTS.DetectionStatus.REOPENED,
+            CC_OBJECTS.DetectionStatus.UNRESOLVED
+          ].map(this.stateConverter);
+
+          return state;
         },
         getIconClass : function (value) {
           return 'customIcon detection-status-' + value.toLowerCase();
@@ -530,9 +549,24 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
     initAll : function (queryParams) {
       if (!queryParams) queryParams = {};
 
-      if (!this._isInitalized && !queryParams.newcheck)
-        this._newCheckFilterToggle.hide();
+      if (!this.isInitalized()) {
+        if (!queryParams.newcheck)
+          this._newCheckFilterToggle.hide();
 
+        // Set default values if the tab has not been initalized before and if
+        // it is initalized by user clicks not by the URL.
+        if (this.openedByUserEvent)
+          this._filters.forEach(function (filter) {
+            if (filter.defaultValues) {
+              var defaultValues = filter.defaultValues();
+              for (var key in defaultValues)
+                if (!queryParams[key])
+                  queryParams[key] = defaultValues[key];
+            }
+          });
+      }
+
+      // Init filters by the parameter values.
       this._filters.forEach(function (filter) {
         filter.initByUrl(queryParams);
       });

--- a/www/scripts/codecheckerviewer/filter/UniqueFilter.js
+++ b/www/scripts/codecheckerviewer/filter/UniqueFilter.js
@@ -11,7 +11,7 @@ define([
   'codechecker/filter/FilterBase'],
 function (dom, declare, CheckBox, FilterBase) {
   return declare(FilterBase, {
-    defaultValue : true,
+    defaultValue : false,
 
     postCreate : function () {
       var that = this;
@@ -32,7 +32,7 @@ function (dom, declare, CheckBox, FilterBase) {
 
     initByUrl : function (queryParams) {
       var state = queryParams[this.class];
-      var isUnique = state === 'off' ? false : true;
+      var isUnique = state === 'on' ? true : false;
       this._uniqueCheckBox.set('checked', isUnique, false);
       this.updateReportFilter(isUnique);
     },
@@ -46,7 +46,7 @@ function (dom, declare, CheckBox, FilterBase) {
       var state = {};
 
       var isUnique = this._uniqueCheckBox.get('checked');
-      state[this.class] = isUnique ? null : 'off';
+      state[this.class] = isUnique ? 'on' : null;
 
       return state;
     }

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -616,3 +616,7 @@ html, body {
 .CodeMirror-selection-highlight-scrollbar {
   background-color: green
 }
+
+.checker-statistics-filter .is-unique {
+  margin-left: 10px;
+}


### PR DESCRIPTION
> Closes #1443 and Closes #1541

Consistent report counting
  * `Number of reports` should be `Number of unresolved reports` and should be equal with `non unique all reports - resolved - false positive - intentional`.
  * Disable uniqueing at detection status count on the Runs page.
  * Disable uniqueing at the left hand side filter by default.
  * Set default filter set to the following values:
    - Review status: Unreviewed, Confirmed
    - Detection status: New, Reopened, Unresolved
  * Uniqueing can be disabled at the command line and UI.