### PR TITLE
[cmd] Redirect output to stderr if the output format is not table

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyzer_version.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzer_version.py
@@ -86,6 +86,12 @@ def main(args):
     Get and print the version information from the version config
     file and Thrift API definition.
     """
-    logger.setup_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    logger.setup_logger(args.verbose if 'verbose' in args else None, stream)
 
     print_version(args.output_format)

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -99,7 +99,13 @@ def main(args):
     """
     List the analyzers' basic information supported by CodeChecker.
     """
-    logger.setup_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    logger.setup_logger(args.verbose if 'verbose' in args else None, stream)
 
     context = analyzer_context.get_context()
     working, errored = \

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -116,7 +116,13 @@ def main(args):
     alongside with their description or enabled status in various formats.
     """
 
-    logger.setup_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    logger.setup_logger(args.verbose if 'verbose' in args else None, stream)
 
     # If nothing is set, list checkers for all supported analyzers.
     analyzers = args.analyzers \

--- a/codechecker_common/logger.py
+++ b/codechecker_common/logger.py
@@ -146,11 +146,13 @@ class LOG_CFG_SERVER(object):
             self.log_server.join()
 
 
-def setup_logger(log_level=None):
+def setup_logger(log_level=None, stream=None):
     """
     Modifies the log configuration.
     Overwrites the log levels for the loggers and handlers in the
     configuration.
+    Redirects the output of all handlers to the given stream. Short names can
+    be given (stderr -> ext://sys.stderr, 'stdout' -> ext://sys.stdout).
     """
 
     LOG_CONFIG = json.loads(DEFAULT_LOG_CONFIG)
@@ -166,5 +168,17 @@ def setup_logger(log_level=None):
             LOG_CONFIG['handlers'][k]['level'] = log_level
             if log_level == 'DEBUG' or log_level == 'DEBUG_ANALYZER':
                 LOG_CONFIG['handlers'][k]['formatter'] = 'precise'
+
+    if stream:
+        if stream == 'stderr':
+            stream = 'ext://sys.stderr'
+        elif stream == 'stdout':
+            stream = 'ext://sys.stdout'
+
+        handlers = LOG_CONFIG.get("handlers", {})
+        for k in handlers.keys():
+            handler = LOG_CONFIG['handlers'][k]
+            if 'stream' in handler:
+                handler['stream'] = stream
 
     config.dictConfig(LOG_CONFIG)

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -243,8 +243,13 @@ def add_filter_conditions(client, report_filter, args):
 
 
 def handle_list_runs(args):
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
 
-    init_logger(args.verbose if 'verbose' in args else None)
+    init_logger(args.verbose if 'verbose' in args else None, stream)
 
     client = setup_client(args.product_url)
 
@@ -293,7 +298,14 @@ def handle_list_runs(args):
 
 
 def handle_list_results(args):
-    init_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    init_logger(args.verbose if 'verbose' in args else None, stream)
+
     check_deprecated_arg_usage(args)
 
     client = setup_client(args.product_url)
@@ -352,8 +364,14 @@ def handle_list_results(args):
 
 
 def handle_diff_results(args):
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
 
-    init_logger(args.verbose if 'verbose' in args else None)
+    init_logger(args.verbose if 'verbose' in args else None, stream)
+
     check_deprecated_arg_usage(args)
 
     f_severities, f_checkers, f_file_path, _, _ = check_filter_values(args)
@@ -1239,7 +1257,13 @@ def handle_login(args):
 
 
 def handle_list_run_histories(args):
-    init_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    init_logger(args.verbose if 'verbose' in args else None, stream)
 
     client = setup_client(args.product_url)
     run_ids = None

--- a/web/client/codechecker_client/product_client.py
+++ b/web/client/codechecker_client/product_client.py
@@ -36,7 +36,13 @@ def init_logger(level, logger_name='system'):
 
 def handle_list_products(args):
 
-    init_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    init_logger(args.verbose if 'verbose' in args else None, stream)
 
     protocol, host, port = split_server_url(args.server_url)
     client = setup_product_client(protocol, host, port)

--- a/web/client/codechecker_client/source_component_client.py
+++ b/web/client/codechecker_client/source_component_client.py
@@ -73,7 +73,13 @@ def handle_add_component(args):
 
 
 def handle_list_components(args):
-    init_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    init_logger(args.verbose if 'verbose' in args else None, stream)
 
     client = setup_client(args.product_url)
     components = client.getSourceComponents(None)

--- a/web/client/codechecker_client/token_client.py
+++ b/web/client/codechecker_client/token_client.py
@@ -47,7 +47,13 @@ def handle_list_tokens(args):
     """
     List personal access tokens of the currently logged in user.
     """
-    init_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    init_logger(args.verbose if 'verbose' in args else None, stream)
 
     protocol, host, port = split_server_url(args.server_url)
     client, curr_token = setup_auth_client(protocol, host, port)

--- a/web/codechecker_web/cmd/web_version.py
+++ b/web/codechecker_web/cmd/web_version.py
@@ -96,6 +96,12 @@ def main(args):
     Get and print the version information from the version config
     file and Thrift API definition.
     """
-    logger.setup_logger(args.verbose if 'verbose' in args else None)
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
+
+    logger.setup_logger(args.verbose if 'verbose' in args else None, stream)
 
     print_version(args.output_format)


### PR DESCRIPTION
> Closes #1453 

Redirect logger's output to the `stderr` if the given output format  is not `table`, so the output of the commands will not be an invalid `json`, `csv`, etc. because of the log messages.