### PR TITLE
remove CallAndMessageUnInitRefArg from extreme profile

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -17,7 +17,6 @@
   "checker_config": {
       "clangsa_checkers" : {
         "alpha.core.BoolAssignment" : ["sensitive", "extreme"],
-        "alpha.core.CallAndMessageUnInitRefArg" : ["extreme"],
         "alpha.core.CastSize" : ["sensitive", "extreme"],
         "alpha.core.Conversion" : ["sensitive", "extreme"],
         "alpha.core.DynamicTypeChecker" : ["sensitive", "extreme"],


### PR DESCRIPTION
the checker crashes on bitcoin with clang7 and newer.
it is removed from the extreme profile until further investigation