### PR TITLE
Keep GCC include-fixed dirs in include paths

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -23,6 +23,7 @@ from codechecker_analyzer import env
 
 from .. import analyzer_base
 from ..flag import has_flag
+from ..flag import prepend_all
 
 from . import clang_options
 from . import config_handler
@@ -245,8 +246,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
-            analyzer_cmd.extend(
-                self.buildaction.compiler_includes[compile_lang])
+            analyzer_cmd.extend(prepend_all(
+                '-isystem',
+                self.buildaction.compiler_includes[compile_lang]))
 
             analyzer_cmd.append(self.source_file)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 from .. import analyzer_base
 from ..flag import has_flag
+from ..flag import prepend_all
 
 
 def get_compile_command(action, config, source='', output=''):
@@ -26,7 +27,7 @@ def get_compile_command(action, config, source='', output=''):
             action.target[compile_lang] != "":
         cmd.append("--target=" + action.target[compile_lang])
 
-    cmd.extend(action.compiler_includes[compile_lang])
+    cmd.extend(prepend_all('-isystem', action.compiler_includes[compile_lang]))
     cmd.append('-c')
     if not has_flag('-x', cmd):
         cmd.extend(['-x', action.lang])

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
@@ -22,6 +22,7 @@ import re
 from codechecker_common.logger import get_logger
 
 from ..flag import has_flag
+from ..flag import prepend_all
 
 LOG = get_logger('analyzer')
 
@@ -76,7 +77,9 @@ def build_stat_coll_cmd(action, config, source):
     if not has_flag('-std', cmd) and not has_flag('--std', cmd):
         cmd.append(action.compiler_standard.get(compile_lang, ""))
 
-    cmd.extend(action.compiler_includes.get(compile_lang, []))
+    cmd.extend(prepend_all(
+        '-isystem',
+        action.compiler_includes.get(compile_lang, [])))
 
     if source:
         cmd.append(source)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -21,6 +21,7 @@ from codechecker_analyzer import env
 
 from .. import analyzer_base
 from ..flag import has_flag
+from ..flag import prepend_all
 from ..clangsa.analyzer import ClangSA
 
 from . import config_handler
@@ -144,8 +145,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
-            analyzer_cmd.extend(
-                self.buildaction.compiler_includes[compile_lang])
+            analyzer_cmd.extend(prepend_all(
+                '-isystem',
+                self.buildaction.compiler_includes[compile_lang]))
 
             if not has_flag('-std', analyzer_cmd) and not \
                     has_flag('--std', analyzer_cmd):

--- a/analyzer/codechecker_analyzer/analyzers/flag.py
+++ b/analyzer/codechecker_analyzer/analyzers/flag.py
@@ -8,3 +8,16 @@
 def has_flag(flag, cmd):
     """Return true if a cmd contains a flag or false if not."""
     return bool(next((x for x in cmd if x.startswith(flag)), False))
+
+
+def prepend_all(flag, params):
+    """
+    Returns a list where all elements of "params" is prepended with the given
+    flag. For example in case "flag" is -f and "params" is ['a', 'b', 'c'] the
+    result is ['-f', 'a', '-f', 'b', '-f', 'c'].
+    """
+    result = []
+    for param in params:
+        result.append(flag)
+        result.append(param)
+    return result

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -102,6 +102,17 @@ def add_arguments_to_parser(parser):
                              "specified file rather than invoke the compiler "
                              "executable.")
 
+    parser.add_argument('--skip-gcc-fix-include',
+                        dest="skip_gcc_fix_include",
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help="DEPRECATED. There are some implicit include "
+                             "paths which are only used by GCC "
+                             "(include-fixed). This flag determines whether "
+                             "these should be skipped from the implicit "
+                             "include paths.")
+
     parser.add_argument('-t', '--type', '--output-format',
                         dest="output_format",
                         required=False,
@@ -582,8 +593,8 @@ def main(args):
             report_dir,
             args.compile_uniqueing,
             skip_handler,
-            compiler_info_file
-            )
+            compiler_info_file,
+            args.skip_gcc_fix_include)
 
     if not actions:
         LOG.info("No analysis is required.\nThere were no compilation "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -108,6 +108,17 @@ def add_arguments_to_parser(parser):
                              "incrementally update defect reports for source "
                              "files that were analysed.)")
 
+    parser.add_argument('--skip-gcc-fix-include',
+                        dest="skip_gcc_fix_include",
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help="DEPRECATED. There are some implicit include "
+                             "paths which are only used by GCC "
+                             "(include-fixed). This flag determines whether "
+                             "these should be skipped from the implicit "
+                             "include paths.")
+
     log_args = parser.add_argument_group(
         "log arguments",
         """
@@ -580,7 +591,8 @@ def main(args):
             logfile=[logfile],
             output_path=output_dir,
             output_format='plist',
-            jobs=args.jobs
+            jobs=args.jobs,
+            skip_gcc_fix_include=args.skip_gcc_fix_include
         )
         # Some arguments don't have default values.
         # We can't set these keys to None because it would result in an error

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -154,8 +154,6 @@ class TestAnalyze(unittest.TestCase):
                 self.assertEquals(len(data), 2)
                 self.assertTrue("clang++" in data)
                 self.assertTrue("g++" in data)
-                self.assertEqual(
-                    data["clang++"]['c++']["compiler_includes"][0], "-isystem")
             except ValueError:
                 self.fail("json.load should successfully parse the file %s"
                           % info_File)

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -380,6 +380,24 @@ class OptionParserTest(unittest.TestCase):
         self.assertEqual(res,
                          '/usr/lib/ccache/g++')
 
+    def test_compiler_gcc_implicit_includes(self):
+        action = {
+            'file': 'main.cpp',
+            'directory': '',
+            'command': 'g++ main.cpp'
+        }
+
+        # In this test we assume that there will always be an "include-fixed"
+        # directory among the implicit include paths. Otherwise this test may
+        # fail.
+
+        res = log_parser.parse_options(action, skip_gcc_fix_headers=False)
+        self.assertTrue(any(map(lambda x: x.endswith('include-fixed'),
+                                res.compiler_includes['c++'])))
+        res = log_parser.parse_options(action, skip_gcc_fix_headers=True)
+        self.assertFalse(any(map(lambda x: x.endswith('include-fixed'),
+                                 res.compiler_includes['c++'])))
+
     def test_compiler_include_file(self):
         action = {
             'file': 'main.cpp',
@@ -405,4 +423,4 @@ class OptionParserTest(unittest.TestCase):
 
             res = log_parser.parse_options(action, info_file_tmp.name)
             self.assertEqual(res.compiler_includes['c++'],
-                             ['-isystem', '/FAKE_INCLUDE_DIR'])
+                             ['/FAKE_INCLUDE_DIR'])

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -79,7 +79,8 @@ subcommand.
 
 ```
 usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q] [-f]
-                         (-b COMMAND | -l LOGFILE) [-j JOBS] [-c]
+                         [--skip-gcc-fix-include] (-b COMMAND | -l LOGFILE)
+                         [-j JOBS] [-c]
                          [--compile-uniqueing COMPILE_UNIQUEING]
                          [--report-hash {context-free}] [-i SKIPFILE]
                          [--analyzers ANALYZER [ANALYZER ...]]
@@ -113,6 +114,11 @@ optional arguments:
                         coming from files not affected by the analysis, and
                         only incrementally update defect reports for source
                         files that were analysed.)
+  --skip-gcc-fix-include
+                        DEPRECATED. There are some implicit include paths which
+                        are only used by GCC (include-fixed). This flag
+                        determines whether these should be skipped from the
+                        implicit include paths. (default: False)
   --compile-uniqueing COMPILE_UNIQUEING
                         Specify the method the compilation actions in the
                         compilation database are uniqued before analysis. CTU
@@ -387,7 +393,7 @@ below:
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
                            [--compiler-info-file COMPILER_INFO_FILE]
-                           [-t {plist}] [-q] [-c]
+                           [--skip-gcc-fix-include] [-t {plist}] [-q] [-c]
                            [--compile-uniqueing COMPILE_UNIQUEING]
                            [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]
@@ -427,6 +433,11 @@ optional arguments:
                         Read the compiler includes and target from the
                         specified file rather than invoke the compiler
                         executable.
+  --skip-gcc-fix-include
+                        DEPRECATED. There are some implicit include paths which
+                        are only used by GCC (include-fixed). This flag
+                        determines whether these should be skipped from the
+                        implicit include paths. (default: False)
   -t {plist}, --type {plist}, --output-format {plist}
                         Specify the format the analysis results should use.
                         (default: plist)
@@ -607,6 +618,11 @@ recorded int the `<report-directory>/compiler_info.json`.
 If you want to run the analysis with a specific compiler configuration
 instead of the auto-detection you can pass that to the
 `--compiler-info-file compiler_info.json` parameter.
+
+There are some implicit include paths (for example those which contain
+`include-fixed` directory) which are used only by GCC. By default CodeChecker
+doesn't collect them if `--skip-gcc-fix-include` flag is given. For
+further information see [GCC incompatibilities](gcc_incompatibilities.md).
 
 #### Forwarding compiler options <a name="forwarding-compiler-options"></a>
 


### PR DESCRIPTION
There are some implicit include directories which are omitted
explicitly by CodeChecker. See the details in
/docs/analyzer/gcc_incompatibilities.md.

In this commit the user can keep these directories by providing an
extra flag to CodeChecker [analyze|check] commands.