### PR TITLE
Resurrect --compiler-info-file analyze flag

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -427,6 +427,7 @@ below:
 
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
+                           [--compiler-info-file COMPILER_INFO_FILE]
                            [-t {plist}] [-q] [-c]
                            [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]
@@ -462,6 +463,10 @@ optional arguments:
                         User guide on how a Skipfile should be laid out.
   -o OUTPUT_PATH, --output OUTPUT_PATH
                         Store the analysis output in the given folder.
+  --compiler-info-file COMPILER_INFO_FILE
+                        Read the compiler includes and target from the
+                        specified file rather than invoke the compiler
+                        executable.
   -t {plist}, --type {plist}, --output-format {plist}
                         Specify the format the analysis results should use.
                         (default: plist)

--- a/libcodechecker/libhandlers/analyze.py
+++ b/libcodechecker/libhandlers/analyze.py
@@ -124,6 +124,14 @@ def add_arguments_to_parser(parser):
                         default=argparse.SUPPRESS,
                         help="Store the analysis output in the given folder.")
 
+    parser.add_argument('--compiler-info-file',
+                        dest="compiler_info_file",
+                        required=False,
+                        default=argparse.SUPPRESS,
+                        help="Read the compiler includes and target from the "
+                             "specified file rather than invoke the compiler "
+                             "executable.")
+
     parser.add_argument('-t', '--type', '--output-format',
                         dest="output_format",
                         required=False,
@@ -512,6 +520,12 @@ def main(args):
     # Process the skip list if present.
     skip_handler = __get_skip_handler(args)
 
+    if 'compiler_info_file' in args:
+        LOG.debug("Compiler info is read from: %s", args.compiler_info_file)
+        dump_path = args.compiler_info_file
+    else:
+        dump_path = args.output_path
+
     # Parse the JSON CCDBs and retrieve the compile commands.
     actions = []
     for log_file in args.logfile:
@@ -521,9 +535,8 @@ def main(args):
             continue
 
         actions += log_parser.parse_log(
-            load_json_or_empty(log_file),
-            skip_handler,
-            os.path.join(args.output_path, 'compiler_info.json'))
+            load_json_or_empty(log_file), dump_path, skip_handler)
+
     if not actions:
         LOG.info("None of the specified build log files contained "
                  "valid compilation commands. No analysis needed...")

--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -301,14 +301,27 @@ def assemble_zip(inputs, zip_file, client):
             map(lambda f_: " - " + f_, missing_source_files)))
 
 
+def should_be_zipped(input_file, input_files):
+    """
+    Determine whether a given input file should be included in the zip.
+    Compiler includes and target files should only be included if there is
+    no compiler info file present.
+    """
+    return (input_file in ['metadata.json', 'compiler_info.json']
+            or (input_file in ['compiler_includes.json',
+                               'compiler_target.json']
+                and 'compiler_info.json' not in input_files))
+
+
 def get_analysis_statistics(inputs, limits):
     """
     Collects analysis statistics information and returns them.
 
     This function will return the path of failed zips and the following files:
       - compile_cmd.json
-      - compiler_includes.json
-      - compiler_target.json
+      - either
+        - compiler_info.json, or
+        - compiler_includes.json and compiler_target.json
       - metadata.json
 
     If the input directory doesn't contain any failed zip this function will
@@ -342,10 +355,7 @@ def get_analysis_statistics(inputs, limits):
                     LOG.debug("Copying file '%s' to analyzer statistics "
                               "ZIP...", compilation_db)
                     statistics_files.append(compilation_db)
-            elif inp_f in ['compiler_includes.json',
-                           'compiler_target.json',
-                           'compiler_info.json',
-                           'metadata.json']:
+            elif should_be_zipped(inp_f, files):
                 analyzer_file = os.path.join(input_path, inp_f)
                 statistics_files.append(analyzer_file)
         for inp_dir in dirs:

--- a/tests/unit/test_buildcmd_escaping.py
+++ b/tests/unit/test_buildcmd_escaping.py
@@ -93,7 +93,8 @@ class BuildCmdTestNose(unittest.TestCase):
         compile_cmd = self.compiler + \
             ' -DDEBUG \'-DMYPATH="/this/some/path/"\''
 
-        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd))
+        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd),
+                                            self.tmp_dir)
 
         for comp_action in comp_actions:
             cmd = [self.compiler]
@@ -118,7 +119,8 @@ class BuildCmdTestNose(unittest.TestCase):
         If the escaping fails the source file will not compile.
         """
         compile_cmd = self.compiler + ''' '-DMYPATH=\"/some/other/path\"' '''
-        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd))
+        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd),
+                                            self.tmp_dir)
 
         for comp_action in comp_actions:
             cmd = [self.compiler]

--- a/tests/unit/test_log_parser.py
+++ b/tests/unit/test_log_parser.py
@@ -51,7 +51,8 @@ class LogParserTest(unittest.TestCase):
         # option_parser, so here we aim for a non-failing stalemate of the
         # define being considered a file and ignored, for now.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 0)
@@ -69,7 +70,8 @@ class LogParserTest(unittest.TestCase):
         # Logfile contains -DVARIABLE="some value"
         # and --target=x86_64-linux-gnu.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -80,7 +82,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -96,7 +99,8 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -107,7 +111,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -127,7 +132,8 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -138,7 +144,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -167,7 +174,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -M /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_log(preprocessor_actions,
+                                             self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-M' not in build_actions[0].original_command)
         self.assertTrue('-E' not in build_actions[0].original_command)
@@ -182,7 +190,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_log(preprocessor_actions,
+                                             self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-MD' in build_actions[0].original_command)
 
@@ -197,7 +206,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -E -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_log(preprocessor_actions,
+                                             self.__this_dir)
         self.assertEqual(len(build_actions), 0)
 
     def test_include_rel_to_abs(self):
@@ -206,7 +216,8 @@ class LogParserTest(unittest.TestCase):
         """
         logfile = os.path.join(self.__test_files, "include.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.parse_log(load_json_or_empty(logfile),
+                                            self.__this_dir)[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
         self.assertEqual(build_action.analyzer_options[0], '-I')


### PR DESCRIPTION
This option was removed by 5519409 under the assumption that it is not
used by the users. The truth is that this flag is very useful for debugging
purposes and some debug tools in the `/scripts` directory do use it.
This commit re-introduces the `--compiler-info-file` option on top of the
refactored log parser.