### PR TITLE
Fix --timeout as clang-sa spawned child processes are not killed now

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -604,7 +604,7 @@ def check(check_data):
                     called. Set up a timeout for the analysis.
                     """
                     timeout_cleanup[0] = util.setup_process_timeout(
-                        analyzer_process, analysis_timeout, signal.SIGKILL)
+                        analyzer_process, analysis_timeout)
             else:
                 def __create_timeout(analyzer_process):
                     # If no timeout is given by the client, this callback


### PR DESCRIPTION
Clang-sa spawns a child process which in turn spawns another child process.
Using os.kill kills only the parent letting child clang-sa to continue.
It's not what we expect from timeout.
Using killpg kills parent, its children and their children too.