### PR TITLE
[server] Refactoring review status change permission check

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1261,8 +1261,6 @@ class ThriftRequestHandler(object):
         a session parameter which represents a database transaction. This is
         needed because during storage a specific session object has to be used.
         """
-        self.__require_permission([permissions.PRODUCT_ACCESS,
-                                   permissions.PRODUCT_STORE])
         report = session.query(Report).get(report_id)
         if report:
             review_status = session.query(ReviewStatus).get(report.bug_id)
@@ -1302,6 +1300,9 @@ class ThriftRequestHandler(object):
         """
         Change review status of the bug by report id.
         """
+        self.__require_permission([permissions.PRODUCT_ACCESS,
+                                   permissions.PRODUCT_STORE])
+
         if self.isReviewStatusChangeDisabled():
             msg = "Review status change is disabled!"
             raise shared.ttypes.RequestFailed(


### PR DESCRIPTION
Previously in the `_setReviewStatus` function we checked the required permissions. The problem was here that this function was called multiple times in the `__store_reports` function which was called by the `massStoreRun` function but this was unnecessary because we already checked the required permissions in the `massStoreRun` function.

The `_setReviewStatus` function is also called in the `changeReviewStatus` so now we check the required permissions in the begining of this function too.