### PR TITLE
Whitespace escaping in source path

### DIFF
--- a/libcodechecker/analyze/analysis_manager.py
+++ b/libcodechecker/analyze/analysis_manager.py
@@ -405,7 +405,7 @@ def is_ctu_active(source_analyzer):
         source_analyzer.is_ctu_enabled()
 
 
-def prepare_check(source, action, analyzer_config_map, output_dir,
+def prepare_check(action, analyzer_config_map, output_dir,
                   severity_map, skip_handler, statistics_data,
                   disable_ctu=False):
     """
@@ -447,7 +447,7 @@ def prepare_check(source, action, analyzer_config_map, output_dir,
 
     # Source is the currently analyzed source file
     # there can be more in one buildaction.
-    source_analyzer.source_file = source
+    source_analyzer.source_file = action.source
 
     # The result handler for analysis is an empty result handler
     # which only returns metadata, but can't process the results.
@@ -461,7 +461,7 @@ def prepare_check(source, action, analyzer_config_map, output_dir,
     # analyzer command is constructed.
     # The analyzer output file is based on the currently
     # analyzed source.
-    rh.analyzed_source_file = source
+    rh.analyzed_source_file = action.source
 
     if os.path.exists(rh.analyzer_result_file):
         reanalyzed = True
@@ -574,10 +574,8 @@ def check(check_data):
             LOG.debug_analyzer(source_file_name + ' is skipped')
             skipped = True
         else:
-            source = util.escape_source_path(action.source)
-
             source_analyzer, analyzer_cmd, rh, reanalyzed = \
-                prepare_check(source, action, analyzer_config_map,
+                prepare_check(action, analyzer_config_map,
                               output_dir, context.severity_map,
                               skip_handler, statistics_data)
 
@@ -679,7 +677,7 @@ def check(check_data):
                     LOG.error("Try to reanalyze without CTU")
                     # Try to reanalyze with CTU disabled.
                     source_analyzer, analyzer_cmd, rh, reanalyzed = \
-                        prepare_check(source, action,
+                        prepare_check(action,
                                       analyzer_config_map,
                                       output_dir,
                                       context.severity_map,

--- a/libcodechecker/analyze/pre_analysis_manager.py
+++ b/libcodechecker/analyze/pre_analysis_manager.py
@@ -102,8 +102,6 @@ def pre_analyze(params):
 
     _, source_filename = os.path.split(action.source)
 
-    action.source = util.escape_source_path(action.source)
-
     LOG.info("[%d/%d] %s" %
              (progress_checked_num.value,
               progress_actions.value, source_filename))

--- a/libcodechecker/log/log_parser.py
+++ b/libcodechecker/log/log_parser.py
@@ -689,6 +689,13 @@ def parse_options(compilation_db_entry):
     if details['source'] == '.':
         details['source'] = ''
 
+    # Escape the spaces in the source path, but make sure not to
+    # over-escape already escaped spaces. A filename containing a space
+    # character should be passed to the analyzers escaped, otherwise it would
+    # be considered multiple command line arguments.
+    details['source'] = \
+        r'\ '.join(details['source'].replace(r'\ ', ' ').split(' '))
+
     lang = get_language(os.path.splitext(details['source'])[1])
     if lang:
         if details['lang'] is None:

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -624,14 +624,6 @@ def get_last_mod_time(file_path):
         return None
 
 
-def escape_source_path(source):
-    """
-    Escape the spaces in the source path, but make sure not to
-    over-escape already escaped spaces.
-    """
-    return r'\ '.join(source.replace(r'\ ', ' ').split(' '))
-
-
 def trim_path_prefixes(path, prefixes):
     """
     Removes the longest matching leading path from the file path.

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -82,7 +82,7 @@ class LogParserTest(unittest.TestCase):
 
         build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
 
-        self.assertEqual(build_action.source, r'/tmp/a b.cpp')
+        self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
 
     def test_old_intercept_build(self):
@@ -109,7 +109,7 @@ class LogParserTest(unittest.TestCase):
 
         build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
 
-        self.assertEqual(build_action.source, r'/tmp/a b.cpp')
+        self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
 
     def test_new_intercept_build(self):
@@ -140,7 +140,7 @@ class LogParserTest(unittest.TestCase):
 
         build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
 
-        self.assertEqual(build_action.source, r'/tmp/a b.cpp')
+        self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
 
     def test_omit_preproc(self):


### PR DESCRIPTION
The BuildAction objects are immutable so they should contain all attributes in
a form so they can be passed directly to the analyzers. For example the source
file path should be kept escaped.