### PR TITLE
Allow more product endpoint names to be valid

### DIFF
--- a/libcodechecker/server/routing.py
+++ b/libcodechecker/server/routing.py
@@ -47,7 +47,7 @@ def is_valid_product_endpoint(uripart):
     if uripart in NON_PRODUCT_ENDPOINTS:
         return False
 
-    pattern = r'^[A-Za-z0-9_]+$'
+    pattern = r'^[A-Za-z0-9_\-]+$'
     if not re.match(pattern, uripart):
         return False
 


### PR DESCRIPTION
Product endpoint names can contains dashes.