### PR TITLE
Exception on regex characters in checker name

### DIFF
--- a/analyzer/codechecker_analyzer/checkers.py
+++ b/analyzer/codechecker_analyzer/checkers.py
@@ -20,7 +20,7 @@ def available(ordered_checkers, available_checkers):
         checker_name, _ = checker
         name_match = False
         for available_checker in available_checkers:
-            regex = "^" + str(checker_name) + ".*$"
+            regex = "^" + re.escape(str(checker_name)) + ".*$"
             c_name = available_checker
             match = re.match(regex, c_name)
             if match:

--- a/analyzer/tests/unit/test_checkers.py
+++ b/analyzer/tests/unit/test_checkers.py
@@ -53,14 +53,16 @@ class TestCheckers(unittest.TestCase):
         ordered_checkers = [("unix.Malloc", True),
                             ("core.VLASize", True),
                             ("core.DivideZero", True),
-                            ("cppcoreguidelines-avoid-goto", False)]
+                            ("cppcoreguidelines-avoid-goto", False),
+                            ("Wc++11-extensions", False)]
 
         missing_checkers = available(ordered_checkers,
                                      self.__available_checkers)
 
         self.assertSetEqual(missing_checkers,
                             {"core.VLASize",
-                             "cppcoreguidelines-avoid-goto"})
+                             "cppcoreguidelines-avoid-goto",
+                             "Wc++11-extensions"})
 
     def test_profile_not_available(self):
         """Test for missing profile."""


### PR DESCRIPTION
In case an enabled/disabled checker name contains a regex character,
CodeChecker threw an exception. For example "-d Wc++11-extensions"
where "+" should be escaped.