### PR TITLE
More Python 3 compatibility fixes.

### DIFF
--- a/web/codechecker_web/shared/host_check.py
+++ b/web/codechecker_web/shared/host_check.py
@@ -27,7 +27,7 @@ def check_zlib():
     """
     try:
         import zlib
-        zlib.compress('Compress this')
+        zlib.compress(b'Compress this')
         return True
     except Exception as ex:
         LOG.error(str(ex))

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -24,7 +24,10 @@ import socket
 import ssl
 import sys
 import stat
-import urllib
+try:
+    from urllib import unquote, quote_plus
+except ImportError:
+    from urllib.parse import unquote, quote_plus
 
 try:
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
@@ -157,7 +160,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         if self.server.manager.is_enabled and not self.auth_session \
                 and routing.is_protected_GET_entrypoint(path):
             # If necessary, prompt the user for authentication.
-            returnto = '?returnto=' + urllib.quote_plus(self.path.lstrip('/'))\
+            returnto = '?returnto=' + quote_plus(self.path.lstrip('/'))\
                 if self.path != '/' else ''
 
             self.send_response(307)  # 307 Temporary Redirect
@@ -472,7 +475,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         # Abandon query parameters.
         path = path.split('?', 1)[0]
         path = path.split('#', 1)[0]
-        path = posixpath.normpath(urllib.unquote(path))
+        path = posixpath.normpath(unquote(path))
         words = path.split('/')
         words = filter(None, words)
         path = self.server.www_root

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -145,7 +145,7 @@ class SessionManager(object):
         self.__database_connection = None
         self.__logins_since_prune = 0
         self.__sessions = []
-        self.__session_salt = hashlib.sha1(session_salt).hexdigest()
+        self.__session_salt = hashlib.sha1(session_salt.encode()).hexdigest()
         self.__configuration_file = configuration_file
 
         scfg_dict = self.__get_config_dict()


### PR DESCRIPTION
With these changes it is possible to boot up CodeChecker server in a Python 3 environment.
Unfortunately, viewing or storing the results are still not functional, something is going on with Thrift.