### PR TITLE
allow to set the base wp dir from env variable for tests

### DIFF
--- a/analyzer/tests/libtest/env.py
+++ b/analyzer/tests/libtest/env.py
@@ -33,12 +33,16 @@ def codechecker_cmd():
 
 
 def get_workspace(test_id='test'):
-    tmp_dir = os.path.join(REPO_ROOT, 'build')
-    base_dir = os.path.join(tmp_dir, 'workspace')
-    if not os.path.exists(base_dir):
-        os.makedirs(base_dir)
+    """ return a temporary workspace for the tests """
+    workspace_root = os.environ.get("CC_TEST_WORKSPACE_ROOT")
+    if not workspace_root:
+        # if no external workspace is set create under the build dir
+        workspace_root = os.path.join(REPO_ROOT, 'build', 'workspace')
+
+    if not os.path.exists(workspace_root):
+        os.makedirs(workspace_root)
 
     if test_id:
-        return tempfile.mkdtemp(prefix=test_id+"-", dir=base_dir)
+        return tempfile.mkdtemp(prefix=test_id+"-", dir=workspace_root)
     else:
-        return base_dir
+        return workspace_root

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -17,6 +17,16 @@ make package
 |`make test_psql` | functional tests (PostgreSQL)
 |`make TEST="tests/functional/cmdline" run_test` | run only a specific test (SQLite) |
 
+### Change test workspace root
+
+With the `CC_TEST_WORKSPACE` environment variable the root directory for the tests can be changed. With this environment variable multiple test types (sqlite, postgresql) can be run parallel. Every test should create the temporary directories under the given root directory.
+
+Sqlite tests with a changed workspace root can be run like this:
+
+```sh
+CC_TEST_WORKSPACE=/tmp/sqlite_test_workspace make -C web test_sqlite
+```
+
 ### Clean test workspace
 ~~~~~~{.sh}
 make test_clean

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -13,9 +13,9 @@ CLANG_VERSION ?= TEST_CLANG_VERSION=stable
 TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
-WORKSPACE ?= $(BUILD_DIR)/workspace
+CC_TEST_WORKSPACE_ROOT ?= $(BUILD_DIR)/workspace
 
-CLEAR_WORKSPACE_CMD = rm -rf $(WORKSPACE)
+CLEAR_WORKSPACE_CMD = rm -rf $(CC_TEST_WORKSPACE_ROOT)
 
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
@@ -49,12 +49,12 @@ pylint: venv_dev
 
 CODECHECKER_CMD = $(BUILD_DIR)/CodeChecker/bin/CodeChecker
 SHUTDOWN_SERVER_CMD = echo "Shutting down server..."; \
-    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server -l; \
-    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server \
-			--config-directory $(WORKSPACE) \
-	    --port `cat "$(WORKSPACE)/serverport"` --stop; \
-    rm -f "$(WORKSPACE)/serverport"; \
-    HOME="$(WORKSPACE)" ${CODECHECKER_CMD} server -l
+    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l; \
+    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server \
+			--config-directory $(CC_TEST_WORKSPACE_ROOT) \
+	    --port `cat "$(CC_TEST_WORKSPACE_ROOT)/serverport"` --stop; \
+    rm -f "$(CC_TEST_WORKSPACE_ROOT)/serverport"; \
+    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l
 
 # Preserve the error status of the previous command but always be able to
 # shut down servers.

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -18,7 +18,6 @@ import shutil
 import socket
 import stat
 import subprocess
-import sys
 
 from .thrift_client_to_db import get_auth_client
 from .thrift_client_to_db import get_config_client
@@ -257,15 +256,19 @@ def parts_to_url(codechecker_cfg):
 
 
 def get_workspace(test_id='test'):
-    tmp_dir = os.path.join(REPO_ROOT, 'build')
-    base_dir = os.path.join(tmp_dir, 'workspace')
-    if not os.path.exists(base_dir):
-        os.makedirs(base_dir)
+    """ return a temporary workspace for the tests """
+    workspace_root = os.environ.get("CC_TEST_WORKSPACE_ROOT")
+    if not workspace_root:
+        # if no external workspace is set create under the build dir
+        workspace_root = os.path.join(REPO_ROOT, 'build', 'workspace')
+
+    if not os.path.exists(workspace_root):
+        os.makedirs(workspace_root)
 
     if test_id:
-        return tempfile.mkdtemp(prefix=test_id+"-", dir=base_dir)
+        return tempfile.mkdtemp(prefix=test_id+"-", dir=workspace_root)
     else:
-        return base_dir
+        return workspace_root
 
 
 def clean_wp(workspace):


### PR DESCRIPTION
the previously introduced WORKSPACE env var the base directory can be
set for the tests, every temporary directory should be created
under the base workspace dir for the functional tests