### PR TITLE
Use cogwheel for filter option icon

### DIFF
--- a/www/scripts/codecheckerviewer/filter/SelectFilter.js
+++ b/www/scripts/codecheckerviewer/filter/SelectFilter.js
@@ -69,7 +69,7 @@ function (declare, dom, Standby, ContentPane, FilterBase, FilterTooltip,
       //--- Filter options ---//
 
       this._edit = dom.create('span', {
-        class : 'customIcon edit',
+        class : 'customIcon cogwheel',
         onclick : function () {
           that._filterTooltip.show();
         }

--- a/www/style/bugfilter.css
+++ b/www/style/bugfilter.css
@@ -98,13 +98,8 @@
   display: none;
 }
 
-.bug-filters .edit::before {
-  content: "\e01c";
-  color: #878d96;
-}
-
 .bug-filters .clean,
-.bug-filters .edit{
+.bug-filters .cogwheel {
   cursor: pointer;
 }
 

--- a/www/style/icons.css
+++ b/www/style/icons.css
@@ -126,6 +126,11 @@
   content: "\e003";
 }
 
+.customIcon.cogwheel:before {
+  content: "\e01c";
+  color: #878d96;
+}
+
 /* Review Status */
 
 .review-status-unreviewed::before {


### PR DESCRIPTION
During CSS code refactoring (#1495) pencil icon was used instead of cogwheel for filter option icons.