### PR TITLE
fix review status comment typo handling

### DIFF
--- a/libcodechecker/source_code_comment_handler.py
+++ b/libcodechecker/source_code_comment_handler.py
@@ -8,6 +8,7 @@ Source code comment handling.
 """
 
 import abc
+import os
 import re
 
 from libcodechecker import util
@@ -193,8 +194,15 @@ class SourceCodeCommentHandler(object):
             if has_any_marker:
                 rev = list(reversed(curr_suppress_comment))
                 suppress_comment = ''.join(rev).replace('//', '')
-                source_line_comments.append(
-                    self.__process_source_line_comment(suppress_comment))
+                comment = self.__process_source_line_comment(suppress_comment)
+                if comment:
+                    source_line_comments.append(comment)
+                else:
+                    _, file_name = os.path.split(source_file)
+                    LOG.warning(
+                        "Misspelled review status comment in %s@%d: %s",
+                        file_name, previous_line_num, ' '.join(rev))
+
                 curr_suppress_comment = []
 
             if previous_line_num > 0:

--- a/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/tests/functional/analyze_and_parse/test_files/Makefile
@@ -1,5 +1,7 @@
 multi_error_suppress:
 	$(CXX) -w multi_error_suppress.cpp -o /dev/null
+multi_error_suppress_typo:
+	$(CXX) -w multi_error_suppress_typo.cpp -o /dev/null
 multi_error:
 	$(CXX) -w multi_error.cpp -o /dev/null
 nofail:

--- a/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.cpp
+++ b/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.cpp
@@ -1,0 +1,15 @@
+int* foo() {
+  int x = 42;
+  return &x;
+}
+
+int main() {
+  int y;
+
+  // codechecker_suppressssss [all] some comment
+  y = 7;
+  int* x = foo();
+  y = 10;
+
+  return y + *x;
+}

--- a/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
+++ b/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
@@ -1,0 +1,46 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error_suppress_typo" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make multi_error_suppress_typo" --output $OUTPUT$ --quiet --analyzers clangsa
+-----------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed multi_error_suppress_typo.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total analyzed compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[HIGH] multi_error_suppress_typo.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
+  return &x;
+  ^
+
+[] - Misspelled review status comment in multi_error_suppress_typo.cpp@9: // codechecker_suppressssss [all] some comment
+[LOW] multi_error_suppress_typo.cpp:10:3: Value stored to 'y' is never read [deadcode.DeadStores]
+  y = 7;
+  ^
+
+Found 2 defect(s) while analyzing multi_error_suppress_typo.cpp
+
+
+----==== Summary ====----
+--------------------------------------------
+Filename                      | Report count
+--------------------------------------------
+multi_error_suppress_typo.cpp |            2
+--------------------------------------------
+-----------------------
+Severity | Report count
+-----------------------
+HIGH     |            1
+LOW      |            1
+-----------------------
+----=================----
+Total number of reports: 2
+----=================----


### PR DESCRIPTION
If the valid review status comment is part of the misspelled
review status comment it will be detected as a mark but parsing the
comment will fail.