### PR TITLE
Context free hash

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -192,15 +192,17 @@ here. For example the CTU related arguments are documented at `analyze`
 subcommand.
 
 ~~~~~~~~~~~~~~~~~~~~~
-usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-q] [-f]
-                         (-b COMMAND | -l LOGFILE) [-j JOBS] [-i SKIPFILE]
+usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q] [-f]
+                         (-b COMMAND | -l LOGFILE) [-j JOBS] [-c]
+                         [--report-hash {context-free}] [-i SKIPFILE]
                          [--analyzers ANALYZER [ANALYZER ...]]
-                         [--add-compiler-defaults]
+                         [--add-compiler-defaults] [--capture-analysis-output]
                          [--saargs CLANGSA_ARGS_CFG_FILE]
-                         [--tidyargs TIDY_ARGS_CFG_FILE] [--timeout TIMEOUT]
+                         [--tidyargs TIDY_ARGS_CFG_FILE]
                          [--tidy-config TIDY_CONFIG] [--timeout TIMEOUT]
+                         [--ctu | --ctu-collect | --ctu-analyze]
                          [-e checker/group/profile] [-d checker/group/profile]
-                         [--print-steps]
+                         [--enable-all] [--print-steps]
                          [--verbose {info,debug,debug_analyzer}]
 
 Run analysis for a project with printing results immediately on the standard
@@ -236,6 +238,7 @@ analyzer arguments:
 
   -j JOBS, --jobs JOBS
   -c, --clean
+  --report-hash {context-free}
   -i SKIPFILE, --ignore SKIPFILE, --skip SKIPFILE
   --analyzers ANALYZER [ANALYZER ...]
   --add-compiler-defaults
@@ -407,13 +410,19 @@ below:
 
 ~~~~~~~~~~~~~~~~~~~~~
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
-                           [-t {plist}] [-q] [-c] [-n NAME]
+                           [--compiler-includes-file COMPILER_INCLUDES_FILE]
+                           [--compiler-target-file COMPILER_TARGET_FILE]
+                           [--compiler-info-file COMPILER_INFO_FILE]
+                           [-t {plist}] [-q] [-c]
+                           [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]
                            [--add-compiler-defaults]
                            [--capture-analysis-output]
                            [--saargs CLANGSA_ARGS_CFG_FILE]
-                           [--tidyargs TIDY_ARGS_CFG_FILE] [--timeout TIMEOUT]
+                           [--tidyargs TIDY_ARGS_CFG_FILE]
                            [--tidy-config TIDY_CONFIG] [--timeout TIMEOUT]
+                           [--ctu | --ctu-collect | --ctu-analyze]
+                           [--ctu-reanalyze-on-failure]
                            [-e checker/group/profile]
                            [-d checker/group/profile] [--enable-all]
                            [--verbose {info,debug,debug_analyzer}]
@@ -448,6 +457,15 @@ optional arguments:
                         directory. (By default, CodeChecker would keep reports
                         and overwrites only those files that were update by
                         the current build command).
+ --report-hash {context-free}
+                        EXPERIMENTAL feature. Specify the hash calculation
+                        method for reports. If this option is not set, the
+                        default calculation method for Clang Static Analyzer
+                        will be context sensitive and for Clang Tidy it will
+                        be context insensitive. If this option is set to
+                        'context-free' bugs will be identified with the
+                        CodeChecker generated context free hash for every
+                        analyzers. USE WISELY AND AT YOUR OWN RISK!
   -n NAME, --name NAME  Annotate the run analysis with a custom name in the
                         created metadata file.
   --verbose {info,debug,debug_analyzer}

--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -23,7 +23,8 @@ from libcodechecker.logger import get_logger
 from libcodechecker.util import get_binary_in_path
 from libcodechecker.analyze.analyzer_env import\
     extend_analyzer_cmd_with_resource_dir
-from libcodechecker.analyze.analyzers import result_handler_base
+from libcodechecker.analyze.analyzers.result_handler_clangsa import \
+    ResultHandlerClangSA
 
 LOG = get_logger('analyzer')
 
@@ -278,9 +279,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         """
         See base class for docs.
         """
-        res_handler = result_handler_base.ResultHandler(buildaction,
-                                                        report_output)
+        res_handler = ResultHandlerClangSA(buildaction, report_output)
 
+        res_handler.report_hash = self.config_handler.report_hash
         res_handler.severity_map = severity_map
         res_handler.skiplist_handler = skiplist_handler
+
         return res_handler

--- a/libcodechecker/analyze/analyzers/analyzer_types.py
+++ b/libcodechecker/analyze/analyzers/analyzer_types.py
@@ -264,6 +264,9 @@ def __build_clangsa_config_handler(args, context):
     config_handler.compiler_resource_dir =\
         __get_compiler_resource_dir(context, config_handler.analyzer_binary)
 
+    config_handler.report_hash = args.report_hash \
+        if 'report_hash' in args else None
+
     check_env = analyzer_env.get_check_env(context.path_env_extra,
                                            context.ld_lib_path_extra)
 

--- a/libcodechecker/analyze/analyzers/config_handler.py
+++ b/libcodechecker/analyze/analyzers/config_handler.py
@@ -33,6 +33,7 @@ class AnalyzerConfigHandler(object):
         self.compiler_resource_dir = ''
         self.analyzer_extra_arguments = ''
         self.checker_config = ''
+        self.report_hash = None
 
         # The key is the checker name, the value is a tuple.
         # False if disabled (should be by default).

--- a/libcodechecker/analyze/analyzers/result_handler_clangsa.py
+++ b/libcodechecker/analyze/analyzers/result_handler_clangsa.py
@@ -1,0 +1,80 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Result handler for Clang Static Analyzer.
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import plistlib
+import sys
+import traceback
+from xml.parsers.expat import ExpatError
+
+from libcodechecker.analyze.analyzers.result_handler_base \
+    import ResultHandler
+from libcodechecker.analyze.plist_parser import get_checker_name
+from libcodechecker.logger import get_logger
+from libcodechecker.report import generate_report_hash
+
+LOG = get_logger('report')
+
+
+def use_context_free_hashes(path):
+    """
+    Override issue hash in the given file by using context free hashes.
+    """
+    try:
+        plist = plistlib.readPlist(path)
+
+        files = plist['files']
+
+        for diag in plist['diagnostics']:
+            file_path = files[diag['location']['file']]
+
+            report_hash = generate_report_hash(diag['path'],
+                                               file_path,
+                                               get_checker_name(diag))
+            diag['issue_hash_content_of_line_in_context'] = report_hash
+
+        if plist['diagnostics']:
+            plistlib.writePlist(plist, path)
+
+    except (ExpatError, TypeError, AttributeError) as err:
+        LOG.warning('Failed to process plist file: %s wrong file format?',
+                    path)
+        LOG.warning(err)
+    except IndexError as iex:
+        LOG.warning('Indexing error during processing plist file %s', path)
+        LOG.warning(type(iex))
+        LOG.warning(repr(iex))
+        _, _, exc_traceback = sys.exc_info()
+        traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
+    except Exception as ex:
+        LOG.warning('Error during processing reports from the plist file: %s',
+                    path)
+        traceback.print_exc()
+        LOG.warning(type(ex))
+        LOG.warning(ex)
+
+
+class ResultHandlerClangSA(ResultHandler):
+    """
+    Use context free hash if enabled.
+    """
+
+    def __init__(self, action, workspace):
+        super(ResultHandlerClangSA, self).__init__(action, workspace)
+        self.report_hash = None
+
+    def postprocess_result(self):
+        """
+        Override the context sensitive issue hash in the plist files to
+        context insensitive if it is enabled during analysis.
+        """
+        if self.report_hash == 'context-free':
+            use_context_free_hashes(self.analyzer_result_file)

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -176,6 +176,22 @@ def add_arguments_to_parser(parser):
                              "reports and overwrites only those files that "
                              "were update by the current build command).")
 
+    parser.add_argument('--report-hash',
+                        dest="report_hash",
+                        default=argparse.SUPPRESS,
+                        required=False,
+                        choices=['context-free'],
+                        help="EXPERIMENTAL feature. "
+                             "Specify the hash calculation method for "
+                             "reports. If this option is not set, the default "
+                             "calculation method for Clang Static Analyzer "
+                             "will be context sensitive and for Clang Tidy it "
+                             "will be context insensitive. If this option is "
+                             "set to 'context-free' bugs will be identified "
+                             "with the CodeChecker generated context free "
+                             "hash for every analyzers. USE WISELY AND AT "
+                             "YOUR OWN RISK!")
+
     parser.add_argument('-n', '--name',
                         dest="name",
                         required=False,

--- a/libcodechecker/libhandlers/check.py
+++ b/libcodechecker/libhandlers/check.py
@@ -183,6 +183,24 @@ used to generate a log file on the fly.""")
                                     "overwrites only those files that were "
                                     "update by the current build command).")
 
+    analyzer_opts.add_argument('--report-hash',
+                               dest="report_hash",
+                               default=argparse.SUPPRESS,
+                               required=False,
+                               choices=['context-free'],
+                               help="EXPERIMENTAL feature. "
+                                    "Specify the hash calculation method for "
+                                    "reports. If this option is not set, the "
+                                    "default calculation method for Clang "
+                                    "Static Analyzer will be context "
+                                    "sensitive and for Clang Tidy it will be "
+                                    "context insensitive. If this option is "
+                                    "set to 'context-free' bugs will be "
+                                    "identified with the CodeChecker "
+                                    "generated context free hash for every "
+                                    "analyzers. USE WISELY AND AT YOUR OWN "
+                                    "RISK!")
+
     analyzer_opts.add_argument('-i', '--ignore', '--skip',
                                dest="skipfile",
                                required=False,
@@ -550,7 +568,8 @@ def main(args):
                           'stats_min_sample_count',
                           'enable_all',
                           'ordered_checkers',  # --enable and --disable.
-                          'timeout'
+                          'timeout',
+                          'report_hash'
                           ]
         for key in args_to_update:
             __update_if_key_exists(args, analyze_args, key)

--- a/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/tests/functional/analyze_and_parse/test_files/Makefile
@@ -29,3 +29,5 @@ compiler_warning_wno_group:
 	$(CXX) -w compiler_warning.cpp -Wno-unused -o /dev/null
 compiler_warning_unused:
 	$(CXX) -w compiler_warning.cpp -Wunused -o /dev/null
+context_hash:
+	$(CXX) -w context_hash.cpp -o /dev/null

--- a/tests/functional/analyze_and_parse/test_files/context_free_hash.output
+++ b/tests/functional/analyze_and_parse/test_files/context_free_hash.output
@@ -1,0 +1,57 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make context_hash" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --report-hash=context-free
+NORMAL#CodeChecker parse $OUTPUT$ --print-steps
+CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --analyzers clangsa --print-steps --report-hash=context-free
+--------------------------------------------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed context_hash.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total analyzed compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[LOW] context_hash.cpp:4:3: Value stored to 'x' is never read [deadcode.DeadStores]
+  x = 1;
+  ^
+  Report hash: 6b4c3229b153aee03839967dd4a01d0c
+  Steps:
+    1, context_hash.cpp:4:3: Value stored to 'x' is never read
+
+[LOW] context_hash.cpp:10:3: Value stored to 'x' is never read [deadcode.DeadStores]
+  x = 1;
+  ^
+  Report hash: 6b4c3229b153aee03839967dd4a01d0c
+  Steps:
+    1, context_hash.cpp:10:3: Value stored to 'x' is never read
+
+[LOW] context_hash.cpp:16:3: Value stored to 'z' is never read [deadcode.DeadStores]
+  z = 1;
+  ^
+  Report hash: 370acc61ed643cd70e88f05d62c26222
+  Steps:
+    1, context_hash.cpp:16:3: Value stored to 'z' is never read
+
+Found 3 defect(s) in context_hash.cpp
+
+
+----==== Summary ====----
+-------------------------------
+Filename         | Report count
+-------------------------------
+context_hash.cpp |            3
+-------------------------------
+-----------------------
+Severity | Report count
+-----------------------
+LOW      |            3
+-----------------------
+----=================----
+Total number of reports: 3
+----=================----

--- a/tests/functional/analyze_and_parse/test_files/context_hash.cpp
+++ b/tests/functional/analyze_and_parse/test_files/context_hash.cpp
@@ -1,0 +1,26 @@
+void foo()
+{
+  int x;
+  x = 1;
+}
+
+void bar()
+{
+  int x;
+  x = 1;
+}
+
+void baz()
+{
+  int z;
+  z = 1;
+}
+
+int main()
+{
+  foo();
+  bar();
+  baz();
+
+  return 0;
+}

--- a/tests/functional/analyze_and_parse/test_files/context_sensitive_hash.output
+++ b/tests/functional/analyze_and_parse/test_files/context_sensitive_hash.output
@@ -1,0 +1,57 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make context_hash" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa
+NORMAL#CodeChecker parse $OUTPUT$ --print-steps
+CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --analyzers clangsa --print-steps
+--------------------------------------------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed context_hash.cpp successfully.
+[] - ----==== Summary ====----
+[] - Total analyzed compilation commands: 1
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[LOW] context_hash.cpp:4:3: Value stored to 'x' is never read [deadcode.DeadStores]
+  x = 1;
+  ^
+  Report hash: 4abb30748ee3602453f082aa7a62cf7e
+  Steps:
+    1, context_hash.cpp:4:3: Value stored to 'x' is never read
+
+[LOW] context_hash.cpp:10:3: Value stored to 'x' is never read [deadcode.DeadStores]
+  x = 1;
+  ^
+  Report hash: 93f74370332b638f82b83d01657058d0
+  Steps:
+    1, context_hash.cpp:10:3: Value stored to 'x' is never read
+
+[LOW] context_hash.cpp:16:3: Value stored to 'z' is never read [deadcode.DeadStores]
+  z = 1;
+  ^
+  Report hash: d9b4eef69882572b10798f53483edb5b
+  Steps:
+    1, context_hash.cpp:16:3: Value stored to 'z' is never read
+
+Found 3 defect(s) in context_hash.cpp
+
+
+----==== Summary ====----
+-------------------------------
+Filename         | Report count
+-------------------------------
+context_hash.cpp |            3
+-------------------------------
+-----------------------
+Severity | Report count
+-----------------------
+LOW      |            3
+-----------------------
+----=================----
+Total number of reports: 3
+----=================----


### PR DESCRIPTION
> Closes #1801

The bug identification hash generated by `Clang Static Analyzer` contains the function name in the hash calculation. This is not appropriate for projects where the name of the functions change frequently. This commit introduces a new argument for the analyze and check subcommands which would calculate the hash value as `Clang Tidy`. If this switch is used, the bugs will be identified with the CodeChecker generated context free hash even though the `Clang Static Analyzer` generated a context sensitive hash.