### PR TITLE
Fix database error when storing with force flag enabled

### DIFF
--- a/libcodechecker/server/api/store_handler.py
+++ b/libcodechecker/server/api/store_handler.py
@@ -229,6 +229,9 @@ def addCheckerRun(session, command, name, tag, username,
 
             LOG.info('Removing previous analysis results ...')
             session.delete(run)
+            # Not flushing after delete leads to a constraint violation error
+            # later, when adding run entity with the same name as the old one.
+            session.flush()
 
             checker_run = Run(name, version, command)
             session.add(checker_run)


### PR DESCRIPTION
When storing runs to the database with the --force flag enabled, not
flushing the database session after deletion seems to cause the
following insert operation to fail in case of PostgreSQL.
Fixes #1802 