### PR TITLE
Disable detection status counts in unique mode

### DIFF
--- a/www/scripts/codecheckerviewer/filter/DetectionStatusFilter.js
+++ b/www/scripts/codecheckerviewer/filter/DetectionStatusFilter.js
@@ -1,0 +1,89 @@
+// -------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -------------------------------------------------------------------------
+
+define([
+  'dojo/dom-construct',
+  'dojo/dom-class',
+  'dojo/_base/declare',
+  'dojo/Deferred',
+  'codechecker/filter/SelectFilter',
+  'codechecker/util'],
+function (dom, domClass, declare, Deferred, SelectFilter, util) {
+  return declare(SelectFilter, {
+    notAvailableMsg : 'Not available in uniqueing mode! Several detection '
+                    + 'statuses could belong to the same bug!',
+
+    postCreate : function () {
+      this.inherited(arguments);
+
+      this._notAvailable = dom.create('i', {
+        class : 'customIcon warn hide',
+        title : this.notAvailableMsg
+      }, this._title, 'after');
+    },
+
+    stateConverter : function (value) {
+      var status = util.enumValueToKey(
+        CC_OBJECTS.DetectionStatus, parseInt(value));
+      return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+    },
+    stateDecoder : function (key) {
+      return CC_OBJECTS.DetectionStatus[key.toUpperCase()];
+    },
+    defaultValues : function () {
+      var state = {};
+      state[this.class] = [
+        CC_OBJECTS.DetectionStatus.NEW,
+        CC_OBJECTS.DetectionStatus.REOPENED,
+        CC_OBJECTS.DetectionStatus.UNRESOLVED
+      ].map(this.stateConverter);
+
+      return state;
+    },
+    getIconClass : function (value) {
+      return 'customIcon detection-status-' + value.toLowerCase();
+    },
+    getItems : function (opt) {
+      opt = this.parent.initReportFilterOptions(opt);
+      opt.reportFilter.detectionStatus = null;
+
+      var deferred = new Deferred();
+
+      if (opt.reportFilter.isUnique) {
+        var count = '<span title="' + this.notAvailableMsg + '">N/A</span>'
+        return deferred.resolve(Object.keys(CC_OBJECTS.DetectionStatus).map(
+        function (key) {
+          var value = CC_OBJECTS.DetectionStatus[key];
+          return {
+            value : util.detectionStatusFromCodeToString(value),
+            count : count
+          };
+        }));
+      }
+
+      CC_SERVICE.getDetectionStatusCounts(opt.runIds, opt.reportFilter,
+      opt.cmpData, function (res) {
+        deferred.resolve(Object.keys(CC_OBJECTS.DetectionStatus).map(
+          function (key) {
+            var value = CC_OBJECTS.DetectionStatus[key];
+            return {
+              value : util.detectionStatusFromCodeToString(value),
+              count : res[value] !== undefined ? res[value] : 0
+            };
+        }));
+      });
+      return deferred;
+    },
+
+    notAvailable : function () {
+      domClass.remove(this._notAvailable, 'hide');
+    },
+
+    available : function () {
+      domClass.add(this._notAvailable, 'hide');
+    },
+  });
+});

--- a/www/scripts/codecheckerviewer/filter/UniqueFilter.js
+++ b/www/scripts/codecheckerviewer/filter/UniqueFilter.js
@@ -42,11 +42,13 @@ function (dom, declare, CheckBox, FilterBase) {
       this._uniqueCheckBox.set('checked', this.defaultValue, false);
     },
 
+    isUnique : function () {
+      return this._uniqueCheckBox.get('checked');
+    },
+
     getUrlState : function () {
       var state = {};
-
-      var isUnique = this._uniqueCheckBox.get('checked');
-      state[this.class] = isUnique ? 'on' : null;
+      state[this.class] = this.isUnique() ? 'on' : null;
 
       return state;
     }

--- a/www/style/bugfilter.css
+++ b/www/style/bugfilter.css
@@ -304,3 +304,8 @@
   letter-spacing: 0.025em;
   cursor: pointer;
 }
+
+.bug-filters .detection-status .warn {
+  color: #e92625;
+  margin-left: 5px;
+}

--- a/www/style/icons.css
+++ b/www/style/icons.css
@@ -189,6 +189,10 @@
   content: "\e013";
 }
 
+.customIcon.warn:before {
+  content: "\e015";
+}
+
 /* Run history */
 
 .customIcon.run-name:before {
@@ -217,7 +221,6 @@
   background-color: #ee8985;
   color: white;
   font-weight: bold;
-
 }
 
 .customIcon.yesterday:before {


### PR DESCRIPTION
> Closes #1513 and Closes #1337

A detection status belongs to a report. If uniqueing is enabled multiple detection statuses can belong to the same bug. With this patch report count for detection status filtering will be disabled if uniqueing is enabled.