### PR TITLE
Distinguish BuildAction objects on original build command

### DIFF
--- a/libcodechecker/analyze/log_parser.py
+++ b/libcodechecker/analyze/log_parser.py
@@ -326,7 +326,7 @@ def parse_compile_commands_json(logfile, parseLogOptions):
             action.target = compiler_target[results.compiler]
 
         if results.action != option_parser.ActionType.COMPILE:
-            action.skip = True
+            continue
 
         # TODO: Check arch.
         action.directory = entry['directory']
@@ -364,4 +364,4 @@ def parse_log(logfilepath, parseLogOptions):
 
     LOG.debug('Parsing log file done.')
 
-    return [build_action for build_action in actions if not build_action.skip]
+    return actions

--- a/libcodechecker/log/build_action.py
+++ b/libcodechecker/log/build_action.py
@@ -21,7 +21,6 @@ class BuildAction(object):
         self._target = ''
         self._source_count = 0
         self._sources = []
-        self._skip = False
 
     def __str__(self):
         # For debugging.
@@ -134,14 +133,6 @@ class BuildAction(object):
     @target.setter
     def target(self, value):
         self._target = value
-
-    @property
-    def skip(self):
-        return self._skip
-
-    @skip.setter
-    def skip(self, value):
-        self._skip = value
 
     def __eq__(self, other):
         return other._original_command == self._original_command


### PR DESCRIPTION
When there are two build actions which differ only in the manner of the
action (complation/preprocess) then only the first one will be included:

g++ -M main.cpp
g++ -c main.cpp

The second one is the relevant from analysis point of view.