### PR TITLE
Don't follow symlink in the logger

### DIFF
--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -17,7 +17,7 @@ function assert_json {
 [
 	{
 		"directory": "$(pwd)",
-		"command": "$(readlink -f $(which $2)) $1",
+		"command": "$(which $2) $1",
 		"file": "$source_file"
 	}
 ]


### PR DESCRIPTION
The build environment can be set so "g++" is a symlink to
/usr/bin/ccache. CCache can detect whether it was run through this
symlink or it was run directly. In the former case CCache forwards
the command line arguments to the original g++ compiler. This way
we can query the implicit include paths from the compiler later in
CodeChecker. If we resolve the symlink, then the implicit include
path getter command line arguments go to CCache binary. The solution
is not to resolve the symlinks in the logger.