### PR TITLE
Do not show false positive and intentional bugs at parse

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -42,7 +42,8 @@ from libcodechecker import util
 from libcodechecker.logger import get_logger
 from libcodechecker.report import Report
 from libcodechecker.report import generate_report_hash
-from libcodechecker.source_code_comment_handler import SourceCodeCommentHandler
+from libcodechecker.source_code_comment_handler import \
+    SourceCodeCommentHandler, skip_suppress_status
 
 LOG = get_logger('report')
 
@@ -400,17 +401,19 @@ class PlistToPlaintextFormatter(object):
                 checker_name)
 
             if len(src_comment_data) == 1:
+                status = src_comment_data[0]['status']
+
                 LOG.debug("Suppressed by source code comment.")
                 if self.src_comment_handler:
                     file_name = os.path.basename(source_file)
                     message = src_comment_data[0]['message']
-                    status = src_comment_data[0]['status']
                     self.src_comment_handler.store_suppress_bug_id(
                         report_hash,
                         file_name,
                         message,
                         status)
-                continue
+                if skip_suppress_status(status):
+                    continue
             elif len(src_comment_data) > 1:
                 LOG.warning("Multiple source code comment can be found "
                             "for '{0}' checker in '{1}' at line {2}. "

--- a/libcodechecker/generic_package_suppress_handler.py
+++ b/libcodechecker/generic_package_suppress_handler.py
@@ -11,7 +11,7 @@ import os
 
 from libcodechecker import suppress_file_handler
 from libcodechecker.source_code_comment_handler import \
-    BaseSourceCodeCommentHandler
+    BaseSourceCodeCommentHandler, skip_suppress_status
 from libcodechecker.logger import get_logger
 
 # Warning! this logger should only be used in this module.
@@ -82,4 +82,5 @@ class GenericSuppressHandler(BaseSourceCodeCommentHandler):
 
         return any([suppress for suppress in self.__suppress_info
                     if suppress[0] == bug['hash_value'] and
-                    suppress[1] == os.path.basename(bug['file_path'])])
+                    suppress[1] == os.path.basename(bug['file_path']) and
+                    skip_suppress_status(suppress[3])])

--- a/libcodechecker/source_code_comment_handler.py
+++ b/libcodechecker/source_code_comment_handler.py
@@ -16,6 +16,19 @@ from libcodechecker.logger import get_logger
 LOG = get_logger('system')
 
 
+def skip_suppress_status(status):
+    """
+    Returns True if the given status is in the skip list, otherwise False.
+    """
+
+    # Note: codechecker_suppress source code comment will be also
+    # marked as false_positive.
+    skip_suppress_statuses = ['false_positive',
+                              'intentional']
+
+    return status in skip_suppress_statuses
+
+
 class BaseSourceCodeCommentHandler(object):
     """ Source code handler base class. """
 

--- a/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/tests/functional/analyze_and_parse/test_files/Makefile
@@ -12,3 +12,5 @@ tidy_check:
 	$(CXX) -w tidy_check.cpp -o /dev/null
 saargs_forward:
 	$(CXX) -w -std=c++11 saargs_forward.cpp -o /dev/null
+source_code_comments:
+	$(CXX) -w source_code_comments.cpp -o /dev/null

--- a/tests/functional/analyze_and_parse/test_files/source_code_comments.cpp
+++ b/tests/functional/analyze_and_parse/test_files/source_code_comments.cpp
@@ -1,0 +1,16 @@
+int main()
+{
+  // codechecker_suppress [all] Source code comment message
+  sizeof(40);
+
+  // codechecker_false_positive [all] Source code comment message
+  sizeof(41);
+
+  // codechecker_intentional [all] Source code comment message
+  sizeof(42);
+
+  // codechecker_confirmed [all] Source code comment message
+  sizeof(43);
+
+  return 0;
+}

--- a/tests/functional/analyze_and_parse/test_files/source_code_comments.output
+++ b/tests/functional/analyze_and_parse/test_files/source_code_comments.output
@@ -1,0 +1,40 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make source_code_comments" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make source_code_comments" --output $OUTPUT$ --quiet --analyzers clang-tidy
+--------------------------------------------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clang-tidy analyzed source_code_comments.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total analyzed compilation commands: 1
+[] - Successfully analyzed
+[] -   clang-tidy: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[HIGH] source_code_comments.cpp:13:3: suspicious usage of 'sizeof(K)'; did you mean 'K'? [misc-sizeof-expression]
+  sizeof(43);
+  ^
+
+Found 1 defect(s) while analyzing source_code_comments.cpp
+
+
+----==== Summary ====----
+---------------------------------------
+Filename                 | Report count
+---------------------------------------
+source_code_comments.cpp |            1
+---------------------------------------
+-----------------------
+Severity | Report count
+-----------------------
+HIGH     |            1
+-----------------------
+----=================----
+Total number of reports: 1
+----=================----


### PR DESCRIPTION
> Closes #1484

Do not show bugs which was suppressed as `false poistive` or `intentional` in the source code when using the `parse` command.