### PR TITLE
[ui] Fix report hash filter url state

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/filter/ReportHashFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/ReportHashFilter.js
@@ -77,7 +77,9 @@ function (dom, declare, domClass, TextBox, SelectFilter) {
 
     getUrlState : function () {
       var state = {};
-      state[this.class] = this.getValue();
+
+      var value = this.getValue();
+      state[this.class] = value && value.length ? value : null;
 
       return state;
     },


### PR DESCRIPTION
Report hash filter query parameter is always set in the URL even if the value is an empty string (`http://localhost:8001/Default&report-hash=`).
With this commit we solve this problem and we set this parameter only if the report hash filter is set.