### PR TITLE
Skip '-Xclang <opt>'

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -144,7 +144,9 @@ IGNORED_OPTION_MAP = {
     # '-Werror', '-pedantic-errors' the analysis with Clang can fail even
     # if the compilation passes with GCC.
     '-Werror': 0,
-    '-pedantic-errors': 0
+    '-pedantic-errors': 0,
+    # Skip paired Xclang options like "-Xclang -mllvm".
+    '-Xclang': 1
 }
 
 IGNORED_OPTION_MAP_REGEX = {

--- a/tests/unit/test_option_parser.py
+++ b/tests/unit/test_option_parser.py
@@ -194,7 +194,9 @@ class OptionParserTest(unittest.TestCase):
     def test_ignore_flags(self):
         ignore = ["-Werror", "-MT hello", "-M", "-fsyntax-only",
                   "-mfloat-gprs=double", "-mfloat-gprs=yes",
-                  "-mabi=spe", "-mabi=eabi"]
+                  "-mabi=spe", "-mabi=eabi",
+                  '-Xclang', '-mllvm',
+                  '-Xclang', '-instcombine-lower-dbg-declare=0']
         build_cmd = "g++ {} main.cpp".format(' '.join(ignore))
         res = option_parser.parse_options(build_cmd)
         self.assertEqual(res.compile_opts, ["-fsyntax-only"])


### PR DESCRIPTION
Essential for checking the Chromium project.
Without this patch `-Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -fcomplete-member-pointers`
becomes (for clangsa options parser) `-mllvm -fcomplete-member-pointers` which is incorrect.