### PR TITLE
Collect compiler info for both languages C/C++

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -220,7 +220,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             extend_analyzer_cmd_with_resource_dir(analyzer_cmd,
                                                   config.compiler_resource_dir)
 
-            analyzer_cmd.extend(self.buildaction.compiler_includes)
+            analyzer_cmd.extend(
+                self.buildaction.compiler_includes[self.buildaction.lang])
 
             analyzer_cmd.append(self.source_file)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
@@ -27,7 +27,7 @@ def get_compile_command(action, config, source='', output=''):
         cmd.append("--target=" + action.target)
     extend_analyzer_cmd_with_resource_dir(cmd,
                                           config.compiler_resource_dir)
-    cmd.extend(action.compiler_includes)
+    cmd.extend(action.compiler_includes[action.lang])
     cmd.append('-c')
     cmd.extend(['-x', action.lang])
     cmd.extend(config.analyzer_extra_arguments)
@@ -38,7 +38,7 @@ def get_compile_command(action, config, source='', output=''):
         cmd.append(source)
 
     if all(not opt.startswith('-std=') for opt in action.analyzer_options):
-        cmd.append(action.compiler_standard)
+        cmd.append(action.compiler_standard[action.lang])
 
     return cmd
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
@@ -67,7 +67,7 @@ def build_stat_coll_cmd(action, config, source):
         cmd.append("--target=" + action.target)
     extend_analyzer_cmd_with_resource_dir(cmd,
                                           config.compiler_resource_dir)
-    cmd.extend(action.compiler_includes)
+    cmd.extend(action.compiler_includes[action.lang])
 
     if source:
         cmd.append(source)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -143,12 +143,14 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             extend_analyzer_cmd_with_resource_dir(analyzer_cmd,
                                                   config.compiler_resource_dir)
 
-            analyzer_cmd.extend(self.buildaction.compiler_includes)
+            analyzer_cmd.extend(
+                self.buildaction.compiler_includes[self.buildaction.lang])
 
             if not next((x for x in analyzer_cmd if x.startswith('-std=') or
                         x.startswith('--std')),
                         False):
-                analyzer_cmd.append(self.buildaction.compiler_standard)
+                analyzer_cmd.append(
+                    self.buildaction.compiler_standard[self.buildaction.lang])
 
             analyzer_cmd.extend(compiler_warnings)
 


### PR DESCRIPTION
Collect compiler includes and standards for both
language (C/C++) independent from the actual compilation
command and select the right values at analyzer command
build time.

It is possible that in a compile command json the same
compiler binary is used to build C and C++ source.
In this case the include paths and the standard will be
detected for the first command but it will be used for the
command too which is wrong.