### PR TITLE
Fix getProducts API function to do exact match

### DIFF
--- a/libcodechecker/libclient/client.py
+++ b/libcodechecker/libclient/client.py
@@ -276,8 +276,11 @@ def setup_client(product_url, product_client=False):
     client = setup_product_client(protocol, host, port, product_name=None)
     product = client.getProducts(product_name, None)
     product_error_str = None
-    if not (product and len(product) == 1):
+    if not product:
         product_error_str = "It does not exist."
+    elif len(product) != 1:
+        product_error_str = "Multiple products can be found with the given " \
+                            "name."
     else:
         if product[0].endpoint != product_name:
             # Only a "substring" match was found. We explicitly reject it

--- a/libcodechecker/server/api/product_server.py
+++ b/libcodechecker/server/api/product_server.py
@@ -23,7 +23,7 @@ from libcodechecker.profiler import timeit
 from libcodechecker.server import permissions
 from libcodechecker.server.database.config_db_model import IDENTIFIER, \
     Product, ProductPermission
-from libcodechecker.server.database.database import SQLServer
+from libcodechecker.server.database.database import SQLServer, conv
 from libcodechecker.server.database.run_db_model import Run
 from libcodechecker.server.routing import is_valid_product_endpoint
 
@@ -197,12 +197,14 @@ class ThriftProductHandler(object):
                                                       in all_products])
 
             if product_endpoint_filter:
-                prods = prods.filter(Product.endpoint.ilike('%{0}%'.format(
-                    util.escape_like(product_endpoint_filter)), escape='*'))
+                prods = prods.filter(Product.endpoint.ilike(
+                    conv(util.escape_like(product_endpoint_filter, '\\')),
+                    escape='\\'))
 
             if product_name_filter:
-                prods = prods.filter(Product.display_name.ilike('%{0}%'.format(
-                    util.escape_like(product_name_filter)), escape='*'))
+                prods = prods.filter(Product.display_name.ilike(
+                    conv(util.escape_like(product_name_filter, '\\')),
+                    escape='\\'))
 
             prods = prods.all()
             for prod in prods:

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -40,6 +40,7 @@ from libcodechecker.report import get_report_path_hash
 from libcodechecker.server import permissions
 from libcodechecker.server.database import db_cleanup
 from libcodechecker.server.database.config_db_model import Product
+from libcodechecker.server.database.database import conv
 from libcodechecker.server.database.run_db_model import \
     Report, ReviewStatus, File, Run, RunHistory, \
     RunLock, Comment, BugPathEvent, BugReportPoint, \
@@ -78,15 +79,6 @@ def exc_to_thrift_reqfail(func):
                                               ex.message)
 
     return wrapper
-
-
-def conv(filter_value):
-    """
-    Convert * to % got from clients for the database queries.
-    """
-    if filter_value is None:
-        return '%'
-    return filter_value.replace('*', '%')
 
 
 def get_component_values(session, component_name):

--- a/libcodechecker/server/database/database.py
+++ b/libcodechecker/server/database/database.py
@@ -575,3 +575,12 @@ class SQLiteDatabase(SQLServer):
 
     def get_db_location(self):
         return self.dbpath
+
+
+def conv(filter_value):
+    """
+    Convert * to % got from clients for the database queries.
+    """
+    if filter_value is None:
+        return '%'
+    return filter_value.replace('*', '%')

--- a/www/scripts/productlist/ListOfProducts.js
+++ b/www/scripts/productlist/ListOfProducts.js
@@ -296,7 +296,7 @@ function (declare, domClass, dom, ItemFileWriteStore, topic, DataGrid,
         }
       });
 
-      this._populateProducts(productNameFilter);
+      this._populateProducts(productNameFilter + '*');
     },
 
     toggleAdminButtons : function (adminLevel) {


### PR DESCRIPTION
`getProducts` API function extended the filters with '%' wildcards. This way we couldn't do exact match on product names and endpoints. Client should set wildcards instead of the server.