### PR TITLE
Remove unused analyze arguments from User Guide.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -426,9 +426,6 @@ below:
 
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
-                           [--compiler-includes-file COMPILER_INCLUDES_FILE]
-                           [--compiler-target-file COMPILER_TARGET_FILE]
-                           [--compiler-info-file COMPILER_INFO_FILE]
                            [-t {plist}] [-q] [-c]
                            [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]


### PR DESCRIPTION
The optional `--compiler-includes-file`, `--compiler-target-file`, and
`--compiler-info-file` `analyze` arguments have been removed by 5519409.
This commit removes leftover docs from the User Guide.