### PR TITLE
Call getSeverityCounts correctly

### DIFF
--- a/www/scripts/codecheckerviewer/CheckerStatistics.js
+++ b/www/scripts/codecheckerviewer/CheckerStatistics.js
@@ -298,9 +298,7 @@ function (declare, lang, ItemFileWriteStore, dom, Deferred, all, Memory,
     _populateStatistics : function (runIds, reportFilter) {
       var that = this;
 
-      var limit = null;
-      var offset = null;
-      CC_SERVICE.getSeverityCounts(runIds, reportFilter, null, limit, offset,
+      CC_SERVICE.getSeverityCounts(runIds, reportFilter, null,
       function (res) {
         for (key in res) {
           that.store.newItem({


### PR DESCRIPTION
Call `getSeverityCounts` API function with the correct number of parameter.

See:
https://github.com/Ericsson/codechecker/blob/fecec6f4dca8c24b7030645212a95eec9a8016e5/api/v6/report_server.thrift#L400-L403