### PR TITLE
[server] Set rowsPerPage attribute to a lower value

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/ListOfBugs.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfBugs.js
@@ -248,7 +248,7 @@ function (declare, dom, style, Deferred, ObjectStore, Store, QueryResults,
       this.store = new ObjectStore({ objectStore : new BugStore() });
       this.escapeHTMLInData = false;
       this.selectionMode = 'single';
-      this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
+      this.rowsPerPage = 50;
       this._lastSelectedRow = 0;
     },
 

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -167,7 +167,7 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
       this.selectable = true;
       this.keepSelection = true;
       this.escapeHTMLInData = false;
-      this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
+      this.rowsPerPage = 50;
 
       this._dialog = new Dialog({
         style : 'max-width: 75%; min-width: 25%'

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -108,7 +108,7 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
       this.selectable = true;
       this.keepSelection = true;
       this.escapeHTMLInData = false;
-      this.rowsPerPage = CC_OBJECTS.MAX_QUERY_SIZE;
+      this.rowsPerPage = 50;
 
       this._dialog = new Dialog({
         style : 'max-width: 75%; min-width: 25%'


### PR DESCRIPTION
`rowsPerPage` attribute of the dojo `DataGrid` controlls how many
pages will be rendered. It is adviced to render only a small subset
(perhaps 25-50) records of the entire dataset. In this commit we will
set this value to `50` so it will increase the performance of the UI.