### PR TITLE
A compmiler doesn't provide an architecture target.

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -341,6 +341,9 @@ class ImplicitCompilerInfo(object):
         """
         lines = ImplicitCompilerInfo.__get_compiler_err(compiler + ' -v')
 
+        if lines is None:
+            return ""
+
         target_label = "Target:"
         target = ""
 


### PR DESCRIPTION
If ccache is the compiler in a build action then the architecture
target can't be queried.