### PR TITLE
No need for handling Clang commands separately

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -719,19 +719,6 @@ def __skip(flag_iterator, _):
     return False
 
 
-def __keep_except(substring):
-    def f(flag_iterator, details):
-        """
-        This function keeps the flag pointed by the given flag_iterator except
-        if it contains the given substring.
-        """
-        if substring not in flag_iterator.item:
-            details['analyzer_options'].append(flag_iterator.item)
-            return True
-        return False
-    return f
-
-
 def parse_options(compilation_db_entry, compiler_info_file=None):
     """
     This function parses a GCC compilation action and returns a BuildAction
@@ -771,24 +758,15 @@ def parse_options(compilation_db_entry, compiler_info_file=None):
     if '++' in details['compiler'] or 'cpp' in details['compiler']:
         details['lang'] = 'c++'
 
-    if 'clang' in details['compiler']:
-        flag_transformers = [
-            __skip,
-            __determine_action_type,
-            __skip_sources,
-            __get_language,
-            __get_output,
-            __keep_except(compilation_db_entry['file'])]
-    else:
-        flag_transformers = [
-            __skip,
-            __replace,
-            __collect_compile_opts,
-            __determine_action_type,
-            __skip_sources,
-            __get_arch,
-            __get_language,
-            __get_output]
+    flag_transformers = [
+        __skip,
+        __replace,
+        __collect_compile_opts,
+        __determine_action_type,
+        __skip_sources,
+        __get_arch,
+        __get_language,
+        __get_output]
 
     for it in OptionIterator(gcc_command[1:]):
         for flag_transformer in flag_transformers:


### PR DESCRIPTION
Since there is a common skip list and white list for GCC and Clang
commands, there is no need for handling Clang commands separately.
The idea is to interpret skip list as "flags which are not needed
for analysis".

Fixes #2103
Fixes #2097