### PR TITLE
Reset URL parameters when history tab is active

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -375,7 +375,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
 
           var state = hashHelper.getState();
 
-          hashHelper.setStateValues({
+          hashHelper.resetStateValues({
             'tab' : state.tab,
             'subtab' : 'runHistory'
           });


### PR DESCRIPTION
> Closes #1392 

Reset URL query parameter values with correct values if Run history tab is active.