### PR TITLE
[travis] Stop travis job after script command error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,13 +84,16 @@ addons:
     postgresql: "9.6"
 
 script:
-    - make pip_dev_deps
-    - make pycodestyle
-    - make pylint
-    - make clean_travis
-    - make package
-    - make -C tools/plist_to_html test
-    - BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer test_unit test_functional
-    - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then make -C analyzer test_tu_collector test_build_logger; fi
-    - BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C web test_unit test_functional
-    - make clean_travis
+    - >
+      make pip_dev_deps &&
+      make pycodestyle &&
+      make pylint &&
+      make clean_travis &&
+      make package &&
+      make -C tools/plist_to_html test &&
+      BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer test_unit test_functional &&
+      if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
+        make -C analyzer test_tu_collector test_build_logger;
+      fi &&
+      BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C web test_unit test_functional &&
+      make clean_travis


### PR DESCRIPTION
Previously if a script failed other scripts are still being run. Now if a script gives a command error than travis will immediately stop the build process.