### PR TITLE
[web] Refactoring source code comment handler

### DIFF
--- a/codechecker_common/plist_parser.py
+++ b/codechecker_common/plist_parser.py
@@ -354,10 +354,11 @@ def skip_report(report_hash, source_file, report_line, checker_name,
                   report_line, checker_name, report_hash)
         return True
 
-    sc_handler = SourceCodeCommentHandler(source_file)
+    sc_handler = SourceCodeCommentHandler()
 
     # Check for source code comment.
     src_comment_data = sc_handler.filter_source_line_comments(
+        source_file,
         report_line,
         checker_name)
 

--- a/codechecker_common/source_code_comment_handler.py
+++ b/codechecker_common/source_code_comment_handler.py
@@ -84,9 +84,6 @@ class SourceCodeCommentHandler(object):
         'codechecker_intentional',
         'codechecker_confirmed']
 
-    def __init__(self, source_file):
-        self.__source_file = source_file
-
     @staticmethod
     def __check_if_comment(source_line):
         """
@@ -172,21 +169,20 @@ class SourceCodeCommentHandler(object):
                     'message': message,
                     'status': review_status}
 
-    def has_source_line_comments(self, line):
+    def has_source_line_comments(self, source_file, line):
         """
         Return True if there is any source code comment or False if not.
         """
-        comments = self.get_source_line_comments(line)
+        comments = self.get_source_line_comments(source_file, line)
         return len(comments)
 
-    def get_source_line_comments(self, bug_line):
+    def get_source_line_comments(self, source_file, bug_line):
         """
         This function returns the available preprocessed source code comments
         for a bug line.
         """
-        source_file = self.__source_file
         LOG.debug("Checking for source code comments in the source file '%s'"
-                  "at line %s", self.__source_file, bug_line)
+                  "at line %s", source_file, bug_line)
 
         previous_line_num = bug_line - 1
 
@@ -266,7 +262,7 @@ class SourceCodeCommentHandler(object):
 
         return source_line_comments
 
-    def filter_source_line_comments(self, bug_line, checker_name):
+    def filter_source_line_comments(self, source_file, bug_line, checker_name):
         """
         This function filters the available source code comments for bug line
         by the checker name and returns a list of source code comments.
@@ -293,7 +289,8 @@ class SourceCodeCommentHandler(object):
                  comment1 */
 
         """
-        source_line_comments = self.get_source_line_comments(bug_line)
+        source_line_comments = self.get_source_line_comments(source_file,
+                                                             bug_line)
 
         if not source_line_comments:
             return []
@@ -320,7 +317,7 @@ class SourceCodeCommentHandler(object):
         elif len(checker_name_comments) > 1:
             LOG.debug("Multiple source code comment can be found for '%s' "
                       "checker in '%s' at line %s.", checker_name,
-                      self.__source_file, bug_line)
+                      source_file, bug_line)
             LOG.debug(checker_name_comments)
         else:
             LOG.debug("The following source code comment is found for"

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -229,6 +229,8 @@ def assemble_zip(inputs, zip_file, client):
         """
         source_file_mod_times = {}
         missing_files = []
+        sc_handler = SourceCodeCommentHandler()
+
         try:
             files, reports = plist_parser.parse_plist_file(plist_file)
 
@@ -255,8 +257,7 @@ def assemble_zip(inputs, zip_file, client):
                     continue
 
                 report_line = last_report_event['location']['line']
-                sc_handler = SourceCodeCommentHandler(file_path)
-                if sc_handler.has_source_line_comments(report_line):
+                if sc_handler.has_source_line_comments(file_path, report_line):
                     file_hash_with_review_status.add(file_hash)
 
             return missing_files, source_file_mod_times

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -548,14 +548,16 @@ def handle_diff_results(args):
         Returns suppressed reports.
         """
         suppressed_in_code = []
+        sc_handler = SourceCodeCommentHandler()
+
         for rep in reports:
             bughash = rep.report_hash
             source_file = rep.main['location']['file_name']
             bug_line = rep.main['location']['line']
             checker_name = rep.main['check_name']
 
-            sc_handler = SourceCodeCommentHandler(source_file)
             src_comment_data = sc_handler.filter_source_line_comments(
+                source_file,
                 bug_line,
                 checker_name)
 

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2289,6 +2289,8 @@ class ThriftRequestHandler(object):
             return not checker_name.startswith('clang-diagnostic-') and \
                 enabled_checkers and checker_name not in enabled_checkers
 
+        sc_handler = SourceCodeCommentHandler()
+
         # Processing PList files.
         _, _, report_files = next(os.walk(report_dir), ([], [], []))
         for f in report_files:
@@ -2367,12 +2369,11 @@ class ThriftRequestHandler(object):
                     os.path.join(source_root, file_name.strip("/")))
 
                 if os.path.isfile(source_file_name):
-                    sc_handler = SourceCodeCommentHandler(source_file_name)
-
                     report_line = last_report_event['location']['line']
                     source_file = os.path.basename(file_name)
 
                     src_comment_data = sc_handler.filter_source_line_comments(
+                        source_file_name,
                         report_line,
                         checker_name)
 

--- a/web/server/tests/unit/test_source_code_comment.py
+++ b/web/server/tests/unit/test_source_code_comment.py
@@ -34,31 +34,37 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_src_comment_first_line(self):
         """Bug is reported for the first line."""
         bug_line = 3
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertFalse(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 0)
 
     def test_no_comment(self):
         """There is no comment above the bug line."""
         bug_line = 9
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertFalse(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 0)
 
     def test_no_src_comment_comment(self):
         """There is no source comment above the bug line."""
         bug_line = 16
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -69,11 +75,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_multi_liner_all(self):
         """There is source code comment above the bug line."""
         bug_line = 23
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -84,11 +92,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_one_liner_all(self):
         """There is source code comment above the bug line."""
         bug_line = 29
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my_checker_1', 'my_checker_2'},
@@ -99,11 +109,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_multi_liner_all_2(self):
         """There is source code comment above the bug line."""
         bug_line = 36
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my.checker_1', 'my.checker_2'},
@@ -114,11 +126,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_one_liner_some_checkers(self):
         """There is source code comment above the bug line."""
         bug_line = 43
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my.Checker_1', 'my.Checker_2'},
@@ -129,21 +143,25 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_multi_liner_some_checkers(self):
         """There is source code comment above the bug line."""
         bug_line = 50
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertFalse(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 0)
 
     def test_comment_characters(self):
         """Check for different special comment characters."""
         bug_line = 57
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my.checker_1', 'my.checker_2'},
@@ -154,11 +172,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_fancy_comment_characters(self):
         """Check fancy comment."""
         bug_line = 64
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my_checker_1'},
@@ -169,11 +189,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_no_fancy_comment(self):
         """Check no fancy comment."""
         bug_line = 70
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_1, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my_checker_1'},
@@ -184,21 +206,25 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_malformed_commment_format(self):
         """Check malformed comment."""
         bug_line = 1
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_2)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_2,
+                                                  bug_line)
         self.assertFalse(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_2, bug_line)
         self.assertEqual(len(source_line_comments), 0)
 
     def test_source_code_comment(self):
         """Check source code comment."""
         bug_line = 2
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -209,11 +235,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_false_positive_comment(self):
         """Check False positive comment."""
         bug_line = 7
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -224,11 +252,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_intentional_comment(self):
         """Check Intentional comment."""
         bug_line = 12
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -239,11 +269,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_confirmed_comment(self):
         """Check Confirmed comment."""
         bug_line = 17
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'all'},
@@ -254,11 +286,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_multiple_comments(self):
         """Check multiple comment."""
         bug_line = 23
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 2)
 
         expected = [{
@@ -275,7 +309,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertDictEqual(expected[1], source_line_comments[1])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_1')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_1')
         self.assertEqual(len(current_line_comments), 1)
         self.assertEqual(current_line_comments[0]['message'],
                          expected[0]['message'])
@@ -283,7 +319,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[0]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_2')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_2')
         self.assertEqual(len(current_line_comments), 1)
 
         self.assertEqual(current_line_comments[0]['message'],
@@ -292,17 +330,21 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.dummy')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.dummy')
         self.assertEqual(len(current_line_comments), 0)
 
     def test_multiple_multi_line_comments(self):
         """Check multi line long line comments."""
         bug_line = 31
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 2)
 
         expected = [{
@@ -321,11 +363,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
     def test_multiple_all_comments(self):
         """Check multiple comment."""
         bug_line = 37
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
-        source_line_comments = sc_handler.get_source_line_comments(bug_line)
+        source_line_comments = \
+            sc_handler.get_source_line_comments(self.__tmp_srcfile_3, bug_line)
         self.assertEqual(len(source_line_comments), 2)
 
         expected = [{
@@ -342,7 +386,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertDictEqual(expected[1], source_line_comments[1])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_1')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_1')
         self.assertEqual(len(current_line_comments), 1)
 
         self.assertEqual(current_line_comments[0]['message'],
@@ -351,7 +397,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[0]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, '')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   '')
         self.assertEqual(len(current_line_comments), 1)
         self.assertEqual(current_line_comments[0]['message'],
                          expected[1]['message'])
@@ -359,7 +407,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.dummy')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.dummy')
         self.assertEqual(len(current_line_comments), 1)
 
         self.assertEqual(len(current_line_comments), 1)
@@ -375,11 +425,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 43
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_3,
             bug_line)
         self.assertEqual(len(source_line_comments), 2)
 
@@ -398,7 +450,8 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertDictEqual(expected[1], source_line_comments[1])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line,
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
                                                    'my.checker_1')
         self.assertEqual(len(current_line_comments), 2)
 
@@ -409,11 +462,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 76
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_1,
             bug_line)
 
         for l in source_line_comments:
@@ -438,11 +493,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 83
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_1,
             bug_line)
 
         for l in source_line_comments:
@@ -466,11 +523,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 89
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_1,
             bug_line)
 
         for l in source_line_comments:
@@ -498,11 +557,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 98
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_1,
             bug_line)
 
         for l in source_line_comments:
@@ -533,11 +594,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 108
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_1)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_1,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_1,
             bug_line)
 
         for l in source_line_comments:
@@ -564,11 +627,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 49
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_3,
             bug_line)
 
         for l in source_line_comments:
@@ -590,7 +655,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertDictEqual(expected[1], source_line_comments[1])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_1')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_1')
         self.assertEqual(len(current_line_comments), 2)
         self.assertEqual(current_line_comments[0]['message'],
                          expected[0]['message'])
@@ -602,7 +669,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_2')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_2')
         self.assertEqual(len(current_line_comments), 1)
 
         self.assertEqual(current_line_comments[0]['message'],
@@ -611,7 +680,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.dummy')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.dummy')
         self.assertEqual(len(current_line_comments), 0)
 
     def test_cstyle_multi_comment_multi_line_long(self):
@@ -629,11 +700,13 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         """
 
         bug_line = 60
-        sc_handler = SourceCodeCommentHandler(self.__tmp_srcfile_3)
-        res = sc_handler.has_source_line_comments(bug_line)
+        sc_handler = SourceCodeCommentHandler()
+        res = sc_handler.has_source_line_comments(self.__tmp_srcfile_3,
+                                                  bug_line)
         self.assertTrue(res)
 
         source_line_comments = sc_handler.get_source_line_comments(
+            self.__tmp_srcfile_3,
             bug_line)
 
         for l in source_line_comments:
@@ -655,7 +728,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertDictEqual(expected[1], source_line_comments[1])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_1')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_1')
         self.assertEqual(len(current_line_comments), 2)
         self.assertEqual(current_line_comments[0]['message'],
                          expected[0]['message'])
@@ -667,7 +742,9 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.checker_2')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.checker_2')
         self.assertEqual(len(current_line_comments), 1)
 
         self.assertEqual(current_line_comments[0]['message'],
@@ -676,5 +753,7 @@ class SourceCodeCommentTestCase(unittest.TestCase):
                          expected[1]['status'])
 
         current_line_comments = \
-            sc_handler.filter_source_line_comments(bug_line, 'my.dummy')
+            sc_handler.filter_source_line_comments(self.__tmp_srcfile_3,
+                                                   bug_line,
+                                                   'my.dummy')
         self.assertEqual(len(current_line_comments), 0)


### PR DESCRIPTION
`SourceCodeCommentHandler` object was created multiple times when iterating over reports because we had to pass the source file path to the constructor. With this patch we refactored the `SourceCodeCommentHandler` class to pass the source file name for each function which are require it so there is no need to create new object so many times.