### PR TITLE
Processing target architecture first in log parser

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -736,9 +736,9 @@ def parse_options(compilation_db_entry):
 
     flag_transformers = [
         __skip,
+        __replace,
         __collect_compile_opts,
         __determine_action_type,
-        __replace,
         __skip_sources,
         __get_arch,
         __get_language,


### PR DESCRIPTION
The target information should be processed and replaced before it
is collected as a simple compiler flag.