### PR TITLE
[fix] Fix getDiffResultsHash API function

### DIFF
--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -351,9 +351,13 @@ service codeCheckerDBAccess {
 
   // Returns report hashes based on the diffType parameter.
   // PERMISSION: PRODUCT_ACCESS
+  // skipDetectionStatuses - you can filter out reports from the database which
+  // have these detection statuses, so these hashes will be marked as
+  // New/Unresolved reports when doing the comparison.
   list<string> getDiffResultsHash(1: list<i64>    runIds,
                                   2: list<string> reportHashes,
-                                  3: DiffType     diffType)
+                                  3: DiffType     diffType,
+                                  4: optional list<DetectionStatus> skipDetectionStatuses)
                                   throws (1: shared.RequestFailed requestError),
 
   // PERMISSION: PRODUCT_ACCESS

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -606,7 +606,8 @@ def handle_diff_results(args):
             remote_hashes = \
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
-                                          ttypes.DiffType.RESOLVED)
+                                          ttypes.DiffType.RESOLVED,
+                                          None)
 
             results = get_diff_base_results(client, run_ids,
                                             remote_hashes,
@@ -619,7 +620,8 @@ def handle_diff_results(args):
             remote_hashes = \
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
-                                          ttypes.DiffType.UNRESOLVED)
+                                          ttypes.DiffType.UNRESOLVED,
+                                          None)
             for result in report_dir_results:
                 rep_h = result.report_hash
                 if rep_h in remote_hashes and rep_h not in suppressed_in_code:
@@ -630,7 +632,8 @@ def handle_diff_results(args):
             remote_hashes = \
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
-                                          ttypes.DiffType.UNRESOLVED)
+                                          ttypes.DiffType.UNRESOLVED,
+                                          None)
             for result in report_dir_results:
                 if result.report_hash not in remote_hashes:
                     filtered_reports.append(result)
@@ -652,7 +655,8 @@ def handle_diff_results(args):
 
         remote_hashes = client.getDiffResultsHash(run_ids,
                                                   local_report_hashes,
-                                                  diff_type)
+                                                  diff_type,
+                                                  None)
 
         if diff_type in [ttypes.DiffType.NEW, ttypes.DiffType.UNRESOLVED]:
             # Shows reports from the report dir which are not present in

--- a/web/client/codechecker_client/thrift_helper.py
+++ b/web/client/codechecker_client/thrift_helper.py
@@ -59,7 +59,8 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def getDiffResultsHash(self, run_ids, report_hashes, diff_type):
+    def getDiffResultsHash(self, run_ids, report_hashes, diff_type,
+                           skip_detection_statuses):
         pass
 
     @ThriftClientCall

--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_NAME = '__ccPrivilegedAccessToken'
 # The newest supported minor version (value) for each supported major version
 # (key) in this particular build.
 SUPPORTED_VERSIONS = {
-    6: 20
+    6: 21
 }
 
 # Used by the client to automatically identify the latest major and minor

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -927,8 +927,18 @@ class ThriftRequestHandler(object):
 
     @exc_to_thrift_reqfail
     @timeit
-    def getDiffResultsHash(self, run_ids, report_hashes, diff_type):
+    def getDiffResultsHash(self, run_ids, report_hashes, diff_type,
+                           skip_detection_statuses):
         self.__require_access()
+
+        if not skip_detection_statuses:
+            skip_detection_statuses = [ttypes.DetectionStatus.RESOLVED,
+                                       ttypes.DetectionStatus.OFF,
+                                       ttypes.DetectionStatus.UNAVAILABLE]
+
+        # Convert statuses to string.
+        skip_statuses_str = [detection_status_str(status)
+                             for status in skip_detection_statuses]
 
         with DBSession(self.__Session) as session:
             if diff_type == DiffType.NEW:
@@ -940,7 +950,8 @@ class ThriftRequestHandler(object):
                     return []
 
                 base_hashes = session.query(Report.bug_id.label('bug_id')) \
-                    .outerjoin(File, Report.file_id == File.id)
+                    .outerjoin(File, Report.file_id == File.id) \
+                    .filter(Report.detection_status.notin_(skip_statuses_str))
 
                 if run_ids:
                     base_hashes = \
@@ -981,7 +992,8 @@ class ThriftRequestHandler(object):
 
             elif diff_type == DiffType.UNRESOLVED:
                 results = session.query(Report.bug_id) \
-                    .filter(Report.bug_id.in_(report_hashes))
+                    .filter(Report.bug_id.in_(report_hashes)) \
+                    .filter(Report.detection_status.notin_(skip_statuses_str))
 
                 if run_ids:
                     results = results.filter(Report.run_id.in_(run_ids))

--- a/web/server/www/scripts/version.js
+++ b/web/server/www/scripts/version.js
@@ -1,2 +1,2 @@
-CC_API_VERSION = '6.20';
+CC_API_VERSION = '6.21';
 CC_AUTH_COOKIE_NAME = '__ccPrivilegedAccessToken';

--- a/web/tests/functional/diff_local_remote/__init__.py
+++ b/web/tests/functional/diff_local_remote/__init__.py
@@ -104,6 +104,12 @@ def setup_package():
         sys.exit(1)
     print('Analyzing local was successful.')
 
+    # Store results to the remote server.
+    test_project_name_remote = project_info['name'] + '_' + uuid.uuid4().hex
+    ret = codechecker.store(codechecker_cfg, test_project_name_remote)
+    if ret:
+        sys.exit(1)
+
     # Remote analysis, results will be stored to the remote server.
     altered_file = os.path.join(test_proj_path_local, "call_and_message.cpp")
     project.insert_suppression(altered_file)
@@ -118,8 +124,8 @@ def setup_package():
         sys.exit(1)
     print('Analyzing new was successful.')
 
-    # Store results to the remote server.
-    test_project_name_remote = project_info['name'] + '_' + uuid.uuid4().hex
+    # Store results again to the remote server. We need this second store to
+    # set the detection status to the required states.
     ret = codechecker.store(codechecker_cfg, test_project_name_remote)
     if ret:
         sys.exit(1)

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -513,7 +513,8 @@ class DiffRemote(unittest.TestCase):
         report_hashes = [str(i) for i in range(0, 10000)]
         diff_res = self._cc_client.getDiffResultsHash([base_run_id],
                                                       report_hashes,
-                                                      DiffType.NEW)
+                                                      DiffType.NEW,
+                                                      None)
         self.assertEqual(len(diff_res), len(report_hashes))
 
     def test_diff_run_tags(self):


### PR DESCRIPTION
Let's suppose that a report can be found in the database in a run with
detection status of `Resolved` and this report reappeared again in the
report directory. If we do comparison between this report directory
and the remote run the newly introduced report will not be shown as
new report because it is already can be found in the database.

This commit will solve this problem by filtering out reports which
have detection status of `Resolved`, `Off` or `Unavailable` when
getting diff report hashes for `NEW` and `UNRESOLVED` diff types.