### PR TITLE
fix non breakable space character

### DIFF
--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -498,7 +498,7 @@ def get_line(file_name, line_no):
     string.
     """
     try:
-        with open(file_name, 'U') as source_file:
+        with io.open(file_name) as source_file:
             for line in source_file:
                 line_no -= 1
                 if line_no == 0:

--- a/tests/functional/analyze_and_parse/test_files/source_code_comments.cpp
+++ b/tests/functional/analyze_and_parse/test_files/source_code_comments.cpp
@@ -1,6 +1,6 @@
 int main()
 {
-  // codechecker_suppress [all] Source code comment message
+  // codechecker_suppress [all] Source code comment message
   sizeof(40);
 
   // codechecker_false_positive [all] Source code comment message

--- a/tests/unit/test_source_code_comment.py
+++ b/tests/unit/test_source_code_comment.py
@@ -161,7 +161,7 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my_checker_1'},
-                    'message': "áúőóüöáé ▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬",
+                    'message': u"áúőóüöáé ▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬",
                     'status': 'false_positive'}
         self.assertDictEqual(expected, source_line_comments[0])
 


### PR DESCRIPTION
If there is a non breakable space character in the
review status comment the parsing and the comment handling fails.