### PR TITLE
Set default severity level for compiler warnings

### DIFF
--- a/libcodechecker/analyze/plist_parser.py
+++ b/libcodechecker/analyze/plist_parser.py
@@ -455,8 +455,7 @@ class PlistToPlaintextFormatter(object):
                     continue
 
                 file_stats[f_path] += 1
-                severity = self.__severity_map.get(checker_name,
-                                                   'UNSPECIFIED')
+                severity = self.__severity_map.get(checker_name)
                 severity_stats[severity] += 1
                 report_count["report_count"] += 1
 

--- a/libcodechecker/libhandlers/checkers.py
+++ b/libcodechecker/libhandlers/checkers.py
@@ -219,8 +219,7 @@ def main(args):
             if 'details' not in args:
                 rows.append([checker_name])
             else:
-                severity = context.severity_map.get(checker_name,
-                                                    'UNSPECIFIED')
+                severity = context.severity_map.get(checker_name)
                 rows.append([enabled, checker_name, analyzer,
                              severity, description])
 

--- a/libcodechecker/server/api/store_handler.py
+++ b/libcodechecker/server/api/store_handler.py
@@ -316,7 +316,7 @@ def addReport(session,
     try:
 
         checker_name = main_section['check_name']
-        severity_name = severity_map.get(checker_name, 'UNSPECIFIED')
+        severity_name = severity_map.get(checker_name)
         severity = ttypes.Severity._NAMES_TO_VALUES[severity_name]
 
         report = Report(run_id,

--- a/tests/functional/analyze_and_parse/test_files/compiler_warning_simple.output
+++ b/tests/functional/analyze_and_parse/test_files/compiler_warning_simple.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make compiler_warning_simple" --output $OUTPUT$
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[UNSPECIFIED] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
+[MEDIUM] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
   int i;
       ^
 
@@ -30,11 +30,11 @@ Filename             | Report count
 -----------------------------------
 compiler_warning.cpp |            1
 -----------------------------------
---------------------------
-Severity    | Report count
---------------------------
-UNSPECIFIED |            1
---------------------------
+-----------------------
+Severity | Report count
+-----------------------
+MEDIUM   |            1
+-----------------------
 ----=================----
 Total number of reports: 1
 ----=================----

--- a/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_group.output
+++ b/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_group.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make compiler_warning_wno_group" --output $OUTP
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[UNSPECIFIED] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
+[MEDIUM] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
   int i;
       ^
 
@@ -30,11 +30,11 @@ Filename             | Report count
 -----------------------------------
 compiler_warning.cpp |            1
 -----------------------------------
---------------------------
-Severity    | Report count
---------------------------
-UNSPECIFIED |            1
---------------------------
+-----------------------
+Severity | Report count
+-----------------------
+MEDIUM   |            1
+-----------------------
 ----=================----
 Total number of reports: 1
 ----=================----

--- a/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_simple1.output
+++ b/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_simple1.output
@@ -17,7 +17,7 @@ CHECK#CodeChecker check --build "make compiler_warning_wno_simple" --output $OUT
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[UNSPECIFIED] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
+[MEDIUM] compiler_warning.cpp:3:7: unused variable 'i' [clang-diagnostic-unused-variable]
   int i;
       ^
 
@@ -30,11 +30,11 @@ Filename             | Report count
 -----------------------------------
 compiler_warning.cpp |            1
 -----------------------------------
---------------------------
-Severity    | Report count
---------------------------
-UNSPECIFIED |            1
---------------------------
+-----------------------
+Severity | Report count
+-----------------------
+MEDIUM   |            1
+-----------------------
 ----=================----
 Total number of reports: 1
 ----=================----

--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -86,8 +86,7 @@ class HtmlBuilder:
         # Add severity levels for reports.
         for report in report_data['reports']:
             checker = report['checkerName']
-            report['severity'] = \
-                self._severity_map.get(checker, 'UNSPECIFIED')
+            report['severity'] = self._severity_map.get(checker)
 
         self.generated_html_reports[output_path] = report_data['reports']
         content = self._layout.replace('<$REPORT_DATA$>',


### PR DESCRIPTION
Set severity level of `MEDIUM` for compiler warnings by default.