### PR TITLE
Fix storing check command

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -2381,11 +2381,10 @@ class ThriftRequestHandler(object):
                 check_commands, check_durations, cc_version, statistics = \
                     store_handler.metadata_info(metadata_file)
 
-                if len(check_commands) == 0:
-                    command = ' '.join(sys.argv)
-                elif len(check_commands) == 1:
+                command = ''
+                if len(check_commands) == 1:
                     command = ' '.join(check_commands[0])
-                else:
+                elif len(check_commands) > 1:
                     command = "multiple analyze calls: " + \
                               '; '.join([' '.join(com)
                                          for com in check_commands])


### PR DESCRIPTION
If the analyze command doesn't exit in the `metadata.json` file use an empty string instead of the server command when storing analysis results.