### PR TITLE
[server] Do not throw an exception when highlighting the bug step

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/BugViewer.js
+++ b/web/server/www/scripts/codecheckerviewer/BugViewer.js
@@ -886,11 +886,9 @@ function (declare, domClass, dom, style, fx, Toggler, keys, on, query, Memory,
 
           highlight.iconOverride = "returning";
         } else {
-          throw {
-            name : 'StackError',
-            message : "Returned from " + func + " while the last function " +
-                      "was " + stack.funcStack[stack.funcStack.length - 1]
-          };
+          console.warn("StackError: Returned from " + func
+            + " while the last function " + "was "
+            + stack.funcStack[stack.funcStack.length - 1]);
         }
       } else if (msg.startsWith("Assuming the condition")) {
         highlight.iconOverride = "assume_switch";


### PR DESCRIPTION
Do not throw an exception when highlighting the bug step at the
Bug Tree view when it is failed to get 'Returning from' item from
the stack just write a warning message to the console.