### PR TITLE
Do not convert notes to events

### DIFF
--- a/libcodechecker/analyze/analyzers/analyzer_clangsa.py
+++ b/libcodechecker/analyze/analyzers/analyzer_clangsa.py
@@ -176,11 +176,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                          '-analyzer-disable-checker=' +
                                          checker_name])
 
-            # Get analyzer notes as events from clang.
-            analyzer_cmd.extend(['-Xclang',
-                                 '-analyzer-config',
-                                 '-Xclang', 'notes-as-events=true'])
-
             if config.ctu_dir and not self.__disable_ctu:
                 analyzer_cmd.extend(
                     ['-Xclang', '-analyzer-config', '-Xclang',


### PR DESCRIPTION
> Closes #1539

Parsing notes from the plist files is supported now this conversion to events is not required anymore