### PR TITLE
Fix run history tab value in the URL on show event

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -424,10 +424,8 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
 
           this.initRunHistory(baseline.concat(newcheck));
 
-          var state = hashHelper.getState();
-
           hashHelper.resetStateValues({
-            'tab' : state.tab,
+            'tab' : that.tab,
             'subtab' : 'runHistory'
           });
           that.subtab = 'runHistory';


### PR DESCRIPTION
This commit fixes the following problem:
 - Click to All reports tab
 - Click to Run history tab
 - Click to Runs tab
 - Click again to the All reports tab but it will remain to the Runs tab.