### PR TITLE
cleanup make targets with/without virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then while ! pg_isready; do sleep 1; done; createuser -s postgres; fi
 
 install:
-    - pip install nose pycodestyle
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install --ignore-installed nose --user; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=/Users/travis/Library/Python/2.7/bin:$PATH; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install virtualenv; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 100; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100; fi
@@ -82,6 +83,9 @@ addons:
     postgresql: "9.6"
 
 script:
+    - make pip_dev_deps
+    - make pycodestyle
+    - make pylint
     - make clean_travis
     - make package
     - make -C tools/plist_to_html test

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -11,6 +11,9 @@ VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 
 include tests/Makefile
 
+pip_dev_deps:
+	pip install -r $(VENV_DEV_REQ_FILE)
+
 venv_dev:
 	# Create a virtual environment for development.
 	virtualenv -p python2 venv_dev && \

--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -8,13 +8,16 @@ REPO_ROOT ?= REPO_ROOT=$(ROOT)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: test_unit test_functional test_build_logger test_tu_collector
+test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env test_functional_in_env test_build_logger test_tu_collector_in_env
 
-test_novenv: test_unit_novenv test_functional_novenv
+test: pycodestyle pylint test_unit test_functional test_build_logger test_tu_collector
 
 PYCODESTYLE_TEST_CMD = pycodestyle bin codechecker_analyzer tests
 
-pycodestyle: venv_dev
+pycodestyle:
+	$(PYCODESTYLE_TEST_CMD)
+
+pycodestyle_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYCODESTYLE_TEST_CMD)
 
 PYLINT_TEST_CMD = pylint ./bin ./cmd ./codechecker_analyzer ./tests \
@@ -22,35 +25,45 @@ PYLINT_TEST_CMD = pylint ./bin ./cmd ./codechecker_analyzer ./tests \
   --disable=all \
   --enable=logging-format-interpolation,old-style-class
 
-pylint: venv_dev
+pylint:
+	$(PYLINT_TEST_CMD)
+
+pylint_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
 
+run_test:
+	$(REPO_ROOT) $(TEST_PROJECT) \
+		nosetests $(NOSECFG) ${TEST} || exit 1
+
+run_test_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(REPO_ROOT) $(TEST_PROJECT) \
+		nosetests $(NOSECFG) ${TEST} || exit 1
+
 UNIT_TEST_CMD = $(REPO_ROOT) nosetests $(NOSECFG) tests/unit
+
+test_unit:
+	$(UNIT_TEST_CMD)
+
+test_unit_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)
 
 FUNCTIONAL_TEST_CMD = $(REPO_ROOT) $(TEST_PROJECT) \
 		nosetests $(NOSECFG) tests/functional || exit 1
 
-run_test: venv_dev
-	$(ACTIVATE_DEV_VENV) && $(REPO_ROOT) $(TEST_PROJECT) \
-		nosetests $(NOSECFG) ${TEST} || exit 1
-
-test_unit: venv_dev
-	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)
-
-test_unit_novenv:
-	$(UNIT_TEST_CMD)
-
-test_functional: venv_dev
-		python $(ROOT)/scripts/test/check_clang.py || exit 1;
-		$(ACTIVATE_DEV_VENV) && $(FUNCTIONAL_TEST_CMD)
-
-test_functional_novenv:
+test_functional:
 	python $(ROOT)/scripts/test/check_clang.py || exit 1;
 	$(FUNCTIONAL_TEST_CMD)
+
+test_functional_in_env: venv_dev
+		python $(ROOT)/scripts/test/check_clang.py || exit 1;
+		$(ACTIVATE_DEV_VENV) && $(FUNCTIONAL_TEST_CMD)
 
 test_build_logger:
 	make -C tools/build-logger -f Makefile.manual test
 
 test_tu_collector:
+	$(REPO_ROOT) make -C $(ROOT)/tools/tu_collector test
+
+test_tu_collector_in_env:
 	$(ACTIVATE_DEV_VENV) && \
 	$(REPO_ROOT) make -C $(ROOT)/tools/tu_collector test

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -3,14 +3,16 @@
 __At least Clang 7.0 and Clant-tidy 7.0 is required to run the tests.__  
 
 **Before running the tests the CodeChecker package needs to be built!**
-~~~~~~{.sh}
+```sh
 # Build the package
 make package
-~~~~~~
+```
 
+__Every test target has an `*in_env` version (Eg. `make test_in_env`) which automatically creates and sources a virtualenv for the tests.__
 |cmd||  
 |----|---|  
 |`make test`| run all tests (unit and functional)|  
+|`make test_in_env`| run all tests (unit and functional), automatically setup and source a virtualenv|  
 |`make test_unit` | unittests |  
 |`make test_functional` | functional tests (SQLite and PostgreSQL) |  
 |`make test_sqlite` | functional test (SQLite) |  

--- a/tools/plist_to_html/Makefile
+++ b/tools/plist_to_html/Makefile
@@ -29,6 +29,9 @@ venv:
 	# Create a virtual environment which can be used to run the build package.
 	virtualenv -p python2 venv && $(ACTIVATE_RUNTIME_VENV)
 
+pip_dev_deps:
+	pip install -r $(VENV_DEV_REQ_FILE)
+
 venv_dev:
 	# Create a virtual environment for development.
 	virtualenv -p python2 venv_dev && \

--- a/tools/plist_to_html/tests/Makefile
+++ b/tools/plist_to_html/tests/Makefile
@@ -10,27 +10,33 @@ LAYOUT_DIR ?= LAYOUT_DIR=$(STATIC_DIR)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: test_unit
+test: pycodestyle pylint test_unit
 
-test_novenv: test_unit_novenv
+test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env
 
 PYCODESTYLE_TEST_CMD = pycodestyle plist_to_html tests
 
-pycodestyle: venv_dev
+pycodestyle:
+	$(PYCODESTYLE_TEST_CMD)
+
+pycodestyle_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYCODESTYLE_TEST_CMD)
 
 PYLINT_TEST_CMD = pylint ./plist_to_html ./tests \
   --disable=all \
   --enable=logging-format-interpolation,old-style-class
 
-pylint: venv
+pylint:
+	$(PYLINT_TEST_CMD)
+
+pylint_in_env: venv
 	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
 
 UNIT_TEST_CMD = $(REPO_ROOT) $(TEST_PROJECT) $(LAYOUT_DIR) \
   nosetests $(NOSECFG) tests/unit
 
-test_unit: venv_dev dep
-	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)
-
-test_unit_novenv: dep
+test_unit: dep
 	$(UNIT_TEST_CMD)
+
+test_unit_in_env: venv_dev dep
+	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)

--- a/web/Makefile
+++ b/web/Makefile
@@ -13,6 +13,9 @@ VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 include tests/Makefile
 include server/tests/Makefile
 
+pip_dev_deps:
+	pip install -r $(VENV_DEV_REQ_FILE)
+
 thrift: build_dir
 	if [ -d "$(BUILD_DIR)/thrift" ]; then rm -rf $(BUILD_DIR)/thrift; fi
 	mkdir $(BUILD_DIR)/thrift

--- a/web/server/tests/Makefile
+++ b/web/server/tests/Makefile
@@ -1,7 +1,7 @@
 UNIT_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) nosetests $(NOSECFG) -w server tests/unit
 
-test_unit_server: venv_dev thrift
-	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)
-
-test_unit_novenv_server: thrift
+test_unit_server: thrift
 	$(UNIT_TEST_CMD)
+
+test_unit_server_in_env: venv_dev thrift
+	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -22,7 +22,7 @@ NOSECFG = --config .noserc
 
 test: pycodestyle pylint test_unit test_functional
 
-test_novenv: pycodestyle pylint test_unit_novenv test_functional_novenv
+test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env test_functional_novenv
 
 PYCODESTYLE_TEST_CMD = pycodestyle \
   --exclude=server/codechecker_server/migrations \
@@ -31,7 +31,10 @@ PYCODESTYLE_TEST_CMD = pycodestyle \
   server/bin server/codechecker_server server/tests \
   tests
 
-pycodestyle: venv_dev
+pycodestyle:
+	$(PYCODESTYLE_TEST_CMD)
+
+pycodestyle_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYCODESTYLE_TEST_CMD)
 
 PYLINT_TEST_CMD = pylint ./bin/codechecker-web-version \
@@ -44,97 +47,94 @@ PYLINT_TEST_CMD = pylint ./bin/codechecker-web-version \
   --disable=all \
   --enable=logging-format-interpolation,old-style-class
 
-pylint: venv_dev
-	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
+pylint:
+	 $(PYLINT_TEST_CMD)
 
+pylint_in_env:
+	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
+ 
 CODECHECKER_CMD = $(BUILD_DIR)/CodeChecker/bin/CodeChecker
 SHUTDOWN_SERVER_CMD = echo "Shutting down server..."; \
-    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l; \
-    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server \
-			--config-directory $(CC_TEST_WORKSPACE_ROOT) \
-	    --port `cat "$(CC_TEST_WORKSPACE_ROOT)/serverport"` --stop; \
-    rm -f "$(CC_TEST_WORKSPACE_ROOT)/serverport"; \
-    HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l
+  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l; \
+  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server \
+    --config-directory $(CC_TEST_WORKSPACE_ROOT) \
+    --port `cat "$(CC_TEST_WORKSPACE_ROOT)/serverport"` --stop; \
+  rm -f "$(CC_TEST_WORKSPACE_ROOT)/serverport"; \
+  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l
 
 # Preserve the error status of the previous command but always be able to
 # shut down servers.
 EXIT_ERROR = { ${SHUTDOWN_SERVER_CMD}; exit 1; }
 
 FUNCTIONAL_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
-		nosetests $(NOSECFG) tests/functional \
-		&& { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+  nosetests $(NOSECFG) tests/functional \
+  && { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
 
 MAKE_DB_CMD = bash -c 'psql -h localhost \
-		-p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
-		-c "CREATE DATABASE codechecker_config_$${CODECHECKER_DB_DRIVER}"'
+  -p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
+  -c "CREATE DATABASE codechecker_config_$${CODECHECKER_DB_DRIVER}"'
 
 DROP_DB_CMD = bash -c 'psql -h localhost \
-		-p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
-		-c "DROP DATABASE IF EXISTS codechecker_config_$${CODECHECKER_DB_DRIVER}"'
+  -p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
+  -c "DROP DATABASE IF EXISTS codechecker_config_$${CODECHECKER_DB_DRIVER}"'
 
-run_test: venv_dev
-	$(ACTIVATE_DEV_VENV) && \
-		$(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
-		nosetests $(NOSECFG) $(ROOT)/web/${TEST} \
-		&& { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+RUN_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
+  nosetests $(NOSECFG) $(ROOT)/web/${TEST} \
+  && { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+
+run_test:
+	$(RUN_TEST_CMD)
+
+run_test_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(RUN_TEST_CMD)
 
 test_unit: test_unit_server
 
-test_unit_novenv: test_unit_novenv_server
+test_unit_in_env: test_unit_server_in_env
 
 test_functional: test_sqlite test_psql
 
-test_functional_novenv: test_sqlite_novenv test_psql_novenv
+test_functional_in_env: test_sqlite_in_env test_psql_in_env
 
-test_sqlite: venv_dev
-		python $(ROOT)/scripts/test/check_clang.py || exit 1;
-		$(ACTIVATE_DEV_VENV) && $(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
+test_sqlite:
+	python $(ROOT)/scripts/test/check_clang.py || exit 1;
+	$(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
 
-test_sqlite_novenv:
-		python $(ROOT)/scripts/test/check_clang.py || exit 1;
-		$(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
+test_sqlite_in_env: venv_dev
+	python $(ROOT)/scripts/test/check_clang.py || exit 1;
+	$(ACTIVATE_DEV_VENV) && $(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
 
 test_psql: test_psql_psycopg2 test_psql_pg8000
 
-test_psql_novenv: test_psql_psycopg2_novenv test_psql_pg8000_novenv
+test_psql_in_env: test_psql_psycopg2_in_env test_psql_pg8000_in_env
 
-test_psql_psycopg2: venv_dev
-	python $(ROOT)/scripts/test/check_clang.py || exit 1;
-	$(ACTIVATE_DEV_VENV) && \
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
-		$(CLEAR_WORKSPACE_CMD) && \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
-		$(FUNCTIONAL_TEST_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD)
+PSYCOPG2_TEST_CMD = python $(ROOT)/scripts/test/check_clang.py || exit 1; \
+  $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
+  $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
+  $(CLEAR_WORKSPACE_CMD) && \
+  $(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
+  $(FUNCTIONAL_TEST_CMD) && \
+  $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD)
 
-test_psql_psycopg2_novenv:
-		python $(ROOT)/scripts/test/check_clang.py || exit 1;
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
-				$(CLEAR_WORKSPACE_CMD) && \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PSYCOPG2) \
-		$(FUNCTIONAL_TEST_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD)
+test_psql_psycopg2:
+	$(PSYCOPG2_TEST_CMD)
 
-test_psql_pg8000: venv_dev
-	python $(ROOT)/scripts/test/check_clang.py || exit 1;
-	$(ACTIVATE_DEV_VENV) && \
-		$(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
-		$(CLEAR_WORKSPACE_CMD) && \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PG8000) \
-		$(FUNCTIONAL_TEST_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD)
+test_psql_psycopg2_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(PSYCOPG2_TEST_CMD)
 
-test_psql_pg8000_novenv:
-		python $(ROOT)/scripts/test/check_clang.py || exit 1;
-		$(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
-		$(CLEAR_WORKSPACE_CMD) && \
-		$(PSQL) $(DBUNAME) $(DBPORT) $(PG8000) \
-		$(FUNCTIONAL_TEST_CMD) && \
-		$(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD)
+PG8000_TEST_CMD = python $(ROOT)/scripts/test/check_clang.py || exit 1; \
+  $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
+  $(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
+  $(CLEAR_WORKSPACE_CMD) && \
+  $(PSQL) $(DBUNAME) $(DBPORT) $(PG8000) \
+  $(FUNCTIONAL_TEST_CMD) && \
+  $(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD)
+
+test_psql_pg8000:
+	$(PG8000_TEST_CMD)
+
+test_psql_pg8000_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(PG8000_TEST_CMD)
 
 test_clean:
 	$(CLEAR_WORKSPACE_CMD)


### PR DESCRIPTION
There are two targets for each tests the default target assumes
an anlready sourced virtualenv with all the dependecies.
The target names ending *in_env will automatically setup
and source a virtualenv to run the tests.

In travis ci nose needs to be installed explicitly because
pip detects an already installed version under numpy but that binary
is not visible in the PATH.