### PR TITLE
Show supported analyzers at cmd checkers

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -35,10 +35,7 @@ def get_argparser_ctor_args():
 
         # Description is shown when the command's help is queried directly
         'description': "Get the list of checkers available and their enabled "
-                       "status in the supported analyzers. Currently "
-                       "supported analyzers are: " +
-                       ', '.join(analyzer_types.supported_analyzers) +
-                       ".",
+                       "status in the supported analyzers.",
 
         # Epilogue is shown after the arguments when the help is queried
         # directly.
@@ -66,7 +63,9 @@ def add_arguments_to_parser(parser):
                         choices=analyzer_types.supported_analyzers,
                         default=argparse.SUPPRESS,
                         help="Show checkers only from the analyzers "
-                             "specified.")
+                             "specified. Currently supported analyzers are: " +
+                             ', '.join(analyzer_types.
+                                       supported_analyzers) + ".")
 
     parser.add_argument('--details',
                         dest='details',

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -897,12 +897,14 @@ usage: CodeChecker checkers [-h] [--analyzers ANALYZER [ANALYZER ...]]
                             [--verbose {info,debug,debug_analyzer}]
 
 Get the list of checkers available and their enabled status in the supported
-analyzers. Currently supported analyzers are: clangsa, clang-tidy.
+analyzers.
 
 optional arguments:
   -h, --help            show this help message and exit
   --analyzers ANALYZER [ANALYZER ...]
                         Show checkers only from the analyzers specified.
+                        Currently supported analyzers are: clangsa, clang-
+                        tidy.
   --details             Show details about the checker, such as description,
                         if available.
   --profile {PROFILE/list}


### PR DESCRIPTION
Show the list of supported analyzers under the help message of the `--analyzers` option of `cmd checkers` subcommand.