### PR TITLE
fix slow boost build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,17 @@ matrix:
       python: "2.7"
       env: DATABASE=psql_pg8000
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9.4
       sudo: false
       language: generic
       env: DATABASE=sqlite
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9.4
       sudo: false
       language: generic
       env: DATABASE=psql_psycopg2
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9.4
       sudo: false
       language: generic
       env: DATABASE=psql_pg8000


### PR DESCRIPTION
boost build is really slow and times out with xcode8
upgrading to a newer xcode fixes the problem

the previous try to split the boost build/upgrade
into a separate step was not enough #1821