### PR TITLE
Create local auth session by database session

### DIFF
--- a/config_db_migrate/versions/6b9f832d0b20_add_user_name_and_group_to_session.py
+++ b/config_db_migrate/versions/6b9f832d0b20_add_user_name_and_group_to_session.py
@@ -1,0 +1,38 @@
+"""Add user name and group to session
+
+Revision ID: 6b9f832d0b20
+Revises: bb5278995f41
+Create Date: 2018-03-13 10:44:38.446589
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6b9f832d0b20'
+down_revision = 'bb5278995f41'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('user_sessions',
+        sa.Column('user_name', sa.String(), nullable=False),
+        sa.Column('token', sa.CHAR(length=32), nullable=False),
+        sa.Column('groups', sa.String(), nullable=True),
+        sa.Column('last_access', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('user_name', name=op.f('pk_user_sessions')))
+    op.create_index(op.f('ix_user_sessions_token'),
+                    'user_sessions', ['token'], unique=False)
+    op.drop_table('sessions')
+
+
+def downgrade():
+    op.create_table('sessions',
+        sa.Column('auth_string', sa.CHAR(length=64), nullable=False),
+        sa.Column('token', sa.CHAR(length=32), nullable=False),
+        sa.Column('last_access', sa.DATETIME(), nullable=False),
+        sa.PrimaryKeyConstraint('auth_string', name=u'pk_sessions'))
+    op.drop_index(op.f('ix_user_sessions_token'), table_name='user_sessions')
+    op.drop_table('user_sessions')

--- a/libcodechecker/server/database/config_db_model.py
+++ b/libcodechecker/server/database/config_db_model.py
@@ -113,17 +113,20 @@ class ProductPermission(Base):
 
 
 class Session(Base):
-    __tablename__ = 'sessions'
+    __tablename__ = 'user_sessions'
 
-    # Auth-String is a SHA-256 hash, while token is a Python UUID which is
-    # 32 characters (both in hex expanded format).
-    auth_string = Column(CHAR(64), nullable=False, primary_key=True)
-    token = Column(CHAR(32), nullable=False)
+    user_name = Column(String, primary_key=True)
+    token = Column(CHAR(32), nullable=False, index=True)
+
+    # List of group names separated by semicolons.
+    groups = Column(String)
+
     last_access = Column(DateTime, nullable=False)
 
-    def __init__(self, auth_string, token):
-        self.auth_string = auth_string
+    def __init__(self, token, user_name, groups):
         self.token = token
+        self.user_name = user_name
+        self.groups = groups
         self.last_access = datetime.now()
 
 

--- a/tests/functional/products/test_config_db_share.py
+++ b/tests/functional/products/test_config_db_share.py
@@ -19,6 +19,8 @@ import subprocess
 import time
 import unittest
 
+from shared.ttypes import Permission
+
 from ProductManagement_v6.ttypes import ProductConfiguration
 from ProductManagement_v6.ttypes import DatabaseConnection
 
@@ -94,6 +96,12 @@ class TestProductConfigShare(unittest.TestCase):
         # Create a SUPERUSER login.
         root_token = self._auth_client.performLogin("Username:Password",
                                                     "root:root")
+
+        ret = self._auth_client.addPermission(Permission.SUPERUSER,
+                                              "root",
+                                              False,
+                                              "")
+        self.assertTrue(ret)
 
         # Setup a product client to test product API calls.
         self._pr_client = env.setup_product_client(self.test_workspace_main)


### PR DESCRIPTION
Store user specific information in the database (user name, groups) to create local session objects. This way if the user has a valid session token there is no need to login again on server restart.