### PR TITLE
ignore encoding errors

### DIFF
--- a/libcodechecker/cmd/cmd_line_client.py
+++ b/libcodechecker/cmd/cmd_line_client.py
@@ -702,7 +702,7 @@ def handle_diff_results(args):
                 if f not in fname_to_fid:
                     try:
                         with codecs.open(f, 'r', 'UTF-8',
-                                         errors='replace') as source_data:
+                                         errors='ignore') as source_data:
                             content = source_data.read()
                     except (OSError, IOError):
                         content = f + " NOT FOUND."

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -486,7 +486,7 @@ def escape_like(string, escape_char='*'):
                  .replace('_', escape_char + '_')
 
 
-def get_line(file_name, line_no, errors='replace'):
+def get_line(file_name, line_no, errors='ignore'):
     """
     Return the given line from the file. If line_no is larger than the number
     of lines in the file then empty string returns.
@@ -496,9 +496,8 @@ def get_line(file_name, line_no, errors='replace'):
     Try to encode every file as utf-8 to read the line content do not depend
     on the platform settings. By default locale.getpreferredencoding() is used
     which depends on the platform.
-    Encoding errors are handled by replacing the character with '?'.
 
-    Changing the encoding error can influence the hash content!
+    Changing the encoding error handling can influence the hash content!
     """
     try:
         with io.open(file_name, mode='r',

--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -181,7 +181,7 @@ def get_report_data_from_plist(plist, skip_report_handler=None):
             if file_id not in file_sources:
                 file_path = files[file_id]
                 with codecs.open(file_path, 'r', 'UTF-8',
-                                 errors='replace') as source_data:
+                                 errors='ignore') as source_data:
                     file_sources[file_id] = {'id': file_id,
                                              'path': file_path,
                                              'content': source_data.read()}


### PR DESCRIPTION
using "replace" to handle encoding errors is less robust
because the replacement character used in python2 and python3
are different

This could change the generated hash in case the the file encoding changes and reading the source file as utf8 fails. 