### PR TITLE
The skipped flags are skipped in case of Clang too

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -153,6 +153,14 @@ IGNORED_PARAM_OPTIONS = {
     re.compile('-filelist'): 1
 }
 
+# These flag groups are ignored together.
+# TODO: This list is not used yet, but will be applied in the next release.
+IGNORED_FLAG_LISTS = [
+  ['-Xclang', '-mllvm'],
+  ['-Xclang', '-emit-llvm'],
+  ['-Xclang', '-instcombine-lower-dbg-declare=0']
+]
+
 COMPILE_OPTIONS = [
     '-nostdinc',
     r'-nostdinc\+\+',
@@ -759,6 +767,7 @@ def parse_options(compilation_db_entry, compiler_info_file=None):
 
     if 'clang' in details['compiler']:
         flag_transformers = [
+            __skip,
             __determine_action_type,
             __get_language,
             __get_output,

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -232,9 +232,7 @@ class OptionParserTest(unittest.TestCase):
         """
         ignore = ["-Werror", "-fsyntax-only",
                   "-mfloat-gprs=double", "-mfloat-gprs=yes",
-                  "-mabi=spe", "-mabi=eabi",
-                  '-Xclang', '-mllvm',
-                  '-Xclang', '-instcombine-lower-dbg-declare=0']
+                  "-mabi=spe", "-mabi=eabi"]
         action = {
             'file': 'main.cpp',
             'command': "g++ {} main.cpp".format(' '.join(ignore)),
@@ -244,10 +242,9 @@ class OptionParserTest(unittest.TestCase):
 
     def test_ignore_flags_clang(self):
         """
-        Test if Clang compiler preserves the compiler flags except for the
-        preprocessor related flags.
+        Clang has some further flags which should be omitted.
         """
-        ignore = ["-Werror", "-E", "-M", "-fsyntax-only",
+        ignore = ["-Werror", "-fsyntax-only",
                   "-mfloat-gprs=double", "-mfloat-gprs=yes",
                   "-mabi=spe", "-mabi=eabi",
                   '-Xclang', '-mllvm',
@@ -257,9 +254,26 @@ class OptionParserTest(unittest.TestCase):
             'command': "clang++ {} main.cpp".format(' '.join(ignore)),
             'directory': ''}
         res = log_parser.parse_options(action)
-        ignore.remove("-E")
-        ignore.remove("-M")
-        self.assertEqual(res.analyzer_options, ignore)
+        self.assertEqual(res.analyzer_options, ["-fsyntax-only"])
+
+    @unittest.skip("This will be enabled when we distinguish -Xclang params.")
+    def test_ignore_xclang_groups(self):
+        """
+        In case a flag has a parameter, we'd like to skip only the ones with a
+        specific parameter. Currently Clang compiler has such parameters after
+        -Xclang flag.
+        """
+        ignore = ["-Werror", "-fsyntax-only",
+                  '-Xclang', '-mllvm',
+                  '-Xclang', '-instcombine-lower-dbg-declare=0',
+                  '-Xclang', '-something']
+        action = {
+            'file': 'main.cpp',
+            'command': "clang++ {} main.cpp".format(' '.join(ignore)),
+            'directory': ''}
+        res = log_parser.parse_options(action)
+        self.assertEqual(res.analyzer_options,
+                         ["-fsyntax-only", "-Xclang", "-something"])
 
     def test_preserve_flags(self):
         """


### PR DESCRIPTION
The idea is that in skip-list we are enumerating the flags which
are consumed by GCC but not by Clang. Theoretically there shouldn't
be any skipped flag if the original command used Clang since these
are known only by GCC.
However, in case of Clang we'd like to skip flags starting with
-Xclang which is also listed in our skip-list. -Xclang -emit-llvm is
such a flag that makes Clang emit an LLVM IR instead of the PList file.