### PR TITLE
[server] Print an info message when the server is shutting down

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -768,7 +768,6 @@ class CCSimpleHttpServer(HTTPServer):
         Terminating the server.
         """
         try:
-            LOG.info("Shutting down...")
             self.server_close()
             self.__engine.dispose()
 
@@ -1007,9 +1006,10 @@ def start_server(config_directory, package_data, port, config_sql_server,
         """
         Handle SIGTERM to stop the server running.
         """
-        LOG.info("Received shutdown request.")
+        LOG.info("Shutting down the WEB server on [%s:%d].",
+                 listen_address, port)
+
         http_server.terminate()
-        LOG.info("WEB server is shut down.")
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
If we print something after the `ThreadPool` is terminated first the server is being stopped, the terminal will be active and the message will be printed to the active terminal. To reproduce this problem, start a server and hit Ctrl+C.

With these changes we do not print a message after the HTTP server is terminated.

E.g.:
```sh
[INFO 2019-06-26 13:42] - Server waiting for client requests on [localhost:8001]
^C[INFO 2019-06-26 13:42] - Received shutdown request.
[INFO 2019-06-26 13:42] - Shutting down...
username@hostname ~/codechecker $ [INFO 2019-06-26 13:42] - WEB server is shut down.

```