### PR TITLE
remove argument handling class from common module

### DIFF
--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""Argument parsing related helper classes and functions."""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import argparse
+
+
+class RawDescriptionDefaultHelpFormatter(
+        argparse.RawDescriptionHelpFormatter,
+        argparse.ArgumentDefaultsHelpFormatter
+):
+    """
+    Adds default values to argument help and retains any formatting in
+    descriptions.
+    """
+    pass
+
+
+class OrderedCheckersAction(argparse.Action):
+    """
+    Action to store enabled and disabled checkers
+    and keep ordering from command line.
+
+    Create separate lists based on the checker names for
+    each analyzer.
+    """
+
+    # Users can supply invocation to 'codechecker-analyze' as follows:
+    # -e core -d core.uninitialized -e core.uninitialized.Assign
+    # We must support having multiple '-e' and '-d' options and the order
+    # specified must be kept when the list of checkers are assembled for Clang.
+
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(OrderedCheckersAction, self).__init__(option_strings, dest,
+                                                    **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+
+        if 'ordered_checkers' not in namespace:
+            namespace.ordered_checkers = []
+        ordered_checkers = namespace.ordered_checkers
+        ordered_checkers.append((value, self.dest == 'enable'))
+
+        namespace.ordered_checkers = ordered_checkers

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -16,46 +16,16 @@ import os
 import shutil
 import sys
 
-from codechecker_analyzer import analyzer, analyzer_context
+from codechecker_analyzer import analyzer, analyzer_context, arg
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.buildlog import log_parser
 
 from codechecker_common import logger
 from codechecker_common import skiplist_handler
-from codechecker_common.util import RawDescriptionDefaultHelpFormatter, \
-    load_json_or_empty
+from codechecker_common.util import load_json_or_empty
+
 
 LOG = logger.get_logger('system')
-
-
-class OrderedCheckersAction(argparse.Action):
-    """
-    Action to store enabled and disabled checkers
-    and keep ordering from command line.
-
-    Create separate lists based on the checker names for
-    each analyzer.
-    """
-
-    # Users can supply invocation to 'codechecker-analyze' as follows:
-    # -e core -d core.uninitialized -e core.uninitialized.Assign
-    # We must support having multiple '-e' and '-d' options and the order
-    # specified must be kept when the list of checkers are assembled for Clang.
-
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        if nargs is not None:
-            raise ValueError("nargs not allowed")
-        super(OrderedCheckersAction, self).__init__(option_strings, dest,
-                                                    **kwargs)
-
-    def __call__(self, parser, namespace, value, option_string=None):
-
-        if 'ordered_checkers' not in namespace:
-            namespace.ordered_checkers = []
-        ordered_checkers = namespace.ordered_checkers
-        ordered_checkers.append((value, self.dest == 'enable'))
-
-        namespace.ordered_checkers = ordered_checkers
 
 
 def get_argparser_ctor_args():
@@ -66,7 +36,7 @@ def get_argparser_ctor_args():
 
     return {
         'prog': 'CodeChecker analyze',
-        'formatter_class': RawDescriptionDefaultHelpFormatter,
+        'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
 
         # Description is shown when the command's help is queried directly
         'description': """
@@ -478,7 +448,7 @@ https://clang.llvm.org/docs/DiagnosticsReference.html.""")
                                dest="enable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
-                               action=OrderedCheckersAction,
+                               action=arg.OrderedCheckersAction,
                                help="Set a checker (or checker group) "
                                     "to BE USED in the analysis.")
 
@@ -486,7 +456,7 @@ https://clang.llvm.org/docs/DiagnosticsReference.html.""")
                                dest="disable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
-                               action=OrderedCheckersAction,
+                               action=arg.OrderedCheckersAction,
                                help="Set a checker (or checker group) "
                                     "to BE PROHIBITED from use in the "
                                     "analysis.")

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -17,43 +17,14 @@ import os
 import shutil
 import tempfile
 
+from codechecker_analyzer import arg
 from codechecker_analyzer import analyzer_context
 from codechecker_analyzer.analyzers import analyzer_types
 
 from codechecker_common import logger
-from codechecker_common.util import RawDescriptionDefaultHelpFormatter
+
 
 LOG = logger.get_logger('system')
-
-
-class OrderedCheckersAction(argparse.Action):
-    """
-    Action to store enabled and disabled checkers
-    and keep ordering from command line.
-
-    Create separate lists based on the checker names for
-    each analyzer.
-    """
-
-    # Users can supply invocation to 'codechecker-analyze' as follows:
-    # -e core -d core.uninitialized -e core.uninitialized.Assign
-    # We must support having multiple '-e' and '-d' options and the order
-    # specified must be kept when the list of checkers are assembled for Clang.
-
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        if nargs is not None:
-            raise ValueError("nargs not allowed")
-        super(OrderedCheckersAction, self).__init__(option_strings, dest,
-                                                    **kwargs)
-
-    def __call__(self, parser, namespace, value, option_string=None):
-
-        if 'ordered_checkers' not in namespace:
-            namespace.ordered_checkers = []
-        ordered_checkers = namespace.ordered_checkers
-        ordered_checkers.append((value, self.dest == 'enable'))
-
-        namespace.ordered_checkers = ordered_checkers
 
 
 def get_argparser_ctor_args():
@@ -64,7 +35,7 @@ def get_argparser_ctor_args():
 
     return {
         'prog': 'CodeChecker check',
-        'formatter_class': RawDescriptionDefaultHelpFormatter,
+        'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
 
         # Description is shown when the command's help is queried directly
         'description': """
@@ -497,7 +468,7 @@ https://clang.llvm.org/docs/DiagnosticsReference.html.""")
                                dest="enable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
-                               action=OrderedCheckersAction,
+                               action=arg.OrderedCheckersAction,
                                help="Set a checker (or checker group) "
                                     "to BE USED in the analysis.")
 
@@ -505,7 +476,7 @@ https://clang.llvm.org/docs/DiagnosticsReference.html.""")
                                dest="disable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
-                               action=OrderedCheckersAction,
+                               action=arg.OrderedCheckersAction,
                                help="Set a checker (or checker group) "
                                     "to BE PROHIBITED from use in the "
                                     "analysis.")

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import argparse
 import io
 import json
 import os
@@ -25,17 +24,6 @@ import psutil
 from codechecker_common.logger import get_logger
 
 LOG = get_logger('system')
-
-
-class RawDescriptionDefaultHelpFormatter(
-        argparse.RawDescriptionHelpFormatter,
-        argparse.ArgumentDefaultsHelpFormatter
-):
-    """
-    Adds default values to argument help and retains any formatting in
-    descriptions.
-    """
-    pass
 
 
 def find_by_regex_in_envpath(pattern, environment):

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -32,6 +32,17 @@ DEFAULT_FILTER_VALUES = {
 }
 
 
+class RawDescriptionDefaultHelpFormatter(
+        argparse.RawDescriptionHelpFormatter,
+        argparse.ArgumentDefaultsHelpFormatter
+):
+    """
+    Adds default values to argument help and retains any formatting in
+    descriptions.
+    """
+    pass
+
+
 class NewLineDefaultHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
 
     def _split_lines(self, text, width):
@@ -1032,7 +1043,7 @@ def add_arguments_to_parser(parser):
 
     results = subcommands.add_parser(
         'results',
-        formatter_class=util.RawDescriptionDefaultHelpFormatter,
+        formatter_class=RawDescriptionDefaultHelpFormatter,
         description="Show the individual analysis reports' summary.",
         help="List analysis result (finding) summary for a given run.",
         epilog='''Example scenario: List analysis results
@@ -1058,7 +1069,7 @@ Get analysis results for a run and filter the analysis results:
 
     diff = subcommands.add_parser(
         'diff',
-        formatter_class=util.RawDescriptionDefaultHelpFormatter,
+        formatter_class=RawDescriptionDefaultHelpFormatter,
         description="Compare two analysis runs to show the results that "
                     "differ between the two.",
         help="Compare two analysis runs and show the difference.",
@@ -1082,7 +1093,7 @@ by multiple severity values:
 
     sum_p = subcommands.add_parser(
         'sum',
-        formatter_class=util.RawDescriptionDefaultHelpFormatter,
+        formatter_class=RawDescriptionDefaultHelpFormatter,
         description="Show checker statistics for some analysis runs.",
         help="Show statistics of checkers.",
         epilog='''Example scenario: Get checker statistics


### PR DESCRIPTION
RawDescriptionDefaultHelpFormatter was copied to the
analyzer and web parts.
Additionally a new arg module was created for the analyzer part to have
argument parsing related classes and function there,
OrderedCheckersAction was moved there too.