### PR TITLE
return error in case of wrong checker profile name

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -185,7 +185,7 @@ def main(args):
                 LOG.error("Checker profile '%s' does not exist!",
                           args.profile)
                 LOG.error("To list available profiles, use '--profile list'.")
-                return
+                sys.exit(1)
 
             profile_checkers = [(args.profile, True)]
 


### PR DESCRIPTION
Building tools on top of CodeChecker is easier
if proper error codes are returned.