### PR TITLE
[web] Send plist in json format to the server

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -480,7 +480,8 @@ def handle_diff_results(args):
                 file_path = os.path.join(reportdir, filename)
                 LOG.debug("Parsing: %s", file_path)
                 try:
-                    files, reports = plist_parser.parse_plist_file(file_path)
+                    files, reports, _ = \
+                        plist_parser.parse_plist_file(file_path)
                     for report in reports:
                         path_hash = get_report_path_hash(report, files)
                         if path_hash in processed_path_hashes:

--- a/web/server/tests/unit/test_plist_parser.py
+++ b/web/server/tests/unit/test_plist_parser.py
@@ -236,9 +236,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
     def test_empty_file(self):
         """Plist file is empty."""
         empty_plist = os.path.join(self.__plist_test_files, 'empty_file')
-        files, reports = plist_parser.parse_plist_file(empty_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(empty_plist,
+                                                          None,
+                                                          False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -246,9 +246,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """There was no bug in the checked file."""
         no_bug_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7-noerror.plist')
-        files, reports = plist_parser.parse_plist_file(no_bug_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(no_bug_plist,
+                                                          None,
+                                                          False)
         self.assertEquals(files, [])
         self.assertEquals(reports, [])
 
@@ -259,9 +259,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang37_plist = os.path.join(
             self.__plist_test_files, 'clang-3.7.plist')
-        files, reports = plist_parser.parse_plist_file(clang37_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang37_plist,
+                                                          None,
+                                                          False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -275,9 +275,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang38_plist = os.path.join(
             self.__plist_test_files, 'clang-3.8-trunk.plist')
-        files, reports = plist_parser.parse_plist_file(clang38_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang38_plist,
+                                                          None,
+                                                          False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -305,9 +305,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang40_plist = os.path.join(
             self.__plist_test_files, 'clang-4.0.plist')
-        files, reports = plist_parser.parse_plist_file(clang40_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang40_plist,
+                                                          None,
+                                                          False)
 
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
@@ -337,9 +337,9 @@ class PlistParserTestCaseNose(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                          None,
+                                                          False)
         self.assertEquals(files, self.__found_file_names)
         self.assertEquals(len(reports), 3)
 

--- a/web/server/tests/unit/test_report_path_hash.py
+++ b/web/server/tests/unit/test_report_path_hash.py
@@ -33,9 +33,9 @@ class ReportPathHashHandler(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                          None,
+                                                          False)
         self.assertEqual(len(reports), 3)
 
         # Generate dummy file_ids which should come from the database.

--- a/web/server/tests/unit/test_store_handler.py
+++ b/web/server/tests/unit/test_store_handler.py
@@ -36,9 +36,9 @@ class StoreHandler(unittest.TestCase):
         """
         clang50_trunk_plist = os.path.join(
             self.__plist_test_files, 'clang-5.0-trunk.plist')
-        files, reports = plist_parser.parse_plist_file(clang50_trunk_plist,
-                                                       None,
-                                                       False)
+        files, reports, _ = plist_parser.parse_plist_file(clang50_trunk_plist,
+                                                          None,
+                                                          False)
         self.assertEqual(len(reports), 3)
 
         # Generate dummy file_ids which should come from the database.


### PR DESCRIPTION
We are parsing plist files on the client and the server side when storing analyzer results. The performance of parsing a plist file is really bad so if the user analyzed a large project which generated a lot of plist files parsing these files will take a long time.

With this commit we will reduce the overhead of the servers by creating json files from the plist file and sending these files to the server. Loading a json file will be much better then loading and parsing a plist file.