### PR TITLE
Fix thrift exception handling

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/util.js
+++ b/web/server/www/scripts/codecheckerviewer/util.js
@@ -527,7 +527,7 @@ function (locale, dom, style, json) {
     },
 
     handleThriftException : function (ex) {
-      if (ex.indexOf(': 401') !== -1) {
+      if (typeof(ex) === 'string' && ex.indexOf(': 401') !== -1) {
         this.handleAjaxFailure({status: 401});
       } else {
         console.warn(ex);


### PR DESCRIPTION
> This problem is related to #2057

Is it possible for example when the server is not available that the `handleThriftException` gets an object rather than a string as an exception. This commit fixes this problem by checking the parameter type before calling the `indexOf` function on it.