### PR TITLE
[server] Fix default permissions

### DIFF
--- a/docs/web/permissions.md
+++ b/docs/web/permissions.md
@@ -83,13 +83,9 @@ Each permission has a unique name, such as `SUPERUSER` or `PRODUCT_ADMIN`.
 
 Permissions can either be *not granted* or *granted* by default.
 
-Some permissions are *default not granted*, which means that only users whom
-are explicitly given the permission have it.
-
-Some permissions are *default granted*, which means that initially, every user
-has the permission. However, if at least one user or group is explicitly
-given the permission, only the users who have the permission given will be
-able to utilise it.
+If the server is running with authentication &ndash; all permissions are
+*default not granted*, which means only the users (or LDAP groups) where the
+permission is explicitly set will have various access rights.
 
 If the server is running without authentication &ndash; in this case there are
 no "users" as everyone is a guest &ndash; **every permission is automatically

--- a/web/server/codechecker_server/permissions.py
+++ b/web/server/codechecker_server/permissions.py
@@ -626,12 +626,12 @@ PRODUCT_ADMIN = _create_permission(ProductPermission, 'PRODUCT_ADMIN',
                                    manages_self=True)
 
 PRODUCT_STORE = _create_permission(ProductPermission, 'PRODUCT_STORE',
-                                   default_enable=True,
+                                   default_enable=False,
                                    inherited_from=[PRODUCT_ADMIN],
                                    managed_by=[PRODUCT_ADMIN])
 
 PRODUCT_ACCESS = _create_permission(ProductPermission, 'PRODUCT_ACCESS',
-                                    default_enable=True,
+                                    default_enable=False,
                                     inherited_from=[PRODUCT_ADMIN,
                                                     PRODUCT_STORE],
                                     managed_by=[PRODUCT_ADMIN])

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -14,6 +14,8 @@ TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 CC_TEST_WORKSPACE_ROOT ?= $(BUILD_DIR)/workspace
+WOKSPACE_GLOBAL_AUTH_SERVER = $(CC_TEST_WORKSPACE_ROOT)/global_auth_server
+WOKSPACE_GLOBAL_SIMPLE_SERVER = $(CC_TEST_WORKSPACE_ROOT)/global_simple_server
 
 CLEAR_WORKSPACE_CMD = rm -rf $(CC_TEST_WORKSPACE_ROOT)
 
@@ -52,23 +54,28 @@ pylint:
 
 pylint_in_env:
 	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
- 
+
 CODECHECKER_CMD = $(BUILD_DIR)/CodeChecker/bin/CodeChecker
-SHUTDOWN_SERVER_CMD = echo "Shutting down server..."; \
-  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l; \
-  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server \
-    --config-directory $(CC_TEST_WORKSPACE_ROOT) \
-    --port `cat "$(CC_TEST_WORKSPACE_ROOT)/serverport"` --stop; \
-  rm -f "$(CC_TEST_WORKSPACE_ROOT)/serverport"; \
-  HOME="$(CC_TEST_WORKSPACE_ROOT)" ${CODECHECKER_CMD} server -l
+SHUTDOWN_GLOBAL_SERVERS_CMD = \
+  for TEST_ROOT in ${WOKSPACE_GLOBAL_AUTH_SERVER} ${WOKSPACE_GLOBAL_SIMPLE_SERVER}; do \
+    if [ -d "$${TEST_ROOT}" ]; then \
+      echo "Shutting down server..."; \
+      HOME="$${TEST_ROOT}" ${CODECHECKER_CMD} server -l; \
+      HOME="$${TEST_ROOT}" ${CODECHECKER_CMD} server \
+        --config-directory $${TEST_ROOT} \
+        --port `cat "$${TEST_ROOT}/serverport"` --stop; \
+      rm -f "$${TEST_ROOT}/serverport"; \
+      HOME="$${TEST_ROOT}" ${CODECHECKER_CMD} server -l; \
+    fi \
+  done
 
 # Preserve the error status of the previous command but always be able to
 # shut down servers.
-EXIT_ERROR = { ${SHUTDOWN_SERVER_CMD}; exit 1; }
+EXIT_ERROR = { ${SHUTDOWN_GLOBAL_SERVERS_CMD}; exit 1; }
 
 FUNCTIONAL_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
   nosetests $(NOSECFG) tests/functional \
-  && { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+  && { ${SHUTDOWN_GLOBAL_SERVERS_CMD}; } || ${EXIT_ERROR}
 
 MAKE_DB_CMD = bash -c 'psql -h localhost \
   -p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
@@ -78,9 +85,10 @@ DROP_DB_CMD = bash -c 'psql -h localhost \
   -p $${TEST_DBPORT} -U $${TEST_DBUSERNAME} postgres \
   -c "DROP DATABASE IF EXISTS codechecker_config_$${CODECHECKER_DB_DRIVER}"'
 
-RUN_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
+RUN_TEST_CMD = $(CLEAR_WORKSPACE_CMD) && \
+  $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) $(CLANG_VERSION) $(TEST_PROJECT) \
   nosetests $(NOSECFG) $(ROOT)/web/${TEST} \
-  && { ${SHUTDOWN_SERVER_CMD}; } || ${EXIT_ERROR}
+  && { ${SHUTDOWN_GLOBAL_SERVERS_CMD}; } || ${EXIT_ERROR}
 
 run_test:
 	$(RUN_TEST_CMD)

--- a/web/tests/functional/comment/__init__.py
+++ b/web/tests/functional/comment/__init__.py
@@ -59,7 +59,7 @@ def setup_package():
     # Start or connect to the running CodeChecker server and get connection
     # details.
     print("This test uses a CodeChecker server... connecting...")
-    server_access = codechecker.start_or_get_server()
+    server_access = codechecker.start_or_get_server(auth_required=True)
     server_access['viewer_product'] = 'comment'
     codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
 

--- a/web/tests/functional/component/__init__.py
+++ b/web/tests/functional/component/__init__.py
@@ -62,7 +62,7 @@ def setup_package():
     # Start or connect to the running CodeChecker server and get connection
     # details.
     print("This test uses a CodeChecker server... connecting...")
-    server_access = codechecker.start_or_get_server()
+    server_access = codechecker.start_or_get_server(auth_required=True)
     server_access['viewer_product'] = 'component'
     codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
 

--- a/web/tests/functional/products/__init__.py
+++ b/web/tests/functional/products/__init__.py
@@ -68,7 +68,7 @@ def setup_package():
     # Start or connect to the running CodeChecker server and get connection
     # details.
     print("This test uses a CodeChecker server... connecting...")
-    server_access = codechecker.start_or_get_server()
+    server_access = codechecker.start_or_get_server(auth_required=True)
     server_access['viewer_product'] = 'producttest'
     codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
 

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -109,7 +109,8 @@ class TestProductConfigShare(unittest.TestCase):
                             {'codechecker_cfg': self.codechecker_cfg_2})
 
         server_config = dict(self.codechecker_cfg_2)
-        server_config['workspace'] = env.get_workspace(None)
+        server_config['workspace'] = os.path.join(env.get_workspace(None),
+                                                  'global_auth_server')
 
         codechecker.start_server(server_config, EVENT, None,
                                  env.get_postgresql_cfg())

--- a/web/tests/functional/server_configuration/__init__.py
+++ b/web/tests/functional/server_configuration/__init__.py
@@ -48,7 +48,7 @@ def setup_package():
     # Start or connect to the running CodeChecker server and get connection
     # details.
     print("This test uses a CodeChecker server... connecting...")
-    server_access = codechecker.start_or_get_server()
+    server_access = codechecker.start_or_get_server(auth_required=True)
     server_access['viewer_product'] = 'server_configuration'
     codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
 

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -144,7 +144,7 @@ def setup_viewer_client(workspace,
     product = codechecker_cfg['viewer_product']
 
     if session_token is None:
-        session_token = get_session_token(workspace)
+        session_token = get_session_token(workspace, host, port)
 
     if session_token == '_PROHIBIT':
         session_token = None
@@ -159,16 +159,19 @@ def setup_viewer_client(workspace,
 
 
 def setup_auth_client(workspace,
+                      host=None, port=None,
                       uri='/Authentication',
                       auto_handle_connection=True,
                       session_token=None, proto='http'):
 
-    codechecker_cfg = import_test_cfg(workspace)['codechecker_cfg']
-    port = codechecker_cfg['viewer_port']
-    host = codechecker_cfg['viewer_host']
+    # If the host is not set try to get it from the workspace config file.
+    if not host and not port:
+        codechecker_cfg = import_test_cfg(workspace)['codechecker_cfg']
+        port = codechecker_cfg['viewer_port']
+        host = codechecker_cfg['viewer_host']
 
     if session_token is None:
-        session_token = get_session_token(workspace)
+        session_token = get_session_token(workspace, host, port)
 
     if session_token == '_PROHIBIT':
         session_token = None
@@ -181,17 +184,20 @@ def setup_auth_client(workspace,
 
 
 def setup_product_client(workspace,
+                         host=None, port=None,
                          product=None,
                          uri='/Products',
                          auto_handle_connection=True,
                          session_token=None, proto='http'):
 
-    codechecker_cfg = import_test_cfg(workspace)['codechecker_cfg']
-    port = codechecker_cfg['viewer_port']
-    host = codechecker_cfg['viewer_host']
+    # If the host is not set try to get it from the workspace config file.
+    if not host and not port:
+        codechecker_cfg = import_test_cfg(workspace)['codechecker_cfg']
+        host = codechecker_cfg['viewer_host']
+        port = codechecker_cfg['viewer_port']
 
     if session_token is None:
-        session_token = get_session_token(workspace)
+        session_token = get_session_token(workspace, host, port)
 
     if session_token == '_PROHIBIT':
         session_token = None
@@ -214,7 +220,7 @@ def setup_config_client(workspace,
     host = codechecker_cfg['viewer_host']
 
     if session_token is None:
-        session_token = get_session_token(workspace)
+        session_token = get_session_token(workspace, host, port)
 
     if session_token == '_PROHIBIT':
         session_token = None
@@ -397,20 +403,18 @@ def enable_ssl(workspace):
     print("copied "+ssl_cert+" to "+workspace)
 
 
-def get_session_token(test_folder):
+def get_session_token(workspace, viewer_host, viewer_port):
     """
     Retrieve the session token for the server in the test workspace.
     This function assumes that only one entry exists in the session file.
     """
 
     try:
-        server_data = import_test_cfg(test_folder)['codechecker_cfg']
-        session_file = os.path.join(test_folder, '.codechecker.session.json')
+        session_file = os.path.join(workspace, '.codechecker.session.json')
         with open(session_file, 'r') as sess_file:
             sess_dict = json.load(sess_file)
 
-        host_port_key = server_data['viewer_host'] + ':' + \
-            str(server_data['viewer_port'])
+        host_port_key = viewer_host + ':' + str(viewer_port)
         return sess_dict['tokens'][host_port_key]
     except (IOError, KeyError) as err:
         print("Could not load session for session getter because " +


### PR DESCRIPTION
> Closes #2083 

Previously some permissions were default granted if the server was started with authentication, which means that initially, every user has the permission. With these changes all permissions are `default not granted`, which means that only users whom are explicitly given the permission have it.

By default, the `start_or_get_server` function in the test cases created a server which required authentication. With these changes  we will create 2 servers - with authentication and without it. The `add_test_package_product` function will also give permissions for the current product to some users.