### PR TITLE
Preserve -nostdinc++ in command line, the same as for -nostdinc

### DIFF
--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -28,10 +28,11 @@ from libcodechecker.logger import get_logger
 LOG = get_logger('buildlogger')
 
 # Compiler options in the following format
-# argument_name: number of parameters sepearated by space.
+# argument_name: number of parameters separated by space.
 
 COMPILE_OPTION_MAP = {
     '-nostdinc': 0,
+    '-nostdinc++': 0,
     '--sysroot': 1,
     '--include': 1,
     '-pedantic': 0,

--- a/tests/unit/test_option_parser.py
+++ b/tests/unit/test_option_parser.py
@@ -192,6 +192,9 @@ class OptionParserTest(unittest.TestCase):
         self.assertEqual(ActionType.LINK, res.action)
 
     def test_ignore_flags(self):
+        """
+        Test if special compiler options are ignored properly.
+        """
         ignore = ["-Werror", "-MT hello", "-M", "-fsyntax-only",
                   "-mfloat-gprs=double", "-mfloat-gprs=yes",
                   "-mabi=spe", "-mabi=eabi",
@@ -200,6 +203,15 @@ class OptionParserTest(unittest.TestCase):
         build_cmd = "g++ {} main.cpp".format(' '.join(ignore))
         res = option_parser.parse_options(build_cmd)
         self.assertEqual(res.compile_opts, ["-fsyntax-only"])
+
+    def test_preserve_flags(self):
+        """
+        Test if special compiler options are preserved properly.
+        """
+        preserve = ['-nostdinc', '-nostdinc++', '-pedantic']
+        build_cmd = "g++ {} main.cpp".format(' '.join(preserve))
+        res = option_parser.parse_options(build_cmd)
+        self.assertEqual(res.compile_opts, preserve)
 
     def test_compiler_toolchain(self):
         """


### PR DESCRIPTION
Preserve '-nostdinc++' in command line, the same as done for  '-nostdinc'.

Essential for checking the Chromium project.