### PR TITLE
[server] Create separate API function to get analysis statistics

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -156,7 +156,9 @@ struct RunData {
   7: map<DetectionStatus, i32> detectionStatusCount, // Number of reports with a particular detection status.
   8: string                    versionTag,           // Version tag of the latest run.
   9: string                    codeCheckerVersion,   // CodeChecker client version of the latest analysis.
-  10: AnalyzerStatisticsData   analyzerStatistics,   // Statistics for each analyzers.
+  10: AnalyzerStatisticsData   analyzerStatistics,   // Statistics for analyzers. Only number of failed and successfully analyzed
+                                                     // files field will be set. To get full analyzer statistics please use the
+                                                     // 'getAnalysisStatistics' API function.
 }
 typedef list<RunData> RunDataList
 
@@ -169,7 +171,9 @@ struct RunHistoryData {
   6: i64                     id,                 // Id of the run history tag.
   7: string                  checkCommand,       // Check command.
   8: string                  codeCheckerVersion, // CodeChecker client version of the latest analysis.
-  9: AnalyzerStatisticsData  analyzerStatistics, // Statistics for analyzers.
+  9: AnalyzerStatisticsData  analyzerStatistics, // Statistics for analyzers. Only number of failed and successfully analyzed
+                                                 // files field will be set. To get full analyzer statistics please use the
+                                                 // 'getAnalysisStatistics' API function.
 }
 typedef list<RunHistoryData> RunHistoryDataList
 
@@ -610,4 +614,10 @@ service codeCheckerDBAccess {
   bool storeAnalysisStatistics(1: string runName
                                2: string zipfile)
                                throws (1: shared.RequestFailed requestError),
+
+  // Get analysis statistics for a run.
+  // PERMISSION: PRODUCT_ACCESS
+  AnalyzerStatisticsData getAnalysisStatistics(1: i64 runId,
+                                               2: i64 runHistoryId)
+                                               throws (1: shared.RequestFailed requestError),
 }

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -211,6 +211,8 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
     },
 
     onRowClick : function (evt) {
+      var that = this;
+
       var item = this.getItem(evt.rowIndex);
       var runId = item.runid;
 
@@ -248,10 +250,9 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
           break;
 
         case 'analyzerStatistics':
-          var stats = item.runData.analyzerStatistics;
-          if (Object.keys(stats).length) {
-            this._analyzerStatDialog.show(item.runData.analyzerStatistics);
-          }
+          CC_SERVICE.getAnalysisStatistics(runId, null, function (stats) {
+            that._analyzerStatDialog.show(stats);
+          });
 
           break;
       }

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -62,6 +62,7 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
     _formatItems : function(runHistories) {
       return runHistories.map(function (runHistory) {
         return {
+          id: runHistory.id,
           name: runHistory.runName,
           user: runHistory.user,
           date: util.prettifyDate(runHistory.time),
@@ -142,6 +143,8 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
     },
 
     onRowClick : function (evt) {
+      var that = this;
+
       var item = this.getItem(evt.rowIndex);
 
       switch (evt.cell.field) {
@@ -161,10 +164,9 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
           break;
 
         case 'analyzerStatistics':
-          var stats = item.analyzerStatistics;
-          if (Object.keys(stats).length) {
-            this._analyzerStatDialog.show(stats);
-          }
+            CC_SERVICE.getAnalysisStatistics(null, item.id, function (stats) {
+              that._analyzerStatDialog.show(stats);
+            });
 
           break;
       }


### PR DESCRIPTION
At the `getRunData` and `getRunHistory` functions we returned the
whole analysis statistics but we used only the number of failed and
successfully analyzed files fields. To reduce the response message
size of these API functions we created a separate API function called
`getAnalysisStatistics` to get analysis stastistics for a run which
will be called when the user clicks on the Show link on the Run List
and Run History pages.