### PR TITLE
[Gerrit] Output parser workaround for Jenkins bug

### DIFF
--- a/scripts/gerrit_jenkins/parse_output_parser.py
+++ b/scripts/gerrit_jenkins/parse_output_parser.py
@@ -45,7 +45,7 @@ def process_reports(repo_dir, reports, report_url):
         elif line == '\n':
             read = False
         elif read:
-            issues[-1].append(line)
+            issues[-1].append(line.replace('"', '\\"'))
 
     result = -1 if issues else 1
     report = ""


### PR DESCRIPTION
Jenkins environment import removes backslash escapes which makes the JSON file invalid if C string literals are present in the error line. To overcome this we put extra backslashes before double parentheses in the error lines.