### PR TITLE
Constructing config handler is the analyzer classes' responsibility

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,5 @@
 {
   "environment_variables": {
-      "env_package_root" : "CC_PACKAGE_ROOT",
       "env_path" : "PATH",
       "env_ld_lib_path" : "LD_LIBRARY_PATH",
       "cc_logger_bin" : "CC_LOGGER_BIN",

--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -424,7 +424,8 @@ def prepare_check(source, action, analyzer_config_map, output_dir,
         # Needs to be called before construct_analyzer_cmd
         source_analyzer.disable_ctu()
 
-    if action.analyzer_type == analyzer_types.CLANG_SA and statistics_data:
+    if action.analyzer_type == analyzer_clangsa.ClangSA.ANALYZER_NAME and \
+       statistics_data:
         # WARNING! Statistical checkers are only supported by Clang
         # Static Analyzer right now.
         stats_dir = statistics_data['stats_out_dir']

--- a/libcodechecker/analyze/analyzer.py
+++ b/libcodechecker/analyze/analyzer.py
@@ -24,6 +24,7 @@ from libcodechecker.analyze import analysis_manager
 from libcodechecker.analyze import analyzer_env
 from libcodechecker.analyze import pre_analysis_manager
 from libcodechecker.analyze.analyzers import analyzer_types
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
 
 
 LOG = get_logger('analyzer')
@@ -151,14 +152,14 @@ def perform_analysis(args, skip_handler, context, actions, metadata):
     if 'ctu_phases' in args:
         ctu_dir = os.path.join(args.output_path, 'ctu-dir')
         args.ctu_dir = ctu_dir
-        if analyzer_types.CLANG_SA not in analyzers:
+        if ClangSA.ANALYZER_NAME not in analyzers:
             LOG.error("CTU can only be used with the clang static analyzer.")
             return
         ctu_collect = args.ctu_phases[0]
         ctu_analyze = args.ctu_phases[1]
 
     if 'stats_enabled' in args and args.stats_enabled:
-        if analyzer_types.CLANG_SA not in analyzers:
+        if ClangSA.ANALYZER_NAME not in analyzers:
             LOG.debug("Statistics can only be used with "
                       "the Clang Static Analyzer.")
             return
@@ -208,7 +209,7 @@ def perform_analysis(args, skip_handler, context, actions, metadata):
                                      'tmpExternalFnMaps'})
 
         pre_analyze = [a for a in actions
-                       if a.analyzer_type == analyzer_types.CLANG_SA]
+                       if a.analyzer_type == ClangSA.ANALYZER_NAME]
         pre_analysis_manager.run_pre_analysis(pre_analyze,
                                               context,
                                               config_map,

--- a/libcodechecker/analyze/analyzer_env.py
+++ b/libcodechecker/analyze/analyzer_env.py
@@ -99,7 +99,7 @@ def extend_analyzer_cmd_with_resource_dir(analyzer_cmd,
     and describes our intentions more cleanly if we just simply disable the
     inludes from the resource dir.
     """
-    if len(compiler_resource_dir) == 0:
+    if not compiler_resource_dir:
         return
 
     resource_inc = compiler_resource_dir

--- a/libcodechecker/analyze/analyzers/analyzer_base.py
+++ b/libcodechecker/analyze/analyzers/analyzer_base.py
@@ -50,9 +50,6 @@ class SourceAnalyzer(object):
 
     @abstractmethod
     def construct_analyzer_cmd(self, result_handler):
-        """
-        Construct the analyzer command.
-        """
         raise NotImplementedError("Subclasses should implement this!")
 
     @classmethod
@@ -61,6 +58,11 @@ class SourceAnalyzer(object):
         In case of the configured binary for the analyzer is not found in the
         PATH, this method is used to find a callable binary.
         """
+        raise NotImplementedError("Subclasses should implement this!")
+
+    @classmethod
+    def construct_config_handler(cls, args, context):
+        """ Should return a subclass of AnalyzerConfigHandler."""
         raise NotImplementedError("Subclasses should implement this!")
 
     @abstractmethod

--- a/libcodechecker/analyze/analyzers/analyzer_base.py
+++ b/libcodechecker/analyze/analyzers/analyzer_base.py
@@ -34,11 +34,6 @@ class SourceAnalyzer(object):
         self.__build_action = buildaction
         # Currently analyzed source file.
         self.source_file = ''
-        self.__checkers = []
-
-    @property
-    def checkers(self):
-        return self.__checkers
 
     @property
     def buildaction(self):
@@ -110,8 +105,8 @@ class SourceAnalyzer(object):
             res_handler.analyzer_returncode = 1
             return res_handler
 
-    @abstractmethod
-    def get_analyzer_checkers(self, config_handler, env):
+    @classmethod
+    def get_analyzer_checkers(cls, config_handler, env):
         """
         Return the checkers available in the analyzer.
         """

--- a/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clang_tidy.py
@@ -14,12 +14,16 @@ import re
 import shlex
 import subprocess
 
+from libcodechecker.analyze import analyzer_env
+from libcodechecker.analyze import host_check
 from libcodechecker.analyze.analyzers import analyzer_base
-from libcodechecker.logger import get_logger
-from libcodechecker.util import get_binary_in_path
-from libcodechecker.analyze.analyzer_env import\
-    extend_analyzer_cmd_with_resource_dir
+from libcodechecker.analyze.analyzers import config_handler_clang_tidy
 from libcodechecker.analyze.analyzers import result_handler_clang_tidy
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
+from libcodechecker.analyze.analyzer_env import \
+    extend_analyzer_cmd_with_resource_dir
+from libcodechecker.logger import get_logger
+from libcodechecker.util import get_binary_in_path, replace_env_var
 
 LOG = get_logger('analyzer')
 
@@ -28,6 +32,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
     """
     Constructs the clang tidy analyzer commands.
     """
+
+    ANALYZER_NAME = 'clang-tidy'
 
     def add_checker_config(self, checker_cfg):
         LOG.error("Not implemented yet")
@@ -211,3 +217,75 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         res_handler.severity_map = severity_map
         res_handler.skiplist_handler = skiplist_handler
         return res_handler
+
+    @classmethod
+    def construct_config_handler(cls, args, context):
+        handler = config_handler_clang_tidy.ClangTidyConfigHandler()
+        handler.analyzer_binary = context.analyzer_binaries.get(
+            cls.ANALYZER_NAME)
+
+        # FIXME We cannot get the resource dir from the clang-tidy binary,
+        # therefore we get a sibling clang binary which of clang-tidy.
+        # TODO Support "clang-tidy -print-resource-dir" .
+        check_env = analyzer_env.get_check_env(context.path_env_extra,
+                                               context.ld_lib_path_extra)
+        # Overwrite PATH to contain only the parent of the clang binary.
+        if os.path.isabs(handler.analyzer_binary):
+            check_env['PATH'] = os.path.dirname(handler.analyzer_binary)
+        clang_bin = ClangSA.resolve_missing_binary('clang',
+                                                   check_env)
+        handler.compiler_resource_dir = \
+            host_check.get_resource_dir(clang_bin, context)
+
+        try:
+            with open(args.tidy_args_cfg_file, 'rb') as tidy_cfg:
+                handler.analyzer_extra_arguments = \
+                    re.sub(r'\$\((.*?)\)', replace_env_var,
+                           tidy_cfg.read().strip())
+        except IOError as ioerr:
+            LOG.debug_analyzer(ioerr)
+        except AttributeError as aerr:
+            # No clang tidy arguments file was given in the command line.
+            LOG.debug_analyzer(aerr)
+
+        try:
+            # The config file dumped by clang-tidy contains "..." at the end.
+            # This has to be emitted, otherwise -config flag of clang-tidy
+            # cannot consume it.
+            with open(args.tidy_config, 'rb') as tidy_config:
+                lines = tidy_config.readlines()
+                lines = filter(lambda x: x != '...\n', lines)
+                handler.checker_config = ''.join(lines)
+        except IOError as ioerr:
+            LOG.debug_analyzer(ioerr)
+        except AttributeError as aerr:
+            # No clang tidy config file was given in the command line.
+            LOG.debug_analyzer(aerr)
+
+        analyzer = ClangTidy(handler, None)
+        check_env = analyzer_env.get_check_env(context.path_env_extra,
+                                               context.ld_lib_path_extra)
+
+        checkers = analyzer.get_analyzer_checkers(handler, check_env)
+
+        # Read clang-tidy checkers from the config file.
+        clang_tidy_checkers = context.checker_config.get(cls.ANALYZER_NAME +
+                                                         '_checkers')
+
+        try:
+            cmdline_checkers = args.ordered_checkers
+        except AttributeError:
+            LOG.debug_analyzer('No checkers were defined in '
+                               'the command line for ' +
+                               cls.ANALYZER_NAME)
+            cmdline_checkers = None
+
+        handler.initialize_checkers(
+            context.available_profiles,
+            context.package_root,
+            checkers,
+            clang_tidy_checkers,
+            cmdline_checkers,
+            'enable_all' in args and args.enable_all)
+
+        return handler

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -107,7 +107,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
         self.__checker_configs.append(checker_cfg)
 
-    def get_analyzer_checkers(self, config_handler, env):
+    @classmethod
+    def get_analyzer_checkers(cls, config_handler, env):
         """
         Return the list of the supported checkers.
         """
@@ -331,9 +332,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             # No clangsa arguments file was given in the command line.
             LOG.debug_analyzer(aerr)
 
-        analyzer = ClangSA(handler, None)
-
-        checkers = analyzer.get_analyzer_checkers(handler, check_env)
+        checkers = ClangSA.get_analyzer_checkers(handler, check_env)
 
         # Read clang-sa checkers from the config file.
         clang_sa_checkers = context.checker_config.get(cls.ANALYZER_NAME +

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -16,15 +16,17 @@ import re
 import shlex
 import subprocess
 
-from libcodechecker.analyze.analyzers import analyzer_base
-from libcodechecker.analyze.analyzers import ctu_triple_arch
 from libcodechecker.analyze import analyzer_env
-from libcodechecker.logger import get_logger
-from libcodechecker.util import get_binary_in_path
-from libcodechecker.analyze.analyzer_env import\
-    extend_analyzer_cmd_with_resource_dir
+from libcodechecker.analyze import host_check
+from libcodechecker.analyze.analyzers import analyzer_base
+from libcodechecker.analyze.analyzers import config_handler_clangsa
+from libcodechecker.analyze.analyzers import ctu_triple_arch
 from libcodechecker.analyze.analyzers.result_handler_clangsa import \
     ResultHandlerClangSA
+from libcodechecker.analyze.analyzer_env import \
+    extend_analyzer_cmd_with_resource_dir
+from libcodechecker.logger import get_logger
+from libcodechecker.util import get_binary_in_path, replace_env_var
 
 LOG = get_logger('analyzer')
 
@@ -64,6 +66,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     """
     Constructs clang static analyzer commands.
     """
+    ANALYZER_NAME = 'clangsa'
+
     def __init__(self, config_handler, buildaction):
         super(ClangSA, self).__init__(config_handler, buildaction)
         self.__disable_ctu = False
@@ -286,3 +290,68 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         res_handler.skiplist_handler = skiplist_handler
 
         return res_handler
+
+    @classmethod
+    def construct_config_handler(cls, args, context):
+        handler = config_handler_clangsa.ClangSAConfigHandler()
+        handler.analyzer_plugins_dir = context.checker_plugin
+        handler.analyzer_binary = context.analyzer_binaries.get(
+            cls.ANALYZER_NAME)
+        handler.compiler_resource_dir = \
+            host_check.get_resource_dir(handler.analyzer_binary, context)
+
+        handler.report_hash = args.report_hash \
+            if 'report_hash' in args else None
+
+        check_env = analyzer_env.get_check_env(context.path_env_extra,
+                                               context.ld_lib_path_extra)
+
+        if 'ctu_phases' in args:
+            handler.ctu_dir = os.path.join(args.output_path,
+                                           args.ctu_dir)
+
+            handler.ctu_has_analyzer_display_ctu_progress = \
+                host_check.has_analyzer_feature(
+                    context.analyzer_binaries.get(cls.ANALYZER_NAME),
+                    '-analyzer-display-ctu-progress',
+                    check_env)
+            handler.log_file = args.logfile
+            handler.path_env_extra = context.path_env_extra
+            handler.ld_lib_path_extra = context.ld_lib_path_extra
+
+        try:
+            with open(args.clangsa_args_cfg_file, 'rb') as sa_cfg:
+                handler.analyzer_extra_arguments = \
+                    re.sub(r'\$\((.*?)\)',
+                           replace_env_var(args.clangsa_args_cfg_file),
+                           sa_cfg.read().strip())
+        except IOError as ioerr:
+            LOG.debug_analyzer(ioerr)
+        except AttributeError as aerr:
+            # No clangsa arguments file was given in the command line.
+            LOG.debug_analyzer(aerr)
+
+        analyzer = ClangSA(handler, None)
+
+        checkers = analyzer.get_analyzer_checkers(handler, check_env)
+
+        # Read clang-sa checkers from the config file.
+        clang_sa_checkers = context.checker_config.get(cls.ANALYZER_NAME +
+                                                       '_checkers')
+
+        try:
+            cmdline_checkers = args.ordered_checkers
+        except AttributeError:
+            LOG.debug_analyzer('No checkers were defined in '
+                               'the command line for ' + cls.ANALYZER_NAME)
+            cmdline_checkers = None
+
+        handler.initialize_checkers(
+            context.available_profiles,
+            context.package_root,
+            checkers,
+            clang_sa_checkers,
+            cmdline_checkers,
+            'enable_all' in args and args.enable_all)
+
+        return handler

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -173,8 +173,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                          '-analyzer-checker=' + checker_name])
                 else:
                     analyzer_cmd.extend(['-Xclang',
-                                         '-analyzer-disable-checker',
-                                         '-Xclang', checker_name])
+                                         '-analyzer-disable-checker=' +
+                                         checker_name])
 
             # Get analyzer notes as events from clang.
             analyzer_cmd.extend(['-Xclang',

--- a/libcodechecker/analyze/analyzers/analyzer_types.py
+++ b/libcodechecker/analyze/analyzers/analyzer_types.py
@@ -10,27 +10,18 @@ Supported analyzer types.
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-import io
 import os
-import platform
-import re
-import sys
 
 from libcodechecker.analyze import analyzer_env
 from libcodechecker.analyze import host_check
-from libcodechecker.analyze.analyzers import analyzer_clang_tidy
-from libcodechecker.analyze.analyzers import analyzer_clangsa
-from libcodechecker.analyze.analyzers import config_handler_clang_tidy
-from libcodechecker.analyze.analyzers import config_handler_clangsa
+from libcodechecker.analyze.analyzers.analyzer_clang_tidy import ClangTidy
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
 from libcodechecker.logger import get_logger
 
 LOG = get_logger('analyzer')
 
-CLANG_SA = 'clangsa'
-CLANG_TIDY = 'clang-tidy'
-
-supported_analyzers = {CLANG_SA: analyzer_clangsa.ClangSA,
-                       CLANG_TIDY: analyzer_clang_tidy.ClangTidy}
+supported_analyzers = {ClangSA.ANALYZER_NAME: ClangSA,
+                       ClangTidy.ANALYZER_NAME: ClangTidy}
 
 
 def check_supported_analyzers(analyzers, context):
@@ -100,9 +91,6 @@ def check_supported_analyzers(analyzers, context):
 
 def construct_analyzer(buildaction,
                        analyzer_config_map):
-    """
-    Construct an analyzer.
-    """
     try:
         analyzer_type = buildaction.analyzer_type
         # Get the proper config handler for this analyzer type.
@@ -122,282 +110,8 @@ def construct_analyzer(buildaction,
         return None
 
 
-def gen_name_variations(checkers):
-    """
-    Generate all applicable name variations from the given checker list.
-    """
-    checker_names = [name for name, _ in checkers]
-    reserved_names = []
-
-    for name in checker_names:
-        delim = '.' if '.' in name else '-'
-        parts = name.split(delim)
-        # Creates a list of variations from a checker name, e.g.
-        # ['security', 'security.insecureAPI', 'security.insecureAPI.gets']
-        # from 'security.insecureAPI.gets' or
-        # ['misc', 'misc-dangling', 'misc-dangling-handle']
-        # from 'misc-dangling-handle'.
-        variations = [delim.join(parts[:(i + 1)]) for i in range(len(parts))]
-        reserved_names += variations
-
-    return reserved_names
-
-
-def initialize_checkers(config_handler,
-                        available_profiles,
-                        package_root,
-                        checkers,
-                        checker_config=None,
-                        cmdline_checkers=None,
-                        enable_all=False):
-    """
-    Initializes the checker list for the specified config handler based
-    on given checker profiles, commandline arguments and the analyzer-retrieved
-    checker list.
-    """
-
-    # By default disable all checkers.
-    for checker_name, description in checkers:
-        config_handler.add_checker(checker_name, False, description)
-
-    # Set default enabled or disabled checkers, retrieved from the config file.
-    if checker_config:
-        # Check whether a default profile exists.
-        profile_lists = checker_config.values()
-        all_profiles = (
-            profile for check_list in profile_lists for profile in check_list)
-        if 'default' not in all_profiles:
-            LOG.warning("No default profile found!")
-        else:
-            # Turn default checkers on.
-            for checker_name, profile_list in checker_config.items():
-                if 'default' in profile_list:
-                    config_handler.set_checker_enabled(checker_name)
-
-    # If enable_all is given, almost all checkers should be enabled.
-    if enable_all:
-        for checker_name, enabled in checkers:
-            if not checker_name.startswith("alpha.") and \
-                    not checker_name.startswith("debug.") and \
-                    not checker_name.startswith("osx."):
-                # There are a few exceptions, though, which still need to
-                # be manually enabled by the user: alpha and debug.
-                config_handler.set_checker_enabled(checker_name)
-
-            if checker_name.startswith("osx.") and \
-                    platform.system() == 'Darwin':
-                # OSX checkers are only enable-all'd if we are on OSX.
-                config_handler.set_checker_enabled(checker_name)
-
-    # Set user defined enabled or disabled checkers from the command line.
-    if cmdline_checkers:
-
-        # Construct a list of reserved checker names.
-        # (It is used to check if a profile name is valid.)
-        reserved_names = gen_name_variations(checkers)
-
-        for identifier, enabled in cmdline_checkers:
-
-            # The identifier is a profile name.
-            if identifier in available_profiles:
-                profile_name = identifier
-
-                if profile_name == "list":
-                    LOG.error("'list' is a reserved profile keyword. ")
-                    LOG.error("Please choose another profile name in "
-                              "'{0}'/config/config.json and rebuild."
-                              .format(package_root))
-                    sys.exit(1)
-
-                if profile_name in reserved_names:
-                    LOG.error("Profile name '" + profile_name + "' conflicts "
-                              "with a checker(-group) name.")
-                    LOG.error("Please choose another profile name in "
-                              "'{0}'/config/config.json and rebuild."
-                              .format(package_root))
-                    sys.exit(1)
-
-                profile_checkers = (name for name, profile_list
-                                    in checker_config.items()
-                                    if profile_name in profile_list)
-                for checker_name in profile_checkers:
-                    config_handler.set_checker_enabled(checker_name, enabled)
-
-            # The identifier is a checker(-group) name.
-            else:
-                checker_name = identifier
-                config_handler.set_checker_enabled(checker_name, enabled)
-
-
-def __replace_env_var(cfg_file):
-    def replacer(matchobj):
-        env_var = matchobj.group(1)
-        if matchobj.group(1) not in os.environ:
-            LOG.error(env_var + ' environment variable not set in ' + cfg_file)
-            return ''
-        return os.environ[env_var]
-
-    return replacer
-
-
-def __get_compiler_resource_dir(context, analyzer_binary):
-    if context.compiler_resource_dir:
-        resource_dir = context.compiler_resource_dir
-    # If not set then ask the binary for the resource dir.
-    else:
-        # Can be None if Clang is too old.
-        resource_dir = host_check.get_resource_dir(analyzer_binary)
-        if resource_dir is None:
-            resource_dir = ""
-    return resource_dir
-
-
-def __build_clangsa_config_handler(args, context):
-    """
-    Build the config handler for clang static analyzer.
-    Handle config options from the command line and config files.
-    """
-
-    config_handler = config_handler_clangsa.ClangSAConfigHandler()
-    config_handler.analyzer_plugins_dir = context.checker_plugin
-    config_handler.analyzer_binary = context.analyzer_binaries.get(CLANG_SA)
-    config_handler.compiler_resource_dir =\
-        __get_compiler_resource_dir(context, config_handler.analyzer_binary)
-
-    config_handler.report_hash = args.report_hash \
-        if 'report_hash' in args else None
-
-    check_env = analyzer_env.get_check_env(context.path_env_extra,
-                                           context.ld_lib_path_extra)
-
-    if 'ctu_phases' in args:
-        config_handler.ctu_dir = os.path.join(args.output_path,
-                                              args.ctu_dir)
-
-        config_handler.ctu_has_analyzer_display_ctu_progress = \
-            host_check.has_analyzer_feature(
-                context.analyzer_binaries.get(CLANG_SA),
-                '-analyzer-display-ctu-progress',
-                check_env)
-        config_handler.log_file = args.logfile
-        config_handler.path_env_extra = context.path_env_extra
-        config_handler.ld_lib_path_extra = context.ld_lib_path_extra
-
-    try:
-        with open(args.clangsa_args_cfg_file, 'rb') as sa_cfg:
-            config_handler.analyzer_extra_arguments = \
-                re.sub(r'\$\((.*?)\)',
-                       __replace_env_var(args.clangsa_args_cfg_file),
-                       sa_cfg.read().strip())
-    except IOError as ioerr:
-        LOG.debug_analyzer(ioerr)
-    except AttributeError as aerr:
-        # No clangsa arguments file was given in the command line.
-        LOG.debug_analyzer(aerr)
-
-    analyzer = supported_analyzers[CLANG_SA](config_handler, None)
-
-    checkers = analyzer.get_analyzer_checkers(config_handler, check_env)
-
-    # Read clang-sa checkers from the config file.
-    clang_sa_checkers = context.checker_config.get(CLANG_SA + '_checkers')
-
-    try:
-        cmdline_checkers = args.ordered_checkers
-    except AttributeError:
-        LOG.debug_analyzer('No checkers were defined in '
-                           'the command line for ' + CLANG_SA)
-        cmdline_checkers = None
-
-    initialize_checkers(config_handler,
-                        context.available_profiles,
-                        context.package_root,
-                        checkers,
-                        clang_sa_checkers,
-                        cmdline_checkers,
-                        'enable_all' in args and args.enable_all)
-
-    return config_handler
-
-
-def __build_clang_tidy_config_handler(args, context):
-    """
-    Build the config handler for clang tidy analyzer.
-    Handle config options from the command line and config files.
-    """
-
-    config_handler = config_handler_clang_tidy.ClangTidyConfigHandler()
-    config_handler.analyzer_binary = context.analyzer_binaries.get(CLANG_TIDY)
-
-    # FIXME We cannot get the resource dir from the clang-tidy binary,
-    # therefore now we get a clang binary which is a sibling of the clang-tidy.
-    # TODO Support "clang-tidy -print-resource-dir" .
-    check_env = analyzer_env.get_check_env(context.path_env_extra,
-                                           context.ld_lib_path_extra)
-    # Overwrite PATH to contain only the parent of the clang binary.
-    if os.path.isabs(config_handler.analyzer_binary):
-        check_env['PATH'] = os.path.dirname(config_handler.analyzer_binary)
-    clang_bin = analyzer_clangsa.ClangSA.resolve_missing_binary('clang',
-                                                                check_env)
-    config_handler.compiler_resource_dir =\
-        __get_compiler_resource_dir(context, clang_bin)
-
-    try:
-        with open(args.tidy_args_cfg_file, 'rb') as tidy_cfg:
-            config_handler.analyzer_extra_arguments = \
-                re.sub(r'\$\((.*?)\)', __replace_env_var,
-                       tidy_cfg.read().strip())
-    except IOError as ioerr:
-        LOG.debug_analyzer(ioerr)
-    except AttributeError as aerr:
-        # No clang tidy arguments file was given in the command line.
-        LOG.debug_analyzer(aerr)
-
-    try:
-        # The config file dumped by clang-tidy contains "..." at the end. This
-        # has to be emitted, otherwise -config flag of clang-tidy can't consume
-        # it.
-        with io.open(args.tidy_config, 'rb') as tidy_config:
-            lines = tidy_config.readlines()
-            lines = filter(lambda x: x != '...\n', lines)
-            config_handler.checker_config = ''.join(lines)
-    except IOError as ioerr:
-        LOG.debug_analyzer(ioerr)
-    except AttributeError as aerr:
-        # No clang tidy config file was given in the command line.
-        LOG.debug_analyzer(aerr)
-
-    analyzer = supported_analyzers[CLANG_TIDY](config_handler, None)
-    check_env = analyzer_env.get_check_env(context.path_env_extra,
-                                           context.ld_lib_path_extra)
-
-    checkers = analyzer.get_analyzer_checkers(config_handler, check_env)
-
-    # Read clang-tidy checkers from the config file.
-    clang_tidy_checkers = context.checker_config.get(CLANG_TIDY + '_checkers')
-
-    try:
-        cmdline_checkers = args.ordered_checkers
-    except AttributeError:
-        LOG.debug_analyzer('No checkers were defined in '
-                           'the command line for ' +
-                           CLANG_TIDY)
-        cmdline_checkers = None
-
-    initialize_checkers(config_handler,
-                        context.available_profiles,
-                        context.package_root,
-                        checkers,
-                        clang_tidy_checkers,
-                        cmdline_checkers,
-                        'enable_all' in args and args.enable_all)
-
-    return config_handler
-
-
 def build_config_handlers(args, context, enabled_analyzers):
     """
-
     Handle config from command line or from config file if no command line
     config is given.
 
@@ -408,13 +122,8 @@ def build_config_handlers(args, context, enabled_analyzers):
     analyzer_config_map = {}
 
     for ea in enabled_analyzers:
-        if ea == CLANG_SA:
-            config_handler = __build_clangsa_config_handler(args, context)
-        elif ea == CLANG_TIDY:
-            config_handler = __build_clang_tidy_config_handler(args, context)
-        else:
-            config_handler = None
-            LOG.debug("Unhandled analyzer: " + str(ea))
+        config_handler = supported_analyzers[ea].\
+            construct_config_handler(args, context)
         analyzer_config_map[ea] = config_handler
 
     return analyzer_config_map

--- a/libcodechecker/analyze/analyzers/config_handler.py
+++ b/libcodechecker/analyze/analyzers/config_handler.py
@@ -55,9 +55,9 @@ class AnalyzerConfigHandler(object):
     @abstractmethod
     def get_checker_configs(self):
         """
-        Return a list of (checker_name, key, key_valye) tuples.
+        Return a list of (checker_name, key, key_value) tuples.
         """
-        pass
+        raise NotImplementedError("Subclasses should implement this!")
 
     def add_checker(self, checker_name, enabled, description):
         """

--- a/libcodechecker/analyze/analyzers/config_handler.py
+++ b/libcodechecker/analyze/analyzers/config_handler.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 import collections
 import os
+import platform
+import sys
 
 from libcodechecker.logger import get_logger
 
@@ -81,3 +83,108 @@ class AnalyzerConfigHandler(object):
         Return the checkers.
         """
         return self.__available_checkers
+
+    def __gen_name_variations(self):
+        """
+        Generate all applicable name variations from the given checker list.
+        """
+        checker_names = (name for name in self.__available_checkers)
+        reserved_names = []
+
+        for name in checker_names:
+            delim = '.' if '.' in name else '-'
+            parts = name.split(delim)
+            # Creates a list of variations from a checker name, e.g.
+            # ['security', 'security.insecureAPI', 'security.insecureAPI.gets']
+            # from 'security.insecureAPI.gets' or
+            # ['misc', 'misc-dangling', 'misc-dangling-handle']
+            # from 'misc-dangling-handle'.
+            v = [delim.join(parts[:(i + 1)]) for i in range(len(parts))]
+            reserved_names += v
+
+        return reserved_names
+
+    def initialize_checkers(self,
+                            available_profiles,
+                            package_root,
+                            checkers,
+                            checker_config=None,
+                            cmdline_checkers=None,
+                            enable_all=False):
+        """
+        Initializes the checker list for the specified config handler based on
+        given checker profiles, commandline arguments and the
+        analyzer-retrieved checker list.
+        """
+
+        # By default disable all checkers.
+        for checker_name, description in checkers:
+            self.add_checker(checker_name, False, description)
+
+        # Set default enabled or disabled checkers, based on the config file.
+        if checker_config:
+            # Check whether a default profile exists.
+            profiles = checker_config.values()
+            all_profile_names = (
+                profile for check_list in profiles for profile in check_list)
+            if 'default' not in all_profile_names:
+                LOG.warning("No default profile found!")
+            else:
+                # Turn default checkers on.
+                for checker_name, profile_list in checker_config.items():
+                    if 'default' in profile_list:
+                        self.set_checker_enabled(checker_name)
+
+        # If enable_all is given, almost all checkers should be enabled.
+        if enable_all:
+            for checker_name, enabled in checkers:
+                if not checker_name.startswith("alpha.") and \
+                        not checker_name.startswith("debug.") and \
+                        not checker_name.startswith("osx."):
+                    # There are a few exceptions, though, which still need to
+                    # be manually enabled by the user: alpha and debug.
+                    self.set_checker_enabled(checker_name)
+
+                if checker_name.startswith("osx.") and \
+                        platform.system() == 'Darwin':
+                    # OSX checkers are only enable-all'd if we are on OSX.
+                    self.set_checker_enabled(checker_name)
+
+        # Set user defined enabled or disabled checkers from the command line.
+        if cmdline_checkers:
+
+            # Construct a list of reserved checker names.
+            # (It is used to check if a profile name is valid.)
+            reserved_names = self.__gen_name_variations()
+
+            for identifier, enabled in cmdline_checkers:
+
+                # The identifier is a profile name.
+                if identifier in available_profiles:
+                    profile_name = identifier
+
+                    if profile_name == "list":
+                        LOG.error("'list' is a reserved profile keyword. ")
+                        LOG.error("Please choose another profile name in "
+                                  "'{0}'/config/config.json and rebuild."
+                                  .format(package_root))
+                        sys.exit(1)
+
+                    if profile_name in reserved_names:
+                        LOG.error("Profile name '" + profile_name + "'"
+                                  " conflicts with a checker(-group) name.")
+                        LOG.error("Please choose another profile name in "
+                                  "'{0}'/config/config.json and rebuild."
+                                  .format(package_root))
+                        sys.exit(1)
+
+                    profile_checkers = (name for name, profile_list
+                                        in checker_config.items()
+                                        if profile_name in profile_list)
+                    for checker_name in profile_checkers:
+                        self.set_checker_enabled(checker_name, enabled)
+
+                # The identifier is a checker(-group) name.
+                else:
+                    checker_name = identifier
+                    self.set_checker_enabled(checker_name, enabled)

--- a/libcodechecker/analyze/host_check.py
+++ b/libcodechecker/analyze/host_check.py
@@ -67,11 +67,14 @@ def has_analyzer_feature(clang_bin, feature, env=None):
             raise
 
 
-def get_resource_dir(clang_bin, env=None):
+def get_resource_dir(clang_bin, context, env=None):
     """
     Returns the resource_dir of Clang or None if the switch is not supported by
     Clang.
     """
+    if context.compiler_resource_dir:
+        return context.compiler_resource_dir
+    # If not set then ask the binary for the resource dir.
     cmd = [clang_bin, "-print-resource-dir"]
     LOG.debug('run: "' + ' '.join(cmd) + '"')
     try:

--- a/libcodechecker/analyze/pre_analysis_manager.py
+++ b/libcodechecker/analyze/pre_analysis_manager.py
@@ -38,8 +38,7 @@ def collect_statistics(action, source, config, environ, statistics_data):
     """
     cmd, can_collect = statistics_collector.build_stat_coll_cmd(action,
                                                                 config,
-                                                                source,
-                                                                environ)
+                                                                source)
 
     if not can_collect:
         LOG.debug('Can not collect statistical data.')
@@ -49,7 +48,7 @@ def collect_statistics(action, source, config, environ, statistics_data):
     LOG.debug_analyzer(cmd)
 
     ret_code, analyzer_out, analyzer_err = \
-        analyzer_base.SourceAnalyzer.run_proc(cmdstr)
+        analyzer_base.SourceAnalyzer.run_proc(cmdstr, env=environ)
 
     LOG.debug(analyzer_out)
     LOG.debug(analyzer_err)

--- a/libcodechecker/analyze/pre_analysis_manager.py
+++ b/libcodechecker/analyze/pre_analysis_manager.py
@@ -23,8 +23,8 @@ from libcodechecker.analyze import analyzer_env
 from libcodechecker.analyze import ctu_manager
 from libcodechecker.analyze import statistics_collector
 from libcodechecker.analyze.analyzers import analyzer_base
-from libcodechecker.analyze.analyzers import analyzer_types
 from libcodechecker.analyze.analyzers import ctu_triple_arch
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
 from libcodechecker.logger import get_logger
 
 
@@ -98,7 +98,7 @@ def pre_analyze(params):
     for source in action.sources:
         if skip_handler and skip_handler.should_skip(source):
             continue
-        if action.analyzer_type != analyzer_types.CLANG_SA:
+        if action.analyzer_type != ClangSA.ANALYZER_NAME:
             continue
 
         _, source_filename = os.path.split(source)
@@ -109,7 +109,7 @@ def pre_analyze(params):
                  (progress_checked_num.value,
                   progress_actions.value, source_filename))
 
-        config = analyzer_config_map.get(analyzer_types.CLANG_SA)
+        config = analyzer_config_map.get(ClangSA.ANALYZER_NAME)
 
         try:
             if ctu_data:

--- a/libcodechecker/analyze/statistics_collector.py
+++ b/libcodechecker/analyze/statistics_collector.py
@@ -24,7 +24,7 @@ from libcodechecker.logger import get_logger
 LOG = get_logger('analyzer')
 
 
-def build_stat_coll_cmd(action, config, source, environ):
+def build_stat_coll_cmd(action, config, source):
     """
     Build the statistics collector analysis command.
     """

--- a/libcodechecker/host_check.py
+++ b/libcodechecker/host_check.py
@@ -42,12 +42,11 @@ def is_statistics_capable():
     context = package_context.get_context()
 
     clangsa_cfg = ClangSA.construct_config_handler([], context)
-    analyzer = ClangSA(clangsa_cfg, None)
 
     check_env = analyzer_env.get_check_env(context.path_env_extra,
                                            context.ld_lib_path_extra)
 
-    checkers = analyzer.get_analyzer_checkers(clangsa_cfg, check_env)
+    checkers = ClangSA.get_analyzer_checkers(clangsa_cfg, check_env)
 
     stat_checkers_pattern = re.compile(r'.+statisticscollector.+')
 

--- a/libcodechecker/host_check.py
+++ b/libcodechecker/host_check.py
@@ -16,7 +16,6 @@ import os
 import re
 import subprocess
 
-from libcodechecker import package_context
 from libcodechecker.logger import get_logger
 from libcodechecker.analyze import analyzer_env
 from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
@@ -26,9 +25,8 @@ from libcodechecker.analyze.analyzers.analyzer_types \
 LOG = get_logger('system')
 
 
-def is_ctu_capable():
+def is_ctu_capable(context):
     """ Detects if the current clang is CTU compatible. """
-    context = package_context.get_context()
     ctu_func_map_cmd = context.ctu_func_map_cmd
     try:
         version = subprocess.check_output([ctu_func_map_cmd, '-version'])
@@ -37,10 +35,8 @@ def is_ctu_capable():
     return version != 'ERROR'
 
 
-def is_statistics_capable():
+def is_statistics_capable(context):
     """ Detects if the current clang is Statistics compatible. """
-    context = package_context.get_context()
-
     clangsa_cfg = ClangSA.construct_config_handler([], context)
 
     check_env = analyzer_env.get_check_env(context.path_env_extra,

--- a/libcodechecker/host_check.py
+++ b/libcodechecker/host_check.py
@@ -37,6 +37,8 @@ def is_ctu_capable(context):
 
 def is_statistics_capable(context):
     """ Detects if the current clang is Statistics compatible. """
+    # Resolve potentially missing binaries.
+    check_supported_analyzers([ClangSA.ANALYZER_NAME], context)
     clangsa_cfg = ClangSA.construct_config_handler([], context)
 
     check_env = analyzer_env.get_check_env(context.path_env_extra,

--- a/libcodechecker/host_check.py
+++ b/libcodechecker/host_check.py
@@ -19,14 +19,15 @@ import subprocess
 from libcodechecker import package_context
 from libcodechecker.logger import get_logger
 from libcodechecker.analyze import analyzer_env
-from libcodechecker.analyze.analyzers import analyzer_types
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
+from libcodechecker.analyze.analyzers.analyzer_types \
+    import check_supported_analyzers
 
 LOG = get_logger('system')
 
 
 def is_ctu_capable():
     """ Detects if the current clang is CTU compatible. """
-
     context = package_context.get_context()
     ctu_func_map_cmd = context.ctu_func_map_cmd
     try:
@@ -40,15 +41,8 @@ def is_statistics_capable():
     """ Detects if the current clang is Statistics compatible. """
     context = package_context.get_context()
 
-    analyzer = "clangsa"
-    enabled_analyzers = [analyzer]
-    cfg_handlers = analyzer_types.build_config_handlers({},
-                                                        context,
-                                                        enabled_analyzers)
-
-    clangsa_cfg = cfg_handlers[analyzer]
-    analyzer = analyzer_types.supported_analyzers[analyzer](clangsa_cfg,
-                                                            None)
+    clangsa_cfg = ClangSA.construct_config_handler([], context)
+    analyzer = ClangSA(clangsa_cfg, None)
 
     check_env = analyzer_env.get_check_env(context.path_env_extra,
                                            context.ld_lib_path_extra)
@@ -70,7 +64,6 @@ def check_zlib():
     possible the the compression fails which is required to
     store data into the database.
     """
-
     try:
         import zlib
         zlib.compress('Compress this')

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -273,7 +273,8 @@ def add_arguments_to_parser(parser):
                                     "the analysis is considered as a failed "
                                     "one.")
 
-    if host_check.is_ctu_capable():
+    context = package_context.get_context()
+    if host_check.is_ctu_capable(context):
         ctu_opts = parser.add_argument_group(
             "cross translation unit analysis arguments",
             """
@@ -326,7 +327,7 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                    "same translation unit without "
                                    "Cross-TU enabled.")
 
-    if host_check.is_statistics_capable():
+    if host_check.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
             "EXPERIMENTAL statistics analysis feature arguments",
             """

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -20,6 +20,7 @@ import tempfile
 from libcodechecker import logger
 from libcodechecker import host_check
 from libcodechecker import libhandlers
+from libcodechecker import package_context
 from libcodechecker.analyze.analyzers import analyzer_types
 from libcodechecker.util import RawDescriptionDefaultHelpFormatter
 
@@ -284,7 +285,8 @@ used to generate a log file on the fly.""")
                                     "the analysis is considered as a failed "
                                     "one.")
 
-    if host_check.is_ctu_capable():
+    context = package_context.get_context()
+    if host_check.is_ctu_capable(context):
         ctu_opts = parser.add_argument_group(
             "cross translation unit analysis arguments",
             """
@@ -329,7 +331,7 @@ is called.""")
                                     "'<OUTPUT_DIR>/ctu-dir'. (These files "
                                     "will not be cleaned up in this mode.)")
 
-    if host_check.is_statistics_capable():
+    if host_check.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
             "EXPERIMENTAL statistics analysis feature arguments",
             """

--- a/libcodechecker/libhandlers/checkers.py
+++ b/libcodechecker/libhandlers/checkers.py
@@ -171,12 +171,11 @@ def main(args):
     rows = []
     for analyzer in working:
         config_handler = analyzer_config_map.get(analyzer)
-        source_analyzer = \
-            analyzer_types.supported_analyzers[analyzer](config_handler,
-                                                         None)
+        analyzer_class = \
+            analyzer_types.supported_analyzers[analyzer]
 
-        checkers = source_analyzer.get_analyzer_checkers(config_handler,
-                                                         analyzer_environment)
+        checkers = analyzer_class.get_analyzer_checkers(config_handler,
+                                                        analyzer_environment)
         default_checker_cfg = context.checker_config.get(
             analyzer + '_checkers')
 

--- a/libcodechecker/libhandlers/checkers.py
+++ b/libcodechecker/libhandlers/checkers.py
@@ -180,6 +180,7 @@ def main(args):
         default_checker_cfg = context.checker_config.get(
             analyzer + '_checkers')
 
+        profile_checkers = None
         if 'profile' in args:
             if args.profile not in context.available_profiles:
                 LOG.error("Checker profile '" + args.profile +
@@ -188,18 +189,12 @@ def main(args):
                 return
 
             profile_checkers = [(args.profile, True)]
-            analyzer_types.initialize_checkers(config_handler,
-                                               context.available_profiles,
-                                               context.package_root,
-                                               checkers,
-                                               default_checker_cfg,
-                                               profile_checkers)
-        else:
-            analyzer_types.initialize_checkers(config_handler,
-                                               context.available_profiles,
-                                               context.package_root,
-                                               checkers,
-                                               default_checker_cfg)
+
+        config_handler.initialize_checkers(context.available_profiles,
+                                           context.package_root,
+                                           checkers,
+                                           default_checker_cfg,
+                                           profile_checkers)
 
         for checker_name, value in config_handler.checks().items():
             enabled, description = value

--- a/libcodechecker/log/option_parser.py
+++ b/libcodechecker/log/option_parser.py
@@ -500,7 +500,7 @@ def parse_options(args):
             break
 
     if result_map.lang:
-        LOG.debug("Detected language" + result_map.lang)
+        LOG.debug("Detected language: " + result_map.lang)
 
     # If there are no source files in the compilation argument
     # handle it as a link command.

--- a/libcodechecker/package_context.py
+++ b/libcodechecker/package_context.py
@@ -18,7 +18,8 @@ import sys
 from libcodechecker import db_version
 from libcodechecker import logger
 # TODO: Refers subpackage library
-from libcodechecker.analyze.analyzers import analyzer_types
+from libcodechecker.analyze.analyzers.analyzer_clangsa import ClangSA
+from libcodechecker.analyze.analyzers.analyzer_clang_tidy import ClangTidy
 from libcodechecker.util import load_json_or_empty
 
 LOG = logger.get_logger('system')
@@ -144,8 +145,8 @@ class Context(object):
             # will be checked later.
             # Key naming in the dict should be the same as in
             # the supported analyzers list.
-            self.__analyzers[analyzer_types.CLANG_SA] = 'clang'
-            self.__analyzers[analyzer_types.CLANG_TIDY] = 'clang-tidy'
+            self.__analyzers[ClangSA.ANALYZER_NAME] = 'clang'
+            self.__analyzers[ClangTidy.ANALYZER_NAME] = 'clang-tidy'
         else:
             for name, value in compiler_binaries.items():
                 if os.path.isabs(value):

--- a/libcodechecker/package_context.py
+++ b/libcodechecker/package_context.py
@@ -63,8 +63,8 @@ class Context(object):
         self.env_vars = env_vars
 
         self._package_root = package_root
-        self.codechecker_workspace = None
-        self._severity_map = SeverityMap()
+        self._severity_map = SeverityMap(
+            load_json_or_empty(self.checkers_severity_map_file, {}))
         self.__package_version = None
         self.__product_db_version_info = None
         self.__run_db_version_info = None
@@ -76,8 +76,6 @@ class Context(object):
         self.logger_file = None
         self.logger_compilers = None
 
-        self.db_username = None
-
         # Get package specific environment variables.
         self.set_env(env_vars)
 
@@ -88,13 +86,6 @@ class Context(object):
         """
         Get the environment variables.
         """
-        self._package_root = os.environ.get(env_vars['env_package_root'])
-
-        self.codechecker_workspace = os.environ.get('codechecker_workspace')
-
-        self._severity_map = SeverityMap(
-            load_json_or_empty(self.checkers_severity_map_file, {}))
-
         # Get generic package specific environment variables.
         self.logger_bin = os.environ.get(env_vars['cc_logger_bin'])
         self.logger_file = os.environ.get(env_vars['cc_logger_file'])
@@ -149,10 +140,7 @@ class Context(object):
             self.__analyzers[ClangTidy.ANALYZER_NAME] = 'clang-tidy'
         else:
             for name, value in compiler_binaries.items():
-                if os.path.isabs(value):
-                    # Check if it is an absolute path.
-                    self.__analyzers[name] = value
-                elif os.path.dirname(value):
+                if os.path.dirname(value):
                     # Check if it is a package relative path.
                     self.__analyzers[name] = os.path.join(self._package_root,
                                                           value)
@@ -246,20 +234,14 @@ class Context(object):
         resource_dir = self.pckg_layout.get('compiler_resource_dir')
         if not resource_dir:
             return ""
-        if os.path.isabs(resource_dir):
-            return resource_dir
-        else:
-            return os.path.join(self._package_root, resource_dir)
+        return os.path.join(self._package_root, resource_dir)
 
     @property
     def path_env_extra(self):
         extra_paths = self.pckg_layout.get('path_env_extra', [])
         paths = []
         for path in extra_paths:
-            if os.path.isabs(path):
-                paths.append(path)
-            else:
-                paths.append(os.path.join(self._package_root, path))
+            paths.append(os.path.join(self._package_root, path))
         return paths
 
     @property
@@ -267,10 +249,7 @@ class Context(object):
         extra_lib = self.pckg_layout.get('ld_lib_path_extra', [])
         ld_paths = []
         for path in extra_lib:
-            if os.path.isabs(path):
-                ld_paths.append(path)
-            else:
-                ld_paths.append(os.path.join(self._package_root, path))
+            ld_paths.append(os.path.join(self._package_root, path))
         return ld_paths
 
     @property
@@ -364,10 +343,7 @@ def get_context():
     LOG.debug(layout_config)
 
     try:
-        return Context(package_root,
-                       layout_config,
-                       cfg_dict)
-
+        return Context(package_root, layout_config, cfg_dict)
     except KeyError as kerr:
         LOG.error(kerr)
         sys.exit(1)

--- a/libcodechecker/server/api/report_server.py
+++ b/libcodechecker/server/api/report_server.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 import io
 import os
-import sys
 import tempfile
 import zipfile
 import zlib

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -685,3 +685,14 @@ def slugify(text):
     norm_text = re.sub(r'([\s]+|[\/]+)', '_', norm_text)
 
     return norm_text
+
+
+def replace_env_var(cfg_file):
+    def replacer(matchobj):
+        env_var = matchobj.group(1)
+        if env_var not in os.environ:
+            LOG.error(env_var + ' environment variable not set in ' + cfg_file)
+            return ''
+        return os.environ[env_var]
+
+    return replacer

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -671,7 +671,7 @@ def generate_session_token():
     """
     Returns a random session token.
     """
-    return uuid.UUID(bytes=os.urandom(16)).__str__().replace('-', '')
+    return uuid.UUID(bytes=os.urandom(16)).hex
 
 
 def slugify(text):


### PR DESCRIPTION
Another step towards https://github.com/Ericsson/codechecker/issues/1760

Also fixed a bug along the way. If clang-6.0 was available in the path but not clang, and clang-6.0 was not configured in the package config, we failed on the statistics feature check (not finding the binary).

It is hard to add a test for this scenario as there are lots of dependencies on the environment.