### PR TITLE
Fix non existing filter member

### DIFF
--- a/www/scripts/codecheckerviewer/CheckerStatistics.js
+++ b/www/scripts/codecheckerviewer/CheckerStatistics.js
@@ -175,7 +175,7 @@ function (declare, ItemFileWriteStore, dom, Deferred, all, Memory, Observable,
       // Select runs.
       if (this.filterPane.selectedRuns)
         this.filterPane.selectedRuns.forEach(function (runName) {
-          filter._runNameFilter.select(runName);
+          filter._runBaseLineFilter.select(runName);
         });
 
       switch (evt.cell.field) {
@@ -337,7 +337,7 @@ function (declare, ItemFileWriteStore, dom, Deferred, all, Memory, Observable,
       var item = this.getItem(evt.rowIndex);
 
       var filter = this.bugFilterView;
-      var runNameFilter = filter._runNameFilter;
+      var runNameFilter = filter._runBaseLineFilter;
       var severityFilter = filter._severityFilter;
 
        // Clear the filters.

--- a/www/scripts/codecheckerviewer/RunHistory.js
+++ b/www/scripts/codecheckerviewer/RunHistory.js
@@ -61,7 +61,7 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
       var filter = this.bugFilterView;
       var dateFilter = filter._detectionDateFilter;
       var dsFilter = filter._detectionStatusFilter;
-      var runFilter = filter._runNameFilter;
+      var runFilter = filter._runBaseLineFilter;
 
       Object.keys(historyGroupByDate).forEach(function (key) {
         var group = dom.create('div', { class : 'history-group' }, that.domNode);
@@ -114,8 +114,8 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
       var filter = this.bugFilterView;
       this.bugFilterView.clearAll();
 
-      if (filter._runNameFilter)
-        filter._runNameFilter.select(item.runName);
+      if (filter._runBaseLineFilter)
+        filter._runBaseLineFilter.select(item.runName);
 
       if (!item.versionTag) {
         [


### PR DESCRIPTION
> Closes #1481

`_runNameFilter` member has been renamed to `_runBaseLineFilter` at `BugFilterView.js` (#1510) but in some places (CheckerStatistics, RunHistory) we forgot to use the new member.