### PR TITLE
Multiline messages are displayed properly

### DIFF
--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -218,7 +218,7 @@ def plist_to_html(file_path, output_path, html_builder,
     Prints the results in the given file to HTML file.
 
     Returns the skipped plist files because of source
-    file conent change.
+    file content change.
     """
     changed_source = set()
     file_paths = []

--- a/vendor/plist_to_html/plist_to_html/dist/js/bugviewer.js
+++ b/vendor/plist_to_html/plist_to_html/dist/js/bugviewer.js
@@ -181,7 +181,7 @@ var BugViewer = {
       }
 
       var msg = document.createElement('span');
-      msg.innerHTML = bugEvent.msg;
+      msg.innerHTML = bugEvent.msg.replace(/(?:\r\n|\r|\n)/g, '<br>');
       element.appendChild(msg);
 
       var nextBugEvent = bugEvent.step;

--- a/www/scripts/codecheckerviewer/BugViewer.js
+++ b/www/scripts/codecheckerviewer/BugViewer.js
@@ -61,7 +61,7 @@ function (declare, domClass, dom, style, fx, Toggler, keys, on, query, Memory,
    * Parsing the bug step message and replace the `(fixit)` string with an icon.
    */
   function parseBugStepMsg(message) {
-    var ret = message;
+    var ret = message.replace(/(?:\r\n|\r|\n)/g, '<br>');
 
     if (message.indexOf('(fixit)') > -1)
       ret = '<span class="tag fixit">fixit</span>'


### PR DESCRIPTION
Both 'parse' and 'store' ignored newlines. This patch fixes that.