### PR TITLE
Use file path from main section at plist-to-html

### DIFF
--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -189,7 +189,7 @@ def get_report_data_from_plist(plist, skip_report_handler=None):
                                   'step': index + 1})
 
         reports.append({'events': report_events,
-                        'path': file_path,
+                        'path': source_file,
                         'reportHash': report_hash,
                         'checkerName': checker_name})
 


### PR DESCRIPTION
Plist to HTML parser should use the correct file path from the main section of the report.