### PR TITLE
Resurrect --compiler-info-file analyze flag.

### DIFF
--- a/analyzer/tests/unit/test_buildcmd_escaping.py
+++ b/analyzer/tests/unit/test_buildcmd_escaping.py
@@ -92,7 +92,7 @@ class BuildCmdTestNose(unittest.TestCase):
             ' -DDEBUG \'-DMYPATH="/this/some/path/"\''
 
         comp_actions = log_parser.\
-            parse_unique_log(self.__get_cmp_json(compile_cmd))
+            parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
 
         for comp_action in comp_actions:
             cmd = [self.compiler]
@@ -118,7 +118,7 @@ class BuildCmdTestNose(unittest.TestCase):
         """
         compile_cmd = self.compiler + ''' '-DMYPATH=\"/some/other/path\"' '''
         comp_actions = log_parser.\
-            parse_unique_log(self.__get_cmp_json(compile_cmd))
+            parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
 
         for comp_action in comp_actions:
             cmd = [self.compiler]

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -51,7 +51,7 @@ class LogParserTest(unittest.TestCase):
         # define being considered a file and ignored, for now.
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -70,7 +70,7 @@ class LogParserTest(unittest.TestCase):
         # and --target=x86_64-linux-gnu.
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -82,7 +82,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -99,7 +99,7 @@ class LogParserTest(unittest.TestCase):
         # The define is passed to the analyzer properly.
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -111,7 +111,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -132,7 +132,7 @@ class LogParserTest(unittest.TestCase):
         # The define is passed to the analyzer properly.
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -144,7 +144,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -173,7 +173,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -M /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions,
+                                                    self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-M' not in build_actions[0].original_command)
         self.assertTrue('-E' not in build_actions[0].original_command)
@@ -188,7 +189,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions,
+                                                    self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-MD' in build_actions[0].original_command)
 
@@ -203,7 +205,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -E -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions)
+        build_actions = log_parser.parse_unique_log(preprocessor_actions,
+                                                    self.__this_dir)
         self.assertEqual(len(build_actions), 0)
 
     def test_include_rel_to_abs(self):
@@ -213,7 +216,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "include.json")
 
         build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile))[0]
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
         self.assertEqual(build_action.analyzer_options[0], '-I')

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -375,6 +375,7 @@ below:
 
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
+                           [--compiler-info-file COMPILER_INFO_FILE]
                            [-t {plist}] [-q] [-c]
                            [--compile-uniqueing COMPILE_UNIQUEING]
                            [--report-hash {context-free}] [-n NAME]
@@ -384,6 +385,8 @@ usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
                            [--saargs CLANGSA_ARGS_CFG_FILE]
                            [--tidyargs TIDY_ARGS_CFG_FILE]
                            [--tidy-config TIDY_CONFIG] [--timeout TIMEOUT]
+                           [--ctu | --ctu-collect | --ctu-analyze]
+                           [--ctu-reanalyze-on-failure]
                            [-e checker/group/profile]
                            [-d checker/group/profile] [--enable-all]
                            [--verbose {info,debug,debug_analyzer}]
@@ -409,6 +412,10 @@ optional arguments:
                         User guide on how a Skipfile should be laid out.
   -o OUTPUT_PATH, --output OUTPUT_PATH
                         Store the analysis output in the given folder.
+  --compiler-info-file COMPILER_INFO_FILE
+                        Read the compiler includes and target from the
+                        specified file rather than invoke the compiler
+                        executable.
   -t {plist}, --type {plist}, --output-format {plist}
                         Specify the format the analysis results should use.
                         (default: plist)
@@ -570,6 +577,13 @@ to the analyzers:
 
  - `-m32` (32-bit build)
  - `-m64` (64-bit build)
+
+GCC specific hard-coded values are detected during the analysis and
+recorded int the `<report-directory>/compiler_info.json`.
+
+If you want to run the analysis with a specific compiler configuration
+instead of the auto-detection you can pass that to the
+`--compiler-info-file compiler_info.json` parameter.
 
 #### Forwarding compiler options <a name="forwarding-compiler-options"></a>
 

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -320,14 +320,27 @@ def assemble_zip(inputs, zip_file, client):
             map(lambda f_: " - " + f_, missing_source_files)))
 
 
+def should_be_zipped(input_file, input_files):
+    """
+    Determine whether a given input file should be included in the zip.
+    Compiler includes and target files should only be included if there is
+    no compiler info file present.
+    """
+    return (input_file in ['metadata.json', 'compiler_info.json']
+            or (input_file in ['compiler_includes.json',
+                               'compiler_target.json']
+                and 'compiler_info.json' not in input_files))
+
+
 def get_analysis_statistics(inputs, limits):
     """
     Collects analysis statistics information and returns them.
 
     This function will return the path of failed zips and the following files:
       - compile_cmd.json
-      - compiler_includes.json
-      - compiler_target.json
+      - either
+        - compiler_info.json, or
+        - compiler_includes.json and compiler_target.json
       - metadata.json
 
     If the input directory doesn't contain any failed zip this function will
@@ -361,10 +374,7 @@ def get_analysis_statistics(inputs, limits):
                     LOG.debug("Copying file '%s' to analyzer statistics "
                               "ZIP...", compilation_db)
                     statistics_files.append(compilation_db)
-            elif inp_f in ['compiler_includes.json',
-                           'compiler_target.json',
-                           'compiler_info.json',
-                           'metadata.json']:
+            elif should_be_zipped(inp_f, files):
                 analyzer_file = os.path.join(input_path, inp_f)
                 statistics_files.append(analyzer_file)
         for inp_dir in dirs:


### PR DESCRIPTION
This option was removed by 5519409 under the assumption that it is not
used anywhere. The truth is that this flag is very useful for debugging
purposes and some debug tools in the /scripts directory do use it.
This commit re-introduces the --compiler-info-file option on top of the
refactored log parser.