### PR TITLE
Add missing requirement.

### DIFF
--- a/requirements_py/dev/requirements.txt
+++ b/requirements_py/dev/requirements.txt
@@ -1,4 +1,5 @@
 sqlalchemy==1.1.11
+pycodestyle
 alembic==0.9.2
 psycopg2==2.7.1
 pg8000==1.10.2

--- a/requirements_py/dev/requirements.txt
+++ b/requirements_py/dev/requirements.txt
@@ -1,5 +1,5 @@
 sqlalchemy==1.1.11
-pycodestyle
+pycodestyle==2.4.0
 alembic==0.9.2
 psycopg2==2.7.1
 pg8000==1.10.2


### PR DESCRIPTION
In order to run make test we also need pycodestyle, so I think it would make sense to have it in the dev requirements.