### PR TITLE
Fix diff view

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -441,8 +441,15 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           sortMode.type = CC_OBJECTS.SortType.BUG_PATH_LENGTH;
           sortMode.ord = CC_OBJECTS.Order.ASC;
 
+          // Get run ids by the filter set.
+          var runIds = [];
           var opt = that._bugFilterView.initReportFilterOptions();
-          reports = CC_SERVICE.getRunResults(opt.runIds,
+          if (opt.runIds)
+            runIds = runIds.concat(opt.runIds);
+          if (opt.cmpData && opt.cmpData.runIds)
+            runIds = runIds.concat(opt.cmpData.runIds);
+
+          reports = CC_SERVICE.getRunResults(runIds.length ? runIds : null,
             CC_OBJECTS.MAX_QUERY_SIZE, 0, [sortMode], reportFilter, null);
           reportData = reports[0];
         }


### PR DESCRIPTION
> Closes #1466

In diff mode we should get the report data based on baseline and newcheck run ids.