### PR TITLE
Analyzer statistics

### DIFF
--- a/api/v6/report_server.thrift
+++ b/api/v6/report_server.thrift
@@ -114,26 +114,41 @@ struct ReportDetails {
   2: BugPath       executionPath
 }
 
+typedef string AnalyzerType
+
+struct AnalyzerStatistics {
+  1: string        version,         // Version information of the analyzer.
+  2: i64           failed,          // Number of files which failed to analyze.
+  3: i64           successful,      // Number of successfully analyzed files.
+  4: list<string>  failedFilePaths, // List of file paths which failed to analyze.
+}
+
+typedef map<AnalyzerType, AnalyzerStatistics> AnalyzerStatisticsData
+
 struct RunData {
-  1: i64                       runId,        // Unique id of the run.
-  2: string                    runDate,      // Date of the run last updated.
-  3: string                    name,         // Human-given identifier.
-  4: i64                       duration,     // Duration of the run (-1 if not finished).
-  5: i64                       resultCount,  // Number of unresolved results (review status is not FALSE_POSITIVE or INTENTIONAL) in the run.
-  6: string                    runCmd,       // The used check command.
+  1: i64                       runId,                // Unique id of the run.
+  2: string                    runDate,              // Date of the run last updated.
+  3: string                    name,                 // Human-given identifier.
+  4: i64                       duration,             // Duration of the run (-1 if not finished).
+  5: i64                       resultCount,          // Number of unresolved results (review status is not FALSE_POSITIVE or INTENTIONAL) in the run.
+  6: string                    runCmd,               // The used check command.
   7: map<DetectionStatus, i32> detectionStatusCount, // Number of reports with a particular detection status.
-  8: string                    versionTag    // Version tag of the latest run.
+  8: string                    versionTag,           // Version tag of the latest run.
+  9: string                    codeCheckerVersion,   // CodeChecker client version of the latest analysis.
+  10: AnalyzerStatisticsData   analyzerStatistics,   // Statistics for each analyzers.
 }
 typedef list<RunData> RunDataList
 
 struct RunHistoryData {
-  1: i64       runId,        // Unique id of the run.
-  2: string    runName,      // Name of the run.
-  3: string    versionTag,   // Version tag of the report.
-  4: string    user,         // User name who analysed the run.
-  5: string    time,         // Date time when the run was analysed.
-  6: i64       id,           // Id of the run history tag.
-  7: string    checkCommand, // Check command.
+  1: i64                     runId,              // Unique id of the run.
+  2: string                  runName,            // Name of the run.
+  3: string                  versionTag,         // Version tag of the report.
+  4: string                  user,               // User name who analysed the run.
+  5: string                  time,               // Date time when the run was analysed.
+  6: i64                     id,                 // Id of the run history tag.
+  7: string                  checkCommand,       // Check command.
+  8: string                  codeCheckerVersion, // CodeChecker client version of the latest analysis.
+  9: AnalyzerStatisticsData  analyzerStatistics, // Statistics for analyzers.
 }
 typedef list<RunHistoryData> RunHistoryDataList
 

--- a/db_migrate/versions/39f9e96071c0_analyzer_statistics.py
+++ b/db_migrate/versions/39f9e96071c0_analyzer_statistics.py
@@ -1,0 +1,45 @@
+"""Analyzer statistics
+
+Revision ID: 39f9e96071c0
+Revises: 9987aa593ca7
+Create Date: 2018-09-05 17:45:10.746758
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '39f9e96071c0'
+down_revision = '9987aa593ca7'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('analyzer_statistics',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('run_history_id', sa.Integer(), nullable=True),
+                    sa.Column('analyzer_type', sa.String(), nullable=True),
+                    sa.Column('version', sa.Binary(), nullable=True),
+                    sa.Column('successful', sa.Integer(), nullable=True),
+                    sa.Column('failed', sa.Integer(), nullable=True),
+                    sa.Column('failed_files', sa.Binary(), nullable=True),
+                    sa.ForeignKeyConstraint(['run_history_id'],
+                                            [u'run_histories.id'],
+                                            name=op.f('fk_analyzer_statistics_run_history_id_run_histories'),
+                                            ondelete=u'CASCADE',
+                                            initially=u'DEFERRED',
+                                            deferrable=True),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_analyzer_statistics'))
+                    )
+    op.create_index(op.f('ix_analyzer_statistics_run_history_id'),
+                    'analyzer_statistics',
+                    ['run_history_id'],
+                    unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_analyzer_statistics_run_history_id'),
+                  table_name='analyzer_statistics')
+    op.drop_table('analyzer_statistics')

--- a/db_migrate/versions/9987aa593ca7_add_codechecker_version_to_run_history.py
+++ b/db_migrate/versions/9987aa593ca7_add_codechecker_version_to_run_history.py
@@ -1,0 +1,25 @@
+"""Add CodeChecker version to run history
+
+Revision ID: 9987aa593ca7
+Revises: e89887e7d3f0
+Create Date: 2018-09-05 17:43:42.099167
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9987aa593ca7'
+down_revision = 'e89887e7d3f0'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('run_histories',
+                  sa.Column('cc_version', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('run_histories', 'client_version')

--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -235,17 +235,32 @@ def handle_list_runs(args):
         print(CmdLineOutputEncoder().encode(results))
 
     else:  # plaintext, csv
-        header = ['Name', 'Number of reports', 'Storage date', 'Version tag',
-                  'Duration']
+        header = ['Name', 'Number of unresolved reports',
+                  'Analyzer statistics', 'Storage date', 'Version tag',
+                  'Duration', 'CodeChecker version']
         rows = []
         for run in runs:
             duration = str(timedelta(seconds=run.duration)) \
                 if run.duration > -1 else 'Not finished'
+
+            analyzer_statistics = []
+            for analyzer in run.analyzerStatistics:
+                stat = run.analyzerStatistics[analyzer]
+                num_of_all_files = stat.successful + stat.failed
+                analyzer_statistics.append(analyzer + ' (' +
+                                           str(num_of_all_files) + '/' +
+                                           str(stat.successful) + ')')
+
+            codechecker_version = run.codeCheckerVersion \
+                if run.codecheckerVersion else ''
+
             rows.append((run.name,
                          str(run.resultCount),
+                         ', '.join(analyzer_statistics),
                          run.runDate,
                          run.versionTag if run.versionTag else '',
-                         duration))
+                         duration,
+                         codechecker_version))
 
         print(twodim_to_str(args.output_format, header, rows))
 
@@ -1178,12 +1193,23 @@ def handle_list_run_histories(args):
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(run_history))
     else:  # plaintext, csv
-        header = ['Date', 'Run name', 'Version tag', 'User']
+        header = ['Date', 'Run name', 'Version tag', 'User',
+                  'CodeChecker version', 'Analyzer statistics']
         rows = []
         for h in run_history:
+            analyzer_statistics = []
+            for analyzer in h.analyzerStatistics:
+                stat = h.analyzerStatistics[analyzer]
+                num_of_all_files = stat.successful + stat.failed
+                analyzer_statistics.append(analyzer + ' (' +
+                                           str(num_of_all_files) + '/' +
+                                           str(stat.successful) + ')')
+
             rows.append((h.time,
                          h.runName,
                          h.versionTag if h.versionTag else '',
-                         h.user))
+                         h.user,
+                         h.codeCheckerVersion if h.codeCheckerVersion else '',
+                         ', '.join(analyzer_statistics)))
 
         print(twodim_to_str(args.output_format, header, rows))

--- a/libcodechecker/server/database/run_db_model.py
+++ b/libcodechecker/server/database/run_db_model.py
@@ -106,6 +106,32 @@ class RunLock(Base):
         return datetime.now() > self.when_expires(grace_seconds)
 
 
+class AnalyzerStatistic(Base):
+    __tablename__ = 'analyzer_statistics'
+
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    run_history_id = Column(Integer,
+                            ForeignKey('run_histories.id',
+                                       deferrable=True,
+                                       initially="DEFERRED",
+                                       ondelete='CASCADE'),
+                            index=True)
+    analyzer_type = Column(String)
+    version = Column(Binary)
+    successful = Column(Integer)
+    failed = Column(Integer)
+    failed_files = Column(Binary, nullable=True)
+
+    def __init__(self, run_history_id, analyzer_type, version, successful,
+                 failed, failed_files):
+        self.run_history_id = run_history_id
+        self.analyzer_type = analyzer_type
+        self.version = version
+        self.successful = successful
+        self.failed = failed
+        self.failed_files = failed_files
+
+
 class RunHistory(Base):
     __tablename__ = 'run_histories'
 
@@ -118,17 +144,22 @@ class RunHistory(Base):
     user = Column(String, nullable=False)
     time = Column(DateTime, nullable=False)
     check_command = Column(Binary)
+    cc_version = Column(String, nullable=True)
 
     run = relationship(Run, uselist=False)
+    analyzer_statistics = relationship(AnalyzerStatistic,
+                                       lazy="joined")
 
     __table_args__ = (UniqueConstraint('run_id', 'version_tag'),)
 
-    def __init__(self, run_id, version_tag, user, time, check_command):
+    def __init__(self, run_id, version_tag, user, time, check_command,
+                 cc_version):
         self.run_id = run_id
         self.version_tag = version_tag
         self.user = user
         self.time = time
         self.check_command = check_command
+        self.cc_version = cc_version
 
 
 class FileContent(Base):

--- a/libcodechecker/version.py
+++ b/libcodechecker/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 13
+    6: 14
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/www/changelog.html
+++ b/www/changelog.html
@@ -75,7 +75,7 @@
       </div>
     </div>
 
-     <div class="intro-row">
+    <div class="intro-row">
       <h3>Support managing source component on the GUI</h3>
       <div class="content">
         <div class="intro-col intro-col-left col-md-2">
@@ -87,6 +87,22 @@
         <div class="intro-col intro-col-right col-md-2">
           <a href="/images/list_of_source_components.png" data-dojo-type="dojox.image.Lightbox" title="Source component UI management">
             <img src="/images/list_of_source_components.png" alt="Source component UI management" />
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="intro-row">
+      <h3>Analysis Statistics</h3>
+      <div class="content">
+        <div class="intro-col intro-col-left col-md-2">
+          For each run the CodeChecker version (used to run the analysis) and
+          the static analyzer versions along with the success/failure rate of
+          the analysis can be viewed.
+        </div>
+        <div class="intro-col intro-col-right col-md-2">
+          <a href="/images/analysis_statistics.png" data-dojo-type="dojox.image.Lightbox" title="Analysis Statistics">
+            <img src="/images/analysis_statistics.png" alt="Analysis Statistics" />
           </a>
         </div>
       </div>

--- a/www/scripts/codecheckerviewer/AnalyzerStatisticsDialog.js
+++ b/www/scripts/codecheckerviewer/AnalyzerStatisticsDialog.js
@@ -1,0 +1,90 @@
+// -------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -------------------------------------------------------------------------
+
+define([
+  'dojo/_base/declare',
+  'dojo/dom-construct',
+  'dijit/Dialog'],
+function (declare, dom, Dialog) {
+  return declare(Dialog, {
+    title : 'Analyzer statistics',
+    style : 'max-width: 75%; min-width: 50%;',
+
+    show : function (stats) {
+      var ul = dom.create('ul', { class: 'analyzer-statistics' });
+
+      Object.keys(stats).forEach(function (analyzer) {
+        var item = dom.create('li', null, ul);
+        dom.create('h3', { innerHTML : analyzer }, item);
+
+        var items = dom.create('ul', { class : 'items' }, item);
+
+        // Version information
+        if (stats[analyzer].version) {
+          var li = dom.create('li', {
+            class : 'version',
+            title : 'Version information.'
+          }, items);
+
+          dom.create('b', { innerHTML : 'Version: ' }, li);
+
+          var versionList = dom.create('ul', { class : 'version' }, li);
+          stats[analyzer].version.trim().split('\n').forEach(function (item) {
+            dom.create('li', { innerHTML : item.trim() }, versionList);
+          });
+        }
+
+        // Successfully analyzed files.
+        var successLi = dom.create('li', {
+          class : 'successful',
+          title : 'Number of successfully analyzed files.'
+        }, items);
+
+        dom.create('b', {
+          innerHTML : 'Number of successfully analyzed files '
+                    + '(<i class="customIcon check"></i>): '
+        }, successLi);
+
+        dom.create('span', {
+          class : 'num',
+          innerHTML : stats[analyzer].successful
+        }, successLi);
+
+        // Files which failed to analyze.
+        var failureLi = dom.create('li', {
+          class : 'failed',
+          title : 'Number of files which failed to analyze.'
+        }, items);
+
+        dom.create('b', {
+          innerHTML : 'Number of files which failed to analyze '
+                    + '(<i class="customIcon remove"></i>): '
+        }, failureLi);
+
+        dom.create('span', {
+          class : 'num',
+          innerHTML : stats[analyzer].failed
+        }, failureLi);
+
+        if (stats[analyzer].failed) {
+          var failedFiles = dom.create('ul');
+          stats[analyzer].failedFilePaths.forEach(function (file) {
+            dom.create('li', { innerHTML : file }, failedFiles);
+          });
+
+          dom.create('li', {
+            innerHTML : '<b>Files which failed to analyze</b>: '
+                      + failedFiles.outerHTML
+          }, items);
+        }
+      });
+
+      this.set('content', ul);
+      this.resize();
+      this.inherited(arguments);
+    }
+  });
+});

--- a/www/scripts/codecheckerviewer/RunHistory.js
+++ b/www/scripts/codecheckerviewer/RunHistory.js
@@ -11,9 +11,11 @@ define([
   'dijit/Dialog',
   'dojox/widget/Standby',
   'dijit/layout/ContentPane',
+  'codechecker/AnalyzerStatisticsDialog',
   'codechecker/hashHelper',
   'codechecker/util'],
-function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
+function (declare, dom, topic, Dialog, Standby, ContentPane,
+  AnalyzerStatisticsDialog, hashHelper, util) {
 
   return declare(ContentPane, {
     constructor : function () {
@@ -25,6 +27,8 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
         title : 'Check command',
         style : 'max-width: 75%;'
       });
+
+      this._analyzerStatDialog = new AnalyzerStatisticsDialog();
 
       this._standBy = new Standby({
         target : this.domNode,
@@ -111,7 +115,7 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
 
           dom.create('span', { class : 'time', innerHTML : time }, wrapper);
 
-          var runNameWrapper = dom.create('span', { class : 'run-name-wrapper', title: 'Run name'}, wrapper);
+          var runNameWrapper = dom.create('span', { class : 'wrapper', title: 'Run name'}, wrapper);
           dom.create('span', { class : 'customIcon run-name' }, runNameWrapper);
           dom.create('span', { class : 'run-name', innerHTML : data.runName }, runNameWrapper);
 
@@ -120,19 +124,50 @@ function (declare, dom, topic, Dialog, Standby, ContentPane, hashHelper, util) {
             dom.place(runTag, wrapper);
           }
 
-          var userWrapper = dom.create('span', {class : 'user-wrapper', title: 'User name' }, wrapper);
+          var userWrapper = dom.create('span', {class : 'wrapper', title: 'User name' }, wrapper);
           dom.create('span', { class : 'customIcon user' }, userWrapper);
           dom.create('span', { class : 'user', innerHTML : data.user }, userWrapper);
 
-          if (data.checkCommand)
+          // CodeChecker client version.
+          if (data.codeCheckerVersion) {
+            var versionWrapper = dom.create('span', {
+              class : 'wrapper',
+              title: 'CodeChecker version'
+            }, wrapper);
+
             dom.create('span', {
-              class : 'check-command link',
+              class : 'customIcon version'
+            }, versionWrapper);
+
+            dom.create('span', {
+              innerHTML : data.codeCheckerVersion
+            }, versionWrapper);
+          }
+
+          // Analyzer statistics.
+          if (Object.keys(data.analyzerStatistics).length) {
+            dom.create('span', {
+              class : 'wrapper link',
+              innerHTML : '<i class="customIcon statistics"></i> '
+                        + 'Analyzer statistics',
+              onclick : function () {
+                that._analyzerStatDialog.show(data.analyzerStatistics);
+              }
+            }, history);
+          }
+
+          // Check command.
+          if (data.checkCommand) {
+            dom.create('span', {
+              class : 'check-command wrapper link',
               innerHTML : 'Check command',
               onclick : function () {
+                that._dialog.set('title', 'Check command');
                 that._dialog.set('content', data.checkCommand);
                 that._dialog.show();
               }
             }, history);
+          }
         })
       });
     },

--- a/www/scripts/version.js
+++ b/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.13';
+CC_API_VERSION = '6.14';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/www/style/codecheckerviewer.css
+++ b/www/style/codecheckerviewer.css
@@ -723,3 +723,83 @@ html, body {
   color: #669603;
   border: 1px solid #669603;
 }
+
+/* Analyzer statistics */
+td .analyzer-statistics {
+  cursor: pointer;
+}
+
+ul.analyzer-statistics,
+ul.analyzer-statistics .items {
+  padding: 0;
+  margin: 0;
+}
+
+ul.analyzer-statistics h3 {
+  margin: 0;
+  background-color: #7fbed3;
+  padding: 5px;
+  color: white;
+}
+
+ul.analyzer-statistics .items {
+  display: inline-block;
+}
+
+ul.analyzer-statistics .items > li {
+  display: inline;
+  margin-right: 5px;
+}
+
+ul.analyzer-statistics .num {
+  color: #767676;
+  padding-left: 2px;
+}
+
+ul.analyzer-statistics .link {
+  color: #007ea7;
+}
+
+.analyzer-statistics .check {
+  color: #587549;
+}
+
+.analyzer-statistics .remove {
+  color: #964739;
+}
+
+.dijitDialog ul.analyzer-statistics {
+  overflow: auto;
+  height: 450px;
+}
+
+.dijitDialog ul.analyzer-statistics > li {
+  margin-bottom: 10px;
+}
+
+.dijitDialog ul.analyzer-statistics .items > li {
+  display: block;
+}
+
+.dijitDialog ul.analyzer-statistics .items {
+  margin-left: 10px;
+}
+
+.dijitDialog ul.analyzer-statistics .customIcon {
+  margin: 0;
+}
+
+.dijitDialog ul.analyzer-statistics .num {
+  color: white;
+  padding: 0px 5px;
+  text-align: center;
+  font-weight: bold;
+}
+
+.dijitDialog ul.analyzer-statistics .failed .num {
+  background-color: red;
+}
+
+.dijitDialog ul.analyzer-statistics .successful .num {
+  background-color: green;
+}

--- a/www/style/icons.css
+++ b/www/style/icons.css
@@ -365,3 +365,19 @@ span[class*="severity-"] {
 .customIcon.remove::before {
   content: "\e01e";
 }
+
+.customIcon.version {
+  display: inline-block;
+  text-align: center;
+  border-radius: 50%;
+  background-color: #73a7b9;
+  color: white;
+}
+
+.customIcon.version:after {
+  content : 'v';
+}
+
+.customIcon.check:before {
+  content: "\e01d";
+}

--- a/www/style/runhistory.css
+++ b/www/style/runhistory.css
@@ -36,13 +36,14 @@
   margin-right: 10px;
 }
 
-.history .run-name-wrapper,
-.history .tag-wrapper,
-.history .user-wrapper,
-.history .check-command {
+.history .wrapper {
   margin-left: 5px;
 }
 
 .history .customIcon {
   color: #73a7b9;
+}
+
+.dijitDialog ul.failed-files {
+  margin: 0;
 }


### PR DESCRIPTION
> Closes #565

* Add CodeChecker version to the run history table and shows this at the Run and Run history pages.
* Create an analyzer statistic table which stores the number of failed and successfully analyzed files for each analyzer types.
* Show analyzer statistics at the run history and run pages.