### PR TITLE
Fix compiler_info.json parsing

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -453,7 +453,9 @@ class ImplicitCompilerInfo(object):
                       compiler, filename)
 
         ICI = ImplicitCompilerInfo
-        ICI.compiler_includes[compiler] = compiler_info.get('includes')
+        ICI.compiler_includes[compiler] = []
+        for element in map(shlex.split, compiler_info.get('includes')):
+            ICI.compiler_includes[compiler].extend(element)
         ICI.compiler_standard[compiler] = compiler_info.get('default_standard')
         ICI.compiler_target[compiler] = compiler_info.get('target')
 


### PR DESCRIPTION
Having spaces in between "-isystem /bla/bla/path" in compiler_info.json resulted in a wrong passing of arguments.
The fix is to split it into "-isystem", "/bla/bla/path" in the list of arguments.