### PR TITLE
Yet another logger fix

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-util.c
+++ b/analyzer/tools/build-logger/src/ldlogger-util.c
@@ -62,11 +62,12 @@ int predictEscapedSize(const char* str_)
 
   while (*str_)
   {
-    if (strchr("\\\t\b\f\n\"", *str_))
-      ++size;
-
-    if (*str_ == ' ')
+    if (strchr("\\\t\b\f\n ", *str_))
       size += 2;
+    else if (*str_ == '"')
+      /* The quote (") needs an extra escaped escape character because the
+         JSON string literals are surrounded by quote by default. */
+      size += 3;
 
     ++size;
     ++str_;
@@ -87,16 +88,18 @@ char* shellEscapeStr(const char* str_, char* buff_)
     switch (*str_)
     {
       case '\\':
-      case '\"':
       case '\t':
       case '\b':
       case '\f':
       case '\n':
+      case ' ':
+        *out++ = '\\';
         *out++ = '\\';
         *out++ = *str_++;
         break;
 
-      case ' ':
+      case '\"':
+        *out++ = '\\';
         *out++ = '\\';
         *out++ = '\\';
         *out++ = *str_++;

--- a/analyzer/tools/build-logger/src/ldlogger-util.h
+++ b/analyzer/tools/build-logger/src/ldlogger-util.h
@@ -19,8 +19,8 @@
  *
  * hello -> hello (length = 6)
  * hello world -> hello\\ world (length = 14)
- * "hello" -> \"hello\" (length = 10)
- * "hello world" -> \"hello\\ world\" (length = 18)
+ * "hello" -> \\\"hello\\\" (length = 14)
+ * "hello world" -> \\\"hello\\ world\\\" (length = 22)
  */
 int predictEscapedSize(const char* str_);
 

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -96,7 +96,7 @@ function test_quote {
   bash -c "gcc -DVARIABLE=\\\"hello\\\" $source_file"
 
   assert_json \
-    "-DVARIABLE=\\\"hello\\\" $source_file" \
+    "-DVARIABLE=\\\\\\\"hello\\\\\\\" $source_file" \
     gcc
 }
 
@@ -104,7 +104,7 @@ function test_space_quote {
   bash -c "gcc -DVARIABLE=\\\"hello\\ world\\\" $source_file"
 
   assert_json \
-    "-DVARIABLE=\\\"hello\\\\ world\\\" $source_file" \
+    "-DVARIABLE=\\\\\\\"hello\\\\ world\\\\\\\" $source_file" \
     gcc
 }
 


### PR DESCRIPTION
The quote marks need an extra escape character because the JSON strings
are also surrounded by quotes.