### PR TITLE
Fix non existing report in the GUI

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -467,8 +467,12 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
         if (sender && sender !== that._grid)
           return;
 
-        if (reportData !== null && !(reportData instanceof CC_OBJECTS.ReportData))
-          reportData = CC_SERVICE.getReport(reportData);
+        if (reportData !== null &&
+            !(reportData instanceof CC_OBJECTS.ReportData)) {
+          try {
+            reportData = CC_SERVICE.getReport(reportData);
+          } catch (ex) { console.warn(ex); }
+        }
 
         var getAndUseReportHash = reportHash && (!reportData ||
           reportData.reportId === null || reportData.bugHash !== reportHash);
@@ -479,7 +483,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           reportFilter.reportHash = [reportHash];
           reportFilter.isUnique = false;
 
-          if (reportData)
+          if (reportData && reportData.checkedFile)
             reportFilter.filepath = ['*' + reportData.checkedFile];
 
           // We set a sort option to select a report which has the shortest
@@ -510,6 +514,16 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
         }
 
         that.reportData = reportData;
+
+        // No report has been found.
+        if (!reportData) {
+          console.warn('No report can be found: ' + reportHash);
+          hashHelper.setStateValues({
+            'reportHash' : null,
+            'report' : null
+          });
+          return;
+        }
 
         var filename = reportData.checkedFile.substr(
           reportData.checkedFile.lastIndexOf('/') + 1);


### PR DESCRIPTION
> Closes #1469

If no report can be found based on the given URL, remove the report hash and the report id from the URL.