### PR TITLE
[server] Fix reading worker_processes config value

### DIFF
--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -53,10 +53,10 @@ def get_worker_processes(scfg_dict, default=10):
     """
     Return number of worker processes from the config dictionary.
 
-    Return 'worker_process' field from the config dictionary or returns the
+    Return 'worker_processes' field from the config dictionary or returns the
     default value if this field is not set or the value is negative.
     """
-    worker_processes = scfg_dict.get('worker_process', default)
+    worker_processes = scfg_dict.get('worker_processes', default)
 
     if worker_processes < 0:
         LOG.warning("Number of worker processes can not be negative! Default "
@@ -180,7 +180,7 @@ class SessionManager(object):
         # so it should NOT be handled by session_manager. A separate config
         # handler for the server's stuff should be created, that can properly
         # instantiate SessionManager with the found configuration.
-        self.__worker_process = get_worker_processes(scfg_dict)
+        self.__worker_processes = get_worker_processes(scfg_dict)
         self.__max_run_count = scfg_dict.get('max_run_count', None)
         self.__store_config = scfg_dict.get('store', {})
         self.__auth_config = scfg_dict['authentication']
@@ -310,7 +310,7 @@ class SessionManager(object):
 
     @property
     def worker_processes(self):
-        return self.__worker_process
+        return self.__worker_processes
 
     def get_realm(self):
         return {


### PR DESCRIPTION
We are using `worker_processes` config key name in the template
`server_config.json` file and in the documentations but we have
tried to get the value of this key with the `worker_process` key
name. This commit fixes this problem.