### PR TITLE
[fix] Fix redirect output to stderr

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -43,8 +43,8 @@ from .client import handle_auth, setup_client
 LOG = None
 
 
-def init_logger(level, logger_name='system'):
-    logger.setup_logger(level)
+def init_logger(level, stream=None, logger_name='system'):
+    logger.setup_logger(level, stream)
     global LOG
     LOG = logger.get_logger(logger_name)
 

--- a/web/client/codechecker_client/product_client.py
+++ b/web/client/codechecker_client/product_client.py
@@ -28,8 +28,8 @@ from .cmd_line_client import CmdLineOutputEncoder
 LOG = None
 
 
-def init_logger(level, logger_name='system'):
-    logger.setup_logger(level)
+def init_logger(level, stream=None, logger_name='system'):
+    logger.setup_logger(level, stream)
     global LOG
     LOG = logger.get_logger(logger_name)
 

--- a/web/client/codechecker_client/source_component_client.py
+++ b/web/client/codechecker_client/source_component_client.py
@@ -22,8 +22,8 @@ from .client import setup_client
 LOG = None
 
 
-def init_logger(level, logger_name='system'):
-    logger.setup_logger(level)
+def init_logger(level, stream=None, logger_name='system'):
+    logger.setup_logger(level, stream)
     global LOG
     LOG = logger.get_logger(logger_name)
 

--- a/web/client/codechecker_client/token_client.py
+++ b/web/client/codechecker_client/token_client.py
@@ -20,8 +20,8 @@ from .client import setup_auth_client
 LOG = None
 
 
-def init_logger(level, logger_name='system'):
-    logger.setup_logger(level)
+def init_logger(level, stream=None, logger_name='system'):
+    logger.setup_logger(level, stream)
     global LOG
     LOG = logger.get_logger(logger_name)
 


### PR DESCRIPTION
This commit pass the output stream to the `setup_logger` function so errors will be written to the correct output stream.