### PR TITLE
Fix UI filter tooltip toggling items

### DIFF
--- a/www/scripts/codecheckerviewer/filter/FilterTooltip.js
+++ b/www/scripts/codecheckerviewer/filter/FilterTooltip.js
@@ -143,14 +143,14 @@ function (declare, domClass, dom, keys, Standby, TextBox, popup, Tooltip,
 
     // Toggle a filter item.
     toggle : function (value, item) {
+      if (this.itemsDom[value])
+        domClass.toggle(this.itemsDom[value], 'selected');
+
       // Select or deselect the filter item on the filter view.
       if (this.reportFilter.isSelected(value))
         this.reportFilter.deselect(value);
       else
         this.reportFilter.select(value, item);
-
-      if (this.itemsDom[value])
-        domClass.toggle(this.itemsDom[value], 'selected');
 
       // Store the changes to identify if some new actions (add/remove filter
       // items) are made during the tooltip show and hide events. If the item


### PR DESCRIPTION
If an item is selected and the user clicks on that item to deselect it we should first toggle the class of the tooltip item because deselecting the filter item will call the deselect of the tooltip item which cause bad behaviour.