### PR TITLE
py3 fix iterator protocol (next method change)

### DIFF
--- a/libcodechecker/log/log_parser.py
+++ b/libcodechecker/log/log_parser.py
@@ -478,9 +478,11 @@ class OptionIterator(object):
         self._item = None
         self._it = iter(args)
 
-    def next(self):
+    def __next__(self):
         self._item = next(self._it)
         return self
+
+    next = __next__
 
     def __iter__(self):
         return self


### PR DESCRIPTION
`next` method implemented the Iterator protocol in python2
but is now a normal method in python3.
With the alias it will work in python2 too.

https://docs.python.org/3/tutorial/classes.html?highlight=iterator#iterators