### PR TITLE
[clang] Skip sources argument when parsing the precompilation options

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -311,7 +311,7 @@ class ImplicitCompilerInfo(object):
 
         compiler -- The compiler binary of which the implicit include paths are
                     fetched.
-        language -- The programming lenguage being compiled (e.g. 'c' or 'c++')
+        language -- The programming language being compiled (e.g. 'c' or 'c++')
         compiler_flags -- A list of compiler flags which may affect the list
                           of implicit compiler include paths, like -std=,
                           --sysroot= or -m32, -m64.
@@ -775,6 +775,7 @@ def parse_options(compilation_db_entry, compiler_info_file=None):
         flag_transformers = [
             __skip,
             __determine_action_type,
+            __skip_sources,
             __get_language,
             __get_output,
             __keep_except(compilation_db_entry['file'])]

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -242,6 +242,22 @@ class OptionParserTest(unittest.TestCase):
         self.assertEqual(res.source, 'main.cpp')
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
+    def test_preprocess_and_compile_with_extra_file_clang(self):
+        """
+        -MF flag is followed by a dependency file. We shouldn't consider this
+        a source file.
+        """
+        action = {
+            'file': 'main.cpp',
+            'command': 'clang++ -c -MF deps.txt main.cpp',
+            'directory': ''}
+
+        res = log_parser.parse_options(action)
+        print(res)
+        self.assertEqual(res.analyzer_options, [])
+        self.assertEqual(res.source, 'main.cpp')
+        self.assertEqual(BuildAction.COMPILE, res.action_type)
+
     def test_ignore_flags_gcc(self):
         """
         Test if special compiler options are ignored properly.


### PR DESCRIPTION
Precompilation options are needed for clang too.
Example from the Chromium project:
```
...
 "command": "bin/clang++ -MMD -MF new_tab_page_navigation_throttle.o.d -DUSE_UDEV -DUSE_AURA=1
...
```