### PR TITLE
Fix JavaScript old browser compatibility

### DIFF
--- a/www/scripts/codecheckerviewer/filter/BugFilterView.js
+++ b/www/scripts/codecheckerviewer/filter/BugFilterView.js
@@ -628,7 +628,7 @@ function (declare, lang, Deferred, domClass, dom, domStyle, topic,
     },
 
     // Clears all filter.
-    clearAll() {
+    clearAll : function () {
       this._filters.forEach(function (filter) {
         filter.clear();
       });

--- a/www/scripts/codecheckerviewer/util.js
+++ b/www/scripts/codecheckerviewer/util.js
@@ -469,7 +469,7 @@ function (locale, dom, style, json) {
       document.body.removeChild(link);
     },
 
-    createLabelForUniqueCheckbox(uniqueCheckBox) {
+    createLabelForUniqueCheckbox : function (uniqueCheckBox) {
       return dom.create('label', {
         for : uniqueCheckBox.get('id'),
         innerHTML : 'Unique reports <i class="icon-help"></i>',


### PR DESCRIPTION
> Closes  #1666

Shorter syntax for method definitions on objects are introduced in ES2015 which is not supported in older browsers. This pull request fixes this problem.