### PR TITLE
Run python style tests before test target

### DIFF
--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -8,7 +8,7 @@ REPO_ROOT ?= REPO_ROOT=$(ROOT)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: test_unit test_functional test_build_logger test_tu_collector
+test: pylint pycodestyle test_unit test_functional test_build_logger test_tu_collector
 
 test_novenv: test_unit_novenv test_functional_novenv
 

--- a/tools/plist_to_html/tests/Makefile
+++ b/tools/plist_to_html/tests/Makefile
@@ -10,7 +10,7 @@ LAYOUT_DIR ?= LAYOUT_DIR=$(STATIC_DIR)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: test_unit
+test: pylint pycodestyle test_unit
 
 test_novenv: test_unit_novenv
 


### PR DESCRIPTION
Run `pycodestyle` and `pylint` tests before the test target.