### PR TITLE
Add bugprone-parent-virtual-call check for clang-tidy v7+

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -105,6 +105,7 @@
   "bugprone-misplaced-operator-in-strlen-in-alloc":             "MEDIUM",
   "bugprone-misplaced-widening-cast":                           "HIGH",
   "bugprone-multiple-statement-macro":                          "MEDIUM",
+  "bugprone-parent-virtual-call":                               "MEDIUM",
   "bugprone-sizeof-expression":                                 "HIGH",
   "bugprone-sizeof-container":                                  "HIGH",
   "bugprone-string-constructor":                                "HIGH",

--- a/config/config.json
+++ b/config/config.json
@@ -107,6 +107,7 @@
         "bugprone-misplaced-widening-cast" : ["default", "sensitive", "extreme", "portability"],
         "bugprone-move-forwarding-reference" : ["default", "sensitive", "extreme"],
         "bugprone-multiple-statement-macro" : ["sensitive", "extreme"],
+        "bugprone-parent-virtual-call": ["sensitive", "extreme"],
         "bugprone-sizeof-container" : ["default", "sensitive", "extreme"],
         "bugprone-sizeof-expression" : ["default", "sensitive", "extreme"],
         "bugprone-string-constructor" : ["default", "sensitive", "extreme"],


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/bugprone-parent-virtual-call.html