### PR TITLE
New configuration options for statistical counting

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -256,13 +256,15 @@ cross translation unit analysis arguments:
   --ctu-on-the-fly
 
 statistical analysis arguments:
-  These arguments are only available if the Clang Static Analyzer supports
+  This is an EXPERIMENTAL feature.These arguments are only available if the Clang Static Analyzer supports
   Statistical analysis. By default, no Statistical analysis is run when 'CodeChecker
   analyze' is called.
 
   --stats
   --stats-collect
   --stats-use
+  --stats-min-sample-count
+  --stats-relevance-threshold
 
 checker configuration:
 
@@ -797,6 +799,17 @@ EXPERIMENTAL statistics analysis feature arguments:
                         needed by statistics analysis and enables the
                         statistical checkers. No need to enable them
                         explicitly.
+ --stats-min-sample-count STATS_MIN_SAMPLE_COUNT, --stats-min-sample-count STATS_MIN_SAMPLE_COUNT
+                        EXPERIMENTAL feature. Minimum number of samples
+                        (function call occurrences) to be collected for a
+                        statistics to be relevant.(default: 10)
+  --stats-relevance-threshold STATS_RELEVANCE_THRESHOLD, --stats-relevance-threshold STATS_RELEVANCE_THRESHOLD
+                        EXPERIMENTAL feature. The minimum ratio of
+                        calls of function f that must have a certain property
+                        to consider it true for that function (calculated as calls 
+                        with a property/all calls). CodeChecker will warn for calls 
+                        of f that do not have that property.(default: 0.85)
+ 
 ~~~~~~~~~~~~~~~~~~~~~
 
 ## <a name="parse"></a> 3. `parse` mode

--- a/libcodechecker/analyze/analyzer.py
+++ b/libcodechecker/analyze/analyzer.py
@@ -190,6 +190,25 @@ def perform_analysis(args, context, actions, metadata):
         statistics_data = manager.dict({'stats_out_dir':
                                         args.stats_output})
 
+    if 'stats_min_sample_count' in args and statistics_data:
+        if args.stats_min_sample_count > 1:
+            statistics_data['stats_min_sample_count'] =\
+                args.stats_min_sample_count
+        else:
+            LOG.error("stats_min_sample_count"
+                      "must be greater than 1.")
+            return
+
+    if 'stats_relevance_threshold' in args and statistics_data:
+        if (args.stats_relevance_threshold < 1 and
+                args.stats_relevance_threshold > 0):
+            statistics_data['stats_relevance_threshold'] =\
+                args.stats_relevance_threshold
+        else:
+            LOG.error("stats-relevance-threshold must be"
+                      " greater than 0 and smaller than 1.")
+            return
+
     skip_handler = __get_skip_handler(args)
     if ctu_collect or statistics_data:
         ctu_data = None

--- a/libcodechecker/analyze/pre_analysis_manager.py
+++ b/libcodechecker/analyze/pre_analysis_manager.py
@@ -216,7 +216,12 @@ def run_pre_analysis(actions, context, analyzer_config_map,
         stats_in = statistics_data.get('stat_tmp_dir')
         stats_out = statistics_data.get('stats_out_dir')
 
-        statistics_collector.postprocess_stats(stats_in, stats_out)
+        statistics_collector.postprocess_stats(stats_in, stats_out,
+                                               statistics_data.get(
+                                                   'stats_min_sample_count'),
+                                               statistics_data.get(
+                                                   'stats_relevance_threshold')
+                                               )
 
         if os.path.exists(stats_in):
             LOG.debug('Cleaning up temporary statistics directory')

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -342,6 +342,32 @@ def add_arguments_to_parser(parser):
                                     "the statistical checkers. "
                                     "No need to enable them explicitly.")
 
+        stat_opts.add_argument('--stats-min-sample-count',
+                               action='store',
+                               default="10",
+                               type=int,
+                               dest='stats_min_sample_count',
+                               help="EXPERIMENTAL feature. "
+                                    "Minimum number of samples (function call"
+                                    " occurrences) to be collected"
+                                    " for a statistics to be relevant "
+                                    "'<MIN-SAMPLE-COUNT>'.")
+
+        stat_opts.add_argument('--stats-relevance-threshold',
+                               action='store',
+                               default="0.85",
+                               type=float,
+                               dest='stats_relevance_threshold',
+                               help="EXPERIMENTAL feature. "
+                                    "The minimum ratio of calls of function "
+                                    "f that must have a certain property "
+                                    "property to consider it true for that "
+                                    "function (calculated as calls "
+                                    "with a property/all calls)."
+                                    " CodeChecker will warn for"
+                                    " calls of f do not have that property."
+                                    "'<RELEVANCE_THRESHOLD>'.")
+
     checkers_opts = parser.add_argument_group(
         "checker configuration",
         """

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -353,6 +353,30 @@ used to generate a log file on the fly.""")
                                     "the statistical checkers. "
                                     "No need to enable them explicitly.")
 
+        stat_opts.add_argument('--stats-min-sample-count',
+                               action='store',
+                               default="10",
+                               type=int,
+                               dest='stats_min_sample_count',
+                               help="EXPERIMENTAL feature. "
+                                    "Minimum number of samples (function call"
+                                    " occurrences) to be collected"
+                                    " for a statistics to be relevant.")
+
+        stat_opts.add_argument('--stats-relevance-threshold',
+                               action='store',
+                               default="0.85",
+                               type=float,
+                               dest='stats_relevance_threshold',
+                               help="EXPERIMENTAL feature. "
+                                    "The minimum ratio of calls of function "
+                                    "f that must have a certain property "
+                                    "property to consider it true for that "
+                                    "function (calculated as calls "
+                                    "with a property/all calls)."
+                                    " CodeChecker will warn for"
+                                    " calls of f do not have that property.")
+
     checkers_opts = parser.add_argument_group(
         "checker configuration",
         """
@@ -520,6 +544,8 @@ def main(args):
                           'stats_output',
                           'stats_dir',
                           'stats_enabled',
+                          'stats_relevance_threshold',
+                          'stats_min_sample_count',
                           'enable_all',
                           'ordered_checkers',  # --enable and --disable.
                           'timeout'

--- a/tests/functional/statistics/test_statistics.py
+++ b/tests/functional/statistics/test_statistics.py
@@ -100,6 +100,34 @@ class TestSkeleton(unittest.TestCase):
         self.assertIn('SpecialReturn.yaml', stat_files)
         self.assertIn('UncheckedReturn.yaml', stat_files)
 
+    def test_stats_collect_params(self):
+        """
+        Testing collection parameters
+        """
+        if not self.stats_capable:
+            self.skipTest(NO_STATISTICS_MESSAGE)
+
+        test_project_path = self._testproject_data['project_path']
+        stats_dir = os.path.join(test_project_path, 'stats')
+        cmd = [self._codechecker_cmd, 'analyze', '--stats-collect', stats_dir,
+               'compile_command.json',
+               '--stats-min-sample-count', '10',
+               '--stats-relevance-threshold', '0.8',
+               '-o', 'reports']
+        output, err = call_command(cmd, cwd=test_project_path, env=self.env)
+        print(output)
+        print(err)
+        analyze_msg = "Starting static analysis"
+        self.assertNotIn(analyze_msg, output)
+        stat_files = os.listdir(stats_dir)
+        print(stat_files)
+        self.assertIn('SpecialReturn.yaml', stat_files)
+        self.assertIn('UncheckedReturn.yaml', stat_files)
+        with open(os.path.join(stats_dir,
+                               'UncheckedReturn.yaml'), 'r') as statfile:
+            unchecked_stats = statfile.read()
+        self.assertIn("c:@F@readFromFile#*1C#*C#", unchecked_stats)
+
     def test_stats_use(self):
         """
         Use the already collected statistics for the analysis.

--- a/tests/projects/cpp/Makefile
+++ b/tests/projects/cpp/Makefile
@@ -12,6 +12,7 @@ all:
 	$(CXX) -c path_begin2.cpp -Wno-all -Wno-extra
 	$(CXX) -c -DVAR=2 path_begin.cpp -Wno-all -Wno-extra
 	$(CXX) -c -DVAR=1 path_begin.cpp -Wno-all -Wno-extra
+	$(CXX) -c statistical_checkers.c -Wno-all -Wno-extra
 clean:
 	rm -f call_and_message.o
 	rm -f divide_zero.o
@@ -25,3 +26,4 @@ clean:
 	rm -f path_begin1.o
 	rm -f path_begin2.o
 	rm -f path_begin.o
+	rm -f statistical_checkers.o

--- a/tests/projects/cpp/statistical_checkers.c
+++ b/tests/projects/cpp/statistical_checkers.c
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+// core.StackAddressEscape (C)
+// Check that addresses of stack memory do not escape the function.
+
+
+/* Test file for the statistical countinf feature
+/* for alpha.ericsson.statisticscollector.ReturnValueCheck
+ * alpha.ericsson.statisticscollector.SpecialReturnValue
+ */
+
+int readFromFile(const char* fileName, char *text){
+  if (!fileName) //return with error if
+    return -1;
+  else{
+  }
+}
+
+int *getMem();
+
+void testUncheckedReturn(){
+  char txt[100];
+  int err=readFromFile("a.c",txt);
+  if (err==-1)
+    return;
+  readFromFile("k.c",txt); //warning: the return value of readFromFile is usually checked
+  if (readFromFile("b.c",txt) == 0)
+    return;
+  if (readFromFile("c.c",txt)==-2)
+      return;
+  if (readFromFile("d.c",txt)==-1)
+      return;
+  if (readFromFile("e.c",txt)==-1)
+      return;
+  if (readFromFile("f.c",txt)==-1)
+      return;
+  if (readFromFile("g.c",txt)==-1)
+      return;
+  if (readFromFile("h.c",txt)==-1)
+      return;
+  if (readFromFile("i.c",txt)==-1)
+      return;
+  readFromFile("j.c",txt); //warning: the return value of readFromFile is usually checked
+}
+
+
+int testSpecialReturn(){
+  if (getMem()!=0)
+    return 0;
+  if (!getMem())
+    return 0;
+  if (!getMem())
+    return 0;
+  return *getMem();
+
+
+}

--- a/tests/unit/test_statistics_collectors.py
+++ b/tests/unit/test_statistics_collectors.py
@@ -34,7 +34,7 @@ class statistics_collectorsTest(unittest.TestCase):
                       ]
 
         special_ret_collector = \
-            statistics_collector.SpecialReturnValueCollector()
+            statistics_collector.SpecialReturnValueCollector(10, 0.85)
 
         for l in test_input:
             special_ret_collector.process_line(l)
@@ -87,7 +87,7 @@ class statistics_collectorsTest(unittest.TestCase):
                         ]
 
         special_ret_collector = \
-            statistics_collector.SpecialReturnValueCollector()
+            statistics_collector.SpecialReturnValueCollector(10, 0.85)
 
         for l in test_ret_neg:
             special_ret_collector.process_line(l)
@@ -119,7 +119,7 @@ class statistics_collectorsTest(unittest.TestCase):
                         " Return Value Check:/.../x.c:551:12,parsedate,0",
                         ]
 
-        ret_val_collector = statistics_collector.ReturnValueCollector()
+        ret_val_collector = statistics_collector.ReturnValueCollector(10, 0.85)
 
         for l in test_ret_neg:
             ret_val_collector.process_line(l)
@@ -154,7 +154,7 @@ class statistics_collectorsTest(unittest.TestCase):
                         " Return Value Check:/.../x.c:551:12,parsedate,1",
                         ]
 
-        ret_val_collector = statistics_collector.ReturnValueCollector()
+        ret_val_collector = statistics_collector.ReturnValueCollector(10, 0.85)
 
         for l in test_ret_neg:
             ret_val_collector.process_line(l)


### PR DESCRIPTION
New configuration options are introduced for statistical
checker counting: stats-min-sample-count, stats-relevance-threshold

Resolves #1589