### PR TITLE
Redirect the cmd sum command output to the stderr

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -523,6 +523,14 @@ thus the `--url` parameter can be omitted.
 Most result-giving commands also take an `--output` format parameter. If this
 is set to `json`, a more detailed output is given, in JSON format.
 
+If the given output format is not `table` we redirect logger's output to the
+`stderr`, so the output of the commands will not be an invalid `json`, `csv`,
+etc. because of the log messages. To get a valid json output you can redirect
+`stderr` output to `/dev/null` so you can for example send the json output to
+another command for further processing:
+`CodeChecker cmd sum -n my_run -o json 2>/dev/null | python -m json.tool`.
+
+
 ```
 common arguments:
   --host HOST           The address of the CodeChecker viewer server to

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1028,8 +1028,13 @@ def handle_diff_results(args):
 
 
 def handle_list_result_types(args):
+    # If the given output format is not 'table', redirect logger's output to
+    # the stderr.
+    stream = None
+    if 'output_format' in args and args.output_format != 'table':
+        stream = 'stderr'
 
-    init_logger(args.verbose if 'verbose' in args else None)
+    init_logger(args.verbose if 'verbose' in args else None, stream)
     check_deprecated_arg_usage(args)
 
     if 'disable_unique' in args:


### PR DESCRIPTION
* Redirect `CodeChecker cmd sum` command output to the stderr if the given output format is not table so the output of the commands will not be an invalid json, csv, etc. because of the log messages.
* Extend the web userguide with this feature and add an example how to use this.