### PR TITLE
Fix HTML converter layout file default path

### DIFF
--- a/vendor/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/vendor/plist_to_html/plist_to_html/PlistToHtml.py
@@ -353,7 +353,7 @@ def __add_arguments_to_parser(parser):
                         required=True,
                         help="Generate HTML output files in the given folder.")
 
-    curr_file_dir = os.path.dirname(os.path.abspath(__file__))
+    curr_file_dir = os.path.dirname(os.path.realpath(__file__))
     parser.add_argument('-l', '--layout',
                         dest="layout_dir",
                         required=False,


### PR DESCRIPTION
In the built CodeChecker package there is a symlink to the plist-to-html
converter vendor script. This uses a relative path to the layout.html file
which is not correct when the symlink in the path is used.