### PR TITLE
Collect compiler information for multiple languages

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -293,7 +293,7 @@ def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
 
     for of in other_files:
         mentioned_file = os.path.abspath(os.path.join(action.directory, of))
-        key = mentioned_file, action.target
+        key = mentioned_file, action.target[action.lang]
         mentioned_file_action = actions_map.get(key)
         if mentioned_file_action is not None:
             buildactions.append({

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -54,7 +54,7 @@ def create_actions_map(actions, manager):
     result = manager.dict()
 
     for act in actions:
-        key = act.source, act.target
+        key = act.source, act.target[act.lang]
         if key in result:
             LOG.debug("Multiple entires in compile database "
                       "with the same (source, target) pair: (%s, %s)",

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -23,6 +23,7 @@ from codechecker_analyzer import host_check
 from codechecker_analyzer import env
 
 from .. import analyzer_base
+from ..flag import has_flag
 
 from . import config_handler
 from . import ctu_triple_arch
@@ -209,17 +210,20 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                     analyzer_cmd.extend(['-Xclang',
                                          '-analyzer-display-ctu-progress'])
 
-            def has_flag(flag):
-                return bool(next((x for x in analyzer_cmd if
-                                 x.startswith(flag)),
-                                 False))
+            compile_lang = self.buildaction.lang
+            if not has_flag('-x', analyzer_cmd):
+                analyzer_cmd.extend(['-x', compile_lang])
 
-            if not has_flag('-x'):
-                analyzer_cmd.extend(['-x', self.buildaction.lang])
-            if not has_flag('--target') and self.buildaction.target != "":
-                analyzer_cmd.append("--target=" + self.buildaction.target)
-            if not has_flag('-std') and not has_flag('--std'):
-                analyzer_cmd.append(self.buildaction.compiler_standard)
+            if not has_flag('--target', analyzer_cmd) and \
+                    self.buildaction.target.get(compile_lang, "") != "":
+                analyzer_cmd.append("--target=" +
+                                    self.buildaction.target.get(compile_lang))
+
+            if not has_flag('-std', analyzer_cmd) and \
+                    self.buildaction.compiler_standard.get(compile_lang, "") \
+                    != "":
+                analyzer_cmd.append(
+                        self.buildaction.compiler_standard[compile_lang])
 
             analyzer_cmd.extend(config.analyzer_extra_arguments)
 
@@ -228,7 +232,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             env.extend_analyzer_cmd_with_resource_dir(
                 analyzer_cmd, config.compiler_resource_dir)
 
-            analyzer_cmd.extend(self.buildaction.compiler_includes)
+            analyzer_cmd.extend(
+                self.buildaction.compiler_includes[compile_lang])
 
             analyzer_cmd.append(self.source_file)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
@@ -23,6 +23,8 @@ from codechecker_common.logger import get_logger
 
 from codechecker_analyzer.env import extend_analyzer_cmd_with_resource_dir
 
+from ..flag import has_flag
+
 LOG = get_logger('analyzer')
 
 
@@ -65,11 +67,21 @@ def build_stat_coll_cmd(action, config, source):
         cmd.extend(['-Xclang',
                     '-analyzer-checker=' + coll_check])
 
-    if action.target != "":
-        cmd.append("--target=" + action.target)
+    compile_lang = self.action.lang
+    if not has_flag('-x', cmd):
+        analyzer_cmd.extend(['-x', compile_lang])
+
+    if not has_flag('--target', cmd) and \
+            self.action.target[compile_lang] != "":
+        analyzer_cmd.append("--target=" + self.action.target[compile_lang])
+
+    if not has_flag('-std', cmd) and not has_flag('--std', cmd):
+        analyzer_cmd.append(self.action.compiler_standard[compile_lang])
+
     extend_analyzer_cmd_with_resource_dir(cmd,
                                           config.compiler_resource_dir)
-    cmd.extend(action.compiler_includes)
+
+    analyzer_cmd.extend(self.buildaction.compiler_includes[comile_lang])
 
     if source:
         cmd.append(source)

--- a/analyzer/codechecker_analyzer/analyzers/flag.py
+++ b/analyzer/codechecker_analyzer/analyzers/flag.py
@@ -1,0 +1,10 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+
+
+def has_flag(flag, cmd):
+    """Return true if a cmd contains a flag or false if not."""
+    return bool(next((x for x in cmd if x.startswith(flag)), False))

--- a/analyzer/codechecker_analyzer/buildlog/build_action.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_action.py
@@ -73,7 +73,7 @@ class BuildAction(object):
         hash_content = []
         hash_content.extend(self.analyzer_options)
         hash_content.append(str(self.analyzer_type))
-        hash_content.append(self.target)
+        hash_content.append(self.target[self.lang])
         hash_content.append(self.source)
         return hash(''.join(hash_content))
 

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -154,7 +154,8 @@ class TestAnalyze(unittest.TestCase):
                 self.assertEquals(len(data), 2)
                 self.assertTrue("clang++" in data)
                 self.assertTrue("g++" in data)
-                self.assertEqual(data["clang++"]["includes"][0], "-isystem")
+                self.assertEqual(
+                    data["clang++"]['c++']["compiler_includes"][0], "-isystem")
             except ValueError:
                 self.fail("json.load should successfully parse the file %s"
                           % info_File)
@@ -185,22 +186,29 @@ class TestAnalyze(unittest.TestCase):
             source.write(simple_file_content)
 
         with open(compiler_info_file, 'w') as source:
-            source.write('{"clang++": {"default_standard": "-std=FAKE_STD", '
-                         '"target": "FAKE_TARGET", "includes": ["-isystem '
-                         '/FAKE_INCLUDE_DIR"]}}')
+            source.write('''{
+  "clang++": {
+    "c++": {
+      "compiler_standard": "-std=FAKE_STD",
+      "target": "FAKE_TARGET",
+      "compiler_includes": [
+        "-isystem /FAKE_INCLUDE_DIR"
+      ]
+    }
+  }
+}''')
 
         # Create analyze command.
         analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
                        "--compiler-info-file", compiler_info_file,
                        "--analyzers", "clangsa", "--verbose", "debug",
                        "-o", reports_dir]
-
         # Run analyze.
         process = subprocess.Popen(
             analyze_cmd, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=self.test_dir)
         out, _ = process.communicate()
-
+        print(out)
         self.assertTrue("-std=FAKE_STD" in out)
         self.assertTrue("--target=FAKE_TARGET" in out)
         self.assertTrue("-isystem /FAKE_INCLUDE_DIR" in out)
@@ -230,7 +238,8 @@ class TestAnalyze(unittest.TestCase):
             analyze_cmd, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=self.test_dir)
         out, err = process.communicate()
-
+        print(out)
+        print(err)
         errcode = process.returncode
         self.assertEquals(errcode, 0)
 

--- a/analyzer/tests/unit/test_flag.py
+++ b/analyzer/tests/unit/test_flag.py
@@ -1,0 +1,29 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Compiler flag checking functions."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import unittest
+
+from codechecker_analyzer.analyzers import flag
+
+
+class Flag(unittest.TestCase):
+    """Compiler flag related tests."""
+
+    def test_has_flag(self):
+        """Test if flag is found in a command."""
+        cmd = ["g++", "--target", "x86_64"]
+        self.assertTrue(flag.has_flag("--target", cmd))
+        self.assertTrue(flag.has_flag("x86_64", cmd))
+
+    def test_missing_flag(self):
+        """Test if flag was not found in a command."""
+        cmd = ["g++", "--target", "x86_64"]
+        self.assertFalse(flag.has_flag("-std", cmd))

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -105,10 +105,10 @@ class OptionParserTest(unittest.TestCase):
         Test if the compilation architecture is
         detected correctly from the command line.
         """
-        arch = 'x86_64'
+        arch = {'c': 'x86_64'}
         action = {
             'file': 'main.c',
-            'command': "gcc -c -arch " + arch + ' main.c',
+            'command': "gcc -c -arch " + arch['c'] + ' main.c',
             'directory': ''
         }
 
@@ -116,7 +116,7 @@ class OptionParserTest(unittest.TestCase):
         print(res)
 
         self.assertTrue('main.c' == res.source)
-        self.assertEqual(arch, res.target)
+        self.assertEqual(arch['c'], res.target['c'])
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
     def test_compile_optimized(self):
@@ -383,12 +383,19 @@ class OptionParserTest(unittest.TestCase):
                 mode='w',
                 suffix='.json') as info_file_tmp:
 
-            info_file_tmp.write(
-                    '{"g++": {"default_standard": "-std=FAKE_STD", '
-                    '"target": "FAKE_TARGET", "includes": ["-isystem '
-                    '/FAKE_INCLUDE_DIR"]}}')
+            info_file_tmp.write('''{
+  "g++": {
+    "c++": {
+      "compiler_standard": "-std=FAKE_STD",
+      "target": "FAKE_TARGET",
+      "compiler_includes": [
+        "-isystem /FAKE_INCLUDE_DIR"
+      ]
+    }
+  }
+}''')
             info_file_tmp.flush()
 
             res = log_parser.parse_options(action, info_file_tmp.name)
-            self.assertEqual(res.compiler_includes,
+            self.assertEqual(res.compiler_includes['c++'],
                              ['-isystem', '/FAKE_INCLUDE_DIR'])

--- a/scripts/debug_tools/renew_info_files.py
+++ b/scripts/debug_tools/renew_info_files.py
@@ -143,10 +143,20 @@ def create_compiler_info_json(old_info, filepath):
         include_paths = process_includes(old_info[compiler]['includes'])
         for idx, _ in enumerate(include_paths):
             include_paths[idx] = "-isystem %s" % include_paths[idx]
-        info[compiler] = {
+        compiler_data = {
             "includes": include_paths,
             "target": process_target(old_info[compiler]['target']),
             "default_standard": old_info[compiler]['default_standard']}
+
+        # There was no language information in the previous
+        # compiler_info.json files. To be compatible with the new format
+        # are duplicating the information for both languages.
+        # It is possible that the wrong include path will be set
+        # for the wrong language (C includes for C++) but at least one of them
+        # will be right. We can not do better here because the
+        # original compiler might not be available in the current environment.
+        info[compiler]["c"] = compiler_data
+        info[compiler]["c++"] = compiler_data
 
     with io.open(filepath, 'w', encoding='UTF-8') as dest:
         json.dump(info, dest)


### PR DESCRIPTION
If the same compiler was used multiple times in a
compile command json but compiled multiple source
files for differerent languages (C and C++) the implicit
compiler information was collected only when first detected
(only for C).

With this change when a compiler is first found the include
paths, default build targets and compiler standards
will be detected for both languages. So the information can
be used when the same compiler is compiling for a
different language.

Additional changes were done to set the include paths,
build targets and compiler standard at multiple analysis
stages like, statistis collection, ctu pre analysis and
for setting the clang tidy arguments.

New PR replacing #1908