### PR TITLE
fix plist to html converter missing severity

### DIFF
--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -76,7 +76,7 @@ class HtmlBuilder:
         # Add severity levels for reports.
         for report in report_data['reports']:
             checker = report['checkerName']
-            report['severity'] = self._severity_map.get(checker)
+            report['severity'] = self._severity_map.get(checker, 'UNSPECIFIED')
 
         self.generated_html_reports[output_path] = report_data['reports']
         content = self._layout.replace('<$REPORT_DATA$>',


### PR DESCRIPTION
If the plist to html converter was used separately from CodeChecker the missing severity levels caused problems during the html generation.