### PR TITLE
[pylint] Add more path to sys.path in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,13 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook='import sys; sys.path.append("build/thrift/v6/gen-py"); sys.path.append("tools/plist_to_html")'
+init-hook='import sys;
+           sys.path.append("build/thrift/v6/gen-py");
+           sys.path.append("tools/plist_to_html");
+           sys.path.append("analyzer");
+           sys.path.append("web");
+           sys.path.append("web/client");
+           sys.path.append("web/server");'
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.


### PR DESCRIPTION
Add `web`, `web/client` and `web/server` directories to the `sys.path` in the `.pylintrc` file.