### PR TITLE
Improve web test performance

### DIFF
--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -22,6 +22,7 @@ import socket
 import stat
 import subprocess
 import tempfile
+import time
 import uuid
 
 from threading import Timer
@@ -213,6 +214,19 @@ def kill_process_tree(parent_pid, recursive=False):
     _, still_alive = psutil.wait_procs(children, timeout=5)
     for p in still_alive:
         p.kill()
+
+    # Wait until this process is running.
+    n = 0
+    timeout = 10
+    while proc.is_running():
+        if n > timeout:
+            LOG.warning("Waiting for process %s to stop has been timed out"
+                        "(timeout = %s)! Process is still running!",
+                        parent_pid, timeout)
+            break
+
+        time.sleep(1)
+        n += 1
 
 
 def setup_process_timeout(proc, timeout,

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -178,7 +178,6 @@ int f(int x) { return 1 / x; }
         files_in_report_after = self.__get_files_in_report()
 
         event.set()
-        time.sleep(5)
 
         event.clear()
 
@@ -216,4 +215,3 @@ int f(int x) { return 1 / x; }
         self.__check_serverity_of_reports()
 
         event.set()
-        time.sleep(5)

--- a/web/tests/functional/instance_manager/test_instances.py
+++ b/web/tests/functional/instance_manager/test_instances.py
@@ -56,7 +56,6 @@ class TestInstances(unittest.TestCase):
         EVENT_1.clear()
         start_server(codechecker_1, EVENT_1, ['--skip-db-cleanup'])
 
-        time.sleep(5)
         instance = [i for i in instance_manager.get_instances(self.home)
                     if i['port'] == codechecker_1['viewer_port'] and
                     i['workspace'] == self._test_workspace]
@@ -75,7 +74,6 @@ class TestInstances(unittest.TestCase):
         start_server(codechecker_2, EVENT_2, ['--skip-db-cleanup'])
 
         # Workspaces must match, servers were started in the same workspace.
-        time.sleep(5)
         instance_workspaces = [
             i['workspace'] for i in instance_manager.get_instances(self.home)
             if i['workspace'] == self._test_workspace]
@@ -146,7 +144,6 @@ class TestInstances(unittest.TestCase):
                                           '--workspace',
                                           self._test_workspace]),
                          "The stop command didn't return exit code 0.")
-        time.sleep(5)
 
         # Check if the remaining server is still there,
         # we need to make sure that --stop only kills the specified server!
@@ -173,7 +170,6 @@ class TestInstances(unittest.TestCase):
                                           '--workspace',
                                           self._test_workspace]),
                          "The stop command didn't return exit code 0.")
-        time.sleep(5)
 
         instance_1 = [i for i in instance_manager.get_instances(self.home)
                       if i['port'] == codechecker_1['viewer_port'] and
@@ -211,7 +207,6 @@ class TestInstances(unittest.TestCase):
         self.assertEqual(0, self.run_cmd([env.codechecker_cmd(),
                                           'server', '--stop-all']),
                          "The stop-all command didn't return exit code 0.")
-        time.sleep(5)
 
         self.assertEqual(len(instance_manager.get_instances(self.home)), 0,
                          "Both servers were allegedly stopped but they "

--- a/web/tests/functional/ssl/__init__.py
+++ b/web/tests/functional/ssl/__init__.py
@@ -67,7 +67,7 @@ def setup_package():
     # Enable authentication and start the CodeChecker server.
     env.enable_auth(TEST_WORKSPACE)
     print("Starting server to get results")
-    _start_server(codechecker_cfg, test_config, False)
+    codechecker.start_server(codechecker_cfg, __STOP_SERVER)
 
 
 def teardown_package():
@@ -77,40 +77,5 @@ def teardown_package():
     global TEST_WORKSPACE
     __STOP_SERVER.set()
 
-    # The custom server stated in a separate home needs to be waited, so it
-    # can properly execute its finalizers.
-    time.sleep(5)
-
     print("Removing: " + TEST_WORKSPACE)
     shutil.rmtree(TEST_WORKSPACE, ignore_errors=True)
-
-
-# This server uses custom server configuration, which is brought up here
-# and torn down by the package itself --- it does not connect to the
-# test run's "master" server.
-def _start_server(codechecker_cfg, test_config, auth=False):
-    """Start the CodeChecker server."""
-    def start_server_proc(event, server_cmd, checking_env):
-        """Target function for starting the CodeChecker server."""
-        proc = subprocess.Popen(server_cmd, env=checking_env)
-
-        # Blocking termination until event is set.
-        event.wait()
-
-        # If proc is still running, stop it.
-        if proc.poll() is None:
-            proc.terminate()
-
-    server_cmd = codechecker.serv_cmd(codechecker_cfg['workspace'],
-                                      str(codechecker_cfg['viewer_port']),
-                                      env.get_postgresql_cfg())
-
-    server_proc = multiprocessing.Process(
-        name='server',
-        target=start_server_proc,
-        args=(__STOP_SERVER, server_cmd, codechecker_cfg['check_env']))
-
-    server_proc.start()
-
-    # Wait for server to start and connect to database.
-    time.sleep(20)

--- a/web/tests/functional/storage_of_analysis_statistics/__init__.py
+++ b/web/tests/functional/storage_of_analysis_statistics/__init__.py
@@ -82,9 +82,5 @@ def teardown_package():
     # Let the remaining CodeChecker servers die.
     EVENT_1.set()
 
-    # The custom server stated in a separate home needs to be waited, so it
-    # can properly execute its finalizers.
-    time.sleep(5)
-
     print("Removing: " + TEST_WORKSPACE)
     shutil.rmtree(TEST_WORKSPACE, ignore_errors=True)

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -440,7 +440,7 @@ def wait_for_server_start(stdoutfile):
 # This server uses multiple custom servers, which are brought up here
 # and torn down by the package itself --- it does not connect to the
 # test run's "master" server.
-def start_server(codechecker_cfg, event, server_args=None):
+def start_server(codechecker_cfg, event, server_args=None, pg_config=None):
     """Start the CodeChecker server."""
     def start_server_proc(event, server_cmd, checking_env):
         """Target function for starting the CodeChecker server."""
@@ -462,7 +462,7 @@ def start_server(codechecker_cfg, event, server_args=None):
 
     server_cmd = serv_cmd(codechecker_cfg['workspace'],
                           str(codechecker_cfg['viewer_port']),
-                          None,
+                          pg_config,
                           server_args or [])
 
     server_proc = multiprocessing.Process(


### PR DESCRIPTION
- Use `start_server` function from `codechecker` module to start a server.
- Wait until the server process is still running on server stop.
- Remove unnecessary sleeps.