### PR TITLE
encode file content for plistlib

### DIFF
--- a/codechecker_common/plist_parser.py
+++ b/codechecker_common/plist_parser.py
@@ -40,7 +40,8 @@ import math
 import os
 import sys
 import traceback
-from plistlib import PlistParser, writePlist, writePlistToString, readPlist
+from plistlib import PlistParser, writePlist, writePlistToString, \
+    readPlistFromString
 from xml.parsers.expat import ExpatError
 
 from codechecker_common import util
@@ -112,7 +113,8 @@ def parse_plist(plist_file_obj):
     except ImportError:
         LOG.debug("lxml library is not available. Use plistlib to parse plist "
                   "files.")
-        return readPlist(plist_file_obj)
+        return readPlistFromString(
+            plist_file_obj.read().encode('utf8', errors='ignore'))
 
 
 def get_checker_name(diagnostic, path=""):


### PR DESCRIPTION
In case of fallback to the builtin plistlib.
In python2 can not handle file objects opened
with io which return the content of a file in unicode on read().

To fix this we read and encode the file content before parsing
by the plistlib.