### PR TITLE
Fix failed source list of analysis statistics

### DIFF
--- a/analyzer/codechecker/analyze/analysis_manager.py
+++ b/analyzer/codechecker/analyze/analysis_manager.py
@@ -84,7 +84,7 @@ def worker_result_handler(results, metadata, output_path, analyzer_binaries):
                 statistics[analyzer_type]['successful'] += 1
             else:
                 statistics[analyzer_type]['failed'] += 1
-                statistics[analyzer_type]['failed_sources'].extend(sources)
+                statistics[analyzer_type]['failed_sources'].append(sources)
 
     LOG.info("----==== Summary ====----")
     print_analyzer_statistic_summary(statistics,


### PR DESCRIPTION
We assumed that the type of the `source` attribute of a build action is a list but it was changed in #1814 pull request to string.