### PR TITLE
[pylint] Enable checkers in .pylintrc file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -51,11 +51,6 @@ optimize-ast=no
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
 confidence=
 
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-#enable=
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -65,8 +60,12 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
+disable=all
 
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=logging-format-interpolation,old-style-class,unused-import,unused-variable,len-as-condition,bad-indentation
 
 [REPORTS]
 

--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,7 @@ clean_travis:
 
 PYLINT_CMD = $(MAKE) -C $(CC_ANALYZER) pylint && \
   $(MAKE) -C $(CC_WEB) pylint && \
-  pylint ./bin ./codechecker_common ./scripts \
-    --disable=all \
-    --enable=logging-format-interpolation,old-style-class,unused-import,unused-variable,len-as-condition,bad-indentation
+  pylint ./bin ./codechecker_common ./scripts
 
 pylint:
 	$(PYLINT_CMD)

--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -21,9 +21,7 @@ pycodestyle_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYCODESTYLE_TEST_CMD)
 
 PYLINT_TEST_CMD = pylint ./bin ./cmd ./codechecker_analyzer ./tests \
-	--rcfile=$(ROOT)/.pylintrc \
-  --disable=all \
-  --enable=logging-format-interpolation,old-style-class,unused-import,unused-variable,len-as-condition,bad-indentation
+	--rcfile=$(ROOT)/.pylintrc
 
 pylint:
 	$(PYLINT_TEST_CMD)

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -45,9 +45,7 @@ PYLINT_TEST_CMD = pylint ./bin/codechecker-web-version \
   ./client/codechecker_client \
   ./server/bin/codechecker-server ./server/codechecker_server \
   ./server/tests/unit \
-	--rcfile=$(ROOT)/.pylintrc \
-  --disable=all \
-  --enable=logging-format-interpolation,old-style-class,unused-import,unused-variable,len-as-condition,bad-indentation
+	--rcfile=$(ROOT)/.pylintrc
 
 pylint:
 	 $(PYLINT_TEST_CMD)


### PR DESCRIPTION
Use the pylint configuration file (`.pylintrc`) to disable all checkers and enable only specific checkers instead of command line options.