### PR TITLE
Slugify run name when storing analysis statistics

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -48,7 +48,7 @@ from libcodechecker.server.database.run_db_model import \
     AnalyzerStatistic, Report, ReviewStatus, File, Run, RunHistory, \
     RunLock, Comment, BugPathEvent, BugReportPoint, \
     FileContent, SourceComponent
-from libcodechecker.util import DBSession
+from libcodechecker.util import DBSession, slugify
 
 from . import store_handler
 
@@ -2504,13 +2504,16 @@ class ThriftRequestHandler(object):
                 if not os.path.exists(product_dir):
                     os.makedirs(product_dir)
 
+                # Removes and replaces special characters in the run name.
+                run_name = slugify(run_name)
+
                 run_zip_file = os.path.join(product_dir, run_name + '.zip')
                 with open(run_zip_file, 'w') as run_zip:
                     run_zip.write(zlib.decompress(
                         base64.b64decode(b64zip)))
                 return True
             except Exception as ex:
-                LOG.error(ex.message)
+                LOG.error(str(ex))
                 return False
 
         return False

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -662,3 +662,16 @@ def generate_session_token():
     Returns a random session token.
     """
     return uuid.UUID(bytes=os.urandom(16)).__str__().replace('-', '')
+
+
+def slugify(text):
+    """
+    Removes and replaces special characters in a given text.
+    """
+    # Removes non-alpha characters.
+    norm_text = re.sub(r'[^\w\s\-\//]', '', text)
+
+    # Converts spaces and slashes to underscores.
+    norm_text = re.sub(r'([\s]+|[\/]+)', '_', norm_text)
+
+    return norm_text

--- a/tests/unit/test_slugify_file_name.py
+++ b/tests/unit/test_slugify_file_name.py
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Test slugify file names. """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import unittest
+
+from libcodechecker.util import slugify
+
+
+class SlugifyFileNameTestCase(unittest.TestCase):
+    """
+    Test cases to slugify file names.
+    """
+
+    def test_only_alpha(self):
+        self.assertEqual('test', slugify('test'))
+        self.assertEqual('test123', slugify('test123'))
+
+    def test_white_spaces(self):
+        self.assertEqual('test_1', slugify('test 1'))
+        self.assertEqual('test_1_2', slugify('test 1 2'))
+
+    def test_underscore(self):
+        self.assertEqual('test_1', slugify('test_1'))
+        self.assertEqual('test_1_2', slugify('test_1_2'))
+
+    def test_slashes(self):
+        self.assertEqual('test_1', slugify('test/1'))
+        self.assertEqual('test_1_2', slugify('test/1/2'))
+
+    def test_special_characters(self):
+        self.assertEqual('test', slugify('test*?#'))


### PR DESCRIPTION
If run name contained a non-alpha character (for example a slash) the storage of analysis statistics failed because a directory name can not contain such characters. This commit fixes this problem by normalizing the run name.