### PR TITLE
Init filter values on show event of Bug overview

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -111,6 +111,11 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
     query : function (query, options) {
       var deferred = new Deferred();
 
+      // It is possible that this method will be called before we set the
+      // correct filter parameters for example when we first open a run.
+      if (!query.reportFilter)
+        return deferred.reject("ERROR!");
+
       var that = this;
       CC_SERVICE.getRunResults(
         query.runIds,
@@ -332,12 +337,37 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
         title : 'Bug Overview',
         iconClass : 'customIcon list-opened',
         onShow : function () {
-          that._grid.scrollToLastSelected();
-          hashHelper.setStateValues({
-            'report' : null,
-            'reportHash' : null,
-            'subtab' : null
-          });
+          // When opening a run first this onShow method will be called multiple
+          // times. That is the reason why we check that the show method is
+          // already in progress.
+          if (this._showInProgress)
+            return true;
+
+          this._showInProgress = true;
+          var state  = that._bugFilterView.getUrlState();
+          state.tab  = that.tab;
+          state.report = null;
+          state.reportHash = null;
+          state.subtab = null;
+
+          hashHelper.resetStateValues(state);
+
+          // If the filter has not been initalized then we should initalize it.
+          if (!that._bugFilterView.isInitalized()) {
+            if (that.baseline && !state.run)
+              state.run = this.baseline;
+            if (that.newcheck && !state.newcheck)
+              state.newcheck = that.newcheck;
+
+            var self = this;
+            setTimeout(function () {
+              that._bugFilterView.initAll(state);
+              that._grid.scrollToLastSelected();
+              self._showInProgress = false;
+            }, 0);
+          } else {
+            this._showInProgress = false;
+          }
         }
       });
 
@@ -391,7 +421,9 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
 
       this.addChild(this._runHistory);
 
-      initByUrl(this._grid, this.tab);
+      var state = hashHelper.getState();
+      if (state.tab === that.tab && state.subtab !== that.subtab)
+        initByUrl(this._grid, this.tab);
     },
 
     _subscribeTopics : function () {
@@ -502,21 +534,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
     },
 
     onShow : function () {
-      var state  = this._bugFilterView.getUrlState();
-      state.tab  = this.tab;
-      hashHelper.resetStateValues(state);
-
-      // If the filter has not been initalized then we should initalize it.
-      if (!this._bugFilterView.isInitalized()) {
-        if (this.baseline && !state.run)
-          state.run = this.baseline;
-        if (this.newcheck && !state.newcheck)
-          state.newcheck = this.newcheck;
-        this._bugFilterView.initAll(state);
-      }
-
-     //--- Call show method of the selected children ---//
-
+     // Call show method of the selected children.
      this.getChildren().forEach(function (child) {
        if (child.selected)
          child.onShow();

--- a/www/scripts/codecheckerviewer/filter/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/filter/BugFilterView.js
@@ -546,18 +546,22 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic, Button,
 
       // Select initial base line and new check values which come from the
       // constructor.
-      if (this.baseline)
+      if (this.baseline) {
         this.baseline.forEach(function (runName) {
           that._runBaseLineFilter.select(runName);
         });
+        queryParams[that._runBaseLineFilter.class] = this.baseline;
+      }
 
-      if (this.newcheck)
+      if (this.newcheck) {
         this.newcheck.forEach(function (runName) {
           that._runNewCheckFilter.select(runName);
         });
+        queryParams[that._runNewCheckFilter.class] = this.newcheck;
+      }
 
       // Initalize only the current tab.
-      if (this.parent.tab === queryParams.tab)
+      if (this.parent.tab === queryParams.tab || this.openedByUserEvent)
         this.initAll(queryParams);
 
       this._subscribeTopics();


### PR DESCRIPTION
> Closes #1603

Problem: list of reports hadn't been filtered with the default filter values (e.g.: false positive) when the user clicked on a run at the Run page.

Report filter should be initialized when the user opens a run on the Run list page and should set the correct baseline and newcheck values.