### PR TITLE
[fix][makefile] Fix pip upload targets at tools

### DIFF
--- a/tools/plist_to_html/Makefile
+++ b/tools/plist_to_html/Makefile
@@ -56,14 +56,14 @@ dist: dep
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	PKG_NAME := $(shell python setup.py --name)
-	PKG_VERSION := $(shell python setup.py --version)
+	$(eval PKG_NAME := $(shell python setup.py --name))
+	$(eval PKG_VERSION := $(shell python setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	PKG_NAME := $(shell python setup.py --name)
-	PKG_VERSION := $(shell python setup.py --version)
+	$(eval PKG_NAME := $(shell python setup.py --name))
+	$(eval PKG_VERSION := $(shell python setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 vendor_dir:

--- a/tools/tu_collector/Makefile
+++ b/tools/tu_collector/Makefile
@@ -32,14 +32,14 @@ dist:
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	PKG_NAME := $(shell python setup.py --name)
-	PKG_VERSION := $(shell python setup.py --version)
+	$(eval PKG_NAME := $(shell python setup.py --name))
+	$(eval PKG_VERSION := $(shell python setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	PKG_NAME := $(shell python setup.py --name)
-	PKG_VERSION := $(shell python setup.py --version)
+	$(eval PKG_NAME := $(shell python setup.py --name))
+	$(eval PKG_VERSION := $(shell python setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:


### PR DESCRIPTION
Assignment inside a target will be executed as a shell command,     which gives an error. To solve this problem, we need to use the `eval` function.

For more information see: https://stackoverflow.com/questions/6519234/cant-assign-variable-inside-recipe