### PR TITLE
Query reports only when shown.

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -392,6 +392,10 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           } else {
             this._showInProgress = false;
           }
+
+          if (that._grid.rowCount === 0)
+            // Call the notify explicitly to initalize grid filters.
+            that._grid.notify();
         }
       });
 
@@ -410,9 +414,6 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
       });
       this._grid.set('bugFilterView', this._bugFilterView);
       this._bugFilterView.register(this._grid);
-
-      // Call the notify explicitly to initalize grid filters.
-      this._grid.notify();
 
       //--- Run history ---//
 


### PR DESCRIPTION
When opening a product, all reports are queried even if "All reports"
tab is not active. In case of >200000 reports this runs a huge query in
the background which occupies a whole thread for a relatively long time.
With this modification the reports are queried only when the grid is
shown.