### PR TITLE
Support old suppress comment format files

### DIFF
--- a/libcodechecker/suppress_file_handler.py
+++ b/libcodechecker/suppress_file_handler.py
@@ -73,7 +73,8 @@ def get_suppress_data(suppress_file):
             LOG.debug(new_format_match)
             suppress_data.append((new_format_match['bug_hash'],
                                   new_format_match['file_name'],
-                                  new_format_match['comment']))
+                                  new_format_match['comment'],
+                                  'false_positive'))
             continue
 
         old_format_match = re.match(old_format, line.strip())
@@ -83,7 +84,8 @@ def get_suppress_data(suppress_file):
             LOG.debug(old_format_match)
             suppress_data.append((old_format_match['bug_hash'],
                                   u'',  # empty file name
-                                  old_format_match['comment']))
+                                  old_format_match['comment'],
+                                  'false_positive'))
             continue
 
         if line.strip() != '':

--- a/tests/functional/suppress/test_suppress_generation.py
+++ b/tests/functional/suppress/test_suppress_generation.py
@@ -144,7 +144,20 @@ class TestSuppress(unittest.TestCase):
         with open(os.path.join(self._test_project_path,
                                "suppress.expected"), 'r') as expected:
             for line in expected:
-                bug_hash, _, msg, status = line.strip().split('||')
+                src_code_info = line.strip().split('||')
+
+                status = None
+                if len(src_code_info) == 4:
+                    # Newest source code comment format where status is given.
+                    bug_hash, _, msg, status = src_code_info
+                elif len(src_code_info) == 3:
+                    # Old format where review status is not given.
+                    bug_hash, _, msg = src_code_info
+                else:
+                    # Oldest source code comment format where status and file
+                    # name are not given.
+                    bug_hash, msg = src_code_info
+
                 rw_status = ReviewStatus.FALSE_POSITIVE
                 if status == 'confirmed':
                     rw_status = ReviewStatus.CONFIRMED

--- a/tests/projects/suppress/suppress.expected
+++ b/tests/projects/suppress/suppress.expected
@@ -1,4 +1,4 @@
-0c07579523063acece2d7aebd4357cac||suppress.cpp||foo1 simple||false_positive
+0c07579523063acece2d7aebd4357cac||suppress.cpp||foo1 simple
 b206288036d43d440f69305429b5b067||suppress.cpp||foo2 simple||false_positive
 89eed80408973acac30e341779bb6e38||suppress.cpp||foo3 simple||intentional
 2bc45246974627658e7042371c9ccc76||suppress.cpp||foo4 simple||confirmed


### PR DESCRIPTION
* Add new test case to test old source code comment file format.
* If status is not found in the source code comment file use `false_positive` by default.