### PR TITLE
Compile action contains bot compiler and preprocessor flags

### DIFF
--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -211,6 +211,21 @@ class OptionParserTest(unittest.TestCase):
         self.assertTrue(set(compiler_options) == set(res.analyzer_options))
         self.assertEqual(BuildAction.LINK, res.action_type)
 
+    def test_preprocess_and_compile(self):
+        """
+        If the compile command contains a preprocessor related flag like -MP
+        and -c which results compilation then we consider the action as
+        compilation instead of preprocessing.
+        """
+        action = {
+            'file': 'main.cpp',
+            'command': 'g++ -c -MP main.cpp',
+            'directory': ''}
+
+        res = log_parser.parse_options(action)
+        print(res)
+        self.assertEqual(BuildAction.COMPILE, res.action_type)
+
     def test_ignore_flags(self):
         """
         Test if special compiler options are ignored properly.


### PR DESCRIPTION
When a compilation action contains -c which indicates that this is a
compilation, and also contains some preprocessor related flags like -MP
then the action was considered as a preprocessor action. So this action
was skipped when running the checkers. This commit fixes this issue.