### PR TITLE
handle character decoding problems (locale mismatch)

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -1314,7 +1314,8 @@ class ThriftRequestHandler(object):
             if md_file:
                 md_file = os.path.join(self.__checker_md_docs, md_file)
                 try:
-                    with io.open(md_file, 'r') as md_content:
+                    with io.open(md_file, errors='replace',
+                                 mode='r') as md_content:
                         missing_doc = md_content.read()
                 except (IOError, OSError) as oerr:
                     LOG.warning("Failed to read checker documentation: %s",

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -498,7 +498,7 @@ def get_line(file_name, line_no):
     string.
     """
     try:
-        with io.open(file_name) as source_file:
+        with io.open(file_name, errors='replace', mode='r') as source_file:
             for line in source_file:
                 line_no -= 1
                 if line_no == 0:
@@ -570,7 +570,7 @@ def load_json_or_empty(path, default=None, kind=None, lock=False):
 
     ret = default
     try:
-        with io.open(path, 'r') as handle:
+        with io.open(path, errors='replace', mode='r') as handle:
             if lock:
                 portalocker.lock(handle, portalocker.LOCK_SH)
 


### PR DESCRIPTION
In case the decoding to unicode fails for some reason replace the
problematic characters.
The problem could be caused if the host locale settings do not match
the files encoding opened for read (text mode).
Python tries to decode the strings based on the host locale settings.

NOTE: this change could modify the hash generated for clang tidy in case there is some
character which can not be decoded (replaced with `?`) in the source line used for hash generation.