### PR TITLE
Don't log linking build actions by default.

### DIFF
--- a/libcodechecker/libhandlers/log.py
+++ b/libcodechecker/libhandlers/log.py
@@ -69,6 +69,13 @@ def add_arguments_to_parser(parser):
                              "'make', but a more complex command, or the call "
                              "of a custom script file is also supported.")
 
+    parser.add_argument('-k', '--keep-link',
+                        dest="keep_link",
+                        default=argparse.SUPPRESS,
+                        action="store_true",
+                        help="If this flag is given then the output log file "
+                             "will contain the linking build actions too.")
+
     parser.add_argument('-q', '--quiet',
                         dest="quiet",
                         action='store_true',
@@ -96,4 +103,5 @@ def main(args):
     build_manager.perform_build_command(args.logfile,
                                         args.command,
                                         context,
+                                        'keep_link' in args,
                                         silent='quiet' in args)

--- a/vendor/build-logger/src/ldlogger-util.c
+++ b/vendor/build-logger/src/ldlogger-util.c
@@ -285,6 +285,18 @@ size_t loggerVectorFind(
   return SIZE_MAX;
 }
 
+size_t loggerVectorFindIf(
+  LoggerVector* vec_,
+  LoggerPredFuc pred_)
+{
+  size_t i;
+  for (i = 0; i < vec_->size; ++i)
+    if (pred_(vec_->data[i]) != 0)
+      return i;
+
+  return SIZE_MAX;
+}
+
 void loggerVectorErase(LoggerVector* vec_, size_t index_)
 {
   size_t i;

--- a/vendor/build-logger/src/ldlogger-util.h
+++ b/vendor/build-logger/src/ldlogger-util.h
@@ -50,6 +50,12 @@ typedef void* (*LoggerDupFuc)(const void*);
 typedef int (*LoggerCmpFuc)(const void*, const void*);
 
 /**
+ * Typedef for predicate function for a vector. This should return 0 if the
+ * condition is not true for the element.
+ */
+typedef int (*LoggerPredFuc)(const void*);
+
+/**
  * A very simple vector.
  */
 typedef struct _LoggerVector 
@@ -148,17 +154,28 @@ int loggerVectorAddUnique(LoggerVector* vec_, void* data_, LoggerCmpFuc cmp_);
 void loggerVectorErase(LoggerVector* vec_, size_t index_);
 
 /**
- * Funds an elemnt using the given comparation fuction.
+ * Finds an element using the given comparation fuction.
  *
  * @param vec_ a vector struct (must be not NULL).
  * @param data_ an item.
  * @param cmp_ a comparation function.
- * @return SIZE_MAX if the element not found otherwise the item`s index
+ * @return SIZE_MAX if the element not found otherwise the item`s index.
  */
 size_t loggerVectorFind(
   LoggerVector* vec_,
   const void* data_,
   LoggerCmpFuc cmp_);
+
+/**
+ * Finds an element using the given predicate fuction.
+ *
+ * @param vec_ a vector struct (must be not NULL).
+ * @param pred_ a predicate function.
+ * @return SIZE_MAX if the element not found otherwise the item`s index.
+ */
+size_t loggerVectorFindIf(
+  LoggerVector* vec_,
+  LoggerPredFuc pred_);
 
 /**
  * An strdup implementation (its not in ANSI C).


### PR DESCRIPTION
The logger can be given a flag if the user wants to keep the linking
actions in the compilation database.