### PR TITLE
fix dict item was referenced when not iterating py3

### DIFF
--- a/libcodechecker/server/server.py
+++ b/libcodechecker/server/server.py
@@ -836,7 +836,7 @@ class CCSimpleHttpServer(HTTPServer):
         Returns the Product object for the only product connected to by the
         server, or None, if there are 0 or >= 2 products managed.
         """
-        return self.__products.items()[0][1] if self.num_products == 1 \
+        return list(self.__products.items())[0][1] if self.num_products == 1 \
             else None
 
     def remove_product(self, endpoint):


### PR DESCRIPTION
There was still a dict usage where change is needed.
In python3 the objects returned by keys(), values(), items() are
view objects but we use and need lists here.

https://docs.python.org/3/library/stdtypes.html#dict-views