### PR TITLE
Fix Clang version regex in tests

### DIFF
--- a/scripts/test/check_clang.py
+++ b/scripts/test/check_clang.py
@@ -43,7 +43,7 @@ def get_version(output):
     """
     Return the version information from the command output.
     """
-    version_regex = r"version \b(?P<major>[0-9])+(?:\.[0-9]+)?(?:\.[0-9]+)?\b"
+    version_regex = r"version \b(?P<major>[0-9]+)(?:\.[0-9]+)?(?:\.[0-9]+)?\b"
     version_matcher = re.compile(version_regex)
     match = version_matcher.search(output)
     if match:


### PR DESCRIPTION
The Clang version matching regex didn't handle the case when Clang
version is a two digin number (Clang 10).