### PR TITLE
[plist] Use lxml library to parse plist files

### DIFF
--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 nose==1.3.7
 pycodestyle==2.4.0
 psutil==5.2.2

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 portalocker==1.1.0
 psutil==5.2.2
 scan-build==2.0.14

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 sqlalchemy==1.3.3
 alembic==0.9.2
 portalocker==1.1.0

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 sqlalchemy==1.3.3
 alembic==0.9.2
 pg8000==1.10.2

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 sqlalchemy==1.3.3
 alembic==0.9.2
 psycopg2-binary==2.7.7

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 sqlalchemy==1.3.3
 pycodestyle==2.4.0
 alembic==0.9.2

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.3.4
 alembic==0.9.2
 portalocker==1.1.0
 psutil==5.2.2


### PR DESCRIPTION
Use `lxml` library to parse plist files.

The benefit of this library that this is faster than other libraries so it will improve the performance of the plist parsing.


**Measurement:**
Original plist parser:
```
----=================----
Total number of reports: 24216
----=================----

real	2m8,736s
user	2m5,753s
sys	0m2,682s
```

Plist parser with lxml:
```----=================----
Total number of reports: 24216
----=================----

real	1m23,167s
user	1m20,807s
sys	0m2,292s
```