### PR TITLE
return 0 in case no analysis is needed

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -616,9 +616,10 @@ def main(args):
             )
 
     if not actions:
-        LOG.info("None of the specified build log files contained "
-                 "valid compilation commands. No analysis needed...")
-        sys.exit(1)
+        LOG.info("No analysis is required.\nThere were no compilation "
+                 "commands in the provided compilation database or "
+                 "all of them were skipped.")
+        sys.exit(0)
 
     uniqued_compilation_db_file = os.path.join(
         args.output_path, "unique_compile_commands.json")

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped.output
@@ -1,21 +1,40 @@
-NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error" --quiet
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error simple1" --quiet
 NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --skip skiplist.txt
 NORMAL#CodeChecker parse --skip skiplist.txt $OUTPUT$
-CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --analyzers clangsa --skip skiplist.txt
+CHECK#CodeChecker check --build "make multi_error simple1" --output $OUTPUT$ --quiet --analyzers clangsa --skip skiplist.txt
 -----------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.
 [] - Starting static analysis ...
+[] - [1/2] clangsa analyzed simple1.cpp successfully.
 [] - ----==== Summary ====----
-[] - Total analyzed compilation commands: 0
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - Total analyzed compilation commands: 1
 [] - ----=================----
 [] - Analysis finished.
 [] - To view results in the terminal use the "CodeChecker parse" command.
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero]
+  return 2015 / x;
+              ^
+
+Found 1 defect(s) in simple1.cpp
+
 
 ----==== Summary ====----
+--------------------------
+Filename    | Report count
+--------------------------
+simple1.cpp |            1
+--------------------------
+-----------------------
+Severity | Report count
+-----------------------
+HIGH     |            1
+-----------------------
 ----=================----
-Total number of reports: 0
+Total number of reports: 1
 ----=================----

--- a/analyzer/tests/functional/skip/test_skip.py
+++ b/analyzer/tests/functional/skip/test_skip.py
@@ -48,8 +48,7 @@ class TestSkip(unittest.TestCase):
             shutil.rmtree(self.report_dir)
 
     def test_skip(self):
-        """
-        """
+        """Analyze a project with a skip file."""
         build_json = os.path.join(self.test_workspace, "build.json")
 
         clean_cmd = ["make", "clean"]


### PR DESCRIPTION
If the compile command json is empty CodeChecker
returned with 1 which indicates and error which is might
not the case.
The compiler command json can be empty for several reasons:
- logging the compile commands failed for some reason
- no compilation actions were called by the buid system (noting changed)