### PR TITLE
change component filtering behavior

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1542,33 +1542,49 @@ optional arguments:
                         source component.
   -i COMPONENT_FILE, --import COMPONENT_FILE
                         Path to the source component file which contains
-                        multiple file paths. Each file path start with a '+'
-                        (results from this path should be listed) or '-'
-                        (results from this path should not be listed) sign.
+                        multiple file paths. Each file path should start with
+                        a '+' or '-' sign.Results will be listed only from
+                        paths with a '+' sign. Results will not be listed from
+                        paths with a '-' sign. Let's assume there are three
+                        directories: test_files, test_data and test_config. In
+                        the given example only the results from the test_files
+                        and test_data directories will be listed.
                         E.g.:
-                        +/a/b/x.cpp
-                        -/a/b/
+                        +*/test*/*
+                        -*/test_dat*/*
                         Please see the User guide for more information.
+
 ~~~~~~~~~~~~~~~~~~~~~
 
 ##### <a name="component-file"></a> Format of component file
 
 Source component helps us to filter run results by multiple file paths.
 
-Each line in the source component file begins with a `-` or a `+`, followed by
+Each line in the source component file should begin with a `+` or a `-`, followed by
 a path glob pattern:
- * `-` means that if a file matches a pattern it should **not** be filtered
- * `+` means that it should be filtered.
+ * `+` ONLY results from the matching file paths will be listed
+ * `-` results from the matching file paths will not be listed
 
 Example:
+~~~~~~~~~~~~~~~~~~~~~
+-/dont/list/results/in/directory/*
+-/dont/list/this.file
++/dir/list/in/directory/*
++/dir/list.this.file
+~~~~~~~~~~~~~~~~~~~~~
+Results will be listed only from `/dir/list/in/directory/*` and from the
+`/dir/list.this.file`.
+In this case removing the `-` rules would not change the list of results.
 
+Example 2:
 ~~~~~~~~~~~~~~~~~~~~~
--/dont/filter/files/in/directory/*
--/dont/filter/this.file
--/dir/*
-+/dir/filter/in/directory/*
-+/dir/filter.this.file
++*/test*
++*/test_files/*
++*/test_data/*
+-*/test_p*
 ~~~~~~~~~~~~~~~~~~~~~
+Results will be listed only from the directories which name begin with
+`test` except the results form the directories which name begin with `test_p`.
 
 Note: the order of the source component value is not important. E.g.:
 ~~~~~~~~~~~~~~~~~~~~~

--- a/libcodechecker/libhandlers/cmd.py
+++ b/libcodechecker/libhandlers/cmd.py
@@ -761,12 +761,18 @@ def __register_source_components(parser):
                             required=True,
                             help="Path to the source component file which "
                                  "contains multiple file paths. Each file "
-                                 "path start with a '+' (results from this "
-                                 "path should be listed) or '-' (results from "
-                                 "this path should not be listed) sign. "
+                                 "path should start with a '+' or '-' sign. "
+                                 "Results will be listed only from paths with "
+                                 "a '+' sign. "
+                                 "Results will not be listed from paths with "
+                                 "a '-' sign. Let's assume there are three "
+                                 "directories: test_files, test_data and "
+                                 "test_config. In the given example only the "
+                                 "results from the test_files and test_data "
+                                 "directories will be listed.\n"
                                  "E.g.: \n"
-                                 "  +/a/b/x.cpp\n"
-                                 "  -/a/b/\n"
+                                 "  +*/test*/*\n"
+                                 "  -*/test_dat*/*\n"
                                  "Please see the User guide for more "
                                  "information.")
 

--- a/tests/functional/component/test_component.py
+++ b/tests/functional/component/test_component.py
@@ -97,14 +97,12 @@ class TestComponent(unittest.TestCase):
             {
                 'name': 'complex1',
                 'value': '\n'.join(['+*/divide_zero.cpp',
-                                    '-*/call_and_message.cpp',
-                                    '-*'])
+                                    '-*/call_and_message.cpp'])
             },
             {
                 'name': 'complex2',
                 'value': '\n'.join(['+*/null_dereference.cpp',
-                                    '-*/new_delete.cpp',
-                                    '-*'])
+                                    '-*/new_delete.cpp'])
             },
             {
                 'name': 'exclude_all',
@@ -188,11 +186,12 @@ class TestComponent(unittest.TestCase):
                               r.checkedFile.endswith('new_delete.cpp')]
         self.assertEqual(len(new_delete_reports), 0)
 
-        # Check that reports which can be found in file what the source
-        # component does not includes or excludes are in the filtered results.
+        # No reports should be listed which is not in an inclusion or if
+        # it is an exclusion filter.
+
         divide_zero_reports = [r for r in run_results if
                                r.checkedFile.endswith('null_dereference.cpp')]
-        self.assertNotEqual(len(divide_zero_reports), 0)
+        self.assertEqual(len(divide_zero_reports), 0)
 
         self.__remove_source_component(test_component['name'])
 
@@ -237,11 +236,11 @@ class TestComponent(unittest.TestCase):
                                 r.checkedFile.endswith('call_and_message.cpp')]
         self.assertEqual(len(call_and_msg_reports), 0)
 
-        # Check that reports which can be found in file what the source
-        # component does not includes or excludes are in the filtered results.
+        # No reports should be listed which is not in an inclusion or if
+        # it is in an exclusion filter.
         divide_zero_reports = [r for r in run_results if
                                r.checkedFile.endswith('path_begin.cpp')]
-        self.assertNotEqual(len(divide_zero_reports), 0)
+        self.assertEqual(len(divide_zero_reports), 0)
 
         self.__remove_source_component(test_component['name'])
 
@@ -263,6 +262,7 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=[test_component1['name'],
                                                 test_component2['name']])
+
         run_results = self._cc_client.getRunResults(None,
                                                     500,
                                                     0,


### PR DESCRIPTION
* filtering sub path values was not handled properly

  if there are test, test_proj, test_files, test_data directories
  the following filter did not work properly, results from test_data
  and test_proj were shown in the results list after the filtering

  +*/test*
  +*/test_files/*
  +*/test_data/*
  -*/test_p*