### PR TITLE
Default standard in first CTU phase.

### DIFF
--- a/libcodechecker/analyze/analyzers/ctu_triple_arch.py
+++ b/libcodechecker/analyze/analyzers/ctu_triple_arch.py
@@ -35,6 +35,10 @@ def get_compile_command(action, config, source='', output=''):
         cmd.extend(['-o', output])
     if source:
         cmd.append(source)
+
+    if all(not opt.startswith('-std=') for opt in action.analyzer_options):
+        cmd.append(action.compiler_standard)
+
     return cmd
 
 


### PR DESCRIPTION
CTU analyzes in two phases. The first phase where the AST dumps are created
should happen with the same C/C++ standard version which may be implicit.
Fixes #1838