### PR TITLE
ugrade boost before thrift install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install doxygen; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm@3.9; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade boost; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install thrift@0.9; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=/usr/local/Cellar/thrift@0.9/0.9.3/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which thrift; fi


### PR DESCRIPTION
If the boost package is installed by the thrift package (dependency)
it will be build from source which takes to much time on travis without
any output so the travis jobs fail.