### PR TITLE
enable build matrix for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: 
+language:
     - python
 
 services:
@@ -11,12 +11,52 @@ matrix:
       sudo: required
       dist: xenial
       python: "2.7"
+      env: CC_MODULE=analyzer
+    - os: linux
+      name: "Server/client test cases (sqlite)"
+      sudo: required
+      dist: xenial
+      python: "2.7"
+      env: DATABASE=sqlite
+    - os: linux
+      name: "Server/client test cases (psycopg2)"
+      sudo: required
+      dist: xenial
+      python: "2.7"
+      env: DATABASE=psql_psycopg2
+    - os: linux
+      name: "Server/client test cases (pg8000)"
+      sudo: required
+      dist: xenial
+      python: "2.7"
+      env: DATABASE=psql_pg8000
+    - os: osx
+      osx_image: xcode9.4
+      name: "Analyzer test cases"
+      sudo: false
+      language: generic
+      env: CC_MODULE=analyzer
+    - os: osx
+      osx_image: xcode9.4
+      name: "Server/client test cases (sqlite)"
+      sudo: false
+      language: generic
+      env: DATABASE=sqlite
+    - os: osx
+      osx_image: xcode9.4
+      name: "Server/client test cases (psycopg2)"
+      sudo: false
+      language: generic
+      env:
+        - DATABASE=psql_psycopg2
+        - POSTGRESQL_VERSION=9.6
     - os: osx
       osx_image: xcode9.4
       name: "Analyzer, web (sqlite, psycopg2, pg8000) and tools test cases."
       sudo: false
       language: generic
       env:
+        - DATABASE=psql_pg8000
         - POSTGRESQL_VERSION=9.6
 
 before_install:
@@ -91,9 +131,13 @@ script:
       make clean_travis &&
       make package &&
       make -C tools/plist_to_html test &&
-      BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer test_unit test_functional &&
-      if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
-        make -C analyzer test_tu_collector test_build_logger;
-      fi &&
-      BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C web test_unit test_functional &&
-      make clean_travis
+      if [[ "$CC_MODULE" = "analyzer" ]]; then
+        BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer test_unit test_functional test_tu_collector;
+        if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
+          make -C analyzer test_build_logger
+        fi
+      elif [[ ! -z "$DATABASE" ]]; then
+        make -C web test_matrix_${DATABASE};
+      else
+        make test;
+      fi

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,14 @@ test_web:
 test_web_sqlite:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) test_sqlite
 
+# Run all the functional tests for the web with psycopg2.
+test_web_psql_psycopg2:
+	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) test_psql_psycopg2
+
+# Run all the functional tests for the web with pg8000.
+test_web_psql_pg8000:
+	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) test_psql_pg8000
+
 # Run a specific web test.
 test_web_feature:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) run_test

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -144,3 +144,13 @@ test_psql_pg8000_in_env: venv_dev
 
 test_clean:
 	$(CLEAR_WORKSPACE_CMD)
+
+# Use the proper requirement file for the given test configuration
+test_matrix_sqlite: VENV_DEV_REQ_FILE = web/requirements_py/dev/requirements.txt
+test_matrix_sqlite: test_unit test_sqlite
+
+test_matrix_psql_psycopg2: VENV_DEV_REQ_FILE = web/requirements_py/db_psycopg2/requirements.txt
+test_matrix_psql_psycopg2: test_unit test_psql_psycopg2
+
+test_matrix_psql_pg8000: VENV_DEV_REQ_FILE = requirements_py/db_pg8000/requirements.txt
+test_matrix_psql_pg8000: test_unit test_psql_pg8000


### PR DESCRIPTION
Additional tests are introduced and they do not fit
into the time limit for one job, splitting them
to multiple jobs help.

Each supported database type is tested in separate jobs.