### PR TITLE
Convert relative include paths to absolute

### DIFF
--- a/libcodechecker/analyze/log_parser.py
+++ b/libcodechecker/analyze/log_parser.py
@@ -370,16 +370,16 @@ def parse_compile_commands_json(log_data, parseLogOptions):
 
         action.original_command = command
 
-        # If the original include directory could not be found
-        # in the filesystem, it is possible that it was provided
-        # relative to the working directory in the compile json.
+        # If the include directory is given as relative path then the working
+        # directory is prepended.
         compile_opts = results.compile_opts
         for i, opt in enumerate(compile_opts):
             if opt.startswith('-I'):
                 inc_dir = opt[2:].strip()
-                if not os.path.isdir(inc_dir):
+                if not os.path.isabs(inc_dir):
                     compile_opts[i] = '-I' + \
-                        os.path.join(entry['directory'], inc_dir)
+                        os.path.normpath(os.path.join(
+                            entry['directory'], inc_dir))
 
         action.analyzer_options = compile_opts
 

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -211,14 +211,13 @@ class LogParserTest(unittest.TestCase):
 
     def test_include_rel_to_abs(self):
         """
-        Test working directory prepending to non-existent
-        (probably relative) include paths.
+        Test working directory prepending to relative include paths.
         """
         logfile = os.path.join(self.__test_files, "include.json")
 
         build_action = log_parser.parse_log(logfile, ParseLogOptions())[0]
 
         self.assertEqual(len(build_action.analyzer_options), 3)
-        self.assertEqual(build_action.analyzer_options[0], '-I/tmp/../include')
-        self.assertEqual(build_action.analyzer_options[1], '-I/tmp/../include')
+        self.assertEqual(build_action.analyzer_options[0], '-I/include')
+        self.assertEqual(build_action.analyzer_options[1], '-I/include')
         self.assertEqual(build_action.analyzer_options[2], '-I/tmp')


### PR DESCRIPTION
In pull request #1553 the relative include paths have been changed to absolute based on the working directory from the build json file. The intention was to accomplish as less modifications on the provided build command as possible. However, leaving relative paths in a plist interferes with the skipfile functionality:

project files:
```
/absolute/path/to/the/project/a/b/f.h
/absolute/path/to/the/project/main.cpp
```

good build command: `g++ -I/absolute/path/to/the/project/a main.cpp`
bad build command: `g++ -I./a main.cpp`

main.cpp:
```cpp
#include "b/f.h"
int main() { ... }
```

skipfile:
```
-/absolute/path/to/the/project/a*
```

This configuration doesn't skip the reports from subdirectory "a" with the bad build command.