### PR TITLE
[cli] Gettings results for runs which contain colons

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -803,19 +803,19 @@ usage: CodeChecker cmd results [-h] [--uniqueing {on,off}]
                                [--url PRODUCT_URL]
                                [-o {plaintext,rows,table,csv,json}]
                                [--verbose {info,debug,debug_analyzer}]
-                               RUN_NAMES
+                               RUN_NAMES [RUN_NAMES ...]
 
 Show the individual analysis reports' summary.
 
 positional arguments:
-  RUN_NAME              Names of the analysis runs to show result summaries of.
-                        This has the following format:
-                        <run_name_1>:<run_name_2>:<run_name_3> where run names
-                        can contain * quantifiers which matches any number of
-                        characters (zero or more). So if you have
-                        run_1_a_name, run_2_b_name, run_2_c_name, run_3_d_name
-                        then "run_2*:run_3_d_name" selects the last three runs.
-                        Use 'CodeChecker cmd runs' to get the available runs.
+  RUN_NAMES             Names of the analysis runs to show result summaries
+                        of. This has the following format: <run_name_1>
+                        <run_name_2> <run_name_3> where run names can contain
+                        * quantifiers which matches any number of characters
+                        (zero or more). So if you have run_1_a_name,
+                        run_2_b_name, run_2_c_name, run_3_d_name then "run_2*
+                        run_3_d_name" selects the last three runs. Use
+                        'CodeChecker cmd runs' to get the available runs.
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -829,7 +829,7 @@ optional arguments:
 CodeChecker cmd results my_run
 
 # Get analysis results for multiple runs:
-CodeChecker cmd results "my_run1:my_run2"
+CodeChecker cmd results my_run1 my_run2
 
 # Get analysis results by using regex:
 CodeChecker cmd results "my_run*"

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -321,16 +321,17 @@ def __register_results(parser):
     """
 
     parser.add_argument(type=str,
-                        dest="name",
+                        nargs='+',
+                        dest="names",
                         metavar='RUN_NAMES',
                         help="Names of the analysis runs to show result "
                              "summaries of. This has the following format: "
-                             "<run_name_1>:<run_name_2>:<run_name_3> "
+                             "<run_name_1> <run_name_2> <run_name_3> "
                              "where run names can contain * quantifiers which "
                              "matches any number of characters (zero or "
                              "more). So if you have run_1_a_name, "
                              "run_2_b_name, run_2_c_name, run_3_d_name then "
-                             "\"run_2*:run_3_d_name\" selects the last three "
+                             "\"run_2* run_3_d_name\" selects the last three "
                              "runs. Use 'CodeChecker cmd runs' to get the "
                              "available runs.")
 
@@ -1031,7 +1032,7 @@ Get analysis results for a run:
     CodeChecker cmd results my_run
 
 Get analysis results for multiple runs:
-    CodeChecker cmd results "my_run1:my_run2"
+    CodeChecker cmd results my_run1 my_run2
 
 Get analysis results by using regex:
     CodeChecker cmd results "my_run*"

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -346,8 +346,7 @@ def handle_list_results(args):
 
     client = setup_client(args.product_url)
 
-    run_names = map(lambda x: x.strip(), args.name.split(':'))
-    run_filter = ttypes.RunFilter(names=run_names)
+    run_filter = ttypes.RunFilter(names=args.names)
     run_ids = [run.runId for run in get_run_data(client, run_filter)]
 
     if not run_ids:

--- a/web/tests/functional/cmdline/test_cmdline.py
+++ b/web/tests/functional/cmdline/test_cmdline.py
@@ -131,6 +131,18 @@ class TestCmdline(unittest.TestCase):
         self.assertEqual(0, ret)
         self.assertEqual(1, len(json.loads(res)))
 
+    def test_results_multiple_runs(self):
+        """
+        Test cmd results with multiple run names.
+        """
+        check_env = self._test_config['codechecker_cfg']['check_env']
+
+        res_cmd = [self._codechecker_cmd, 'cmd', 'results', 'test_files1*',
+                   'test_files1*', '-o', 'json', '--url', str(self.server_url)]
+
+        ret, res, _ = run_cmd(res_cmd, env=check_env)
+        self.assertEqual(0, ret)
+
     def test_stderr_results(self):
         """
         Test results command that we redirect logger's output to the stderr if


### PR DESCRIPTION
> Part of #2113

Filtering and getting the results for run names with colon punctuation mark does not work properly. If there is a timestamp in the run name we want to filter "myrun-12:23:12" the punctuation mark will be used as a delimiter of multiple run names even if this is not the case.
For this reason we set the `nargs` option to `+` for the run names option of the `CodeChecker cmd results` subcommand so we will be able to get results for run names which contains colon punctuation marks.

E.g: `CodeChecker cmd results myrun-12:23:12 myrun-22:00:10`