### PR TITLE
Create commands.json for sub-commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ userguide: build_dir
 
 package: clean_package build_dir gen-docs thrift userguide build_plist_to_html build_tu_collector build_vendor
 	./scripts/build_package.py -r $(ROOT) -o $(BUILD_DIR) -b $(BUILD_DIR) && \
-	./scripts/build/extend_version_file.py -r $(ROOT) -b $(BUILD_DIR)
+	./scripts/build/extend_version_file.py -r $(ROOT) -b $(BUILD_DIR) && \
+	./scripts/build/create_commands.py -b $(BUILD_DIR) $(ROOT)/bin
 
 build_vendor:
 	$(MAKE) -C $(VENDOR_DIR) build BUILD_DIR=$(CC_BUILD_WEB_PLUGINS_DIR)

--- a/scripts/build/create_commands.py
+++ b/scripts/build/create_commands.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Copy CodeChecker entry point sub-commands.
+"""
+import argparse
+import glob
+import json
+import logging
+import os
+import shutil
+
+LOG = logging.getLogger('EntryPoints')
+
+msg_formatter = logging.Formatter('[%(levelname)s] - %(message)s')
+log_handler = logging.StreamHandler()
+log_handler.setFormatter(msg_formatter)
+LOG.setLevel(logging.INFO)
+LOG.addHandler(log_handler)
+
+
+def copy_entry_points(input_dirs, build_dir):
+    """
+    Copy CodeChecker entry point sub-commands.
+    """
+    package_root = os.path.join(build_dir, 'CodeChecker')
+    package_bin = os.path.join(package_root, 'bin')
+    target_cc = os.path.join(package_root, 'cc_bin')
+
+    available_commands = []
+    for input_dir in input_dirs:
+        for input_file in glob.glob(os.path.join(input_dir, '*')):
+            file_name = os.path.basename(input_file)
+            if not file_name.endswith(".py"):
+                # Non-py files use the environment to appear as python
+                # files, they go into the folder in PATH as they are
+                # entry points.
+                if file_name.startswith("codechecker-"):
+                    command_name = file_name.replace("codechecker-", "")
+                    available_commands.append(command_name)
+
+                    skip_content = "# DO_NOT_INSTALL_TO_PATH"
+                    with open(input_file, 'r', encoding='utf-8') as file:
+                        if file.readline().strip() == skip_content:
+                            LOG.info("Registering sub-command '%s'",
+                                     command_name)
+                            # If the file is marked not to install, do not
+                            # install it. This happens with entry points
+                            # whom should not act as "lowercase" entries,
+                            # but the sub-command exists as an available
+                            # command.
+                            continue
+
+                    LOG.info("Registering sub-command '%s' installed to "
+                             "PATH", command_name)
+                shutil.copy2(input_file, package_bin)
+            else:
+                # .py files are Python code that must run in a valid env.
+                shutil.copy2(input_file, target_cc)
+
+    available_commands.sort()
+
+    commands_json = os.path.join(target_cc, 'commands.json')
+    with open(commands_json, 'w', encoding='utf-8') as commands:
+        json.dump(available_commands, commands, sort_keys=True)
+
+
+if __name__ == "__main__":
+    description = '''CodeChecker copy entry point sub-commands'''
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=description)
+
+    parser.add_argument('input',
+                        type=str,
+                        nargs='+',
+                        metavar='folder',
+                        help="List of directories which contains CodeChecker "
+                              "sub-commands")
+
+    parser.add_argument('-b', '--build-dir',
+                        required=True,
+                        action='store',
+                        dest='build_dir',
+                        help="Build directory of the source repository.")
+
+    parser.add_argument('-v', '--verbose',
+                        action='store_true',
+                        dest='verbose',
+                        help="Set verbosity level.")
+
+    args = vars(parser.parse_args())
+
+    if 'verbose' in args:
+        LOG.setLevel(logging.DEBUG)
+
+    if isinstance(args['input'], str):
+        args.input = [args.input]
+
+    copy_entry_points(args['input'], args['build_dir'])

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -341,45 +341,6 @@ def build_package(repository_root, build_package_config, env=None):
     target = os.path.join(package_root, package_layout['config'])
     copy_tree(source, target)
 
-    # CodeChecker main scripts.
-    LOG.debug('Copy main codechecker files')
-    source = os.path.join(repository_root, 'bin')
-    target = os.path.join(package_root, package_layout['bin'])
-    target_cc = os.path.join(package_root, package_layout['cc_bin'])
-
-    available_commands = []
-
-    for _, _, files in os.walk(source):
-        for f in files:
-            if not f.endswith(".py"):
-                # Non-py files use the environment to appear as python files,
-                # they go into the folder in PATH as they are entrypoints.
-                if f.startswith("codechecker-"):
-                    commandname = f.replace("codechecker-", "")
-                    available_commands.append(commandname)
-                    with open(os.path.join(source, f), 'r') as file:
-                        if file.readline().strip() ==\
-                                "# DO_NOT_INSTALL_TO_PATH":
-
-                            LOG.info("Registering subcommand '{0}'"
-                                     .format(commandname))
-                            # If the file is marked not to install, do not
-                            # install it. This happens with entry points whom
-                            # should not act as "lowercase" entries, but
-                            # the subcommand exists as an available command.
-                            continue
-
-                    LOG.info("Registering subcommand '{0}' installed to PATH"
-                             .format(commandname))
-                shutil.copy2(os.path.join(source, f), target)
-            else:
-                # .py files are Python code that must run in a valid env.
-                shutil.copy2(os.path.join(source, f), target_cc)
-
-    available_commands.sort()
-    with open(os.path.join(target_cc, 'commands.json'), 'w') as commands:
-        json.dump(available_commands, commands, sort_keys=True)
-
     # CodeChecker web client.
     LOG.debug('Copy web client files')
     source = os.path.join(repository_root, 'www')


### PR DESCRIPTION
Create separate python scripts to copy CodeChecker sub-commands and create a `commands.json` file which will contain all the available sub-commands.