### PR TITLE
Fix ccache handling

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -550,6 +550,8 @@ def determine_compiler(gcc_command):
     In the second case the compiler can be given by config files or an
     environment variable. Currently we don't handle this version, and in this
     case the compiler remanis "ccache" and the gcc_command is not changed.
+    The two cases are distinguished by checking whether the second parameter is
+    an executable or not.
 
     gcc_command -- A split build action as a list which may or may not start
                    with ccache.
@@ -559,11 +561,6 @@ def determine_compiler(gcc_command):
     files or environment variables.
     """
     if 'ccache' in gcc_command[0]:
-        gcc_like = os.environ.get('CC_LOGGER_GCC_LIKE')
-        if gcc_like:
-            if all(l not in gcc_command[1] for l in gcc_like.split(':')):
-                return gcc_command[0]
-
         if ImplicitCompilerInfo.is_executable_compiler(gcc_command[1]):
             return gcc_command[1]
 


### PR DESCRIPTION
CCache basically has two ways to use:

ccache <compiler> <flags>
ccache <flags>

Currently we intend to support the first case. For this we have to
determine whether it is a compiler at the second position. Earlier
we checked if it matches on CC_LOGGER_GCC_LIKE. However, if this
environment variable is set to "ccache" (since the user wanted to
log ccache invocations directly) then the compiler at the second
position won't match. In this commit we consider the second parameter
a compiler if it is executable in the current environment.