### PR TITLE
Show bug path length for a report

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -625,7 +625,7 @@ class ThriftRequestHandler(object):
                 reviewData=create_review_data(review_status),
                 detectionStatus=detection_status_enum(report.detection_status),
                 detectedAt=str(report.detected_at),
-                fixedAt=str(report.fixed_at))
+                fixedAt=str(report.fixed_at) if report.fixed_at else None)
 
     @exc_to_thrift_reqfail
     @timeit
@@ -849,7 +849,7 @@ class ThriftRequestHandler(object):
                                    detectionStatus=detection_status_enum(
                                        d_status),
                                    detectedAt=str(detected_at),
-                                   fixedAt=str(fixed_at),
+                                   fixedAt=str(fixed_at) if fixed_at else None,
                                    bugPathLength=bug_path_len))
 
             return results

--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -606,7 +606,14 @@ function (declare, domClass, dom, style, fx, Toggler, keys, on, query, Memory,
         function (result) {
           result.sort(function (r1, r2) {
             // Order reports by line.
-            return r1.line - r2.line;
+            if (r1.line < r2.line) return -1;
+            if (r1.line > r2.line) return 1;
+
+            // Order report by bug path length if lines are same.
+            if (r1.bugPathLength < r2.bugPathLength) return -1;
+            if (r1.bugPathLength > r2.bugPathLength) return 1;
+
+            return 0;
           }).forEach(function (report) { that._addReport(report); });
 
           that.bugStore.query({ parent : 'root' }).forEach(function (severity) {

--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -219,13 +219,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
 
   function bugPathLengthFormatter(length) {
     var d = dom.create('span', { innerHTML : length, class : 'length' });
-
-    // This value says that bug path length with this value and above are
-    // difficult to understand. The background color of these bug path lengths
-    // will be red.
-    var bugPathLengthLimit = 20;
-    var blendColor = util.generateRedGreenGradientColor(length,
-        bugPathLengthLimit, 0.5);
+    var blendColor = util.getBugPathLenColor(length);
     style.set(d, 'background-color', blendColor);
 
     return d.outerHTML;

--- a/www/scripts/codecheckerviewer/util.js
+++ b/www/scripts/codecheckerviewer/util.js
@@ -124,6 +124,17 @@ function (locale, dom, style, json) {
        + ',' + opacity + ')';
     },
 
+    getBugPathLenColor : function (length, bugPathLengthLimit) {
+      // This value says that bug path length with this value and above are
+      // difficult to understand. The background color of these bug path lengths
+      // will be red.
+      if (bugPathLengthLimit === undefined)
+        bugPathLengthLimit = 20;
+
+      return this.generateRedGreenGradientColor(length,
+        bugPathLengthLimit, 0.5);
+    },
+
     /**
      * Converts the given number of seconds into a more human-readable
      * 'hh:mm:ss' format.

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -602,3 +602,9 @@ html, body {
   display: block;
   text-align: center;
 }
+
+.same-report-selector .bug-path-length,
+.dijitTree .bug-path-length,
+.dijitTooltip .bug-path-length {
+  padding: 0px 4px;
+}


### PR DESCRIPTION
> Closes #1505

Show bug path length for a report in bug report selection at bug tree and same report selector.

Screenshots:
![cc_bug_path_len1](https://user-images.githubusercontent.com/6695818/38612123-fee17de0-3d85-11e8-8bbe-86d53b6d4c19.png)

![cc_bug_path_len2](https://user-images.githubusercontent.com/6695818/38612128-02058ad4-3d86-11e8-8529-8b1cad424aa7.png)

