### PR TITLE
Set default filter values on run history click

### DIFF
--- a/www/scripts/codecheckerviewer/RunHistory.js
+++ b/www/scripts/codecheckerviewer/RunHistory.js
@@ -117,16 +117,10 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
       if (filter._runBaseLineFilter)
         filter._runBaseLineFilter.select(item.runName);
 
-      if (!item.versionTag) {
-        [
-          CC_OBJECTS.DetectionStatus.NEW,
-          CC_OBJECTS.DetectionStatus.UNRESOLVED,
-          CC_OBJECTS.DetectionStatus.REOPENED
-        ].forEach(function (status) {
-          filter._detectionStatusFilter.select(
-            filter._detectionStatusFilter.stateConverter(status));
-        });
+      filter._detectionStatusFilter.selectDefaultValues();
+      filter._reviewStatusFilter.selectDefaultValues();
 
+      if (!item.versionTag) {
         var date = new Date(item.time.replace(/ /g,'T'));
         filter._detectionDateFilter.initFixedDateInterval(
           this._formatDate(date));

--- a/www/scripts/codecheckerviewer/filter/SelectFilter.js
+++ b/www/scripts/codecheckerviewer/filter/SelectFilter.js
@@ -110,6 +110,18 @@ function (declare, dom, Standby, ContentPane, Tooltip, FilterBase,
       return state;
     },
 
+    defaultValues : function () { return {}; },
+
+    selectDefaultValues : function () {
+      var that = this;
+
+      var values = this.defaultValues();
+      var states = values[this.class];
+      if (!states) return;
+
+      states.forEach(function (status) { that.select(status); });
+    },
+
     // Returns the selected filter item values.
     getSelectedItemValues : function () {
       var keys = Object.keys(this.selectedItems);


### PR DESCRIPTION
If the user clicks on a run history item select default filter values for review status and detection status.