### PR TITLE
Implicit joker at the beginning of text field

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -301,7 +301,7 @@ function (declare, dom, ItemFileWriteStore, topic, Dialog, Button,
           var runNameFilter = this.get('value');
           this.timer = setTimeout(function () {
             var runFilter = new CC_OBJECTS.RunFilter();
-            runFilter.names = [runNameFilter + '*'];
+            runFilter.names = ['*' + runNameFilter + '*'];
             that.listOfRunsGrid.refreshGrid(runFilter);
           }, 500);
         }

--- a/web/server/www/scripts/codecheckerviewer/filter/FilterTooltip.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/FilterTooltip.js
@@ -175,7 +175,11 @@ function (declare, domClass, dom, keys, Standby, TextBox, popup, Tooltip,
       var that = this;
       if (!this.cachedIems) {
         if (opt.filter) {
-          opt.query = [ opt.filter + (this.search.regex ? '*' : '') ];
+          opt.query = [
+            (this.search.regex ? '*' : '') +
+            opt.filter +
+            (this.search.regex ? '*' : '')
+          ];
         }
 
         this.reportFilter.getItems(opt).then(function (items) {

--- a/web/server/www/scripts/productlist/ListOfProducts.js
+++ b/web/server/www/scripts/productlist/ListOfProducts.js
@@ -322,7 +322,7 @@ function (declare, domClass, domBase, dom, ItemFileWriteStore, topic, DataGrid,
         }
       });
 
-      this._populateProducts(productNameFilter + '*');
+      this._populateProducts('*' + productNameFilter + '*');
     },
 
     toggleAdminButtons : function (adminLevel) {


### PR DESCRIPTION
In case a text box requires a regex in the search fields, we sould put
an implicit * joker character at the beginning. This is a usability
enhancment so the user doesn't have to put this character there
explicitly.

Fixes #2134