### PR TITLE
Test for dependency file

### DIFF
--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -226,6 +226,22 @@ class OptionParserTest(unittest.TestCase):
         print(res)
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
+    def test_preprocess_and_compile_with_extra_file(self):
+        """
+        -MF flag is followed by a dependency file. We shouldn't consider this
+        a source file.
+        """
+        action = {
+            'file': 'main.cpp',
+            'command': 'g++ -c -MF deps.txt main.cpp',
+            'directory': ''}
+
+        res = log_parser.parse_options(action)
+        print(res)
+        self.assertEqual(res.analyzer_options, [])
+        self.assertEqual(res.source, 'main.cpp')
+        self.assertEqual(BuildAction.COMPILE, res.action_type)
+
     def test_ignore_flags_gcc(self):
         """
         Test if special compiler options are ignored properly.


### PR DESCRIPTION
Adding a test case for a build action which contains a dependency
file after -MF flag and it is a compilation action too.
Fixes #2050