### PR TITLE
fix plist parsing for skip files

### DIFF
--- a/analyzer/tests/functional/skip/__init__.py
+++ b/analyzer/tests/functional/skip/__init__.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Setup for the skip test for the analyze command.
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import os
+import shutil
+
+from libtest import env
+
+
+# Test workspace should be initialized in this module.
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for the tests."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('skip')
+
+    report_dir = os.path.join(TEST_WORKSPACE, 'reports')
+    os.makedirs(report_dir)
+
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+
+def teardown_package():
+    """Delete the workspace associated with this test"""
+
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
+    global TEST_WORKSPACE
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/analyzer/tests/functional/skip/test_files/Makefile
+++ b/analyzer/tests/functional/skip/test_files/Makefile
@@ -1,0 +1,14 @@
+OBJS = $(SRCS:.cpp=.o)
+
+CXXFLAGS = -Wno-all -Wno-extra -Wno-division-by-zero
+
+SRCS = skip_header.cpp \
+		file_to_be_skipped.cpp
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) -c $<  -o $@
+
+all: $(OBJS)
+
+clean:
+	rm -rf *.o

--- a/analyzer/tests/functional/skip/test_files/file_to_be_skipped.cpp
+++ b/analyzer/tests/functional/skip/test_files/file_to_be_skipped.cpp
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+// This file is to be included in a skip list file.
+
+void skipped_test(int z) {
+  if (z == 0)
+    int x = 1 / z; // warn
+}

--- a/analyzer/tests/functional/skip/test_files/skip.h
+++ b/analyzer/tests/functional/skip/test_files/skip.h
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+int null_div(int z) {
+    int x = z / 0; // warn
+    return x;
+}
+

--- a/analyzer/tests/functional/skip/test_files/skip_header.cpp
+++ b/analyzer/tests/functional/skip/test_files/skip_header.cpp
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+#include "skip.h"
+
+int test() {
+    int x = null_div(42);
+    return x;
+}
+
+int test1(int i) {
+    int y = i / 0; // warn
+    return y;
+}
+

--- a/analyzer/tests/functional/skip/test_files/skipfile
+++ b/analyzer/tests/functional/skip/test_files/skipfile
@@ -1,0 +1,2 @@
+-*file_to_be_skipped.cpp
+-*skip.h

--- a/analyzer/tests/functional/skip/test_skip.py
+++ b/analyzer/tests/functional/skip/test_skip.py
@@ -1,0 +1,108 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""
+Test skipping the analysis of a file and the removal
+of skipped reports from the report files.
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import os
+import plistlib
+import subprocess
+import unittest
+import shutil
+
+from libtest import env
+
+
+class TestSkip(unittest.TestCase):
+    _ccClient = None
+
+    def setUp(self):
+
+        # TEST_WORKSPACE is automatically set by test package __init__.py .
+        self.test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self.test_workspace)
+
+        # Get the CodeChecker cmd if needed for the tests.
+        self._codechecker_cmd = env.codechecker_cmd()
+        self.report_dir = os.path.join(self.test_workspace, "reports")
+        self.test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
+        # Change working dir to testfile dir so CodeChecker can be run easily.
+        self.__old_pwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        """Restore environment after tests have ran."""
+        os.chdir(self.__old_pwd)
+        if os.path.isdir(self.report_dir):
+            shutil.rmtree(self.report_dir)
+
+    def test_skip(self):
+        """
+        """
+        build_json = os.path.join(self.test_workspace, "build.json")
+
+        clean_cmd = ["make", "clean"]
+        out = subprocess.check_output(clean_cmd)
+        print(out)
+
+        # Create and run log command.
+        log_cmd = [self._codechecker_cmd, "log", "-b", "make",
+                   "-o", build_json]
+        out = subprocess.check_output(log_cmd)
+        print(out)
+        # Create and run analyze command.
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "--analyzers", "clangsa", "--verbose", "debug",
+                       "--ignore", "skipfile", "-o", self.report_dir]
+
+        process = subprocess.Popen(
+            analyze_cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=self.test_dir)
+        out, err = process.communicate()
+
+        print(out)
+        print(err)
+        errcode = process.returncode
+        self.assertEquals(errcode, 0)
+
+        # Check if file is skipped.
+        report_dir_files = os.listdir(self.report_dir)
+        for f in report_dir_files:
+            self.assertFalse("file_to_be_skipped.cpp" in f)
+
+        # Check if report from the report file is removed.
+        report_dir_files = os.listdir(self.report_dir)
+        report_file_to_check = None
+        for f in report_dir_files:
+            if "skip_header.cpp" in f:
+                report_file_to_check = os.path.join(self.report_dir, f)
+                break
+
+        self.assertIsNotNone(report_file_to_check,
+                             "Report file should be generated.")
+        report_data = plistlib.readPlist(report_file_to_check)
+        files = report_data['files']
+
+        skiped_file_index = None
+        for i, f in enumerate(files):
+            if "skip.h" in f:
+                skiped_file_index = i
+                break
+
+        for diag in report_data['diagnostics']:
+            self.assertNotEqual(diag['location']['file'],
+                                skiped_file_index,
+                                "Found a location which points to "
+                                "skiped file, this report should "
+                                "have been removed.")

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -230,7 +230,7 @@ def assemble_zip(inputs, zip_file, client):
         source_file_mod_times = {}
         missing_files = []
         try:
-            files, reports = plist_parser.parse_plist(plist_file)
+            files, reports = plist_parser.parse_plist_file(plist_file)
 
             for f in files:
                 if not os.path.isfile(f):

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -459,7 +459,7 @@ def handle_diff_results(args):
                 file_path = os.path.join(reportdir, filename)
                 LOG.debug("Parsing: %s", file_path)
                 try:
-                    files, reports = plist_parser.parse_plist(file_path)
+                    files, reports = plist_parser.parse_plist_file(file_path)
                     for report in reports:
                         path_hash = get_report_path_hash(report, files)
                         if path_hash in processed_path_hashes:

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2288,7 +2288,7 @@ class ThriftRequestHandler(object):
             LOG.debug("Parsing input file '%s'", f)
 
             try:
-                files, reports = plist_parser.parse_plist(
+                files, reports = plist_parser.parse_plist_file(
                     os.path.join(report_dir, f), source_root)
             except Exception as ex:
                 LOG.error('Parsing the plist failed: %s', str(ex))

--- a/web/server/tests/unit/test_plist_parser.py
+++ b/web/server/tests/unit/test_plist_parser.py
@@ -236,7 +236,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
     def test_empty_file(self):
         """Plist file is empty."""
         empty_plist = os.path.join(self.__plist_test_files, 'empty_file')
-        files, reports = plist_parser.parse_plist(empty_plist, None, False)
+        files, reports = plist_parser.parse_plist_file(empty_plist,
+                                                       None,
+                                                       False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -244,7 +246,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """There was no bug in the checked file."""
         no_bug_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7-noerror.plist')
-        files, reports = plist_parser.parse_plist(no_bug_plist, None, False)
+        files, reports = plist_parser.parse_plist_file(no_bug_plist,
+                                                       None,
+                                                       False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -255,7 +259,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang37_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7.plist')
-        files, reports = plist_parser.parse_plist(clang37_plist, None, False)
+        files, reports = plist_parser.parse_plist_file(clang37_plist,
+                                                       None,
+                                                       False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -269,7 +275,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang38_plist = os.path.join(
             self.__plist_test_files, 'clang-3.8-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang38_plist, None, False)
+        files, reports = plist_parser.parse_plist_file(clang38_plist,
+                                                       None,
+                                                       False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -297,7 +305,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang40_plist = os.path.join(
             self.__plist_test_files, 'clang-4.0.plist')
-        files, reports = plist_parser.parse_plist(clang40_plist, None, False)
+        files, reports = plist_parser.parse_plist_file(clang40_plist,
+                                                       None,
+                                                       False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -327,8 +337,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang50_trunk_plist, None,
-                                                  False)
+        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                       None,
+                                                       False)
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
 

--- a/web/server/tests/unit/test_report_path_hash.py
+++ b/web/server/tests/unit/test_report_path_hash.py
@@ -33,8 +33,9 @@ class ReportPathHashHandler(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang50_trunk_plist, None,
-                                                  False)
+        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                       None,
+                                                       False)
         self.assertEqual(len(reports), 3)
 
         # Generate dummy file_ids which should come from the database.

--- a/web/server/tests/unit/test_store_handler.py
+++ b/web/server/tests/unit/test_store_handler.py
@@ -36,8 +36,9 @@ class StoreHandler(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist(clang50_trunk_plist, None,
-                                                  False)
+        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                       None,
+                                                       False)
         self.assertEqual(len(reports), 3)
 
         # Generate dummy file_ids which should come from the database.


### PR DESCRIPTION
The intoduced new plist xml parsing method with lxml
was not introduced for the use cases where the a skip file
was used. In case of a skip file the report plist files
can be rewritten (the reports based on the skip file content)
are removed.

Previous tests did not fail because a second skip is done
at the server side during storage and the server skip tests
worked on the stored reports.