### PR TITLE
call setup.py only in the target

### DIFF
--- a/tools/plist_to_html/Makefile
+++ b/tools/plist_to_html/Makefile
@@ -16,8 +16,6 @@ STATIC_DIR = $(CURRENT_DIR)/plist_to_html/static
 VENDOR_DIR = $(STATIC_DIR)/vendor
 CODEMIRROR_DIR = $(VENDOR_DIR)/codemirror
 
-PKG_NAME := $(shell python setup.py --name)
-PKG_VERSION := $(shell python setup.py --version)
 
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
@@ -58,10 +56,14 @@ dist: dep
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
+	PKG_NAME := $(shell python setup.py --name)
+	PKG_VERSION := $(shell python setup.py --version)
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
+	PKG_NAME := $(shell python setup.py --name)
+	PKG_VERSION := $(shell python setup.py --version)
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 vendor_dir:

--- a/tools/tu_collector/Makefile
+++ b/tools/tu_collector/Makefile
@@ -9,9 +9,6 @@ BIN_DIR = $(BUILD_DIR)/bin
 
 TU_COLLECTOR_DIR = $(BUILD_DIR)/tu_collector
 
-PKG_NAME := $(shell python setup.py --name)
-PKG_VERSION := $(shell python setup.py --version)
-
 ACTIVATE_VENV ?= . venv/bin/activate
 
 venv:
@@ -35,10 +32,14 @@ dist:
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
+	PKG_NAME := $(shell python setup.py --name)
+	PKG_VERSION := $(shell python setup.py --version)
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
+	PKG_NAME := $(shell python setup.py --name)
+	PKG_VERSION := $(shell python setup.py --version)
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:


### PR DESCRIPTION
setup.py requires setuptools which is available only in a virtualenv
or needs to be installed separately.
Getting the name and the version command did run always for every target
in the Makefile.