### PR TITLE
Add __clang_analayzer__ macro to CTU imported tus

### DIFF
--- a/libcodechecker/analyze/ctu_manager.py
+++ b/libcodechecker/analyze/ctu_manager.py
@@ -106,7 +106,8 @@ def generate_ast(triple_arch, action, source, config, env):
             pass
 
     cmd = ctu_triple_arch.get_compile_command(action, config, source)
-    cmd.extend(['-emit-ast', '-w', '-o', ast_path])
+    # __clang__analyzer__ macro needs to be set in the imported TUs too.
+    cmd.extend(['-emit-ast', '-D__clang_analyzer__', '-w', '-o', ast_path])
 
     cmdstr = ' '.join(cmd)
     LOG.debug_analyzer("Generating AST using '%s'" % cmdstr)


### PR DESCRIPTION
When running clang analysis, the __clang_analyzer__ macro
needs to be defined. This should also be true for CTU imported TUs.