### PR TITLE
Fix changing run tab

### DIFF
--- a/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -519,6 +519,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
           listOfBugsGrid : that._grid,
           onShow : function () {
             hashHelper.setStateValues({
+              'tab' : that.tab,
               'reportHash' : reportData.bugHash,
               'report' : reportData.reportId,
               'subtab' : reportData.bugHash


### PR DESCRIPTION
> Closes #1748 

There was an error when changing run tab:
- Open a run.
- Open a bug in the previously opened run tab.
- Open another run.
- We can not see the results in the firstly opened run tab.

This commit solves this problem by set the correct tab value in the URL.