### PR TITLE
Allow more product endpoint names to be valid

### DIFF
--- a/libcodechecker/server/routing.py
+++ b/libcodechecker/server/routing.py
@@ -47,9 +47,7 @@ def is_valid_product_endpoint(uripart):
     if uripart in NON_PRODUCT_ENDPOINTS:
         return False
 
-    # Like programming variables: begin with letter and then letters, numbers,
-    # underscores.
-    pattern = r'^[A-Za-z][A-Za-z0-9_]*$'
+    pattern = r'^[A-Za-z0-9_]+$'
     if not re.match(pattern, uripart):
         return False
 

--- a/tests/functional/products/test_products.py
+++ b/tests/functional/products/test_products.py
@@ -99,14 +99,6 @@ class TestProducts(unittest.TestCase):
         product_cfg.connection = dbc
 
         with self.assertRaises(RequestFailed):
-            product_cfg.endpoint = "_INVALID"
-            self._root_client.addProduct(product_cfg)
-
-        with self.assertRaises(RequestFailed):
-            product_cfg.endpoint = "0foobar"
-            self._root_client.addProduct(product_cfg)
-
-        with self.assertRaises(RequestFailed):
             product_cfg.endpoint = "$$$$$$$"
             self._root_client.addProduct(product_cfg)
 


### PR DESCRIPTION
Product endpoint names can be started with digits or underscores.