### PR TITLE
ctu display progress flag changed in clang8

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -61,8 +61,8 @@ def is_z3_capable(context):
     check_supported_analyzers([ClangSA.ANALYZER_NAME], context)
     analyzer_binary = context.analyzer_binaries.get(ClangSA.ANALYZER_NAME)
 
-    return host_check.has_analyzer_feature(analyzer_binary,
-                                           '-analyzer-constraints=z3')
+    return host_check.has_analyzer_option(analyzer_binary,
+                                          ['-analyzer-constraints=z3'])
 
 
 def check_supported_analyzers(analyzers, context):

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -205,9 +205,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                      'experimental-enable-naive-ctu-analysis=true',
                      '-Xclang', '-analyzer-config', '-Xclang',
                      'ctu-dir=' + self.get_ctu_dir()])
-                if config.ctu_has_analyzer_display_ctu_progress:
-                    analyzer_cmd.extend(['-Xclang',
-                                         '-analyzer-display-ctu-progress'])
+                ctu_display_progress = config.ctu_capability.display_progress
+                if ctu_display_progress:
+                    analyzer_cmd.extend(ctu_display_progress)
 
             def has_flag(flag):
                 return bool(next((x for x in analyzer_cmd if
@@ -261,7 +261,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             return set()
 
         regex_for_ctu_ast_load = re.compile(
-            r"ANALYZE \(CTU loaded AST for source file\): (.*)")
+            r"CTU loaded AST file: (.*).ast")
 
         paths = set()
 
@@ -337,11 +337,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             handler.ctu_dir = os.path.join(args.output_path,
                                            args.ctu_dir)
 
-            handler.ctu_has_analyzer_display_ctu_progress = \
-                host_check.has_analyzer_feature(
-                    context.analyzer_binaries.get(cls.ANALYZER_NAME),
-                    '-analyzer-display-ctu-progress',
-                    environ)
             handler.log_file = args.logfile
             handler.path_env_extra = context.path_env_extra
             handler.ld_lib_path_extra = context.ld_lib_path_extra

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
@@ -16,6 +16,7 @@ import re
 import subprocess
 
 from codechecker_common.logger import get_logger
+from codechecker_analyzer import host_check
 
 LOG = get_logger('analyzer.clangsa')
 
@@ -245,6 +246,28 @@ class CTUAutodetection(object):
             return postfixed_tool_path
 
         return False
+
+    @property
+    def display_progress(self):
+        """Return analyzer args if it is capable to display ctu progress.
+
+        Returns None if the analyzer can not display ctu progress.
+        The ctu display progress arguments depend on
+        the clang analyzer version.
+        """
+
+        if not self.analyzer_version_info:
+            return None
+        ctu_display_progress_args = ['-Xclang',
+                                     '-analyzer-config',
+                                     '-Xclang',
+                                     'display-ctu-progress=true']
+
+        ok = host_check.has_analyzer_config_option(
+            self.__analyzer_binary, "display-ctu-progress", self.environ)
+        if not ok:
+            return None
+        return ctu_display_progress_args
 
     @property
     def mapping_file_name(self):

--- a/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
@@ -53,9 +53,11 @@ class TestCtuFailure(unittest.TestCase):
         print("'analyze' reported CTU-compatibility? " + str(self.ctu_capable))
 
         self.ctu_has_analyzer_display_ctu_progress = \
-            host_check.has_analyzer_feature(self.__getClangSaPath(),
-                                            '-analyzer-display-ctu-progress')
-        print("Has -analyzer-display-ctu-progress? " +
+            host_check.has_analyzer_config_option(self.__getClangSaPath(),
+                                                  'display-ctu-progress',
+                                                  self.env)
+
+        print("Has display-ctu-progress=true? " +
               str(self.ctu_has_analyzer_display_ctu_progress))
 
         # Fix the "template" build JSONs to contain a proper directory
@@ -89,7 +91,7 @@ class TestCtuFailure(unittest.TestCase):
 
         output = self.__do_ctu_all(reparse=False,
                                    extra_args=["--verbose", "debug"])
-        self.assertIn("ANALYZE (CTU loaded AST for source file)", output)
+        self.assertIn("CTU loaded AST file", output)
 
     def test_ctu_failure_zip(self):
         """ Test the failure zip contains the source of imported TU
@@ -109,9 +111,7 @@ class TestCtuFailure(unittest.TestCase):
                                    ])
 
         # lib.c should be logged as its AST is loaded by Clang
-        self.assertRegexpMatches(
-                output,
-                r"ANALYZE \(CTU loaded AST for source file\): .*lib\.c")
+        self.assertRegexpMatches(output, r"CTU loaded AST file: .*lib\.c.ast")
 
         # We expect a failure archive to be in the failed directory.
         failed_dir = os.path.join(self.report_dir, "failed")
@@ -162,9 +162,7 @@ class TestCtuFailure(unittest.TestCase):
                                    ])
 
         # lib.c should be logged as its AST is loaded by Clang
-        self.assertRegexpMatches(
-                output,
-                r"ANALYZE \(CTU loaded AST for source file\): .*lib\.c")
+        self.assertRegexpMatches(output, r"CTU loaded AST file: .*lib\.c.ast")
 
         # We expect a failure archive to be in the failed directory.
         failed_dir = os.path.join(self.report_dir, "failed")
@@ -213,9 +211,7 @@ class TestCtuFailure(unittest.TestCase):
                                    ])
 
         # lib.c should be logged as its AST is loaded by Clang
-        self.assertRegexpMatches(
-                output,
-                r"ANALYZE \(CTU loaded AST for source file\): .*lib\.c")
+        self.assertRegexpMatches(output, r"CTU loaded AST file: .*lib\.c.ast")
 
         # We expect two failure archives to be in the failed directory.
         # One failure archive is produced by the CTU analysis and the

--- a/analyzer/tests/functional/host_check/test_host_check.py
+++ b/analyzer/tests/functional/host_check/test_host_check.py
@@ -15,20 +15,30 @@ import unittest
 import codechecker_analyzer.host_check as hc
 
 
-class Test_has_analyzer_feature(unittest.TestCase):
-    def test_existing_feature(self):
+class Test_has_analyzer_option(unittest.TestCase):
+    def test_existing_option(self):
         self.assertEqual(
-            hc.has_analyzer_feature("clang",
-                                    "-analyzer-display-progress"),
+            hc.has_analyzer_option("clang",
+                                   ["-analyzer-display-progress"]),
             True)
 
-    def test_non_existing_feature(self):
+    def test_non_existing_option(self):
         self.assertEqual(
-            hc.has_analyzer_feature("clang",
-                                    "-non-existent-feature"),
+            hc.has_analyzer_option("clang",
+                                   ["-non-existent-feature"]),
             False)
 
-    def test_non_existent_binary_throws(self):
+    def test_non_existent_option_binary_throws(self):
         with self.assertRaises(OSError):
-            hc.has_analyzer_feature("non-existent-binary-Yg4pEna5P7",
-                                    "")
+            hc.has_analyzer_option("non-existent-binary-Yg4pEna5P7",
+                                   [""])
+
+    def test_non_existing_congif_option(self):
+        self.assertEqual(
+            hc.has_analyzer_config_option("clang",
+                                          "non-existent-config-option"),
+            False)
+
+    def test_non_existent_config_option_binary(self):
+        with self.assertRaises(OSError):
+            hc.has_analyzer_config_option("non-existent-binary-Yg4pEna5P7", "")


### PR DESCRIPTION
The ctu-display-progress flag did change in clang8.
The argument is turned on in case of ctu failure to
collect the source files used by ctu for analysis.

Not just the flag but the analyzer output format did
changed in clang8 too.