### PR TITLE
Pass severity map dictionary instead of the file

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -318,8 +318,7 @@ def handle_diff_results(args):
         the given filter set.
         """
         if f_severities:
-            severity_name = context.severity_map.get(report.main['check_name'],
-                                                     'UNSPECIFIED')
+            severity_name = context.severity_map.get(report.main['check_name'])
             if severity_name.lower() not in map(str.lower, f_severities):
                 return True
 
@@ -730,7 +729,7 @@ def handle_diff_results(args):
         """
         html_builder = PlistToHtml.HtmlBuilder(
             context.path_plist_to_html_dist,
-            context.checkers_severity_map_file)
+            context.severity_map)
 
         file_report_map = defaultdict(list)
         for report in reports:
@@ -814,7 +813,7 @@ def handle_diff_results(args):
                 checked_file = report.main['location']['file_name']\
                     + ':' + str(bug_line) + ":" + str(bug_col)
                 check_name = report.main['check_name']
-                sev = context.severity_map.get(check_name, 'UNSPECIFIED')
+                sev = context.severity_map.get(check_name)
                 check_msg = report.main['description']
                 source_line =\
                     get_line_from_file(report.main['location']['file_name'],

--- a/libcodechecker/libhandlers/parse.py
+++ b/libcodechecker/libhandlers/parse.py
@@ -305,7 +305,7 @@ def main(args):
             if not html_builder:
                 html_builder = \
                     PlistToHtml.HtmlBuilder(context.path_plist_to_html_dist,
-                                            context.checkers_severity_map_file)
+                                            context.severity_map)
 
             LOG.info("Generating html output files:")
             PlistToHtml.parse(input_path,

--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -33,20 +33,10 @@ class HtmlBuilder:
     """
     Helper class to create html file from a report data.
     """
-    def __init__(self, layout_dir, checkers_severity_map_file=None):
-        self._severity_map = dict()
+    def __init__(self, layout_dir, severity_map=None):
+        self._severity_map = severity_map if severity_map else {}
         self.layout_dir = layout_dir
-        self.checkers_severity_map_file = checkers_severity_map_file
         self.generated_html_reports = {}
-
-        if self.checkers_severity_map_file:
-            try:
-                with open(self.checkers_severity_map_file) as severity_file:
-                    self._severity_map = json.load(severity_file)
-            except (IOError, ValueError):
-                print("{0} doesn't exist or not JSON format. Severity "
-                      "levels will not be available!".format(
-                          self.checkers_severity_map_file))
 
         # Mapping layout tags to files.
         self._layout_tag_files = {


### PR DESCRIPTION
Pass the checker severiy map dictionary (instance of SeverityMap) to the PlistToHtml parser instead of the file path. This way we will get default severity levels for clang warnings and for unspecified checker names by using this map.