### PR TITLE
Add new checker profile: portability

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -12,7 +12,8 @@
   "available_profiles": {
       "default" : "High-quality standard checks with a low false positive rate.",
       "sensitive" : "Default checks + more comprehensive checks with a low false positive rate.",
-      "extreme" : "Sensitive checks + more comprehensive checks with a manageable false positive rate."
+      "extreme" : "Sensitive checks + more comprehensive checks with a manageable false positive rate.",
+      "portability" : "Checks that aim to detect code issues emerging from platform differences (eg. between 32-bit and 64-bit architectures)."
   },
   "checker_config": {
       "clangsa_checkers" : {
@@ -69,7 +70,7 @@
         "nullability.NullablePassedToNonnull" : ["sensitive", "extreme"],
         "nullability.NullableReturnedFromNonnull" : ["sensitive", "extreme"],
         "optin.mpi.MPI-Checker" : ["sensitive", "extreme"],
-        "optin.portability.UnixAPI" : ["default", "sensitive", "extreme"],
+        "optin.portability.UnixAPI" : ["default", "sensitive", "extreme", "portability"],
         "security.FloatLoopCounter" : ["default", "sensitive", "extreme"],
         "security.insecureAPI.UncheckedReturn" : ["default", "sensitive", "extreme"],
         "security.insecureAPI.getpw" : ["default", "sensitive", "extreme"],
@@ -146,7 +147,7 @@
         "misc-lambda-function-name" : ["default", "sensitive", "extreme"],
         "misc-macro-repeated-side-effects" : ["default", "sensitive", "extreme"],
         "misc-misplaced-const" : ["default", "sensitive", "extreme"],
-        "misc-misplaced-widening-cast" : ["default", "sensitive", "extreme"],
+        "misc-misplaced-widening-cast" : ["default", "sensitive", "extreme", "portability"],
         "misc-move-const-arg" : ["default", "sensitive", "extreme"],
         "misc-move-constructor-init" : ["default", "sensitive", "extreme"],
         "misc-move-forwarding-reference" : ["default", "sensitive", "extreme"],

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -687,8 +687,12 @@ https://clang.llvm.org/docs/DiagnosticsReference.html.
 Checker profiles describe custom sets of enabled checks which can be specified
 in the `{INSTALL_DIR}/config/config.json` file. Three built-in options are
 available grouping checkers by their quality (measured by their false positive
-rate): `default`, `sensitive` and `extreme`. Detailed information about profiles
-can be retrieved by the `CodeChecker checkers` command.
+rate): `default`, `sensitive` and `extreme`. In addition, profile `portability`
+contains checkers for detecting platform-dependent code issues. These issues
+can arise when migrating code from 32-bit to 64-bit architectures, and the root
+causes of the bugs tend to be overflows, sign extensions and widening
+conversions or casts. Detailed information about profiles can be retrieved by
+the `CodeChecker checkers` command.
 
 Note: `list` is a reserved keyword used to show all the available profiles and
 thus should not be used as a profile name. Profile names should also be


### PR DESCRIPTION
Introduce a new checker profile, which is used to group checkers detecting platform specific issues.