### PR TITLE
[doc] Fix documentation links in the web userguide

### DIFF
--- a/web/server/www/userguide/userguide.md
+++ b/web/server/www/userguide/userguide.md
@@ -222,7 +222,7 @@ select the reports on the given severity levels.
 bug reports. In this field you can choose the date of detection or fixing.
 - **File path**: You can choose a set of files to restrict the list of bug
 reports.
-- [**Source component**](https://github.com/Ericsson/codechecker/blob/master/docs/user_guide.md#source-components) -
+- [**Source component**](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#source-components) -
 Here you can select multiple source components which are named collection of
 directories specified as directory filter.
 - **Checker name** - If you are interested in specific type of bugs then here
@@ -289,7 +289,7 @@ Reports can be assigned a review status of the following values:
 This is really a bug.
 - <span class="customIcon review-status-false-positive"></span>
 **False positive**: This is not a bug. Before marking a bug false positive
-you should read the [false positive how to](https://github.com/Ericsson/codechecker/blob/master/docs/false_positives.md).
+you should read the [false positive how to](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/false_positives.md).
 - <span class="customIcon review-status-intentional"></span> **Intentional**:
 This report is a bug but we don't want to fix it.
 


### PR DESCRIPTION
> Closes #2096 

In the web user guide there were some broken links to the other user
guides after the repository and documentation split. With this commit
we fix these broken links.