### PR TITLE
Zombie processes remain on analysis interruption

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -716,7 +716,7 @@ def check(check_data):
 def start_workers(actions_map, actions, context, analyzer_config_map,
                   jobs, output_path, skip_handler, metadata,
                   quiet_analyze, capture_analysis_output, timeout,
-                  ctu_reanalyze_on_failure, statistics_data):
+                  ctu_reanalyze_on_failure, statistics_data, manager):
     """
     Start the workers in the process pool.
     For every build action there is worker which makes the analysis.
@@ -726,6 +726,7 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
     def signal_handler(*arg, **kwarg):
         try:
             pool.terminate()
+            manager.shutdown()
         finally:
             sys.exit(1)
 

--- a/libcodechecker/analyze/pre_analysis_manager.py
+++ b/libcodechecker/analyze/pre_analysis_manager.py
@@ -149,7 +149,7 @@ def pre_analyze(params):
 
 
 def run_pre_analysis(actions, context, analyzer_config_map,
-                     jobs, skip_handler, ctu_data, statistics_data):
+                     jobs, skip_handler, ctu_data, statistics_data, manager):
     """
     Run multiple pre analysis jobs before the actual analysis.
     """
@@ -162,6 +162,7 @@ def run_pre_analysis(actions, context, analyzer_config_map,
     def signal_handler(*arg, **kwarg):
         try:
             pool.terminate()
+            manager.shutdown()
         finally:
             sys.exit(1)
 


### PR DESCRIPTION
When the analysis stops with Ctrl-C then the subprocesses in the process
pool are not terminated. The reason is that the shared data structures
managed by multiprocess.managers.SyncManager() type die before the
termination of processes. This causes an exception in pool.terminate()
which makes the subprocesses of the pool zombies.