### PR TITLE
Remove the build output from the build action hash.

### DIFF
--- a/libcodechecker/log/build_action.py
+++ b/libcodechecker/log/build_action.py
@@ -156,7 +156,6 @@ class BuildAction(object):
         hash_content = []
         hash_content.extend(self.analyzer_options)
         hash_content.append(str(self._analyzer_type))
-        hash_content.append(self.output)
         hash_content.append(self.target)
         hash_content.extend(self.sources)
         return hashlib.sha1(''.join(hash_content)).hexdigest()


### PR DESCRIPTION
Since version 6.3 the build action hash contains the build output, which led to multiple analysis of files with essentially the same build actions compiled into different outputs (due to their different hash). This is unnecessary, since the output does not change the analysis, and results in a performance drawback. Removing the build output from the hash seems to increase the performance without affecting the analysis results.