### PR TITLE
Distinguish reports of different checkers

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -151,7 +151,7 @@ class PlistToPlaintextFormatter(object):
                                     key=lambda r: r.main['location']['line'])
 
             for report in sorted_reports:
-                path_hash = get_report_path_hash(report.bug_path, report.files)
+                path_hash = get_report_path_hash(report)
                 if path_hash in self._processed_path_hashes:
                     LOG.debug("Not showing report because it is a "
                               "deduplication of an already processed report!")
@@ -609,7 +609,7 @@ def main(args):
         comments.
         """
         report = Report(None, diag['path'], files)
-        path_hash = get_report_path_hash(report.bug_path, files)
+        path_hash = get_report_path_hash(report)
         if path_hash in processed_path_hashes:
             LOG.debug("Skip report because it is a deduplication of an "
                       "already processed report!")
@@ -617,13 +617,13 @@ def main(args):
             LOG.debug(diag)
             return True
 
-        skip = skip_report(report_hash,
-                           source_file,
-                           report_line,
-                           checker_name,
-                           suppr_handler)
-        if skip_handler:
-            skip |= skip_handler.should_skip(source_file)
+        skip = plist_parser.skip_report(report_hash,
+                                        source_file,
+                                        report_line,
+                                        checker_name,
+                                        suppr_handler)
+        if skip_handler and not skip:
+            skip = skip_handler.should_skip(source_file)
 
         if not skip:
             processed_path_hashes.add(path_hash)

--- a/codechecker_common/report.py
+++ b/codechecker_common/report.py
@@ -43,6 +43,10 @@ class Report(object):
         return self.__main['issue_hash_content_of_line_in_context']
 
     @property
+    def check_name(self):
+        return self.__main['check_name']
+
+    @property
     def bug_path(self):
         return self.__bug_path
 

--- a/tools/codechecker_report_hash/codechecker_report_hash/hash.py
+++ b/tools/codechecker_report_hash/codechecker_report_hash/hash.py
@@ -270,25 +270,27 @@ def get_report_hash(diag, file_path, hash_type):
         raise Exception("Invalid report hash type: " + str(hash_type))
 
 
-def get_report_path_hash(bug_path, files):
+def get_report_path_hash(report):
     """ Returns path hash for the given bug path.
 
     This can be used to filter deduplications of multiple reports.
     """
     report_path_hash = ''
-    events = [i for i in bug_path if i.get('kind') == 'event']
+    events = [i for i in report.bug_path if i.get('kind') == 'event']
 
     for event in events:
-        file_name = os.path.basename(files[event['location']['file']])
+        file_name = os.path.basename(report.files[event['location']['file']])
         line = str(event['location']['line']) if 'location' in event else 0
         col = str(event['location']['col']) if 'location' in event else 0
 
         report_path_hash += line + '|' + col + '|' + event['message'] + \
             file_name
 
+    report_path_hash += report.check_name
+
     if not report_path_hash:
         LOG.error('Failed to generate report path hash!')
-        LOG.error(bug_path)
+        LOG.error(report.bug_path)
 
     LOG.debug(report_path_hash)
     return __str_to_hash(report_path_hash)

--- a/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
+++ b/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
@@ -11,6 +11,7 @@ import plistlib
 import unittest
 import shutil
 import tempfile
+from collections import namedtuple
 
 from codechecker_report_hash.hash import get_report_hash, \
     get_report_path_hash, HashType, replace_report_hash
@@ -92,15 +93,15 @@ class CodeCheckerReportHashTest(unittest.TestCase):
 
         expected_path_hash = {
             'f48840093ef89e291fb68a95a5181612':
-                'a92b18ee6ee267cd82d0f056ef2bbe4b',
+                '93cb93bdcee10434f9cf9f486947c88e',
             'e4907182b363faf2ec905fc32cc5a4ab':
-                '2b010e31810074749d485f1db8e419e9'}
+                '71a4dc24bf88af2b13be83d8d15bd6f0'}
 
-        files = plist['files']
         for diag in plist['diagnostics']:
-            file_path = files[diag['location']['file']]
-            path_hash = get_report_path_hash(diag['path'],
-                                             file_path)
+            diag['bug_path'] = diag['path']
+            diag['files'] = plist['files']
+            path_hash = get_report_path_hash(
+                    namedtuple('Report', diag.keys())(*diag.values()))
             actual_report_hash = diag['issue_hash_content_of_line_in_context']
             self.assertEqual(path_hash,
                              expected_path_hash[actual_report_hash])

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -550,8 +550,7 @@ def handle_diff_results(args):
                     LOG.debug("Parsing: %s", file_path)
                     files, reports = plist_parser.parse_plist_file(file_path)
                     for report in reports:
-                        path_hash = get_report_path_hash(report.bug_path,
-                                                         files)
+                        path_hash = get_report_path_hash(report)
                         if path_hash in processed_path_hashes:
                             LOG.debug("Not showing report because it is a "
                                       "deduplication of an already processed "

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2538,7 +2538,7 @@ class ThriftRequestHandler(object):
                 bug_paths, bug_events, bug_extended_data = \
                     store_handler.collect_paths_events(report, file_ids,
                                                        files)
-                report_path_hash = get_report_path_hash(report.bug_path, files)
+                report_path_hash = get_report_path_hash(report)
                 if report_path_hash in already_added:
                     LOG.debug('Not storing report. Already added')
                     LOG.debug(report)

--- a/web/server/tests/unit/test_report_path_hash.py
+++ b/web/server/tests/unit/test_report_path_hash.py
@@ -46,14 +46,14 @@ class ReportPathHashHandler(unittest.TestCase):
 
         report_hash_to_path_hash = {
             '79e31a6ba028f0b7d9779faf4a6cb9cf':
-                'c473c1a55df72ea4c6e055e18370ac65',
+                'acb1d3dc1459f681bd3c743e6c015b37',
             '8714f42d8328bc78d5d7bff6ced918cc':
-                '94f2a6eee8af6462a810218dff35056a',
+                'dcaaf2905d607a16e3fa330edb8e9f89',
             'a6d3464f8aab9eb31a8ea7e167e84322':
-                '11f410136724cf43c63526841007897e'
+                'd089a50f34051c68c7bb4c5ac2c4c5d5'
         }
 
         for report in reports:
-            path_hash = get_report_path_hash(report.bug_path, files)
+            path_hash = get_report_path_hash(report)
             bug_hash = report.main['issue_hash_content_of_line_in_context']
             self.assertEqual(path_hash, report_hash_to_path_hash[bug_hash])


### PR DESCRIPTION
When a checker is alias of another then it is possible that two
checkers are reporting the same message. We wouldn't like to unique
them because it was random which checker won the possibility of
reporting. Now both checkers are emitting the report and the user can
explicitly choose to switch off any of them.

This commit also contains some improvement on checking "skipping". The
operator "|=" is not lazy and it is not always necessary to evaluate
the right hand side.