### PR TITLE
[server] Run history limitation

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -320,6 +320,12 @@ service codeCheckerDBAccess {
                                    4: RunHistoryFilter runHistoryFilter)
                                    throws (1: shared.RequestFailed requestError),
 
+  // Get the number of run history for runs.
+  // PERMISSION: PRODUCT_ACCESS
+  i64 getRunHistoryCount(1: list<i64> runIds,
+                         2: RunHistoryFilter runHistoryFilter)
+                         throws (1: shared.RequestFailed requestError),
+
   // Returns report hashes based on the diffType parameter.
   // PERMISSION: PRODUCT_ACCESS
   list<string> getDiffResultsHash(1: list<i64>    runIds,

--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 16
+    6: 17
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -101,44 +101,6 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
     return label;
   }
 
-  function analyzerStatisticsFormatter(stats) {
-    var ul = dom.create('ul', { class: 'analyzer-statistics' });
-
-    Object.keys(stats).forEach(function (analyzer) {
-      var items = dom.create('ul', { class : 'items' });
-
-      if (stats[analyzer].successful) {
-        var successLi = dom.create('li', {
-          title : 'Number of successfully analyzed files.'
-        }, items);
-
-        dom.create('i', { class : 'customIcon check' }, successLi);
-        dom.create('span', {
-          class : 'num',
-          innerHTML : '(' + stats[analyzer].successful + ')'
-        }, successLi);
-      }
-
-      if (stats[analyzer].failed) {
-        var failedLi = dom.create('li', {
-          title : 'Number of files which failed to analyze.'
-        }, items);
-
-        dom.create('i', { class : 'customIcon remove' }, failedLi);
-        dom.create('span', {
-          class : 'num link',
-          innerHTML : '(' + stats[analyzer].failed + ')'
-        }, failedLi);
-      }
-
-      dom.create('li', {
-        innerHTML : analyzer + ': ' + items.outerHTML
-      }, ul);
-    });
-
-    return ul.outerHTML;
-  }
-
   var ListOfRunsGrid = declare(DataGrid, {
     constructor : function () {
       this.store = new ItemFileWriteStore({
@@ -150,7 +112,7 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
         { name : 'Name', field : 'name', styles : 'text-align: left;', width : '100%', formatter: runNameFormatter },
         { name : '<span title="' + util.getTooltip('numOfUnresolved') + '">Number of unresolved reports</span>', field : 'numberofbugs', formatter: numberOfUnresolvedBugsFormatter, styles : 'text-align: center;', width : '20%' },
         { name : '<span title="' + util.getTooltip('detectionStatus') + '">Detection status</span>', field : 'detectionstatus', styles : 'text-align: center;', width : '30%' },
-        { name : 'Analyzer statistics', field : 'analyzerStatistics', styles : 'text-align: center;', width : '30%', formatter : analyzerStatisticsFormatter },
+        { name : 'Analyzer statistics', field : 'analyzerStatistics', styles : 'text-align: center;', width : '30%', formatter : util.analyzerStatisticsFormatter },
         { name : 'Storage date', field : 'date', styles : 'text-align: center;', width : '25%' },
         { name : 'Analysis duration', field : 'duration', styles : 'text-align: center;' },
         { name : 'Check command', field : 'checkcmd', styles : 'text-align: center;' },

--- a/web/server/www/scripts/codecheckerviewer/util.js
+++ b/web/server/www/scripts/codecheckerviewer/util.js
@@ -534,6 +534,44 @@ function (locale, dom, style, json) {
       } else {
         console.warn(ex);
       }
+    },
+
+    analyzerStatisticsFormatter : function (stats) {
+      var ul = dom.create('ul', { class: 'analyzer-statistics' });
+
+      Object.keys(stats).forEach(function (analyzer) {
+        var items = dom.create('ul', { class : 'items' });
+
+        if (stats[analyzer].successful) {
+          var successLi = dom.create('li', {
+            title : 'Number of successfully analyzed files.'
+          }, items);
+
+          dom.create('i', { class : 'customIcon check' }, successLi);
+          dom.create('span', {
+            class : 'num',
+            innerHTML : '(' + stats[analyzer].successful + ')'
+          }, successLi);
+        }
+
+        if (stats[analyzer].failed) {
+          var failedLi = dom.create('li', {
+            title : 'Number of files which failed to analyze.'
+          }, items);
+
+          dom.create('i', { class : 'customIcon remove' }, failedLi);
+          dom.create('span', {
+            class : 'num link',
+            innerHTML : '(' + stats[analyzer].failed + ')'
+          }, failedLi);
+        }
+
+        dom.create('li', {
+          innerHTML : analyzer + ': ' + items.outerHTML
+        }, ul);
+      });
+
+      return ul.outerHTML;
     }
   };
 });

--- a/web/server/www/scripts/version.js
+++ b/web/server/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.16';
+CC_API_VERSION = '6.17';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';


### PR DESCRIPTION
Use `DataGrid` and `Store` at Run history page to show the items. This will allow us to load run history on page scroll.

Create a new API function called `getRunHistoryCount` to get the number of run history based on a filter set. This is needed by the `DataGrid` to support page scroll.