### PR TITLE
Plist to html browser support

### DIFF
--- a/vendor/plist_to_html/Makefile
+++ b/vendor/plist_to_html/Makefile
@@ -21,6 +21,7 @@ package: dep
 	cp plist_to_html/dist/css/icon.css $(DIST_DIR)
 	cp plist_to_html/dist/css/style.css $(DIST_DIR)
 	cp plist_to_html/dist/js/bugviewer.js $(DIST_DIR)
+	cp plist_to_html/dist/js/browsersupport.js $(DIST_DIR)
 	cp plist_to_html/PlistToHtml.py $(BIN_DIR)/plist-to-html
 
 dist_dir:

--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -56,7 +56,8 @@ class HtmlBuilder:
             'CODEMIRROR_CSS': 'codemirror.min.css',
             'CODEMIRROR_JS': 'codemirror.min.js',
             'CLIKE_JS': 'clike.min.js',
-            'BUG_VIEWER': 'bugviewer.js'
+            'BUG_VIEWER': 'bugviewer.js',
+            'BROWSER_SUPPORT': 'browsersupport.js'
         }
 
         # Get the HTML layout file content.

--- a/vendor/plist_to_html/plist_to_html/dist/index.html
+++ b/vendor/plist_to_html/plist_to_html/dist/index.html
@@ -38,6 +38,8 @@
     </style>
 
     <script>
+      <$BROWSER_SUPPORT$>
+
       generateRedGreenGradientColor = function (value, max, opacity) {
         var red   = (255 * value) / max;
         var green = (255 * (max - value)) / max;
@@ -47,11 +49,15 @@
       }
 
       window.onload = function () {
-        document.querySelectorAll('.bug-path-length').forEach(
-        function (widget) {
-          widget.style.backgroundColor =
-            generateRedGreenGradientColor(widget.innerHTML, 20, 0.5);
-        });
+        if (!browserCompatible) {
+          setNonCompatibleBrowserMessage();
+        } else {
+          document.querySelectorAll('.bug-path-length').forEach(
+          function (widget) {
+            widget.style.backgroundColor =
+              generateRedGreenGradientColor(widget.innerHTML, 20, 0.5);
+          });
+        }
       }
     </script>
   </head>

--- a/vendor/plist_to_html/plist_to_html/dist/js/browsersupport.js
+++ b/vendor/plist_to_html/plist_to_html/dist/js/browsersupport.js
@@ -1,0 +1,40 @@
+function setNonCompatibleBrowserMessage() {
+  document.body.innerHTML =
+    '<h2 style="margin-left: 20px;">Your browser is not compatible with CodeChecker Viewer!</h2> \
+     <p style="margin-left: 20px;">The version required for the following browsers are:</p> \
+     <ul style="margin-left: 20px;"> \
+     <li>Internet Explorer: version 9 or newer</li> \
+     <li>Firefox: version 22.0 or newer</li> \
+     </ul>';
+}
+
+// http://stackoverflow.com/questions/5916900/how-can-you-detect-the-version-of-a-browser
+var browserVersion = (function(){
+  var ua = navigator.userAgent, tem,
+    M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+
+  if (/trident/i.test(M[1])) {
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+    return 'IE ' + (tem[1] || '');
+  }
+
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\b(OPR|Edge)\/(\d+)/);
+    if (tem != null) return tem.slice(1).join(' ').replace('OPR', 'Opera');
+  }
+
+  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
+  if ((tem = ua.match(/version\/(\d+)/i)) != null) M.splice(1, 1, tem[1]);
+    return M.join(' ');
+})();
+
+var pos = browserVersion.indexOf(' ');
+var browser = browserVersion.substr(0, pos);
+var version = parseInt(browserVersion.substr(pos + 1));
+
+var browserCompatible
+  = browser === 'Firefox'
+  ? version >= 22
+  : browser === 'IE'
+  ? version >= 9
+  : true;

--- a/vendor/plist_to_html/plist_to_html/dist/js/bugviewer.js
+++ b/vendor/plist_to_html/plist_to_html/dist/js/bugviewer.js
@@ -104,7 +104,6 @@ var BugViewer = {
     var events = report['events'];
     var lastBugEvent = events[events.length - 1];
     this.setCurrentBugEvent(lastBugEvent);
-    console.log(report);
     this.setCheckerName(report.checkerName);
 
     window.location.hash = '#reportHash=' + report.reportHash;

--- a/vendor/plist_to_html/plist_to_html/dist/layout.html
+++ b/vendor/plist_to_html/plist_to_html/dist/layout.html
@@ -12,6 +12,8 @@
     </style>
 
     <script type="text/javascript">
+      <$BROWSER_SUPPORT$>
+
       /* <$CODEMIRROR_LICENSE$> */
       <$CODEMIRROR_JS$>
       <$CLIKE_JS$>
@@ -19,9 +21,13 @@
 
       var data = <$REPORT_DATA$>;
       window.onload = function() {
-        BugViewer.init(data.files, data.reports);
-        BugViewer.create();
-        BugViewer.initByUrl();
+        if (!browserCompatible) {
+          setNonCompatibleBrowserMessage();
+        } else {
+          BugViewer.init(data.files, data.reports);
+          BugViewer.create();
+          BugViewer.initByUrl();
+        }
       };
     </script>
   </head>


### PR DESCRIPTION
Show warning message if the browser is not supported when looking html files generated by Plist to HTML parser.