### PR TITLE
fix analyzer_statistics module import

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -572,7 +572,7 @@ def main(args):
         LOG.debug("Copying compilation database JSON file failed.")
 
     try:
-        from codechecker import analyzer_statistics
+        from codechecker_analyzer import analyzer_statistics
         analyzer_statistics.collect(metadata, "analyze")
     except Exception:
         pass


### PR DESCRIPTION
there is no python package named codechecker anymore
analysis related packages are moved under codechecker_analyzer