### PR TITLE
exit on missing checker or profile names

### DIFF
--- a/analyzer/codechecker_analyzer/checkers.py
+++ b/analyzer/codechecker_analyzer/checkers.py
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+import re
+
+
+def available(ordered_checkers, available_checkers):
+    """Verify if every element in the ordered checkers a valid checker name.
+
+    Every element in the ordered checkers should match partially
+    a checker or profile name in available_checkers.
+
+    Returns the set of checker names without any match.
+    """
+    missing_checkers = set()
+    for checker in ordered_checkers:
+        checker_name, _ = checker
+        name_match = False
+        for available_checker in available_checkers:
+            regex = "^" + str(checker_name) + ".*$"
+            c_name = available_checker
+            match = re.match(regex, c_name)
+            if match:
+                name_match = True
+                break
+
+        if not name_match:
+            missing_checkers.add(checker_name)
+    return missing_checkers

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -522,3 +522,81 @@ class TestAnalyze(unittest.TestCase):
         self.assertEquals(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
         self.unique_json_helper(unique_json, True, True, True)
+
+    def test_invalid_enabled_checker_name(self):
+        """Exit in case of an invalid enabled checker."""
+        build_json = os.path.join(self.test_workspace, "build_success.json")
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "--analyzers", "clangsa", "-o", self.report_dir,
+                       "-e", "non-existing-checker-name"]
+
+        source_file = os.path.join(self.test_dir, "success.c")
+        build_log = [{"directory": self.test_workspace,
+                      "command": "gcc -c " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w') as outfile:
+            json.dump(build_log, outfile)
+
+        print(analyze_cmd)
+        process = subprocess.Popen(
+            analyze_cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=self.test_dir)
+        out, err = process.communicate()
+
+        errcode = process.returncode
+        self.assertEquals(errcode, 1)
+
+    def test_invalid_disabled_checker_name(self):
+        """Exit in case of an invalid disabled checker."""
+        build_json = os.path.join(self.test_workspace, "build_success.json")
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "--analyzers", "clangsa", "-o", self.report_dir,
+                       "-d", "non-existing-checker-name"]
+
+        source_file = os.path.join(self.test_dir, "success.c")
+        build_log = [{"directory": self.test_workspace,
+                      "command": "gcc -c " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w') as outfile:
+            json.dump(build_log, outfile)
+
+        print(analyze_cmd)
+        process = subprocess.Popen(
+            analyze_cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=self.test_dir)
+        out, err = process.communicate()
+
+        errcode = process.returncode
+        self.assertEquals(errcode, 1)
+
+    def test_multiple_invalid_checker_names(self):
+        """Exit in case of multiple invalid checker names."""
+        build_json = os.path.join(self.test_workspace, "build_success.json")
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "--analyzers", "clangsa", "-o", self.report_dir,
+                       "-e", "non-existing-checker-name",
+                       "-e", "non-existing-checker",
+                       "-d", "missing.checker",
+                       "-d", "other.missing.checker"]
+
+        source_file = os.path.join(self.test_dir, "success.c")
+        build_log = [{"directory": self.test_workspace,
+                      "command": "gcc -c " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w') as outfile:
+            json.dump(build_log, outfile)
+
+        print(analyze_cmd)
+        process = subprocess.Popen(
+            analyze_cmd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=self.test_dir)
+        out, err = process.communicate()
+
+        errcode = process.returncode
+        self.assertEquals(errcode, 1)

--- a/analyzer/tests/unit/test_checkers.py
+++ b/analyzer/tests/unit/test_checkers.py
@@ -1,0 +1,78 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Tests for checker handling."""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import unittest
+
+from codechecker_analyzer.checkers import available
+
+
+class TestCheckers(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        """Initialize a checkers list for the tests."""
+        cls.__available_checkers = {"unix.Malloc",
+                                    "core.DivideZero",
+                                    "core.CallAndMessage",
+                                    "readability-simd",
+                                    "readability-else-after-return"}
+
+    def test_checker_available(self):
+        """Test for available checker."""
+        ordered_checkers = [("unix.Malloc", True),
+                            ("core.DivideZero", False)]
+        missing_checkers = available(ordered_checkers,
+                                     self.__available_checkers)
+        self.assertSetEqual(missing_checkers, set())
+
+    def test_profile_available(self):
+        """Test for available profile."""
+        profile_names = {"extreme", "sensitive"}
+        checkers_with_profiles = self.__available_checkers
+        checkers_with_profiles.update(profile_names)
+        ordered_checkers = [("unix.Malloc", True),
+                            ("core", True),
+                            ("readability", False),
+                            ("sensitive", True),
+                            ("extreme", False)]
+        missing_checkers = available(ordered_checkers,
+                                     checkers_with_profiles)
+        self.assertSetEqual(missing_checkers, set())
+
+    def test_checker_not_available(self):
+        """Test for missing checker."""
+        ordered_checkers = [("unix.Malloc", True),
+                            ("core.VLASize", True),
+                            ("core.DivideZero", True),
+                            ("cppcoreguidelines-avoid-goto", False)]
+
+        missing_checkers = available(ordered_checkers,
+                                     self.__available_checkers)
+
+        self.assertSetEqual(missing_checkers,
+                            {"core.VLASize",
+                             "cppcoreguidelines-avoid-goto"})
+
+    def test_profile_not_available(self):
+        """Test for missing profile."""
+        profile_names = {"extreme", "sensitive"}
+        checkers_with_profiles = self.__available_checkers
+        checkers_with_profiles.update(profile_names)
+        ordered_checkers = [("unix.Malloc", True),
+                            ("core", True),
+                            ("readability", False),
+                            ("sensstive", True),
+                            ("extremee", False)]
+        missing_checkers = available(ordered_checkers,
+                                     checkers_with_profiles)
+        self.assertSetEqual(missing_checkers,
+                            {"extremee", "sensstive"})


### PR DESCRIPTION
It is possible that there is typo in the checker name
or the checker was removed/renamed in a newer clang version.
The analysis starts but the user will not get any results
because there is no checker with that name.
To prevent this exit before the analysis if a checker name is missing.

Every checker argument is checked because it is possible
that multiple checkers are missing or there are multiple typos.