### PR TITLE
security update for SQLAlchemy

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
+sqlalchemy==1.3.3
 alembic==0.9.2
 portalocker==1.1.0
 psutil==5.2.2
-sqlalchemy==1.1.11
 thrift==0.9.1

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy==1.1.11
+sqlalchemy==1.3.3
 alembic==0.9.2
 pg8000==1.10.2
 thrift==0.9.1

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy==1.1.11
+sqlalchemy==1.3.3
 alembic==0.9.2
 psycopg2==2.7.1
 thrift==0.9.1

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,4 +1,4 @@
-sqlalchemy==1.1.11
+sqlalchemy==1.3.3
 pycodestyle==2.4.0
 alembic==0.9.2
 psycopg2==2.7.1

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -1,5 +1,5 @@
 alembic==0.9.2
 portalocker==1.1.0
 psutil==5.2.2
-sqlalchemy==1.1.11
+sqlalchemy==1.3.3
 thrift==0.9.1


### PR DESCRIPTION
SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection
via the order_by parameter.
See: https://nvd.nist.gov/vuln/detail/CVE-2019-7164

SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be
controlled.
See: https://nvd.nist.gov/vuln/detail/CVE-2019-7548