### PR TITLE
Init run filters with the correct values

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -350,7 +350,9 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
         splitter : true,
         parent   : this,
         diffView : this.newcheck,
-        openedByUserEvent : this.openedByUserEvent
+        openedByUserEvent : this.openedByUserEvent,
+        baseline : this.baseline,
+        newcheck : this.newcheck
       });
       this._grid.set('bugFilterView', this._bugFilterView);
       this._bugFilterView.register(this._grid);

--- a/www/scripts/codecheckerviewer/codecheckerviewer.js
+++ b/www/scripts/codecheckerviewer/codecheckerviewer.js
@@ -56,17 +56,9 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
         return;
     }
 
-    var baseline = state.run;
-    if (baseline && !(baseline instanceof Array))
-      baseline = [baseline];
-
-    var newcheck = state.newcheck;
-    if (newcheck && !(newcheck instanceof Array))
-      newcheck = [newcheck];
-
     topic.publish('openRun', {
-      baseline : baseline,
-      newcheck : newcheck,
+      baseline : state.run,
+      newcheck : state.newcheck,
       tabId    : state.tab,
       difftype : state.difftype ? state.difftype : CC_OBJECTS.DiffType.NEW
     });
@@ -182,6 +174,14 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
     topic.subscribe('openRun', function (param) {
       var tabId = param.tabId;
 
+      var baseline = param.baseline;
+      if (baseline && !(baseline instanceof Array))
+        baseline = [baseline];
+
+      var newcheck = param.newcheck;
+      if (newcheck && !(newcheck instanceof Array))
+        newcheck = [newcheck];
+
       if (!(tabId in runIdToTab)) {
         var runs = tabId.split('_diff_');
         var title = runs.length == 2
@@ -189,8 +189,8 @@ function (declare, topic, Dialog, Button, BorderContainer, TabContainer,
           : runs[0];
 
         runIdToTab[tabId] = new ListOfBugs({
-          baseline : param.baseline,
-          newcheck : param.newcheck,
+          baseline : baseline,
+          newcheck : newcheck,
           title : title,
           iconClass : 'customIcon reports',
           closable : true,

--- a/www/scripts/codecheckerviewer/filter/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/filter/BugFilterView.js
@@ -151,6 +151,12 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
       this.register(this._runBaseLineFilter);
       baselineFilterToggle.addChild(this._runBaseLineFilter);
 
+      // Select initial base line values which come from the constructor.
+      if (this.baseline)
+        this.baseline.forEach(function (runName) {
+          that._runBaseLineFilter.select(runName);
+        });
+
       //--- Run history tags filter ---//
 
       this._runHistoryTagFilter = new RunHistoryTagFilter({
@@ -206,6 +212,12 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
       });
       this.register(this._runNewCheckFilter);
       this._newCheckFilterToggle.addChild(this._runNewCheckFilter);
+
+      // Select initial new check values which come from the constructor.
+      if (this.newcheck)
+        this.newcheck.forEach(function (runName) {
+          that._runNewCheckFilter.select(runName);
+        });
 
       //--- Run history tags filter for newcheck ---//
 


### PR DESCRIPTION
If the user clicks on a run at the Run page, it will not filter the results by runs only by other filters. We should set the correct run values in the initialization time when the Bug viewer tab first being opened.