### PR TITLE
[analyzer] Add CTU On-demand analysis support

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -40,6 +40,18 @@ def is_ctu_capable(context):
     return clangsa_cfg.ctu_capability.is_ctu_capable
 
 
+def is_ctu_on_demand_available(context):
+    """ Detects if the current clang is capable of on-demand AST loading. """
+    enabled_analyzers, _ = \
+        check_supported_analyzers([ClangSA.ANALYZER_NAME], context)
+    if not enabled_analyzers:
+        return False
+
+    clangsa_cfg = ClangSA.construct_config_handler([], context)
+
+    return clangsa_cfg.ctu_capability.is_on_demand_ctu_available
+
+
 def is_statistics_capable(context):
     """ Detects if the current clang is Statistics compatible. """
     # Resolve potentially missing binaries.

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -27,6 +27,7 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
     def __init__(self, environ):
         super(ClangSAConfigHandler, self).__init__()
         self.ctu_dir = ''
+        self.ctu_on_demand = False
         self.log_file = ''
         self.path_env_extra = ''
         self.ld_lib_path_extra = ''

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
@@ -9,7 +9,6 @@
 Clang Static Analyzer related functions.
 """
 
-
 import subprocess
 
 from codechecker_common.logger import get_logger
@@ -17,6 +16,8 @@ from codechecker_analyzer import host_check
 from codechecker_analyzer.analyzers.clangsa import clang_options, version
 
 LOG = get_logger('analyzer.clangsa')
+
+CTU_ON_DEMAND_OPTION_NAME = 'ctu-invocation-list'
 
 
 def invoke_binary_checked(binary_path, args=None, environ=None):
@@ -170,3 +171,19 @@ class CTUAutodetection(object):
 
         return invoke_binary_checked(tool_path, ['-version'], self.environ) \
             is not False
+
+    @property
+    def is_on_demand_ctu_available(self):
+        """
+        Detects if the current Clang supports on-demand parsing of ASTs for
+        CTU analysis.
+        """
+
+        analyzer_options = invoke_binary_checked(
+            self.__analyzer_binary, ['-cc1', '-analyzer-config-help'],
+            self.environ)
+
+        if analyzer_options is False:
+            return False
+
+        return CTU_ON_DEMAND_OPTION_NAME in analyzer_options

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_manager.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_manager.py
@@ -11,9 +11,11 @@ Arranges the 1st phase of 2 phase executions for CTU
 
 
 import glob
+import yaml
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
 from codechecker_common.logger import get_logger
 
@@ -62,8 +64,39 @@ def generate_ast_cmd(action, config, triple_arch, source):
     return cmd, ast_dir
 
 
+def generate_invocation_list(triple_arch, action, source, config, env):
+    """ Generates the invocation for the source file of the current
+    compilation command. Used during on-demand analysis. The invocation list
+    is a mapping from absolute paths of the source files to the parts of the
+    compilation commands that are used to generate from each one of them. """
+
+    triple_arch_dir = Path(config.ctu_dir, triple_arch)
+    # Ensure, that architecture directory exists.
+    triple_arch_dir.mkdir(parents=True, exist_ok=True)
+
+    invocation_list = triple_arch_dir / 'invocation-list.yml'
+
+    source_path = Path(source).resolve()
+
+    cmd = ctu_triple_arch.get_compile_command(action, config, source)
+    # __clang__analyzer__ macro needs to be set in the imported TUs too.
+    cmd.extend(['-D__clang_analyzer__', '-w'])
+
+    # The YAML mapping entry already has a newline at the end.
+    invocation_line = yaml.dump({str(source_path): cmd})
+
+    LOG.debug_analyzer("Appending invocation list item '%s'", invocation_line)
+
+    # Append the next entry into the invocation list yaml.
+    with invocation_list.open('a', encoding='utf-8', errors='ignore') as \
+            invocation_file:
+        invocation_file.write(invocation_line)
+
+
 def generate_ast(triple_arch, action, source, config, env):
-    """ Generates ASTs for the current compilation command. """
+    """ Generates ASTs for the current compilation command. Used during
+    ast-dump based analysis. """
+
     cmd, ast_dir = generate_ast_cmd(action, config, triple_arch, source)
 
     if not os.path.isdir(ast_dir):
@@ -74,34 +107,50 @@ def generate_ast(triple_arch, action, source, config, env):
 
     cmdstr = ' '.join(cmd)
     LOG.debug_analyzer("Generating AST using '%s'", cmdstr)
-    ret_code, _, err = analyzer_base.SourceAnalyzer.run_proc(cmd,
-                                                             env,
-                                                             action.directory)
+    ret_code, _, err = \
+        analyzer_base.SourceAnalyzer.run_proc(cmd, env, action.directory)
+
     if ret_code != 0:
         LOG.error("Error generating AST.\n\ncommand:\n\n%s\n\nstderr:\n\n%s",
                   cmdstr, err)
 
 
-def func_map_list_src_to_ast(func_src_list):
+def ast_dump_path(source_path):
+    """ AST-dump based analysis uses preprocessed paths, here the path prefix
+    'ast' and the filename suffix '.ast' is added to the name of the original
+    source file. """
+
+    # Normalize path on Windows OS.
+    path = os.path.splitdrive(source_path)[1]
+    # Make relative path out of absolute.
+    path = path[1:] if path[0] == os.sep else path
+    # Prepend path segment, and append filename suffix.
+    return os.path.join("ast", path + ".ast")
+
+
+def func_map_list_src_to_ast(func_src_list, ctu_on_demand):
     """ Turns textual function map list with source files into a
-    function map list with ast files. """
+    mapping from mangled names to mapped paths, which can be absolute paths to
+    the original source files if ctu_on_demand is True, or relative path
+    segments to AST-dump files that reside in CTU-DIR directory otherwise. """
 
     func_ast_list = []
     for fn_src_txt in func_src_list:
         dpos = fn_src_txt.find(" ")
         mangled_name = fn_src_txt[0:dpos]
         path = fn_src_txt[dpos + 1:]
-        # Normalize path on windows as well
-        path = os.path.splitdrive(path)[1]
-        # Make relative path out of absolute
-        path = path[1:] if path[0] == os.sep else path
-        ast_path = os.path.join("ast", path + ".ast")
-        func_ast_list.append(mangled_name + " " + ast_path)
+
+        # On-demand analysis does not require any preprocessing on the source
+        # file paths, contrary to AST-dump based.
+        mapped_path = path if ctu_on_demand else ast_dump_path(path)
+
+        func_ast_list.append(mangled_name + " " + mapped_path)
     return func_ast_list
 
 
 def get_extdef_mapping_cmd(action, config, source, func_map_cmd):
     """ Get command to create CTU index file. """
+
     cmd = ctu_triple_arch.get_compile_command(action, config)
     cmd[0] = func_map_cmd
     cmd.insert(1, source)
@@ -111,7 +160,13 @@ def get_extdef_mapping_cmd(action, config, source, func_map_cmd):
 
 def map_functions(triple_arch, action, source, config, env,
                   func_map_cmd, temp_fnmap_folder):
-    """ Generate function map file for the current source. """
+    """ Generate function map file for the current source.
+
+        On-demand CTU analysis requires the *mangled name* to *source file*
+        mapping. However in case of pre-processed ast-dumps, *mangled name* to
+        *ast dump* mapping must be provided.
+    """
+
     cmd = get_extdef_mapping_cmd(action, config, source, func_map_cmd)
 
     cmdstr = ' '.join(cmd)
@@ -126,7 +181,8 @@ def map_functions(triple_arch, action, source, config, env,
         return
 
     func_src_list = stdout.splitlines()
-    func_ast_list = func_map_list_src_to_ast(func_src_list)
+    func_ast_list = func_map_list_src_to_ast(
+        func_src_list, config.ctu_on_demand)
     extern_fns_map_folder = os.path.join(config.ctu_dir, triple_arch,
                                          temp_fnmap_folder)
     if not os.path.isdir(extern_fns_map_folder):

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -482,6 +482,26 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                    "same translation unit without "
                                    "Cross-TU enabled.")
 
+        # Only check for AST loading modes if CTU is available.
+        if analyzer_types.is_ctu_on_demand_available(context):
+            ctu_opts.add_argument('--ctu-ast-mode',
+                                  action='store',
+                                  dest='ctu_ast_mode',
+                                  choices=['load-from-pch', 'parse-on-demand'],
+                                  default='load-from-pch',
+                                  help="Choose the way ASTs are loaded during "
+                                       "CTU analysis. Mode 'load-from-pch' "
+                                       "generates PCH format serialized ASTs "
+                                       "during the 'collect' phase. Mode "
+                                       "'parse-on-demand' only generates the "
+                                       "invocations needed to parse the ASTs. "
+                                       "Mode 'load-from-pch' can use "
+                                       "significant disk-space for the "
+                                       "serialized ASTs, while mode "
+                                       "'parse-on-demand' can incur some "
+                                       "runtime CPU overhead in the second "
+                                       "phase of the analysis.")
+
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
             "Statistics analysis feature arguments",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -11,7 +11,6 @@ giving an easy way to perform analysis from a log command and print results to
 stdout.
 """
 
-
 import argparse
 import os
 import shutil
@@ -23,7 +22,6 @@ from codechecker_analyzer.arg import OrderedCheckersAction
 
 from codechecker_common import arg, logger
 from codechecker_common.source_code_comment_handler import REVIEW_STATUS_VALUES
-
 
 LOG = logger.get_logger('system')
 
@@ -486,6 +484,26 @@ is called.""")
                                    "the same translation unit without "
                                    "Cross-TU enabled.")
 
+        # Only check for AST loading modes if CTU is available.
+        if analyzer_types.is_ctu_on_demand_available(context):
+            ctu_opts.add_argument('--ctu-ast-mode',
+                                  action='store',
+                                  dest='ctu_ast_mode',
+                                  choices=['load-from-pch', 'parse-on-demand'],
+                                  default='load-from-pch',
+                                  help="Choose the way ASTs are loaded during "
+                                       "CTU analysis. Mode 'load-from-pch' "
+                                       "generates PCH format serialized ASTs "
+                                       "during the 'collect' phase. Mode "
+                                       "'parse-on-demand' only generates the "
+                                       "invocations needed to parse the ASTs. "
+                                       "Mode 'load-from-pch' can use "
+                                       "significant disk-space for the "
+                                       "serialized ASTs, while mode "
+                                       "'parse-on-demand' can incur some "
+                                       "runtime CPU overhead in the second "
+                                       "phase of the analysis.")
+
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
             "Statistics analysis feature arguments",
@@ -637,7 +655,7 @@ was emitted by clang-tidy.""")
                         default=["confirmed", "unreviewed"],
                         help="Filter results by review statuses. Valid "
                              "values are: {0}".format(
-                                 ', '.join(REVIEW_STATUS_VALUES)))
+                            ', '.join(REVIEW_STATUS_VALUES)))
 
     logger.add_verbose_arguments(parser)
     parser.set_defaults(func=main)

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -9,7 +9,6 @@
 Run pre analysis, collect statistics or CTU data.
 """
 
-
 import multiprocessing
 import os
 import shutil
@@ -27,7 +26,6 @@ from .analyzers import analyzer_base
 from .analyzers.clangsa import ctu_manager, ctu_triple_arch
 from .analyzers.clangsa import statistics
 from .analyzers.clangsa.analyzer import ClangSA
-
 
 LOG = get_logger('analyzer')
 
@@ -85,7 +83,6 @@ def init_worker(checked_num, action_num):
 
 
 def pre_analyze(params):
-
     action, context, clangsa_config, skip_handler, \
         ctu_data, statistics_data = params
 
@@ -115,8 +112,22 @@ def pre_analyze(params):
                 ctu_triple_arch.get_triple_arch(action, action.source,
                                                 clangsa_config,
                                                 analyzer_environment)
-            ctu_manager.generate_ast(triple_arch, action, action.source,
-                                     clangsa_config, analyzer_environment)
+
+            # TODO: reorganize the various ctu modes parameters
+            # Dump-based analysis requires serialized ASTs.
+            if clangsa_config.ctu_on_demand:
+                ctu_manager.generate_invocation_list(triple_arch, action,
+                                                     action.source,
+                                                     clangsa_config,
+                                                     analyzer_environment)
+            else:
+                ctu_manager.generate_ast(triple_arch, action, action.source,
+                                         clangsa_config, analyzer_environment)
+            # On-demand analysis does not require AST-dumps.
+            # We map the function names to corresponding sources of ASTs.
+            # In case of On-demand analysis this source is the original source
+            # code. In case of AST-dump based analysis these sources are the
+            # generated AST-dumps.
             ctu_manager.map_functions(triple_arch, action, action.source,
                                       clangsa_config, analyzer_environment,
                                       ctu_func_map_cmd,

--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -1,3 +1,4 @@
 lxml==4.5.0
 portalocker==1.7.0
 psutil==5.7.0
+PyYAML==5.3.1

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -5,3 +5,4 @@ psutil==5.7.0
 portalocker==1.7.0
 pylint==2.4.4
 mkdocs==1.0.4
+PyYAML==5.3.1

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -2,3 +2,4 @@ lxml==4.5.0
 portalocker==1.7.0
 psutil==5.7.0
 scan-build==2.0.19
+PyYAML==5.3.1

--- a/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
@@ -23,6 +23,26 @@ from libtest.codechecker import call_command
 
 NO_CTU_MESSAGE = "CTU is not supported"
 NO_DISPLAY_CTU_PROGRESS = "-analyzer-display-ctu-progress is not supported"
+NO_CTU_ON_DEMAND_MESSAGE = "CTU-on-demand is not supported"
+
+
+def makeSkipUnlessAttributeFound(attribute, message):
+    def deco(f):
+        def wrapper(self, *args, **kwargs):
+            if not getattr(self, attribute):
+                self.skipTest(message)
+            else:
+                f(self, *args, **kwargs)
+        return wrapper
+    return deco
+
+
+skipUnlessCTUCapable = makeSkipUnlessAttributeFound(
+    'ctu_capable', NO_CTU_MESSAGE)
+skipUnlessCTUDisplayCapable = makeSkipUnlessAttributeFound(
+    'ctu_display_progress_capable', NO_DISPLAY_CTU_PROGRESS)
+skipUnlessCTUOnDemandCapable = makeSkipUnlessAttributeFound(
+    'ctu_on_demand_capable', NO_CTU_ON_DEMAND_MESSAGE)
 
 
 class TestCtuFailure(unittest.TestCase):
@@ -52,13 +72,17 @@ class TestCtuFailure(unittest.TestCase):
         self.ctu_capable = '--ctu-' in output
         print("'analyze' reported CTU-compatibility? " + str(self.ctu_capable))
 
-        self.ctu_has_analyzer_display_ctu_progress = \
+        self.ctu_on_demand_capable = '--ctu-ast-mode' in output
+        print("'analyze' reported CTU-on-demand-compatibility? "
+              + str(self.ctu_on_demand_capable))
+
+        self.ctu_display_progress_capable = \
             host_check.has_analyzer_config_option(self.__getClangSaPath(),
                                                   'display-ctu-progress',
                                                   self.env)
 
         print("Has display-ctu-progress=true? " +
-              str(self.ctu_has_analyzer_display_ctu_progress))
+              str(self.ctu_display_progress_capable))
 
         # Fix the "template" build JSONs to contain a proper directory
         # so the tests work.
@@ -82,31 +106,40 @@ class TestCtuFailure(unittest.TestCase):
         shutil.rmtree(self.report_dir, ignore_errors=True)
         os.chdir(self.__old_pwd)
 
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
     def test_ctu_logs_ast_import(self):
         """ Test that Clang indeed logs the AST import events.
         """
         self.__set_up_test_dir('ctu_failure')
-        if not self.ctu_capable:
-            self.skipTest(NO_CTU_MESSAGE)
-        if not self.ctu_has_analyzer_display_ctu_progress:
-            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
 
-        output = self.__do_ctu_all(reparse=False,
+        output = self.__do_ctu_all(on_demand=False,
                                    extra_args=["--verbose", "debug"])
         self.assertIn("CTU loaded AST file", output)
 
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
+    @skipUnlessCTUOnDemandCapable
+    def test_ctu_on_demand_logs_ast_import(self):
+        """ Test that Clang indeed logs the AST import events when using
+        on-demand mode.
+        """
+        self.__set_up_test_dir('ctu_on_demand_failure')
+
+        output = self.__do_ctu_all(on_demand=True,
+                                   extra_args=["--verbose", "debug"])
+        self.assertIn("CTU loaded AST file", output)
+
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
     def test_ctu_failure_zip(self):
         """ Test the failure zip contains the source of imported TU
         """
         self.__set_up_test_dir('ctu_failure')
-        if not self.ctu_capable:
-            self.skipTest(NO_CTU_MESSAGE)
-        if not self.ctu_has_analyzer_display_ctu_progress:
-            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
 
         # The below special checker `ExprInspection` crashes when a function
         # with a specified name is analyzed.
-        output = self.__do_ctu_all(reparse=False,
+        output = self.__do_ctu_all(on_demand=False,
                                    extra_args=[
                                        "--verbose", "debug",
                                        "-e", "debug.ExprInspection"
@@ -146,20 +179,69 @@ class TestCtuFailure(unittest.TestCase):
             check_source_in_archive("main.c")
             check_source_in_archive("lib.c")
 
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
+    @skipUnlessCTUOnDemandCapable
+    def test_ctu_on_demand_failure_zip(self):
+        """ Test the failure zip contains the source of imported TU when using
+        on-demand mode.
+        """
+        self.__set_up_test_dir('ctu_on_demand_failure')
+
+        # The below special checker `ExprInspection` crashes when a function
+        # with a specified name is analyzed.
+        output = self.__do_ctu_all(on_demand=True,
+                                   extra_args=[
+                                       "--verbose", "debug",
+                                       "-e", "debug.ExprInspection"
+                                   ])
+
+        # lib.c should be logged as its AST is loaded by Clang
+        self.assertRegex(output, r"CTU loaded AST file: .*lib\.c")
+
+        # We expect a failure archive to be in the failed directory.
+        failed_dir = os.path.join(self.report_dir, "failed")
+        failed_files = os.listdir(failed_dir)
+
+        self.assertEqual(len(failed_files), 1)
+        # Ctu should fail during analysis of main.c
+        self.assertIn("main.c", failed_files[0])
+
+        fail_zip = os.path.join(failed_dir, failed_files[0])
+
+        with zipfile.ZipFile(fail_zip, 'r') as archive:
+            files = archive.namelist()
+            self.assertIn("build-action", files)
+            self.assertIn("analyzer-command", files)
+
+            def check_source_in_archive(source_in_archive):
+                source_file = os.path.join(self.test_dir, source_in_archive)
+                source_in_archive = os.path.join("sources-root",
+                                                 source_file.lstrip('/'))
+                self.assertIn(source_in_archive, files)
+                # Check file content.
+                with archive.open(source_in_archive, 'r') as archived_code:
+                    with open(source_file, 'r',
+                              encoding="utf-8",
+                              errors="ignore") as source_code:
+                        self.assertEqual(archived_code.read().decode("utf-8"),
+                                         source_code.read())
+
+            check_source_in_archive("main.c")
+            check_source_in_archive("lib.c")
+
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
     def test_ctu_failure_zip_with_headers(self):
         """
         Test the failure zip contains the source of imported TU and all the
         headers on which the TU depends.
         """
         self.__set_up_test_dir('ctu_failure_with_headers')
-        if not self.ctu_capable:
-            self.skipTest(NO_CTU_MESSAGE)
-        if not self.ctu_has_analyzer_display_ctu_progress:
-            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
 
         # The below special checker `ExprInspection` crashes when a function
         # with a specified name is analyzed.
-        output = self.__do_ctu_all(reparse=False,
+        output = self.__do_ctu_all(on_demand=False,
                                    extra_args=[
                                        "--verbose", "debug",
                                        "-e", "debug.ExprInspection"
@@ -200,16 +282,67 @@ class TestCtuFailure(unittest.TestCase):
             check_source_in_archive("lib.c")
             check_source_in_archive("lib.h")
 
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
+    @skipUnlessCTUOnDemandCapable
+    def test_ctu_on_demand_failure_zip_with_headers(self):
+        """
+        Test the failure zip contains the source of imported TU and all the
+        headers on which the TU depends when using on-demand mode.
+        """
+        self.__set_up_test_dir('ctu_on_demand_failure_with_headers')
+
+        # The below special checker `ExprInspection` crashes when a function
+        # with a specified name is analyzed.
+        output = self.__do_ctu_all(on_demand=True,
+                                   extra_args=[
+                                       "--verbose", "debug",
+                                       "-e", "debug.ExprInspection"
+                                   ])
+
+        # lib.c should be logged as its AST is loaded by Clang
+        self.assertRegex(output, r"CTU loaded AST file: .*lib\.c")
+
+        # We expect a failure archive to be in the failed directory.
+        failed_dir = os.path.join(self.report_dir, "failed")
+        failed_files = os.listdir(failed_dir)
+        self.assertEqual(len(failed_files), 1)
+        # Ctu should fail during analysis of main.c
+        self.assertIn("main.c", failed_files[0])
+
+        fail_zip = os.path.join(failed_dir, failed_files[0])
+
+        with zipfile.ZipFile(fail_zip, 'r') as archive:
+            files = archive.namelist()
+
+            self.assertIn("build-action", files)
+            self.assertIn("analyzer-command", files)
+
+            def check_source_in_archive(source_in_archive):
+                source_file = os.path.join(self.test_dir, source_in_archive)
+                source_in_archive = os.path.join("sources-root",
+                                                 source_file.lstrip('/'))
+                self.assertIn(source_in_archive, files)
+                # Check file content.
+                with archive.open(source_in_archive, 'r') as archived_code:
+                    with open(source_file, 'r',
+                              encoding="utf-8",
+                              errors="ignore") as source_code:
+                        self.assertEqual(archived_code.read().decode("utf-8"),
+                                         source_code.read())
+
+            check_source_in_archive("main.c")
+            check_source_in_archive("lib.c")
+            check_source_in_archive("lib.h")
+
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
     def test_ctu_fallback(self):
         """ In case of ctu failure the non ctu analysis will be triggered.
         """
         self.__set_up_test_dir('ctu_failure')
-        if not self.ctu_capable:
-            self.skipTest(NO_CTU_MESSAGE)
-        if not self.ctu_has_analyzer_display_ctu_progress:
-            self.skipTest(NO_DISPLAY_CTU_PROGRESS)
 
-        output = self.__do_ctu_all(reparse=False,
+        output = self.__do_ctu_all(on_demand=False,
                                    extra_args=[
                                        "--verbose", "debug",
                                        "-e", "debug.ExprInspection",
@@ -229,7 +362,36 @@ class TestCtuFailure(unittest.TestCase):
         # Ctu should fail during analysis of main.c
         self.assertIn("main.c", failed_files[0])
 
-    def __do_ctu_all(self, reparse, extra_args=None):
+    @skipUnlessCTUCapable
+    @skipUnlessCTUDisplayCapable
+    @skipUnlessCTUOnDemandCapable
+    def test_ctu_on_demand_fallback(self):
+        """ In case of ctu failure the non ctu analysis will be triggered when
+        using on-demand-mode.
+        """
+        self.__set_up_test_dir('ctu_on_demand_failure')
+
+        output = self.__do_ctu_all(on_demand=True,
+                                   extra_args=[
+                                       "--verbose", "debug",
+                                       "-e", "debug.ExprInspection",
+                                       "--ctu-reanalyze-on-failure"
+                                   ])
+
+        # lib.c should be logged as its AST is loaded by Clang
+        self.assertRegex(output, r"CTU loaded AST file: .*lib\.c")
+
+        # We expect two failure archives to be in the failed directory.
+        # One failure archive is produced by the CTU analysis and the
+        # other archive is produced by the non CTU analysis.
+        failed_dir = os.path.join(self.report_dir, "failed")
+        failed_files = os.listdir(failed_dir)
+        print(failed_files)
+        self.assertEqual(len(failed_files), 2)
+        # Ctu should fail during analysis of main.c
+        self.assertIn("main.c", failed_files[0])
+
+    def __do_ctu_all(self, on_demand, extra_args=None):
         """
         Execute a full CTU run.
         @param extra_args: list of additional arguments
@@ -237,8 +399,8 @@ class TestCtuFailure(unittest.TestCase):
 
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
                '--analyzers', 'clangsa', '--ctu-all']
-        if reparse:
-            cmd.append('--ctu-on-the-fly')
+        if on_demand:
+            cmd.append('--ctu-ast-mode=parse-on-demand')
         if extra_args is not None:
             cmd.extend(extra_args)
         cmd.append(self.buildlog)


### PR DESCRIPTION
On-demand parsing of the ASTs can be now enabled if the relevant Phabricator patch lands. If enabled, on-the-fly analysis removes the need to create AST dumps, but in turn the compilation database must be provided to Clang. The CTU Index also changes if the option is enabled. The mapping form `function name (USR)` -> `AST dump file` becomes `function name (USR)` -> `path to source file`.