### PR TITLE
TU collector crash when preprocess warning

### DIFF
--- a/tools/tu_collector/tests/project/compile_command.json
+++ b/tools/tu_collector/tests/project/compile_command.json
@@ -3,5 +3,10 @@
 		"directory": "/tmp",
 		"command": "g++ -o /dev/null main.cpp",
 		"file": "main.cpp"
-	}
+	},
+  {
+    "directory": "/tmp",
+    "command": "gcc -o /dev/null -std=c++11 main.c",
+    "file": "main.c"
+  }
 ]

--- a/tools/tu_collector/tests/project/main.c
+++ b/tools/tu_collector/tests/project/main.c
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+#include <stdio.h>
+
+int main()
+{
+
+}

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -125,7 +125,6 @@ def __gather_dependencies(command, build_dir):
     try:
         output = subprocess.check_output(command,
                                          bufsize=-1,
-                                         stderr=subprocess.STDOUT,
                                          cwd=build_dir)
         rc = 0
     except subprocess.CalledProcessError as ex:


### PR DESCRIPTION
The compiler can emit the files of a translation unit with the help
of the preprocessor. The output of the compiler call thus can be a
file list: gcc -E -M -MT __dummy main.c
However, if there is a compiler warning at the beginning of this
command's output then TU collector considered the words of the
warning message as file names.