### PR TITLE
[fix] Fix ldlogger symlink

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -76,7 +76,8 @@ package_ld_logger:
 	mkdir -p $(CC_BUILD_DIR)/ld_logger && \
 	mkdir -p $(CC_BUILD_DIR)/bin && \
 	cp -r $(CURRENT_DIR)/tools/build-logger/build/* $(CC_BUILD_DIR)/ld_logger && \
-	ln -sf $(CC_BUILD_DIR)/ld_logger/bin/ldlogger $(CC_BUILD_DIR)/bin/ldlogger
+	cd $(CC_BUILD_DIR) && \
+	ln -sf ../ld_logger/bin/ldlogger bin/ldlogger
 
 build_ld_logger:
 	$(MAKE) -C tools/build-logger -f Makefile.manual 2> /dev/null


### PR DESCRIPTION
> Closes #2100 

The ldlogger symlink under the built package should be relative the path is set to an absolute path during package build time.