### PR TITLE
fix dict.items referenced when not iterating py3

### DIFF
--- a/libcodechecker/libhandlers/store.py
+++ b/libcodechecker/libhandlers/store.py
@@ -274,7 +274,7 @@ def assemble_zip(inputs, zip_file, client):
             LOG.warning("There is no report to store. After uploading these "
                         "results the previous reports become resolved.")
 
-        file_hashes = hash_to_file.keys()
+        file_hashes = list(hash_to_file.keys())
         necessary_hashes = client.getMissingContentHashes(file_hashes) \
             if file_hashes else []
 

--- a/libcodechecker/util.py
+++ b/libcodechecker/util.py
@@ -157,7 +157,7 @@ def get_binary_in_path(basename_list, versioning_pattern, env):
     elif len(binaries) == 1:
         # Return the first found (earliest in PATH) binary for the only
         # found binary name group.
-        return binaries.values()[0][0]
+        return list(binaries.values())[0][0]
     else:
         keys = list(binaries.keys())
         keys.sort()


### PR DESCRIPTION
In python3 the objects returned by keys(), values(), items() are
view objects but we use and need lists here.

https://docs.python.org/3/library/stdtypes.html#dict-views