### PR TITLE
[api] Sort run data

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -74,6 +74,14 @@ enum SortType {
   BUG_PATH_LENGTH,
 }
 
+enum RunSortType {
+  NAME,
+  UNRESOLVED_REPORTS,
+  DATE,
+  DURATION,
+  CC_VERSION
+}
+
 enum StoreLimitKind {
   FAILURE_ZIP_SIZE,         // Maximum size of the collected failed zips which can be store on the server.
   COMPILATION_DATABASE_SIZE // Limit of the compilation database file size.
@@ -93,6 +101,11 @@ struct SourceFileData {
 
 struct SortMode {
   1: SortType type,
+  2: Order    ord
+}
+
+struct RunSortMode {
+  1: RunSortType type,
   2: Order    ord
 }
 
@@ -319,7 +332,8 @@ service codeCheckerDBAccess {
   // PERMISSION: PRODUCT_ACCESS
   RunDataList getRunData(1: RunFilter runFilter,
                          2: optional i64 limit,
-                         3: optional i64 offset)
+                         3: optional i64 offset,
+                         4: optional RunSortMode sortMode)
                          throws (1: codechecker_api_shared.RequestFailed requestError),
 
   // Returns the number of available runs based on the run filter parameter.

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -140,7 +140,7 @@ def get_run_data(client, run_filter, limit=constants.MAX_QUERY_SIZE):
 
     offset = 0
     while True:
-        runs = runs = client.getRunData(run_filter, limit, offset)
+        runs = runs = client.getRunData(run_filter, limit, offset, None)
         all_runs.extend(runs)
         offset += limit
 

--- a/web/client/codechecker_client/thrift_helper.py
+++ b/web/client/codechecker_client/thrift_helper.py
@@ -39,7 +39,7 @@ class ThriftClientHelper(object):
             self.transport.setCustomHeaders(headers)
 
     @ThriftClientCall
-    def getRunData(self, run_name_filter, limit, offset):
+    def getRunData(self, run_name_filter, limit, offset, sort_mode):
         pass
 
     @ThriftClientCall

--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 21
+    6: 22
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/web/server/www/scripts/codecheckerviewer/BugViewer.js
+++ b/web/server/www/scripts/codecheckerviewer/BugViewer.js
@@ -139,7 +139,7 @@ function (declare, domClass, dom, style, fx, Toggler, keys, on, query, Memory,
 
           var runDataSet = [];
           try{
-            runDataSet = CC_SERVICE.getRunData(runFilter, null, 0);
+            runDataSet = CC_SERVICE.getRunData(runFilter, null, 0, null);
           } catch (ex) { util.handleThriftException(ex); }
 
           var options = res.map(function (reportData) {

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -121,6 +121,7 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
         query.runFilter,
         CC_OBJECTS.MAX_QUERY_SIZE,
         options.start,
+        options.sort ? this._toSortMode(options.sort) : null,
         function (runDataList) {
           if (runDataList instanceof RequestFailed) {
             deferred.reject('Failed to get runs: ' + runDataList.message);
@@ -156,6 +157,28 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
       });
 
       return runDataList;
+    },
+
+    _toSortMode : function (sort) {
+      var sortMode = new CC_OBJECTS.RunSortMode();
+
+      sortMode.type
+        = sort.attribute === 'name'
+        ? CC_OBJECTS.RunSortType.NAME
+        : sort.attribute === 'numberofbugs'
+        ? CC_OBJECTS.RunSortType.UNRESOLVED_REPORTS
+        : sort.attribute === 'duration'
+        ? CC_OBJECTS.RunSortType.DURATION
+        : sort.attribute === 'codeCheckerVersion'
+        ? CC_OBJECTS.RunSortType.CC_VERSION
+        : CC_OBJECTS.RunSortType.DATE;
+
+      sortMode.ord
+        = sort.descending
+        ? CC_OBJECTS.Order.DESC
+        : CC_OBJECTS.Order.ASC;
+
+      return sortMode;
     }
   });
 

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -228,7 +228,7 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
         var runFilter = new CC_OBJECTS.RunFilter();
         runFilter.names = runNames;
 
-        CC_SERVICE.getRunData(runFilter, null, 0, function (runData) {
+        CC_SERVICE.getRunData(runFilter, null, 0, null, function (runData) {
           var runIds = runData.map(function (run) { return run.runId; });
           that._runHistoryGrid.refreshGrid(runIds);
         }).fail(function (xhr) { util.handleAjaxFailure(xhr); });

--- a/web/server/www/scripts/codecheckerviewer/filter/RunBaseFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/RunBaseFilter.js
@@ -68,7 +68,7 @@ function (dom, declare, Deferred, SelectFilter, util) {
 
       var runData = [];
       try {
-        runData = CC_SERVICE.getRunData(runFilter, null, 0);
+        runData = CC_SERVICE.getRunData(runFilter, null, 0, null);
       } catch (ex) { util.handleThriftException(ex); }
 
       return runData.map(function (run) { return run.runId; });

--- a/web/server/www/scripts/codecheckerviewer/filter/RunHistoryTagFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/RunHistoryTagFilter.js
@@ -93,7 +93,7 @@ function (dom, declare, Deferred, SelectFilter, util) {
 
       var runIds = [];
       try {
-        runIds = CC_SERVICE.getRunData(runFilter, null, 0).map(
+        runIds = CC_SERVICE.getRunData(runFilter, null, 0, null).map(
         function (run) {
           return run.runId;
         });

--- a/web/server/www/scripts/version.js
+++ b/web/server/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.21';
+CC_API_VERSION = '6.22';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/web/tests/functional/comment/test_comment.py
+++ b/web/tests/functional/comment/test_comment.py
@@ -58,7 +58,7 @@ class TestComment(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         self._test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/component/test_component.py
+++ b/web/tests/functional/component/test_component.py
@@ -64,7 +64,7 @@ class TestComponent(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -100,7 +100,7 @@ int f(int x) { return 1 / x; }
                                     'db_cleanup_test',
                                     self.test_dir)
 
-        runs = self._cc_client.getRunData(run_filter, None, 0)
+        runs = self._cc_client.getRunData(run_filter, None, 0, None)
         run_id = runs[0].runId
 
         reports \
@@ -130,7 +130,7 @@ int f(int x) { return 1 / x; }
         run_filter.names = ['db_cleanup_test']
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter, None, 0)
+        runs = self._cc_client.getRunData(run_filter, None, 0, None)
         run_id = runs[0].runId
 
         reports \

--- a/web/tests/functional/delete_runs/test_delete_runs.py
+++ b/web/tests/functional/delete_runs/test_delete_runs.py
@@ -65,13 +65,13 @@ class TestCmdLineDeletion(unittest.TestCase):
 
         def all_exists(runs):
             run_names = [run.name for run in
-                         self._cc_client.getRunData(None, None, 0)]
+                         self._cc_client.getRunData(None, None, 0, None)]
             print(run_names)
             return set(runs) <= set(run_names)
 
         def none_exists(runs):
             run_names = [run.name for run in
-                         self._cc_client.getRunData(None, None, 0)]
+                         self._cc_client.getRunData(None, None, 0, None)]
             return not bool(set(runs).intersection(run_names))
 
         project_name = self._testproject_data['name']
@@ -98,7 +98,7 @@ class TestCmdLineDeletion(unittest.TestCase):
         # Remove runs before run 2 by run date.
 
         run2 = next(itertools.ifilter(lambda run: run.name == run2_name,
-                    self._cc_client.getRunData(None, None, 0)), None)
+                    self._cc_client.getRunData(None, None, 0, None)), None)
 
         date_run2 = datetime.strptime(run2.runDate, '%Y-%m-%d %H:%M:%S.%f')
         date_run2 = \

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -127,7 +127,7 @@ int main()
         This tests the change of the detection status of bugs when the file
         content changes.
         """
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
@@ -137,7 +137,7 @@ int main()
         self._create_source_file(0)
         self._check_source_file(self._codechecker_cfg)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         run_id = max(map(lambda run: run.runId, runs))
 
         reports = self._cc_client.getRunResults([run_id],
@@ -282,7 +282,7 @@ int main()
         """
         This test checks whether the storage works without a metadata.json.
         """
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
 
@@ -304,7 +304,7 @@ int main()
 
         codechecker.store(self._codechecker_cfg, 'hello')
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         run_id = max(map(lambda run: run.runId, runs))
 
         reports = self._cc_client.getRunResults([run_id],
@@ -321,7 +321,7 @@ int main()
         """
         This test checks reports which have detection status of 'Off'.
         """
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
 

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -19,8 +19,9 @@ import re
 import subprocess
 import unittest
 
-from codeCheckerDBAccess_v6.ttypes import CompareData, DiffType, \
-    ReportFilter, Severity, ReviewStatus, RunHistoryFilter
+from codeCheckerDBAccess_v6.ttypes import CompareData, DiffType, Order, \
+    ReportFilter, ReviewStatus, RunHistoryFilter, RunSortMode, RunSortType, \
+    Severity
 
 from libtest import env
 from libtest.debug_printer import print_run_results
@@ -65,7 +66,8 @@ class DiffRemote(unittest.TestCase):
         # Name order matters from __init__ !
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
         self._test_runs = [run for run in runs if run.name in run_names]
 
         # There should be at least two runs for this test.

--- a/web/tests/functional/extended_report_data/test_extended_report_data.py
+++ b/web/tests/functional/extended_report_data/test_extended_report_data.py
@@ -33,7 +33,7 @@ class TestExtendedReportData(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -48,7 +48,7 @@ class TestExtendedReportData(unittest.TestCase):
         run_filter.names = [run_name]
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter, None, 0)
+        runs = self._cc_client.getRunData(run_filter, None, 0, None)
         run_id = runs[0].runId
 
         return self._cc_client.getRunResults([run_id], None, 0, [], None, None,

--- a/web/tests/functional/func_template/template_test.py
+++ b/web/tests/functional/func_template/template_test.py
@@ -55,7 +55,7 @@ class TestSkeleton(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
     def test_skel(self):

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -85,7 +85,7 @@ class TestProductConfigShare(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace_main)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -192,10 +192,11 @@ class TestProductConfigShare(unittest.TestCase):
         self.assertEqual(store_res, 0, "Storing the test project failed.")
 
         cc_client_2 = env.setup_viewer_client(self.test_workspace_secondary)
-        self.assertEqual(len(cc_client_2.getRunData(None, None, 0)), 1,
+        self.assertEqual(len(cc_client_2.getRunData(None, None, 0, None)), 1,
                          "There should be a run present in the new server.")
 
-        self.assertEqual(len(self._cc_client.getRunData(None, None, 0)), 1,
+        self.assertEqual(len(self._cc_client.getRunData(None, None, 0, None)),
+                         1,
                          "There should be a run present in the database when "
                          "connected through the main server.")
 

--- a/web/tests/functional/products/test_products.py
+++ b/web/tests/functional/products/test_products.py
@@ -66,7 +66,7 @@ class TestProducts(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -247,7 +247,7 @@ class TestProducts(unittest.TestCase):
         # There is no schema initialization if the product database
         # was changed. The inital schema needs to be created manually
         # for the new database.
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         self.assertIsNone(runs)
 
         # Connect back to the old database.
@@ -260,7 +260,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old database name.")
 
         # The old database should have its data available again.
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")
@@ -295,7 +295,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save new endpoint.")
 
         # The old product is gone. Thus, connection should NOT happen.
-        res = self._cc_client.getRunData(None, None, 0)
+        res = self._cc_client.getRunData(None, None, 0, None)
         self.assertIsNone(res)
 
         # The new product should connect and have the data.
@@ -307,7 +307,7 @@ class TestProducts(unittest.TestCase):
             product=new_endpoint,  # Use the new product URL.
             endpoint='/CodeCheckerService',
             session_token=token)
-        self.assertEqual(len(new_client.getRunData(None, None, 0)), 1,
+        self.assertEqual(len(new_client.getRunData(None, None, 0, None)), 1,
                          "The new product did not serve the stored data.")
 
         # Set back to the old endpoint.
@@ -320,7 +320,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old endpoint.")
 
         # The old product should have its data available again.
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")

--- a/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
+++ b/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
@@ -18,9 +18,8 @@ import unittest
 
 from libtest import env
 
-from codeCheckerDBAccess_v6.ttypes import Encoding
-from codeCheckerDBAccess_v6.ttypes import LinesInFilesRequested
-from codeCheckerDBAccess_v6.ttypes import ReportFilter
+from codeCheckerDBAccess_v6.ttypes import Encoding, LinesInFilesRequested, \
+    Order, ReportFilter, RunSortMode, RunSortType
 
 
 class TestGetLinesInFile(unittest.TestCase):
@@ -45,7 +44,8 @@ class TestGetLinesInFile(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -17,11 +17,8 @@ import os
 import re
 import unittest
 
-from codeCheckerDBAccess_v6.ttypes import Encoding
-from codeCheckerDBAccess_v6.ttypes import Order
-from codeCheckerDBAccess_v6.ttypes import ReportFilter
-from codeCheckerDBAccess_v6.ttypes import SortMode
-from codeCheckerDBAccess_v6.ttypes import SortType
+from codeCheckerDBAccess_v6.ttypes import Encoding, Order, ReportFilter, \
+    SortMode, SortType, RunSortMode, RunSortType
 
 from libtest.debug_printer import print_run_results
 from libtest.thrift_client_to_db import get_all_run_results
@@ -51,7 +48,8 @@ class RunResults(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/web/tests/functional/report_viewer_api/test_hash_clash.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 from libtest import env
 from libtest import codechecker
 
-from codeCheckerDBAccess_v6.ttypes import Encoding
+from codeCheckerDBAccess_v6.ttypes import Encoding, RunFilter
 
 
 def _generate_content(cols, lines):
@@ -79,11 +79,22 @@ class HashClash(unittest.TestCase):
                       self._test_dir)
 
         self._codechecker_cfg['reportdir'] = self._test_dir
-        codechecker.store(self._codechecker_cfg,
-                          'test_hash_clash_' + uuid4().hex)
+        self._run_name = 'test_hash_clash_' + uuid4().hex
+        codechecker.store(self._codechecker_cfg, self._run_name)
+
+    def tearDown(self):
+        """
+        Remove the run which was stored by this test case.
+        """
+        run_filter = RunFilter(names=[self._run_name], exactMatch=True)
+        runs = self._report.getRunData(run_filter, None, 0, None)
+        run_id = runs[0].runId
+
+        # Remove the run.
+        self._report.removeRun(run_id)
 
     def _reports_for_latest_run(self):
-        runs = self._report.getRunData(None, None, 0)
+        runs = self._report.getRunData(None, None, 0, None)
         max_run_id = max(map(lambda run: run.runId, runs))
         return self._report.getRunResults([max_run_id],
                                           100,

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -16,7 +16,8 @@ import os
 import sys
 import unittest
 
-from codeCheckerDBAccess_v6.ttypes import ReportFilter, RunFilter
+from codeCheckerDBAccess_v6.ttypes import Order, ReportFilter, RunFilter, \
+    RunSortMode, RunSortType
 
 from libtest import codechecker
 from libtest import env
@@ -49,7 +50,8 @@ class RemoveRunResults(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -70,7 +72,8 @@ class RemoveRunResults(unittest.TestCase):
                                     test_project_path)
 
         run_filter = RunFilter(names=['remove_run_results'], exactMatch=True)
-        runs = self._cc_client.getRunData(run_filter, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(run_filter, None, 0, sort_mode)
         self.assertEqual(len(runs), 1)
 
         run_id = runs[0].runId

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -54,7 +54,8 @@ class TestReportFilter(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
 
         self._test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in self._test_runs]
@@ -586,7 +587,7 @@ class TestReportFilter(unittest.TestCase):
         Run name is randomly generated for all of the test runs.
         """
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         separate_report_counts = 0
         for run in runs:

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -52,7 +52,8 @@ class TestReportFilter(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in test_runs]

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -39,7 +39,7 @@ class TestReviewStatus(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/run_tag/test_run_tag.py
+++ b/web/tests/functional/run_tag/test_run_tag.py
@@ -13,7 +13,8 @@ import json
 import os
 import unittest
 
-from codeCheckerDBAccess_v6.ttypes import ReportFilter
+from codeCheckerDBAccess_v6.ttypes import Order, ReportFilter, RunSortMode, \
+    RunSortType
 
 from libtest import codechecker
 from libtest import env
@@ -144,7 +145,9 @@ int main()
         self._create_source_file(0, 'test_run_tag_update')
 
         # Get the run names which belong to this test
-        runs = self._cc_client.getRunData(None, None, 0)
+
+        sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
+        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
         test_run_ids = [run.runId for run in runs]
 
         self.assertEqual(len(test_run_ids), 2)

--- a/web/tests/functional/skip/test_skip.py
+++ b/web/tests/functional/skip/test_skip.py
@@ -46,7 +46,7 @@ class TestSkip(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/suppress/test_suppress_generation.py
+++ b/web/tests/functional/suppress/test_suppress_generation.py
@@ -61,7 +61,7 @@ class TestSuppress(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/update/test_update_mode.py
+++ b/web/tests/functional/update/test_update_mode.py
@@ -44,7 +44,7 @@ class TestUpdate(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0)
+        runs = self._cc_client.getRunData(None, None, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 


### PR DESCRIPTION
> Closes #2235 

- Extend the `getRunData` function to be able to sort the results by
different run data fields.
- Sort run data list on the GUI.
- Sort run data results by the date field by default.
- Add new test cases.