### PR TITLE
[server] getRunData limitation

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -307,8 +307,15 @@ service codeCheckerDBAccess {
 
   // Gives back all analyzed runs.
   // PERMISSION: PRODUCT_ACCESS
-  RunDataList getRunData(1: RunFilter runFilter)
+  RunDataList getRunData(1: RunFilter runFilter,
+                         2: optional i64 limit,
+                         3: optional i64 offset)
                          throws (1: shared.RequestFailed requestError),
+
+  // Returns the number of available runs based on the run filter parameter.
+  // PERMISSION: PRODUCT_ACCESS
+  i64 getRunCount(1: RunFilter runFilter)
+                  throws (1: shared.RequestFailed requestError),
 
   // Get run history for runs.
   // If an empty run id list is provided the history

--- a/web/client/codechecker_client/thrift_helper.py
+++ b/web/client/codechecker_client/thrift_helper.py
@@ -39,7 +39,7 @@ class ThriftClientHelper(object):
             self.transport.setCustomHeaders(headers)
 
     @ThriftClientCall
-    def getRunData(self, run_name_filter):
+    def getRunData(self, run_name_filter, limit, offset):
         pass
 
     @ThriftClientCall

--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 17
+    6: 18
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/web/server/www/scripts/codecheckerviewer/BugViewer.js
+++ b/web/server/www/scripts/codecheckerviewer/BugViewer.js
@@ -139,7 +139,7 @@ function (declare, domClass, dom, style, fx, Toggler, keys, on, query, Memory,
 
           var runDataSet = [];
           try{
-            runDataSet = CC_SERVICE.getRunData(runFilter);
+            runDataSet = CC_SERVICE.getRunData(runFilter, null, 0);
           } catch (ex) { util.handleThriftException(ex); }
 
           var options = res.map(function (reportData) {

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -89,7 +89,6 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
 
   var ListOfRunHistoryGrid = declare(DataGrid, {
     constructor : function () {
-
       this.store = new ObjectStore({
         objectStore : new RunHistoryStore()
       });

--- a/web/server/www/scripts/codecheckerviewer/filter/RunBaseFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/RunBaseFilter.js
@@ -68,7 +68,7 @@ function (dom, declare, Deferred, SelectFilter, util) {
 
       var runData = [];
       try {
-        runData = CC_SERVICE.getRunData(runFilter);
+        runData = CC_SERVICE.getRunData(runFilter, null, 0);
       } catch (ex) { util.handleThriftException(ex); }
 
       return runData.map(function (run) { return run.runId; });

--- a/web/server/www/scripts/codecheckerviewer/filter/RunHistoryTagFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/RunHistoryTagFilter.js
@@ -93,7 +93,8 @@ function (dom, declare, Deferred, SelectFilter, util) {
 
       var runIds = [];
       try {
-        runIds = CC_SERVICE.getRunData(runFilter).map(function (run) {
+        runIds = CC_SERVICE.getRunData(runFilter, null, 0).map(
+        function (run) {
           return run.runId;
         });
       } catch (ex) { util.handleThriftException(ex); }

--- a/web/server/www/scripts/version.js
+++ b/web/server/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.17';
+CC_API_VERSION = '6.18';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/web/tests/functional/comment/test_comment.py
+++ b/web/tests/functional/comment/test_comment.py
@@ -58,7 +58,7 @@ class TestComment(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         self._test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/component/test_component.py
+++ b/web/tests/functional/component/test_component.py
@@ -64,7 +64,7 @@ class TestComponent(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -100,7 +100,7 @@ int f(int x) { return 1 / x; }
                                     'db_cleanup_test',
                                     self.test_dir)
 
-        runs = self._cc_client.getRunData(run_filter)
+        runs = self._cc_client.getRunData(run_filter, None, 0)
         run_id = runs[0].runId
 
         reports \
@@ -130,7 +130,7 @@ int f(int x) { return 1 / x; }
         run_filter.names = ['db_cleanup_test']
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter)
+        runs = self._cc_client.getRunData(run_filter, None, 0)
         run_id = runs[0].runId
 
         reports \

--- a/web/tests/functional/delete_runs/test_delete_runs.py
+++ b/web/tests/functional/delete_runs/test_delete_runs.py
@@ -64,12 +64,14 @@ class TestCmdLineDeletion(unittest.TestCase):
         """
 
         def all_exists(runs):
-            run_names = [run.name for run in self._cc_client.getRunData(None)]
+            run_names = [run.name for run in
+                         self._cc_client.getRunData(None, None, 0)]
             print(run_names)
             return set(runs) <= set(run_names)
 
         def none_exists(runs):
-            run_names = [run.name for run in self._cc_client.getRunData(None)]
+            run_names = [run.name for run in
+                         self._cc_client.getRunData(None, None, 0)]
             return not bool(set(runs).intersection(run_names))
 
         project_name = self._testproject_data['name']
@@ -96,7 +98,7 @@ class TestCmdLineDeletion(unittest.TestCase):
         # Remove runs before run 2 by run date.
 
         run2 = next(itertools.ifilter(lambda run: run.name == run2_name,
-                    self._cc_client.getRunData(None)), None)
+                    self._cc_client.getRunData(None, None, 0)), None)
 
         date_run2 = datetime.strptime(run2.runDate, '%Y-%m-%d %H:%M:%S.%f')
         date_run2 = \

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -127,7 +127,7 @@ int main()
         This tests the change of the detection status of bugs when the file
         content changes.
         """
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
@@ -137,7 +137,7 @@ int main()
         self._create_source_file(0)
         self._check_source_file(self._codechecker_cfg)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         run_id = max(map(lambda run: run.runId, runs))
 
         reports = self._cc_client.getRunResults([run_id],
@@ -282,7 +282,7 @@ int main()
         """
         This test checks whether the storage works without a metadata.json.
         """
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
 
@@ -304,7 +304,7 @@ int main()
 
         codechecker.store(self._codechecker_cfg, 'hello')
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         run_id = max(map(lambda run: run.runId, runs))
 
         reports = self._cc_client.getRunResults([run_id],
@@ -321,7 +321,7 @@ int main()
         """
         This test checks reports which have detection status of 'Off'.
         """
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
 

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -65,7 +65,7 @@ class DiffRemote(unittest.TestCase):
         # Name order matters from __init__ !
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         self._test_runs = [run for run in runs if run.name in run_names]
 
         # There should be at least two runs for this test.

--- a/web/tests/functional/extended_report_data/test_extended_report_data.py
+++ b/web/tests/functional/extended_report_data/test_extended_report_data.py
@@ -33,7 +33,7 @@ class TestExtendedReportData(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -48,7 +48,7 @@ class TestExtendedReportData(unittest.TestCase):
         run_filter.names = [run_name]
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter)
+        runs = self._cc_client.getRunData(run_filter, None, 0)
         run_id = runs[0].runId
 
         return self._cc_client.getRunResults([run_id], None, 0, [], None, None,

--- a/web/tests/functional/func_template/template_test.py
+++ b/web/tests/functional/func_template/template_test.py
@@ -55,7 +55,7 @@ class TestSkeleton(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         test_runs = [run for run in runs if run.name in run_names]
 
     def test_skel(self):

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -85,7 +85,7 @@ class TestProductConfigShare(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace_main)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -192,10 +192,10 @@ class TestProductConfigShare(unittest.TestCase):
         self.assertEqual(store_res, 0, "Storing the test project failed.")
 
         cc_client_2 = env.setup_viewer_client(self.test_workspace_secondary)
-        self.assertEqual(len(cc_client_2.getRunData(None)), 1,
+        self.assertEqual(len(cc_client_2.getRunData(None, None, 0)), 1,
                          "There should be a run present in the new server.")
 
-        self.assertEqual(len(self._cc_client.getRunData(None)), 1,
+        self.assertEqual(len(self._cc_client.getRunData(None, None, 0)), 1,
                          "There should be a run present in the database when "
                          "connected through the main server.")
 

--- a/web/tests/functional/products/test_products.py
+++ b/web/tests/functional/products/test_products.py
@@ -66,7 +66,7 @@ class TestProducts(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -247,7 +247,7 @@ class TestProducts(unittest.TestCase):
         # There is no schema initialization if the product database
         # was changed. The inital schema needs to be created manually
         # for the new database.
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         self.assertIsNone(runs)
 
         # Connect back to the old database.
@@ -260,7 +260,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old database name.")
 
         # The old database should have its data available again.
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")
@@ -295,7 +295,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save new endpoint.")
 
         # The old product is gone. Thus, connection should NOT happen.
-        res = self._cc_client.getRunData(None)
+        res = self._cc_client.getRunData(None, None, 0)
         self.assertIsNone(res)
 
         # The new product should connect and have the data.
@@ -307,7 +307,7 @@ class TestProducts(unittest.TestCase):
             product=new_endpoint,  # Use the new product URL.
             endpoint='/CodeCheckerService',
             session_token=token)
-        self.assertEqual(len(new_client.getRunData(None)), 1,
+        self.assertEqual(len(new_client.getRunData(None, None, 0)), 1,
                          "The new product did not serve the stored data.")
 
         # Set back to the old endpoint.
@@ -320,7 +320,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old endpoint.")
 
         # The old product should have its data available again.
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")

--- a/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
+++ b/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
@@ -45,7 +45,7 @@ class TestGetLinesInFile(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -51,7 +51,7 @@ class RunResults(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/web/tests/functional/report_viewer_api/test_hash_clash.py
@@ -83,7 +83,7 @@ class HashClash(unittest.TestCase):
                           'test_hash_clash_' + uuid4().hex)
 
     def _reports_for_latest_run(self):
-        runs = self._report.getRunData(None)
+        runs = self._report.getRunData(None, None, 0)
         max_run_id = max(map(lambda run: run.runId, runs))
         return self._report.getRunResults([max_run_id],
                                           100,

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -49,7 +49,7 @@ class RemoveRunResults(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -70,7 +70,7 @@ class RemoveRunResults(unittest.TestCase):
                                     test_project_path)
 
         run_filter = RunFilter(names=['remove_run_results'], exactMatch=True)
-        runs = self._cc_client.getRunData(run_filter)
+        runs = self._cc_client.getRunData(run_filter, None, 0)
         self.assertEqual(len(runs), 1)
 
         run_id = runs[0].runId

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -54,7 +54,7 @@ class TestReportFilter(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         self._test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in self._test_runs]
@@ -586,7 +586,7 @@ class TestReportFilter(unittest.TestCase):
         Run name is randomly generated for all of the test runs.
         """
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         separate_report_counts = 0
         for run in runs:

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -52,7 +52,7 @@ class TestReportFilter(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in test_runs]

--- a/web/tests/functional/report_viewer_api/test_run_data.py
+++ b/web/tests/functional/report_viewer_api/test_run_data.py
@@ -44,7 +44,7 @@ class TestRunData(unittest.TestCase):
         if run_name_filter is not None:
             run_filter.names = [run_name_filter]
 
-        runs = self._cc_client.getRunData(run_filter)
+        runs = self._cc_client.getRunData(run_filter, None, 0)
         return [run for run in runs if run.name in self._run_names]
 
     def test_filter_run_names(self):

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -39,7 +39,7 @@ class TestReviewStatus(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/run_tag/test_run_tag.py
+++ b/web/tests/functional/run_tag/test_run_tag.py
@@ -144,7 +144,7 @@ int main()
         self._create_source_file(0, 'test_run_tag_update')
 
         # Get the run names which belong to this test
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
         test_run_ids = [run.runId for run in runs]
 
         self.assertEqual(len(test_run_ids), 2)

--- a/web/tests/functional/skip/test_skip.py
+++ b/web/tests/functional/skip/test_skip.py
@@ -46,7 +46,7 @@ class TestSkip(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/suppress/test_suppress_generation.py
+++ b/web/tests/functional/suppress/test_suppress_generation.py
@@ -61,7 +61,7 @@ class TestSuppress(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/update/test_update_mode.py
+++ b/web/tests/functional/update/test_update_mode.py
@@ -41,7 +41,7 @@ class TestUpdate(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None)
+        runs = self._cc_client.getRunData(None, None, 0)
 
         test_runs = [run for run in runs if run.name in run_names]
 


### PR DESCRIPTION
Previously `getRunData` function returned all the runs. It is possible that the user stored a lot of runs (`>1000`) so getting these data was too slow. For this reason we introduced a new limit/offset parameters for the getRunData function which limits the number of runs which will be returned to the user.

We've also introduced a new API function called `getRunCount` which will return the number of available runs. This can be filtered by a run filter parameter.