### PR TITLE
Fix exception message printing at server

### DIFF
--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -76,9 +76,10 @@ def exc_to_thrift_reqfail(func):
             LOG.warning(rf.message)
             raise
         except Exception as ex:
-            LOG.warning(ex.message)
+            msg = str(ex)
+            LOG.warning(msg)
             raise shared.ttypes.RequestFailed(shared.ttypes.ErrorCode.GENERAL,
-                                              ex.message)
+                                              msg)
 
     return wrapper
 


### PR DESCRIPTION
Convert exception to string instead of using message attribute because some exception doesn't set this attribute correctly (e.g.: `UnicodeDecodeError`).