### PR TITLE
Issues with relative path in the compile json

### DIFF
--- a/libcodechecker/analyze/log_parser.py
+++ b/libcodechecker/analyze/log_parser.py
@@ -266,7 +266,18 @@ def parse_compile_commands_json(logfile, parseLogOptions):
         results = option_parser.parse_options(command)
 
         action.original_command = command
-        action.analyzer_options = results.compile_opts
+
+        # If the original include directory could not be found
+        # in the filesystem, it is possible that it was provided
+        # relative to the working directory in the compile json.
+        compile_opts = results.compile_opts
+        for i, opt in enumerate(compile_opts):
+            if opt.startswith('-I'):
+                inc_dir = opt[2:].strip()
+                if not os.path.isdir(inc_dir):
+                    compile_opts[i] = '-I' + \
+                        os.path.join(entry['directory'], inc_dir)
+        action.analyzer_options = compile_opts
 
         action.lang = results.lang
         action.target = results.arch

--- a/tests/unit/logparser_test_files/include.json
+++ b/tests/unit/logparser_test_files/include.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ -I ../include -I../include -I/tmp /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	}
+]

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -17,7 +17,7 @@ from libcodechecker.libhandlers.analyze import ParseLogOptions
 
 class LogParserTest(unittest.TestCase):
     """
-    Test the log parser which convers logfiles (JSON CCDBs) to build action
+    Test the log parser which converts logfiles (JSON CCDBs) to build action
     lists.
     """
 
@@ -203,3 +203,17 @@ class LogParserTest(unittest.TestCase):
                                                    ParseLogOptions())
         for build_action in build_actions:
             self.assertTrue(build_action.skip)
+
+    def test_include_rel_to_abs(self):
+        """
+        Test working directory prepending to non-existent
+        (probably relative) include paths.
+        """
+        logfile = os.path.join(self.__test_files, "include.json")
+
+        build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
+
+        self.assertEqual(len(build_action.analyzer_options), 3)
+        self.assertEqual(build_action.analyzer_options[0], '-I/tmp/../include')
+        self.assertEqual(build_action.analyzer_options[1], '-I/tmp/../include')
+        self.assertEqual(build_action.analyzer_options[2], '-I/tmp')


### PR DESCRIPTION
If the logged build command contains an include like "-I relative_path", it is logged into the compile.json as relative to the build directory. However, if other CodeChecker commands try to use this compile.json outside the build directory, includes with relative path will not be available at the defined location. This fix tries to solve this by prepending the build directory if the include path does not represent a directory on the disk.