### PR TITLE
[server] New API function for get check command

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -152,7 +152,7 @@ struct RunData {
   3: string                    name,                 // Human-given identifier.
   4: i64                       duration,             // Duration of the run (-1 if not finished).
   5: i64                       resultCount,          // Number of unresolved results (review status is not FALSE_POSITIVE or INTENTIONAL) in the run.
-  6: string                    runCmd,               // The used check command.
+  6: string                    runCmd,               // The used check command. !!!DEPRECATED!!! This field will be empty so use the getCheckCommand API function to get the check command for a run.
   7: map<DetectionStatus, i32> detectionStatusCount, // Number of reports with a particular detection status.
   8: string                    versionTag,           // Version tag of the latest run.
   9: string                    codeCheckerVersion,   // CodeChecker client version of the latest analysis.
@@ -167,7 +167,7 @@ struct RunHistoryData {
   4: string                  user,               // User name who analysed the run.
   5: string                  time,               // Date time when the run was analysed.
   6: i64                     id,                 // Id of the run history tag.
-  7: string                  checkCommand,       // Check command.
+  7: string                  checkCommand,       // Check command. !!!DEPRECATED!!! This field will be empty so use the getCheckCommand API function to get the check command for a run.
   8: string                  codeCheckerVersion, // CodeChecker client version of the latest analysis.
   9: AnalyzerStatisticsData  analyzerStatistics, // Statistics for analyzers.
 }
@@ -316,6 +316,12 @@ service codeCheckerDBAccess {
   // PERMISSION: PRODUCT_ACCESS
   i64 getRunCount(1: RunFilter runFilter)
                   throws (1: shared.RequestFailed requestError),
+
+  // Get check command for a run.
+  // PERMISSION: PRODUCT_ACCESS
+  string getCheckCommand(1: i64 runHistoryId,
+                         2: i64 runId)
+                         throws (1: shared.RequestFailed requestError),
 
   // Get run history for runs.
   // If an empty run id list is provided the history

--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 18
+    6: 19
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -83,24 +83,7 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
 
   function runNameFormatter(args) {
     var runData = args.runData;
-
-    var label = '<span class="link">' + runData.name + '</span>';
-
-    var ctuEnabled = runData.runCmd.indexOf('--ctu') !== -1;
-    var statsEnabled = runData.runCmd.indexOf('--stats') !== -1;
-    if (ctuEnabled || statsEnabled) {
-      label += '<span class="run-name-labels">';
-      if (ctuEnabled) {
-        label += '<span class="label ctu">ctu</span>';
-      }
-
-      if (statsEnabled) {
-        label += '<span class="label stats">stats</span>';
-      }
-      label += '</span>';
-    }
-
-    return label;
+    return '<span class="link">' + runData.name + '</span>';
   }
 
   var RunStore = declare(Store, {
@@ -211,6 +194,8 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
     },
 
     onRowClick : function (evt) {
+      var that = this;
+
       var item = this.getItem(evt.rowIndex);
       var runId = item.runid;
 
@@ -241,9 +226,15 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
           break;
 
         case 'checkcmd':
-          this._dialog.set('title', 'Check command');
-          this._dialog.set('content', item.runData.runCmd);
-          this._dialog.show();
+          CC_SERVICE.getCheckCommand(null, runId, function (checkCommand) {
+            if (!checkCommand) {
+              checkCommand = 'Unavailable!';
+            }
+
+            that._dialog.set('title', 'Check command');
+            that._dialog.set('content', checkCommand);
+            that._dialog.show();
+          }).fail(function (xhr) { util.handleAjaxFailure(xhr); });
 
           break;
 

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -62,6 +62,7 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
     _formatItems : function(runHistories) {
       return runHistories.map(function (runHistory) {
         return {
+          id: runHistory.id,
           name: runHistory.runName,
           user: runHistory.user,
           date: util.prettifyDate(runHistory.time),
@@ -142,6 +143,8 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
     },
 
     onRowClick : function (evt) {
+      var that = this;
+
       var item = this.getItem(evt.rowIndex);
 
       switch (evt.cell.field) {
@@ -154,9 +157,16 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
           break;
 
         case 'checkCommand':
-          this._dialog.set('title', 'Check command');
-          this._dialog.set('content', item.runCmd);
-          this._dialog.show();
+          CC_SERVICE.getCheckCommand(item.id, null,
+          function (checkCommand) {
+            if (!checkCommand) {
+              checkCommand = 'Unavailable!';
+            }
+
+            that._dialog.set('title', 'Check command');
+            that._dialog.set('content', checkCommand);
+            that._dialog.show();
+          }).fail(function (xhr) { util.handleAjaxFailure(xhr); });
 
           break;
 

--- a/web/server/www/scripts/version.js
+++ b/web/server/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.18';
+CC_API_VERSION = '6.19';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/web/tests/functional/update/test_update_mode.py
+++ b/web/tests/functional/update/test_update_mode.py
@@ -61,6 +61,10 @@ class TestUpdate(unittest.TestCase):
 
         print_run_results(run_results)
 
+        # Get check command for the first storage.
+        original_check_command = \
+            self._cc_client.getCheckCommand(None, self._runid)
+
         # Run the anaysis again with different setup.
         test_project_path = self._testproject_data['project_path']
         ret = project.clean(test_project_path)
@@ -93,3 +97,12 @@ class TestUpdate(unittest.TestCase):
         self.assertTrue(all(map(
             lambda b: b.detectionStatus == 'unresolved',
             filter(lambda x: x in deadcode_bugs, updated_results))))
+
+        # Get check command for the updated storage.
+        updated_check_command = \
+            self._cc_client.getCheckCommand(None, self._runid)
+
+        # Check that the check command is changed.
+        self.assertNotEqual(original_check_command, updated_check_command)
+        self.assertTrue(deadcode not in original_check_command)
+        self.assertTrue(deadcode in updated_check_command)


### PR DESCRIPTION
This commit introduces a new API function to get check command for a run or a run history. This will reduce the HTTP response message size because we will not send back the check command to the client when getting run data or run history data.

In the web client code we will use this function to get the check command when the user clicks on the Show link on the run or run history pages.