### PR TITLE
[server] Configure worker processes from config file

### DIFF
--- a/docs/web/server_config.md
+++ b/docs/web/server_config.md
@@ -17,6 +17,14 @@ Table of Contents
     * [Size of the compilation database](#size-of-the-compilation-database)
 * [Authentication](#authentication)
 
+## Number of worker processes
+The `worker_processes` section of the config file controls how many processes
+will be started on the server to process API requests.
+
+*Default value*: 10
+
+The server needs to be restarted if the value is changed in the config file.
+
 ## Run limitation
 The `max_run_count` section of the config file controls how many runs can be
 stored on the server for a product.

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -706,7 +706,9 @@ class CCSimpleHttpServer(HTTPServer):
                 if not product.cleanup_run_db():
                     LOG.warning("Cleaning database for %s Failed.", endpoint)
 
-        self.__request_handlers = ThreadPool(processes=10)
+        worker_processes = self.manager.worker_processes
+        self.__request_handlers = ThreadPool(processes=worker_processes)
+
         try:
             HTTPServer.__init__(self, server_address,
                                 RequestHandlerClass,

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -49,6 +49,23 @@ def generate_session_token():
     return uuid.UUID(bytes=os.urandom(16)).hex
 
 
+def get_worker_processes(scfg_dict, default=10):
+    """
+    Return number of worker processes from the config dictionary.
+
+    Return 'worker_process' field from the config dictionary or returns the
+    default value if this field is not set or the value is negative.
+    """
+    worker_processes = scfg_dict.get('worker_process', default)
+
+    if worker_processes < 0:
+        LOG.warning("Number of worker processes can not be negative! Default "
+                    "value will be used: %s", default)
+        worker_processes = default
+
+    return worker_processes
+
+
 class _Session(object):
     """A session for an authenticated, privileged client connection."""
 
@@ -163,6 +180,7 @@ class SessionManager(object):
         # so it should NOT be handled by session_manager. A separate config
         # handler for the server's stuff should be created, that can properly
         # instantiate SessionManager with the found configuration.
+        self.__worker_process = get_worker_processes(scfg_dict)
         self.__max_run_count = scfg_dict.get('max_run_count', None)
         self.__store_config = scfg_dict.get('store', {})
         self.__auth_config = scfg_dict['authentication']
@@ -289,6 +307,10 @@ class SessionManager(object):
     @property
     def is_enabled(self):
         return self.__auth_config.get('enabled')
+
+    @property
+    def worker_processes(self):
+        return self.__worker_process
 
     def get_realm(self):
         return {

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -1,4 +1,5 @@
 {
+  "worker_processes": 10,
   "max_run_count": null,
   "store": {
     "analysis_statistics_dir": null,


### PR DESCRIPTION
Now we are able to configure the number of worker processes from the server config file which will control how many processes will be started on the server to process API requests.