### PR TITLE
Introducing --compile-uniqueing parameter

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_action.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_action.py
@@ -58,6 +58,14 @@ class BuildAction(object):
     def __eq__(self, other):
         return other.original_command == self.original_command
 
+    def to_dict(self):
+        """Reverting to original compilation database
+        record for JSON conversion.
+        """
+        return {"command": self.original_command,
+                "directory": self.directory,
+                "file": self.source}
+
     def __hash__(self):
         """
         If the compilation database contains the same compilation action

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -25,7 +25,6 @@ from .build_action import BuildAction
 
 LOG = get_logger('buildlogger')
 
-
 # Replace gcc/g++ build target options with values accepted by Clang.
 REPLACE_OPTIONS_MAP = {
     '-mips32': ['-target', 'mips', '-mips32'],
@@ -33,7 +32,6 @@ REPLACE_OPTIONS_MAP = {
     '-mpowerpc': ['-target', 'powerpc'],
     '-mpowerpc64': ['-target', 'powerpc64']
 }
-
 
 # The compilation flags of which the prefix is any of these regular expressions
 # will not be included in the output Clang command.
@@ -129,7 +127,6 @@ IGNORED_OPTIONS = [
 
 IGNORED_OPTIONS = re.compile('|'.join(IGNORED_OPTIONS))
 
-
 # The compilation flags of which the prefix is any of these regular expressions
 # will not be included in the output Clang command. These flags have further
 # parameters which are also omitted. The number of parameters is indicated in
@@ -155,7 +152,6 @@ IGNORED_PARAM_OPTIONS = {
     re.compile('-filelist'): 1
 }
 
-
 COMPILE_OPTIONS = [
     '-nostdinc',
     r'-nostdinc\+\+',
@@ -172,7 +168,6 @@ COMPILE_OPTIONS = [
 
 COMPILE_OPTIONS = re.compile('|'.join(COMPILE_OPTIONS))
 
-
 COMPILE_OPTIONS_MERGED = [
     '--sysroot',
     '--include',
@@ -188,9 +183,9 @@ COMPILE_OPTIONS_MERGED = [
     '-iwithprefixbefore'
 ]
 
+
 COMPILE_OPTIONS_MERGED = \
     re.compile('(' + '|'.join(COMPILE_OPTIONS_MERGED) + ')')
-
 
 PRECOMPILATION_OPTION = re.compile('-(E|M[T|Q|F|J|P|V|M]*)$')
 
@@ -319,7 +314,7 @@ class ImplicitCompilerInfo(object):
         extra_opts = filter(pattern.match, compiler_flags)
 
         pos = next((pos for pos, val in enumerate(compiler_flags)
-                   if val.startswith('--sysroot')), None)
+                    if val.startswith('--sysroot')), None)
         if pos is not None:
             if compiler_flags[pos] == '--sysroot':
                 extra_opts.append('--sysroot=' + compiler_flags[pos + 1])
@@ -433,8 +428,8 @@ class ImplicitCompilerInfo(object):
                 standard = '-std=iso9899:199409'
             else:
                 standard = '-std=gnu' \
-                         + ('' if language == 'c' else '++') \
-                         + standard
+                    + ('' if language == 'c' else '++') \
+                    + standard
 
         return standard
 
@@ -478,6 +473,7 @@ class ImplicitCompilerInfo(object):
 
 
 class OptionIterator(object):
+
     def __init__(self, args):
         self._item = None
         self._it = iter(args)
@@ -802,9 +798,27 @@ def parse_options(compilation_db_entry):
     return BuildAction(**details)
 
 
-def parse_log(compilation_database,
-              skip_handler=None,
-              compiler_info_file=None):
+class CompileCommandEncoder(json.JSONEncoder):
+    """JSON serializer for objects not serializable by default json code"""
+    def default(self, o):
+        if isinstance(o, BuildAction):
+            return o.to_dict()
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, o)
+
+
+class CompileActionUniqueingType(object):
+    NONE = 0  # Full Action text
+    SOURCE_ALPHA = 1  # Based on source file, uniqueing by
+    # on alphanumerically first target
+    SOURCE_REGEX = 2  # Based on source file, uniqueing by regex filter
+    STRICT = 3  # Gives error in case of duplicate
+
+
+def parse_unique_log(compilation_database,
+                     compile_uniqueing="none",
+                     skip_handler=None,
+                     compiler_info_file=None):
     """
     compilation_database -- A compilation database as a list of dict objects.
                             These object should contain "file", "dictionary"
@@ -812,6 +826,9 @@ def parse_log(compilation_database,
                             by "arguments" which is a split command. Older
                             versions of intercept-build provide the build
                             command this way.
+    compile_uniqueing -- Compilation database uniqueing mode.
+                         If there are more than one compile commands for a
+                         target file, only a single one is kept.
     skip_handler -- A SkipListHandler object which helps to skip build actions
                     that shouldn't be analyzed. The build actions described by
                     this handler will not be the part of the result list.
@@ -820,28 +837,77 @@ def parse_log(compilation_database,
                           targets, default standard version).
     """
     try:
-        filtered_build_actions = set()
+        uniqued_build_actions = dict()
+
+        if compile_uniqueing == "alpha":
+            build_action_uniqueing = CompileActionUniqueingType.SOURCE_ALPHA
+        elif compile_uniqueing == "none":
+            build_action_uniqueing = CompileActionUniqueingType.NONE
+        elif compile_uniqueing == "strict":
+            build_action_uniqueing = CompileActionUniqueingType.STRICT
+        else:
+            build_action_uniqueing = CompileActionUniqueingType.SOURCE_REGEX
+            uniqueing_re = re.compile(compile_uniqueing)
 
         for entry in compilation_database:
             if skip_handler and skip_handler.should_skip(entry['file']):
+                LOG.debug("SKIPPING FILE %s", entry['file'])
                 continue
 
             action = parse_options(entry)
+            LOG.debug(action)
 
             if not action.lang:
                 continue
             if action.action_type != BuildAction.COMPILE:
                 continue
+            if build_action_uniqueing == CompileActionUniqueingType.NONE:
+                if action.__hash__ not in uniqued_build_actions:
+                    uniqued_build_actions[action.__hash__] = action
+            elif build_action_uniqueing == CompileActionUniqueingType.STRICT:
+                if action.source not in uniqued_build_actions:
+                    uniqued_build_actions[action.source] = action
+                else:
+                    LOG.error("Build Action uniqueing failed"
+                              " as both '%s' and '%s'",
+                              uniqued_build_actions[action.source]
+                              .original_command,
+                              action.original_command)
+                    sys.exit(1)
+            elif build_action_uniqueing ==\
+                    CompileActionUniqueingType.SOURCE_ALPHA:
+                if action.source not in uniqued_build_actions:
+                    uniqued_build_actions[action.source] = action
+                elif action.output <\
+                        uniqued_build_actions[action.source].output:
+                    uniqued_build_actions[action.source] = action
+            elif build_action_uniqueing ==\
+                    CompileActionUniqueingType.SOURCE_REGEX:
+                LOG.debug("uniqueing regex")
+                if action.source not in uniqued_build_actions:
+                    uniqued_build_actions[action.source] = action
+                elif uniqueing_re.match(action.original_command) and\
+                    not uniqueing_re.match(
+                        uniqued_build_actions[action.source].original_command):
+                    uniqued_build_actions[action.source] = action
+                elif uniqueing_re.match(action.original_command) and\
+                    uniqueing_re.match(
+                        uniqued_build_actions[action.source].original_command):
+                    LOG.error("Build Action uniqueing failed as both \n %s"
+                              "\n and \n %s \n match regex pattern:%s",
+                              uniqued_build_actions[action.source].
+                              original_command,
+                              action.original_command,
+                              compile_uniqueing)
+                    sys.exit(1)
 
-            # Filter out duplicate compilation commands.
-            filtered_build_actions.add(action)
-
+        # Filter out duplicate compilation commands.
         if compiler_info_file:
             with open(compiler_info_file, 'w') as f:
                 json.dump(ImplicitCompilerInfo.get(), f)
 
         LOG.debug('Parsing log file done.')
-        return list(filtered_build_actions)
+        return list(uniqued_build_actions.values())
 
     except (ValueError, KeyError, TypeError) as ex:
         if not compilation_database:

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -183,6 +183,39 @@ used to generate a log file on the fly.""")
                                     "overwrites only those files that were "
                                     "update by the current build command).")
 
+    parser.add_argument('--compile-uniqueing',
+                        type=str,
+                        dest="compile_uniqueing",
+                        default="none",
+                        required=False,
+                        help="Specify the method the compilation "
+                             "actions in the  compilation database are "
+                             "uniqued before analysis. "
+                             "CTU analysis works properly only if "
+                             "there is exactly one "
+                             "compilation action per source file. "
+                             "none(default in non CTU mode): "
+                             "no uniqueing is done. "
+                             "strict: no uniqueing is done, "
+                             "and an error is given if "
+                             "there is more than one compilation "
+                             "action for a source file. "
+                             "alpha(default in CTU mode): If there is more "
+                             "than one compilation action for a source "
+                             "file, only the one is kept that belongs to the "
+                             "alphabetically first "
+                             "compilation target. "
+                             "If none of the above given, "
+                             "this parameter should "
+                             "be a python regular expression."
+                             "If there is more than one compilation action "
+                             "for a source, "
+                             "only the one is kept which matches the "
+                             "given python regex. If more than one "
+                             "matches an error is given. "
+                             "The whole compilation "
+                             "action text is searched for match.")
+
     analyzer_opts.add_argument('--report-hash',
                                dest="report_hash",
                                default=argparse.SUPPRESS,
@@ -560,6 +593,7 @@ def main(args):
                           'enable_all',
                           'ordered_checkers',  # --enable and --disable.
                           'timeout',
+                          'compile_uniqueing',
                           'report_hash'
                           ]
         for key in args_to_update:

--- a/analyzer/tests/unit/test_buildcmd_escaping.py
+++ b/analyzer/tests/unit/test_buildcmd_escaping.py
@@ -91,7 +91,8 @@ class BuildCmdTestNose(unittest.TestCase):
         compile_cmd = self.compiler + \
             ' -DDEBUG \'-DMYPATH="/this/some/path/"\''
 
-        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd))
+        comp_actions = log_parser.\
+            parse_unique_log(self.__get_cmp_json(compile_cmd))
 
         for comp_action in comp_actions:
             cmd = [self.compiler]
@@ -116,7 +117,8 @@ class BuildCmdTestNose(unittest.TestCase):
         If the escaping fails the source file will not compile.
         """
         compile_cmd = self.compiler + ''' '-DMYPATH=\"/some/other/path\"' '''
-        comp_actions = log_parser.parse_log(self.__get_cmp_json(compile_cmd))
+        comp_actions = log_parser.\
+            parse_unique_log(self.__get_cmp_json(compile_cmd))
 
         for comp_action in comp_actions:
             cmd = [self.compiler]

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -50,7 +50,8 @@ class LogParserTest(unittest.TestCase):
         # option_parser, so here we aim for a non-failing stalemate of the
         # define being considered a file and ignored, for now.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 0)
@@ -68,7 +69,8 @@ class LogParserTest(unittest.TestCase):
         # Logfile contains -DVARIABLE="some value"
         # and --target=x86_64-linux-gnu.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -79,7 +81,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -95,7 +98,8 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -106,7 +110,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -126,7 +131,8 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -137,7 +143,8 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(build_action.source, r'/tmp/a\ b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -166,7 +173,7 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -M /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-M' not in build_actions[0].original_command)
         self.assertTrue('-E' not in build_actions[0].original_command)
@@ -181,7 +188,7 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-MD' in build_actions[0].original_command)
 
@@ -196,7 +203,7 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -E -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 0)
 
     def test_include_rel_to_abs(self):
@@ -205,7 +212,8 @@ class LogParserTest(unittest.TestCase):
         """
         logfile = os.path.join(self.__test_files, "include.json")
 
-        build_action = log_parser.parse_log(load_json_or_empty(logfile))[0]
+        build_action = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile))[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
         self.assertEqual(build_action.analyzer_options[0], '-I')


### PR DESCRIPTION
CTU analysis does not tolerate if a source file is
included multiple times in the compilation database.
Because in this case it is ambigous, which
compiled file shall be inlined.