### PR TITLE
[doc] Fix missing input tag at Doxygen config

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -654,7 +654,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = web/api docs docs/checker_docs
+INPUT                  = web/api docs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is


### PR DESCRIPTION
`docs/checker_docs` is moved under `docs/web/checker_docs` but
at the INPUT tag values we already listed the parent directory
(`docs`) of this directory which is enough, so we remove this
directory at all.