### PR TITLE
Fix default value of Boolean column at migration

### DIFF
--- a/config_db_migrate/versions/3335ff7593cc_disable_review_status_change.py
+++ b/config_db_migrate/versions/3335ff7593cc_disable_review_status_change.py
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 def upgrade():
     op.add_column('products', sa.Column('is_review_status_change_disabled',
                                         sa.Boolean(),
-                                        server_default=sa.text(u'false')))
+                                        server_default=sa.sql.false()))
 
 
 def downgrade():


### PR DESCRIPTION
In SQLite boolean values are stored as integers 0 (false) and 1 (true). Creating the following column `Column('col', Boolean(), server_default=text(u'false'))` will insert `false` value into the SQLite database by default which will cause bad behaviour. Using `sql.false()` for server default will solve this problem.

Same problem here: https://github.com/sqlalchemy/sqlalchemy/issues/2368