### PR TITLE
Exclude build actions which would compile a header file.

### DIFF
--- a/vendor/build-logger/src/ldlogger-tool-gcc.c
+++ b/vendor/build-logger/src/ldlogger-tool-gcc.c
@@ -35,7 +35,7 @@ typedef enum _GccArgsState
  * List of file extensions accepted as source file.
  */
 static const char* const srcExts[] = {
-  "c", "cc", "cpp", "cxx", "h", "hh", "hxx", "hpp", "o", "so", "a", NULL
+  "c", "cc", "cpp", "cxx", "o", "so", "a", NULL
 };
 
 /**


### PR DESCRIPTION
When the build command contains a --include flag with a header file as a
parameter then another build action will belong to that header too. This
is unnecessary, so we include these in this commit.