### PR TITLE
use the environment from context for ctu detection

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -314,7 +314,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def construct_config_handler(cls, args, context):
-        handler = config_handler.ClangSAConfigHandler()
+
+        environ = env.extend(context.path_env_extra,
+                             context.ld_lib_path_extra)
+
+        handler = config_handler.ClangSAConfigHandler(environ)
         handler.analyzer_plugins_dir = context.checker_plugin
         handler.analyzer_binary = context.analyzer_binaries.get(
             cls.ANALYZER_NAME)
@@ -323,9 +327,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
         handler.report_hash = args.report_hash \
             if 'report_hash' in args else None
-
-        environ = env.extend(context.path_env_extra,
-                             context.ld_lib_path_extra)
 
         handler.enable_z3 = 'enable_z3' in args and args.enable_z3
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -24,7 +24,7 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
     Configuration handler for the clang static analyzer.
     """
 
-    def __init__(self):
+    def __init__(self, environ):
         super(ClangSAConfigHandler, self).__init__()
         self.__checker_configs = []
         self.ctu_dir = ''
@@ -33,6 +33,7 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
         self.ld_lib_path_extra = ''
         self.enable_z3 = False
         self.enable_z3_refutation = False
+        self.environ = environ
 
     def add_checker_config(self, config):
         """
@@ -42,4 +43,4 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
 
     @property
     def ctu_capability(self):
-        return CTUAutodetection(self.analyzer_binary)
+        return CTUAutodetection(self.analyzer_binary, self.environ)

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
@@ -20,10 +20,11 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('analyzer.clangsa')
 
 
-def test_binary_existence(tool_path):
+def test_binary_existence(tool_path, environ):
     """ Test the executable for existence by checking its version. """
     try:
-        version = subprocess.check_output([tool_path, '-version'])
+        version = subprocess.check_output([tool_path, '-version'],
+                                          env=environ)
     except (subprocess.CalledProcessError, OSError):
         version = 'ERROR'
     return version != 'ERROR'
@@ -156,9 +157,10 @@ class CTUAutodetection(object):
     name.
     """
 
-    def __init__(self, analyzer_binary):
+    def __init__(self, analyzer_binary, environ):
         self.__analyzer_binary = analyzer_binary
         self.__analyzer_version_info = None
+        self.environ = environ
         self.parser = ClangVersionInfoParser()
 
     @property
@@ -176,7 +178,7 @@ class CTUAutodetection(object):
 
         try:
             analyzer_output = subprocess.check_output(
-                [self.__analyzer_binary, '--version'])
+                [self.__analyzer_binary, '--version'], env=self.environ)
         except (subprocess.CalledProcessError, OSError):
             return False
 
@@ -267,4 +269,4 @@ class CTUAutodetection(object):
         if not tool_path:
             return False
 
-        return test_binary_existence(tool_path)
+        return test_binary_existence(tool_path, self.environ)


### PR DESCRIPTION
It is possible that environment variables (LD_LIBRARY_PATH) required
for clang are modified/extended in the environment built from the
context. If not the same environment is used running the
other tools to detect additional analyzer features might fail.