### PR TITLE
[cli] Mark --force option of check command as deprecated argument

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -128,13 +128,14 @@ def add_arguments_to_parser(parser):
                         default=argparse.SUPPRESS,
                         action='store_true',
                         required=False,
-                        help="Delete analysis results stored in the database "
-                             "for the current analysis run's name and store "
-                             "only the results reported in the 'input' files. "
-                             "(By default, CodeChecker would keep reports "
-                             "that were coming from files not affected by the "
-                             "analysis, and only incrementally update defect "
-                             "reports for source files that were analysed.)")
+                        help="DEPRECATED. Delete analysis results stored in "
+                             "the database for the current analysis run's "
+                             "name and store only the results reported in the "
+                             "'input' files. (By default, CodeChecker would "
+                             "keep reports that were coming from files not "
+                             "affected by the analysis, and only "
+                             "incrementally update defect reports for source "
+                             "files that were analysed.)")
 
     log_args = parser.add_argument_group(
         "log arguments",
@@ -534,6 +535,12 @@ def main(args):
         if key in source:
             setattr(target, key, getattr(source, key))
 
+    if 'force' in args:
+        LOG.warning('"--force" option has been deprecated and it will be '
+                    'removed in the future version of CodeChecker. Use the '
+                    '"--clean" option to delete analysis reports stored in '
+                    'the output directory.')
+
     # If no output directory is given then the checker results go to a
     # temporary directory. This way the subsequent "quick" checks don't pollute
     # the result list of a previous check. If the detection status function is
@@ -610,7 +617,7 @@ def main(args):
                           ]
         for key in args_to_update:
             __update_if_key_exists(args, analyze_args, key)
-        if 'force' in args or 'clean' in args:
+        if 'clean' in args:
             setattr(analyze_args, 'clean', True)
         __update_if_key_exists(args, analyze_args, 'verbose')
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -106,13 +106,13 @@ optional arguments:
                         (default: plist)
   -q, --quiet           If specified, the build tool's and the analyzers'
                         output will not be printed to the standard output.
-  -f, --force           Delete analysis results stored in the database for the
-                        current analysis run's name and store only the results
-                        reported in the 'input' files. (By default,
-                        CodeChecker would keep reports that were coming from
-                        files not affected by the analysis, and only
-                        incrementally update defect reports for source files
-                        that were analysed.)
+  -f, --force           DEPRECATED. Delete analysis results stored in the
+                        database for the current analysis run's name and store
+                        only the results reported in the 'input' files. (By
+                        default, CodeChecker would keep reports that were
+                        coming from files not affected by the analysis, and
+                        only incrementally update defect reports for source
+                        files that were analysed.)
   --compile-uniqueing COMPILE_UNIQUEING
                         Specify the method the compilation actions in the
                         compilation database are uniqued before analysis. CTU

--- a/web/tests/functional/diff/__init__.py
+++ b/web/tests/functional/diff/__init__.py
@@ -68,7 +68,7 @@ def setup_package():
         'suppress_file': suppress_file,
         'skip_list_file': skip_list_file,
         'check_env': test_env,
-        'force': True,
+        'clean': True,
         'workspace': TEST_WORKSPACE,
         'reportdir': os.path.join(TEST_WORKSPACE, 'reports'),
         'checkers': ['-d', 'core.CallAndMessage',

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -186,9 +186,9 @@ def check(codechecker_cfg, test_project_name, test_project_path):
     if skip_file:
         check_cmd.extend(['--skip', skip_file])
 
-    force = codechecker_cfg.get('force')
-    if force:
-        check_cmd.extend(['--force'])
+    clean = codechecker_cfg.get('clean')
+    if clean:
+        check_cmd.extend(['--clean'])
 
     check_cmd.extend(codechecker_cfg['checkers'])
 


### PR DESCRIPTION
> Closes #2125

`CodeChecker check` command has a `--force` argument which is outdated. The check command does not store results, so the force flag is not needed here. Mark this option as a deprecated argument and remove it in a future version of CodeChecker.