### PR TITLE
Fix run filters init

### DIFF
--- a/www/scripts/codecheckerviewer/filter/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/filter/BugFilterView.js
@@ -151,12 +151,6 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
       this.register(this._runBaseLineFilter);
       baselineFilterToggle.addChild(this._runBaseLineFilter);
 
-      // Select initial base line values which come from the constructor.
-      if (this.baseline)
-        this.baseline.forEach(function (runName) {
-          that._runBaseLineFilter.select(runName);
-        });
-
       //--- Run history tags filter ---//
 
       this._runHistoryTagFilter = new RunHistoryTagFilter({
@@ -212,12 +206,6 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
       });
       this.register(this._runNewCheckFilter);
       this._newCheckFilterToggle.addChild(this._runNewCheckFilter);
-
-      // Select initial new check values which come from the constructor.
-      if (this.newcheck)
-        this.newcheck.forEach(function (runName) {
-          that._runNewCheckFilter.select(runName);
-        });
 
       //--- Run history tags filter for newcheck ---//
 
@@ -586,6 +574,18 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
       });
       this.register(this._checkerMessageFilter);
       this.addChild(this._checkerMessageFilter);
+
+      // Select initial base line and new check values which come from the
+      // constructor.
+      if (this.baseline)
+        this.baseline.forEach(function (runName) {
+          that._runBaseLineFilter.select(runName);
+        });
+
+      if (this.newcheck)
+        this.newcheck.forEach(function (runName) {
+          that._runNewCheckFilter.select(runName);
+        });
 
       // Initalize only the current tab.
       if (this.parent.tab === queryParams.tab)


### PR DESCRIPTION
Problem: if the user tries to diff two runs from the Run page gets the following error:
```
Uncaught TypeError: Cannot read property 'defaultDiffType' of undefined
    at Object.updateReportFilter (BugFilterView.js:197)
    at Object.select (SelectFilter.js:206)
    at BugFilterView.js:219
    at Array.forEach (<anonymous>)
    at Object.postCreate (BugFilterView.js:218)
    at Object.create (_WidgetBase.js:84)
    at Object._2ec (dojo.js:15)
    at Object.create (ContentPane.js:17)
    at Object.postscript (_WidgetBase.js:50)
    at new <anonymous> (dojo.js:15)
```
This commit fixes this problem by initializing run filter items based on constructor after filter items are being created.