### PR TITLE
[analyzer] Z3 constraint solver support

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -59,6 +59,15 @@ def is_statistics_capable(context):
     return False
 
 
+def is_z3_capable(context):
+    """ Detects if the current clang is Z3 compatible. """
+    check_supported_analyzers([ClangSA.ANALYZER_NAME], context)
+    analyzer_binary = context.analyzer_binaries.get(ClangSA.ANALYZER_NAME)
+
+    return host_check.has_analyzer_feature(analyzer_binary,
+                                           '-analyzer-constraints=z3')
+
+
 def check_supported_analyzers(analyzers, context):
     """
     Checks the given analyzers in the current context for their executability

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -191,6 +191,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                  'aggressive-binary-operation-simplification'
                                  '=true'])
 
+            # Enable the z3 solver backend.
+            if config.enable_z3:
+                analyzer_cmd.extend(['-Xclang', '-analyzer-constraints=z3'])
+
             if config.ctu_dir and not self.__disable_ctu:
                 analyzer_cmd.extend(
                     ['-Xclang', '-analyzer-config', '-Xclang',
@@ -318,6 +322,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
         check_env = get_check_env(context.path_env_extra,
                                   context.ld_lib_path_extra)
+
+        handler.enable_z3 = 'enable_z3' in args and args.enable_z3
 
         if 'ctu_phases' in args:
             handler.ctu_dir = os.path.join(args.output_path,

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -32,6 +32,7 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
         self.log_file = ''
         self.path_env_extra = ''
         self.ld_lib_path_extra = ''
+        self.enable_z3 = False
 
     def add_checker_config(self, config):
         """

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -290,6 +290,18 @@ def add_arguments_to_parser(parser):
                                     "one.")
 
     context = analyzer_context.get_context()
+
+    if analyzer_types.is_z3_capable(context):
+        analyzer_opts.add_argument('--z3',
+                                   action='store_true',
+                                   dest='enable_z3',
+                                   default=argparse.SUPPRESS,
+                                   help="Enable the z3 solver backend. This "
+                                        "allows reasoning over more complex "
+                                        "queries, but performance is worse "
+                                        "than the default range-based "
+                                        "constraint solver.")
+
     if analyzer_types.is_ctu_capable(context):
         ctu_opts = parser.add_argument_group(
             "cross translation unit analysis arguments",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -318,6 +318,18 @@ used to generate a log file on the fly.""")
                                     "one.")
 
     context = analyzer_context.get_context()
+
+    if analyzer_types.is_z3_capable(context):
+        analyzer_opts.add_argument('--z3',
+                                   action='store_true',
+                                   dest='enable_z3',
+                                   default=argparse.SUPPRESS,
+                                   help="Enable the z3 solver backend. This "
+                                        "allows reasoning over more complex "
+                                        "queries, but performance is worse "
+                                        "than the default range-based "
+                                        "constraint solver.")
+
     if analyzer_types.is_ctu_capable(context):
         ctu_opts = parser.add_argument_group(
             "cross translation unit analysis arguments",

--- a/docs/analyzer/checker_and_analyzer_configuration.md
+++ b/docs/analyzer/checker_and_analyzer_configuration.md
@@ -64,6 +64,22 @@ or source code for more details about the configuration options.
 | graph-trim-interval                   | 1000              |                                          |                                                                                                     |
 
 
+## Z3 Theorem Prover
+The static analyzer supports using the
+[Z3 Theorem Prover](https://github.com/Z3Prover/z3) from Microsoft Research as
+an external constraint solver. This allows reasoning over more complex queries,
+but performance is `~15x` slower than the default range-based constraint
+solver. To enable the Z3 solver backend, Clang must be built with the
+`CLANG_ANALYZER_BUILD_Z3=ON` option, and the
+`-Xanalyzer -analyzer-constraints=z3` arguments passed at runtime. CodeChecker
+will automatically detects that the Clang was built with this option and you
+don't have to pass these arguments to the analyzer command itself when using
+CodeChecker, you just have to run the CodeChecker analyze command with the
+`--z3` option.
+
+You can read more about Z3 Theorem Prover
+[here](https://github.com/Z3Prover/z3/wiki).
+
 # Configure Clang tidy checkers
 
 ## Using Clang tidy configuration files

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -199,6 +199,9 @@ analyzer arguments:
                         analysis of a particular file takes longer than this
                         time, the analyzer is killed and the analysis is
                         considered as a failed one.
+  --z3                  Enable the z3 solver backend. This allows reasoning
+                        over more complex queries, but performance is worse
+                        than the default range-based constraint solver.
 
 checker configuration:
   
@@ -542,6 +545,9 @@ analyzer arguments:
                         analysis of a particular file takes longer than this
                         time, the analyzer is killed and the analysis is
                         considered as a failed one.
+  --z3                  Enable the z3 solver backend. This allows reasoning
+                        over more complex queries, but performance is worse
+                        than the default range-based constraint solver.
 ```
 
 CodeChecker supports several analyzer tools. Currently, these analyzers are
@@ -551,8 +557,9 @@ used to specify which analyzer tool should be used (by default, all supported
 are used). The tools are completely independent, so either can be omitted if
 not present as they are provided by different binaries.
 
-See [Configure Clang Static Analyzer and checkers](checker_and_analyzer_configuration.md) documentation for
-a more detailed description how to use the `saargs` and `tidyargs` arguments.
+See [Configure Clang Static Analyzer and checkers](checker_and_analyzer_configuration.md)
+documentation for a more detailed description how to use the `saargs`,
+`tidyargs` and `z3` arguments.
 
 
 #### Compiler-specific include path and define detection (cross compilation) <a name="include-path"></a>


### PR DESCRIPTION
> Closes #2087

Create new options for the analyzer and check commands which allow us to enable the Z3 solver backend for Clang Static Analyzer if it's supports Z3 analyzer constraints option.