### PR TITLE
Fix escaping in command line arguments

### DIFF
--- a/libcodechecker/log/log_parser.py
+++ b/libcodechecker/log/log_parser.py
@@ -651,6 +651,11 @@ def parse_options(compilation_db_entry):
         details['original_command'] = ' '.join(gcc_command)
     elif 'command' in compilation_db_entry:
         details['original_command'] = compilation_db_entry['command']
+        # This is needed so shlex.split() leaves the quotation mark in the
+        # output list:
+        # gcc -DHELLO="hello world" main.cpp
+        # -->
+        # ['gcc', '-DHELLO="hello world"', 'main.cpp']
         gcc_command = compilation_db_entry['command'] \
             .replace(r'\"', '"') \
             .replace(r'"', r'"\"')
@@ -718,6 +723,11 @@ def parse_options(compilation_db_entry):
 
     toolchain = \
         gcc_toolchain.toolchain_in_args(details['analyzer_options'])
+
+    # Quotation marks must be preserved when passed to the analyzers, so these
+    # have to be escaped.
+    details['analyzer_options'] = \
+        map(lambda x: x.replace('"', r'"\"'), details['analyzer_options'])
 
     # Store the compiler built in include paths and defines.
     if not toolchain:

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -75,7 +75,7 @@ class LogParserTest(unittest.TestCase):
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
-                         r'-DVARIABLE="some value"')
+                         r'-DVARIABLE="\"some value"\"')
 
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
@@ -102,7 +102,7 @@ class LogParserTest(unittest.TestCase):
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
-                         r'-DVARIABLE="some value"')
+                         r'-DVARIABLE="\"some value"\"')
 
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
@@ -133,7 +133,7 @@ class LogParserTest(unittest.TestCase):
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertTrue(len(build_action.target) > 0)
         self.assertEqual(build_action.analyzer_options[0],
-                         r'-DVARIABLE="some value"')
+                         r'-DVARIABLE="\"some value"\"')
 
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")


### PR DESCRIPTION
In this commit we follow the rule of BuildAction objects: these should contain
the final form of every used value. In this case the analyzer options should be
escaped so it will be passed correctly to the analyzer.