### PR TITLE
Logger: compiler on absolute path + refactoring

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-tool-javac.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool-javac.c
@@ -263,7 +263,6 @@ static void processArg(const char* arg_, ParserData* data_)
 
 int loggerJavacParserCollectActions(
   const char* prog_,
-  const char* toolName_,
   const char* const argv_[],
   LoggerVector* actions_)
 {
@@ -278,7 +277,7 @@ int loggerJavacParserCollectActions(
   loggerVectorInit(&data.sources);
   memset(data.classdir, 0, sizeof(data.classdir));
 
-  loggerVectorAdd(&data.commonArgs, loggerStrDup(toolName_));
+  loggerVectorAdd(&data.commonArgs, loggerStrDup(prog_));
 
   for (i = 1; argv_[i]; ++i)
   {
@@ -317,7 +316,7 @@ int loggerJavacParserCollectActions(
   {
     char outputFile[PATH_MAX];
     const char* src = (char*) data.sources.data[i];
-    LoggerAction* action = loggerActionNew(toolName_);
+    LoggerAction* action = loggerActionNew();
     if (!action)
     {
       continue;

--- a/analyzer/tools/build-logger/src/ldlogger-tool.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool.c
@@ -89,7 +89,7 @@ LoggerFile* loggerFileInitFromPath(LoggerFile* file_, const char* path_)
   return file_;
 }
 
-LoggerAction* loggerActionNew(char const* toolName_)
+LoggerAction* loggerActionNew()
 {
   LoggerAction* act = (LoggerAction*) malloc(sizeof(LoggerAction));
   if (!act)
@@ -100,7 +100,6 @@ LoggerAction* loggerActionNew(char const* toolName_)
   loggerFileInitFromPath(&act->output, "./_noobj");
   loggerVectorInit(&act->arguments);
   loggerVectorInit(&act->sources);
-  strcpy(act->toolName, toolName_);
 
   return act;
 }
@@ -138,13 +137,13 @@ int loggerCollectActionsByProgName(
   {
     int ret;
     turnLogging(0);
-    ret = loggerGccParserCollectActions(prog_, toolName, argv_, actions_);
+    ret = loggerGccParserCollectActions(prog_, argv_, actions_);
     turnLogging(1);
     return ret;
   }
   else if (matchToProgramList("CC_LOGGER_JAVAC_LIKE", toolName))
   {
-    return loggerJavacParserCollectActions(prog_, toolName, argv_, actions_);
+    return loggerJavacParserCollectActions(prog_, argv_, actions_);
   }
 
   return 0;

--- a/analyzer/tools/build-logger/src/ldlogger-tool.h
+++ b/analyzer/tools/build-logger/src/ldlogger-tool.h
@@ -45,19 +45,14 @@ typedef struct _LoggerAction
    * Source files.
    */
   LoggerVector sources;
-  /**
-   * Tool`s name.
-   */
-  char toolName[PATH_MAX];
 } LoggerAction;
 
 /**
  * Creates a new action structure.
  *
- * @param toolName_ the name of the tool.
  * @return a new action instance or NULL on error.
  */
-LoggerAction* loggerActionNew(const char* toolName_);
+LoggerAction* loggerActionNew();
 
 /**
  * Frees an action instance.
@@ -84,14 +79,12 @@ int loggerCollectActionsByProgName(
  * Parser function for GCC like commands.
  *
  * @param prog_ the command path or the program name.
- * @param toolName_ the tools name.
  * @param argv_ the arguments of the program (including the first one)
  * @param actions_ output vector for the build actions.
  * @return zero on error, non zero on success.
  */
 int loggerGccParserCollectActions(
   const char* prog_,
-  const char* toolName_,
   const char* const argv_[],
   LoggerVector* actions_);
 
@@ -99,14 +92,12 @@ int loggerGccParserCollectActions(
  * Parser function for JavaC like commands.
  *
  * @param prog_ the command path or the program name.
- * @param toolName_ the tools name.
  * @param argv_ the arguments of the program (including the first one)
  * @param actions_ output vector for the build actions.
  * @return zero on error, non zero on success.
  */
 int loggerJavacParserCollectActions(
   const char* prog_,
-  const char* toolName_,
   const char* const argv_[],
   LoggerVector* actions_);
 

--- a/analyzer/tools/build-logger/src/ldlogger-util.c
+++ b/analyzer/tools/build-logger/src/ldlogger-util.c
@@ -442,10 +442,12 @@ char* loggerGetFilePathWithoutExt(const char* absPath_)
 char* loggerGetFileName(const char* absPath_, int withoutExt_)
 {
   const char* fileName = strrchr(absPath_, '/');
-  if (!fileName || fileName[1] == 0)
-  {
+
+  if (!fileName)
+    fileName = absPath_;
+
+  if (fileName[1] == 0)
     return NULL;
-  }
 
   ++fileName;
   if (withoutExt_)

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -108,6 +108,14 @@ function test_space_quote {
     gcc
 }
 
+function test_compiler_abs {
+  bash -c "/usr/bin/gcc $source_file"
+
+  assert_json \
+    "$source_file" \
+    /usr/bin/gcc
+}
+
 #--- Run tests ---#
 
 echo "int main() {}" > $source_file


### PR DESCRIPTION
The compiler name was indicated as toolName several places in the
logger. This was just the name of the binary without an absolute
path at the beginning. This toolName was also stored in the
LoggerAction objects, but it was not used anywhere, so it has been
removed.

The loggerGccParserCollectActions() and
loggerJavacParserCollectActions() functions had 3 parameters: prog_,
toolName_ and argv_. The first one is the program name caught by the
exec* commands, i.e. the compiler, usually with an absolute path that
may contain symlinks in it. The second one is the longest postfix of
prog_ which doesn't contain a "/" character. The third one is the
original argv_ array which also contains the compiler name at the 0th
position in its original form as it was called.
In this commit I removed the second parameter to decrease the
confusion among the three forms.

Earlier the location of the tool name was determined by looking for
it in the $PATH environment variable. Since we use prog_ instead of
toolName_, the logger will determine the full path of prog_ if it was
absolute. For example: suppose that the user emitted the following
command:

/usr/bin/gcc main.c

Suppose that there is a compiler at /a/b/c/gcc in the $PATH. Since
the toolName_ is gcc, we find it by "which" algorithm that gives
/a/b/c/gcc as result, even if the user chose /usr/bin/gcc directly.

The logger converted the directory paths after -I and -L to absolute
if they were not separated from -I and -L flags with a space
character. This conversion is now eliminated.