### PR TITLE
move get_binary_in_path to analyzer module

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -17,7 +17,6 @@ import shlex
 import subprocess
 
 from codechecker_common.logger import get_logger
-from codechecker_common.util import get_binary_in_path
 
 from codechecker_analyzer import host_check
 from codechecker_analyzer import env
@@ -296,9 +295,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             return False
 
         # clang, clang-5.0, clang++, clang++-5.1, ...
-        clang = get_binary_in_path(['clang', 'clang++'],
-                                   r'^clang(\+\+)?(-\d+(\.\d+){0,2})?$',
-                                   environ)
+        clang = env.get_binary_in_path(['clang', 'clang++'],
+                                       r'^clang(\+\+)?(-\d+(\.\d+){0,2})?$',
+                                       environ)
 
         if clang:
             LOG.debug("Using '%s' for ClangSA!", clang)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -15,7 +15,6 @@ import shlex
 import subprocess
 
 from codechecker_common.logger import get_logger
-from codechecker_common.util import get_binary_in_path
 
 from codechecker_analyzer import host_check
 from codechecker_analyzer import env
@@ -207,9 +206,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             return False
 
         # clang-tidy, clang-tidy-5.0, ...
-        clangtidy = get_binary_in_path(['clang-tidy'],
-                                       r'^clang-tidy(-\d+(\.\d+){0,2})?$',
-                                       environ)
+        clangtidy = env.get_binary_in_path(['clang-tidy'],
+                                           r'^clang-tidy(-\d+(\.\d+){0,2})?$',
+                                           environ)
 
         if clangtidy:
             LOG.debug("Using '%s' for Clang-tidy!", clangtidy)

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 import os
+import re
 
 from codechecker_common.logger import get_logger
 
@@ -127,3 +128,58 @@ def replace_env_var(cfg_file):
         return os.environ[env_var]
 
     return replacer
+
+
+def find_by_regex_in_envpath(pattern, environment):
+    """
+    Searches for files matching the pattern string in the environment's PATH.
+    """
+
+    regex = re.compile(pattern)
+
+    binaries = {}
+    for path in environment['PATH'].split(os.pathsep):
+        _, _, filenames = next(os.walk(path), ([], [], []))
+        for f in filenames:
+            if re.match(regex, f):
+                if binaries.get(f) is None:
+                    binaries[f] = [os.path.join(path, f)]
+                else:
+                    binaries[f].append(os.path.join(path, f))
+
+    return binaries
+
+
+def get_binary_in_path(basename_list, versioning_pattern, env):
+    """
+    Select the most matching binary for the given pattern in the given
+    environment. Works well for binaries that contain versioning.
+    """
+
+    binaries = find_by_regex_in_envpath(versioning_pattern, env)
+
+    if not binaries:
+        return False
+    elif len(binaries) == 1:
+        # Return the first found (earliest in PATH) binary for the only
+        # found binary name group.
+        return list(binaries.values())[0][0]
+    else:
+        keys = list(binaries.keys())
+        keys.sort()
+
+        # If one of the base names match, select that version.
+        files = None
+        for base_key in basename_list:
+            # Cannot use set here as it would destroy precendence.
+            if base_key in keys:
+                files = binaries[base_key]
+                break
+
+        if not files:
+            # Select the "newest" available version if there are multiple and
+            # none of the base names matched.
+            files = binaries[keys[-1]]
+
+        # Return the one earliest in PATH.
+        return files[0]

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -13,68 +13,12 @@ from __future__ import absolute_import
 import io
 import json
 import os
-import re
 
 import portalocker
 
 from codechecker_common.logger import get_logger
 
 LOG = get_logger('system')
-
-
-def find_by_regex_in_envpath(pattern, environment):
-    """
-    Searches for files matching the pattern string in the environment's PATH.
-    """
-
-    regex = re.compile(pattern)
-
-    binaries = {}
-    for path in environment['PATH'].split(os.pathsep):
-        _, _, filenames = next(os.walk(path), ([], [], []))
-        for f in filenames:
-            if re.match(regex, f):
-                if binaries.get(f) is None:
-                    binaries[f] = [os.path.join(path, f)]
-                else:
-                    binaries[f].append(os.path.join(path, f))
-
-    return binaries
-
-
-def get_binary_in_path(basename_list, versioning_pattern, env):
-    """
-    Select the most matching binary for the given pattern in the given
-    environment. Works well for binaries that contain versioning.
-    """
-
-    binaries = find_by_regex_in_envpath(versioning_pattern, env)
-
-    if not binaries:
-        return False
-    elif len(binaries) == 1:
-        # Return the first found (earliest in PATH) binary for the only
-        # found binary name group.
-        return list(binaries.values())[0][0]
-    else:
-        keys = list(binaries.keys())
-        keys.sort()
-
-        # If one of the base names match, select that version.
-        files = None
-        for base_key in basename_list:
-            # Cannot use set here as it would destroy precendence.
-            if base_key in keys:
-                files = binaries[base_key]
-                break
-
-        if not files:
-            # Select the "newest" available version if there are multiple and
-            # none of the base names matched.
-            files = binaries[keys[-1]]
-
-        # Return the one earliest in PATH.
-        return files[0]
 
 
 def arg_match(options, args):


### PR DESCRIPTION
this function is only used in the analyzer package no need for it
to be in the codechecker_common.util