### PR TITLE
[makefile] Build logger libraries for multiple targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ CC_TOOLS = $(CURRENT_DIR)/tools
 # Root of the repository.
 ROOT = $(CURRENT_DIR)
 
+# Set it to YES if you would like to build and package 64 bit only shared
+# objects and ldlogger binary.
+BUILD_LOGGER_64_BIT_ONLY ?= NO
+
 ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 
@@ -47,7 +51,7 @@ package_tu_collector: build_tu_collector package_dir_structure
 	cp -r $(CC_TOOLS)/tu_collector/build/tu_collector/tu_collector $(CC_BUILD_LIB_DIR)
 
 package: package_dir_structure package_plist_to_html package_tu_collector
-	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_ANALYZER) package_analyzer
+	BUILD_DIR=$(BUILD_DIR) BUILD_LOGGER_64_BIT_ONLY=$(BUILD_LOGGER_64_BIT_ONLY) $(MAKE) -C $(CC_ANALYZER) package_analyzer
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) package_web
 
 	# Copy libraries.

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -15,6 +15,10 @@ ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 
 VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 
+# Set it to YES if you would like to build and package 64 bit only shared
+# objects and ldlogger binary.
+BUILD_LOGGER_64_BIT_ONLY ?= NO
+
 include tests/Makefile
 
 pip_dev_deps:
@@ -80,13 +84,11 @@ package_ld_logger:
 	ln -sf ../ld_logger/bin/ldlogger bin/ldlogger
 
 build_ld_logger:
-	$(MAKE) -C tools/build-logger -f Makefile.manual 2> /dev/null
-
-build_ld_logger_x86:
-	$(MAKE) -C tools/build-logger -f Makefile.manual pack32bit 2> /dev/null
-
-build_ld_logger_x64:
-	$(MAKE) -C tools/build-logger -f Makefile.manual pack64bit 2> /dev/null
+  ifeq ($(BUILD_LOGGER_64_BIT_ONLY),YES)
+		$(MAKE) -C tools/build-logger -f Makefile.manual pack64bit 2> /dev/null
+  else
+		$(MAKE) -C tools/build-logger -f Makefile.manual 2> /dev/null
+  endif
 
 # NOTE: extra spaces are allowed and ignored at the beginning of the
 # conditional directive line, but a tab is not allowed.
@@ -95,17 +97,8 @@ ifeq ($(OS),Windows_NT)
 else
   UNAME_S ?= $(shell uname -s)
   ifeq ($(UNAME_S),Linux)
-    UNAME_P ?= $(shell uname -p)
-    ifeq ($(UNAME_P),x86_64)
-      package_ld_logger: build_ld_logger_x64
-      package_analyzer: package_ld_logger
-    else ifneq ($(filter %86,$(UNAME_P)),)
-      package_ld_logger: build_ld_logger_x86
-      package_analyzer: package_ld_logger
-    else
-      package_ld_logger: build_ld_logger
-      package_analyzer: package_ld_logger
-    endif
+    package_ld_logger: build_ld_logger
+    package_analyzer: package_ld_logger
   else ifeq ($(UNAME_S),Darwin)
     ifeq (, $(shell which intercept-build))
       $(info "No intercept-build (scan-build-py) in $(PATH).")

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,12 @@ export PATH="$PWD/build/CodeChecker/bin:$PATH"
 cd ..
 ```
 
+**Note**: By default `make package` will build ldlogger shared objects for
+`32bit` and `64bit` too. If you would like to build and package `64 bit only`
+shared objects and ldlogger binary you can set `BUILD_LOGGER_64_BIT_ONLY`
+environment variable to `YES` before the package build:
+`BUILD_LOGGER_64_BIT_ONLY=YES make package`.
+
 ### Upgrading environment after system or Python upgrade
 
 If you have upgraded your system's Python to a newer version (e.g. from


### PR DESCRIPTION
> Closes #2101

With the current setup we only build the ldlogger.so for that architecture where the package was built, but during runtime in a different environment it is possible that the 32bit shared objects are needed too.

With these changes `make package` by default will build ldlogger shared objects for `32bit` and `64bit` too. We also introduced a new environment variable `BUILD_LOGGER_64_BIT_ONLY` what you can
set to `YES` before the package build to build and package `64 bit only` shared objects and ldlogger binary.