### PR TITLE
Show full file path in parse output

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -368,7 +368,7 @@ class PlistToPlaintextFormatter(object):
         fname = os.path.basename(source_file)
         if name:
             return '[%s] %s:%d:%d: %s [%s]' % (severity,
-                                               fname,
+                                               source_file,
                                                loc['line'],
                                                loc['col'],
                                                event['message'],

--- a/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -107,6 +107,17 @@ class AnalyzeParseTestCase(unittest.TestCase):
                 # replace timestamps
                 line = re.sub(r'\[\w+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}\]',
                               '[]', line)
+
+                # Replace full path only to file name on the following
+                # formatted lines:
+                # [severity] /a/b/x.cpp:line:col: message [checker]
+                # The replacement on this line will be the following:
+                # [severity] x.cpp:line:col: message [checker]
+                sep = re.escape(os.sep)
+                line = re.sub(r'^(\[\w+\]\s)(?P<path>.+{0})'
+                              r'(.+\:\d+\:\d+\:\s.*\s\[.*\])$'.format(sep),
+                              r'\1\3', line)
+
                 if not any([line.startswith(prefix) for prefix
                             in skip_prefixes]):
                     post_processed_output.append(line)


### PR DESCRIPTION
> Closes #1559 and Closes #1062

Show full file path in `CodeChecker parse` ouptut.