### PR TITLE
[dep] Update psycopg2

### DIFF
--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy==1.3.3
 alembic==0.9.2
-psycopg2==2.7.1
+psycopg2-binary==2.7.7
 thrift==0.9.1
 psutil==5.2.2
 portalocker==1.1.0

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,7 +1,7 @@
 sqlalchemy==1.3.3
 pycodestyle==2.4.0
 alembic==0.9.2
-psycopg2==2.7.1
+psycopg2-binary==2.7.7
 pg8000==1.10.2
 thrift==0.9.1
 psutil==5.2.2


### PR DESCRIPTION
Update `psycopg2` and use `psycopg2-binary` as  package name because `psycopg2` starting from release `2.8`, the binary packages will only be released under psycopg2-binary.