### PR TITLE
package independent tu_collector tests

### DIFF
--- a/tools/tu_collector/tests/project/compile_command.json
+++ b/tools/tu_collector/tests/project/compile_command.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ -o /dev/null main.cpp",
+		"file": "main.cpp"
+	}
+]


### PR DESCRIPTION
The current tests depends on a built CodeChecker package.
The tu_collector tests should be independent from that.
The CodeChecker log command is removed and the compile command
json is added to the repository.

resolves #2093