### PR TITLE
[server] Send back a valid Thrift error response

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -363,7 +363,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
             # but the user is expected to properly authenticate first.
             LOG.debug("%s:%s Invalid access, credentials not found "
                       "- session refused.", client_host, str(client_port))
-            self.send_error(401)
+
+            self.send_thrift_exception("Error code 401: Unauthorized!", iprot,
+                                       oprot, otrans)
             return
 
         # Authentication is handled, we may now respond to the user.

--- a/web/server/www/scripts/codecheckerviewer/util.js
+++ b/web/server/www/scripts/codecheckerviewer/util.js
@@ -512,7 +512,7 @@ function (locale, dom, style, json) {
     },
 
     handleAjaxFailure : function (xhr) {
-      if (xhr.status === 401) {
+      if (xhr.responseText.indexOf('Error code 401:') !== -1) {
         var returnTo = '';
         var pathName = window.location.pathname || '';
         var hash = window.location.hash || '';
@@ -527,8 +527,10 @@ function (locale, dom, style, json) {
     },
 
     handleThriftException : function (ex) {
-      if (typeof(ex) === 'string' && ex.indexOf(': 401') !== -1) {
-        this.handleAjaxFailure({status: 401});
+      if (ex instanceof Thrift.TApplicationException &&
+          ex.message.indexOf('Error code 401:') !== -1
+      ) {
+        this.handleAjaxFailure({responseText: ex.message});
       } else {
         console.warn(ex);
       }

--- a/web/tests/functional/authentication/test_authentication.py
+++ b/web/tests/functional/authentication/test_authentication.py
@@ -14,8 +14,6 @@ import os
 import subprocess
 import unittest
 
-from thrift.protocol.TProtocol import TProtocolException
-
 from shared.ttypes import RequestFailed
 
 from libtest import codechecker
@@ -168,11 +166,11 @@ class DictAuth(unittest.TestCase):
 
         self.assertTrue(result, "Server did not allow us to destroy session.")
 
-        with self.assertRaises(TProtocolException):
-            # The server reports a HTTP 401 error which is not a valid
-            # Thrift response. But if it does so, it passes the test!
-            client.getPackageVersion()
-            print("Privileged client allowed access after logout.")
+        # The server reports a HTTP 401 error which is not a valid
+        # Thrift response. But if it does so, it passes the test!
+        version = client.getPackageVersion()
+        self.assertIsNone(version,
+                          "Privileged client allowed access after logout.")
 
         handshake = auth_client.getAuthParameters()
         self.assertFalse(handshake.sessionStillActive,

--- a/web/tests/functional/ssl/test_ssl.py
+++ b/web/tests/functional/ssl/test_ssl.py
@@ -114,11 +114,11 @@ class TestSSL(unittest.TestCase):
                            self._test_workspace,
                            access_protocol)
 
-        with self.assertRaises(TProtocolException):
-            # The server reports a HTTP 401 error which is not a valid
-            # Thrift response. But if it does so, it passes the test!
-            client.getPackageVersion()
-            print("Privileged client allowed access after logout.")
+        # The server reports a HTTP 401 error which is not a valid
+        # Thrift response. But if it does so, it passes the test!
+        version = client.getPackageVersion()
+        self.assertIsNone(version,
+                          "Privileged client allowed access after logout.")
 
         handshake = auth_client.getAuthParameters()
         self.assertFalse(handshake.sessionStillActive,


### PR DESCRIPTION
Send back a valid Thrift error response message to the client if the user is unauthorized. This way on the Javascript side have to check and handle this error message differently on API call failure:
- On async call the `responseText` field of the xhr object will contain the error message.
- On sync call a `TApplicationException` will be thrown.