### PR TITLE
Remove skip list handler from common module

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -19,9 +19,9 @@ import sys
 from codechecker_analyzer import analyzer, analyzer_context, arg
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.buildlog import log_parser
+from codechecker_analyzer import skiplist
 
 from codechecker_common import logger
-from codechecker_common import skiplist_handler
 from codechecker_common.util import load_json_or_empty
 
 
@@ -491,7 +491,7 @@ def __get_skip_handler(args):
         if args.skipfile:
             LOG.debug_analyzer("Creating skiplist handler.")
             with open(args.skipfile) as skip_file:
-                return skiplist_handler.SkipListHandler(skip_file.read())
+                return skiplist.SkipListHandler(skip_file.read())
     except AttributeError:
         LOG.debug_analyzer('Skip file was not set in the command line')
 

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -19,12 +19,11 @@ import sys
 
 from plist_to_html import PlistToHtml
 
-from codechecker_analyzer import analyzer_context, suppress_handler
+from codechecker_analyzer import analyzer_context, suppress_handler, skiplist
 
 from codechecker_common import logger
 from codechecker_common import plist_parser
 from codechecker_common import util
-from codechecker_common.skiplist_handler import SkipListHandler
 from codechecker_common.source_code_comment_handler import \
     SourceCodeCommentHandler
 from codechecker_common.output_formatters import twodim_to_str
@@ -554,7 +553,7 @@ def main(args):
     skip_handler = None
     if 'skipfile' in args:
         with open(args.skipfile, 'r') as skip_file:
-            skip_handler = SkipListHandler(skip_file.read())
+            skip_handler = skiplist.SkipListHandler(skip_file.read())
 
     trim_path_prefixes = args.trim_path_prefix if \
         'trim_path_prefix' in args else None

--- a/analyzer/codechecker_analyzer/skiplist.py
+++ b/analyzer/codechecker_analyzer/skiplist.py
@@ -3,8 +3,8 @@
 #   This file is distributed under the University of Illinois Open Source
 #   License. See LICENSE.TXT for details.
 # -------------------------------------------------------------------------
-"""
-"""
+
+"""Parse the skip list file."""
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
@@ -18,7 +18,17 @@ LOG = get_logger('system')
 
 
 class SkipListHandler(object):
-    """
+    """Parse the skip list file format.
+
+    For every skip line in the skip list a regex is generated
+    which is matched for a given file path to check if
+    it should be skipped or not.
+
+    Order of the lines in the skip file matter!
+    Go from more specific to more global rules like:
+    +*/3pp_other/lib/not_to_skip.cpp
+    -*/3pp_other/*
+
     Skiplist file format:
 
     -/skip/all/source/in/directory*
@@ -28,9 +38,7 @@ class SkipListHandler(object):
     """
 
     def __init__(self, skip_file_content=""):
-        """
-        Process the lines of the skip file.
-        """
+        """Parse the lines of the skip file."""
         self.__skip = []
 
         self.__skip_file_lines = [line.strip() for line
@@ -41,8 +49,7 @@ class SkipListHandler(object):
         self.__gen_regex(valid_lines)
 
     def __gen_regex(self, skip_lines):
-        """
-        Generate a regular expression from the given skip lines
+        """Generate a regular expression from the given skip lines
         and collect them for later match.
 
         The lines should be checked for validity before generating
@@ -54,8 +61,8 @@ class SkipListHandler(object):
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):
-        """
-        Check if the skip line is given in a valid format.
+        """Check if the skip line is given in a valid format.
+
         Returns the list of valid lines.
         """
         valid_lines = []
@@ -70,14 +77,11 @@ class SkipListHandler(object):
 
     @property
     def skip_file_lines(self):
-        """
-        List of the lines from the skip file without changes.
-        """
+        """List of the lines from the skip file without changes."""
         return self.__skip_file_lines
 
     def overwrite_skip_content(self, skip_lines):
-        """
-        Cleans out the already collected skip regular expressions
+        """Clean out the already collected skip regular expressions
         and rebuilds the list from the given skip_lines.
         """
         self.__skip = []
@@ -85,9 +89,9 @@ class SkipListHandler(object):
         self.__gen_regex(valid_lines)
 
     def should_skip(self, source):
-        """
-        Check if the given source should be skipped.
-        Should the analyzer skip the given source file?
+        """Check if the given source should be skipped.
+
+        Match the given source path to the processed regex list.
         """
         if not self.__skip:
             return False

--- a/analyzer/tests/unit/test_skiplist.py
+++ b/analyzer/tests/unit/test_skiplist.py
@@ -1,0 +1,67 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Skip list tests."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import unittest
+
+from codechecker_analyzer.skiplist import SkipListHandler
+
+
+class SkipList(unittest.TestCase):
+    """Skip list related tests."""
+
+    @classmethod
+    def setup_class(cls):
+        """Initialize a checkers list for the tests.
+
+        Order of the lines in the skip file matter!
+        Go from more specific to more global rules like:
+        +*/3pp_other/lib/not_to_skip.cpp
+        -*/3pp_other/*
+        """
+        cls._skip_list = \
+            """
+            -/skip/all/source/in/directory*
+            -/do/not/check/this.file
+            +/dir/check.this.file
+            -/dir/*
+            -*/3pp/to_skip/
+            +*/3pp/not_to_skip/
+            +*/3pp_other/lib/not_to_skip.cpp
+            -*/3pp_other/*
+            """
+
+    def test_skip_absolute_path(self):
+        """Skip rule is an absolute path in the file."""
+        slh = SkipListHandler(self._skip_list)
+
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib1.cpp"))
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib1.h"))
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib2.cpp"))
+        self.assertTrue(slh.should_skip("/do/not/check/this.file"))
+        self.assertTrue(slh.should_skip("/dir/main.cpp"))
+        self.assertTrue(slh.should_skip("/dir/lib.cpp"))
+        self.assertTrue(slh.should_skip("/dir/lib2/lib2.cpp"))
+
+        self.assertFalse(slh.should_skip("/dir/check.this.file"))
+
+    def test_skip_relative_path(self):
+        """Skip rule is not an absolute path in the skip file."""
+        slh = SkipListHandler(self._skip_list)
+
+        self.assertTrue(slh.should_skip("/lib/3pp/to_skip/3pp.cpp"))
+        self.assertTrue(slh.should_skip("/lib/3pp_other/lib/skip.cpp"))
+        self.assertTrue(slh.should_skip("/lib/3pp_other/skip_other.cpp"))
+
+        self.assertFalse(slh.should_skip(
+            "/lib/3pp_other/lib/not_to_skip.cpp"))

--- a/web/server/codechecker_server/skiplist.py
+++ b/web/server/codechecker_server/skiplist.py
@@ -1,0 +1,103 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+
+"""Parse the skip list file."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import fnmatch
+import re
+
+from codechecker_common.logger import get_logger
+
+LOG = get_logger('system')
+
+
+class SkipListHandler(object):
+    """Parse the skip list file format.
+
+    For every skip line in the skip list a regex is generated
+    which is matched for a given file path to check if
+    it should be skipped or not.
+
+    Order of the lines in the skip file matter!
+    Go from more specific to more global rules like:
+    +*/3pp_other/lib/not_to_skip.cpp
+    -*/3pp_other/*
+
+    Skiplist file format:
+
+    -/skip/all/source/in/directory*
+    -/do/not/check/this.file
+    +/dir/check.this.file
+    -/dir/*
+    """
+
+    def __init__(self, skip_file_content=""):
+        """Parse the lines of the skip file."""
+        self.__skip = []
+
+        self.__skip_file_lines = [line.strip() for line
+                                  in skip_file_content.splitlines()
+                                  if line.strip()]
+
+        valid_lines = self.__check_line_format(self.__skip_file_lines)
+        self.__gen_regex(valid_lines)
+
+    def __gen_regex(self, skip_lines):
+        """Generate a regular expression from the given skip lines
+        and collect them for later match.
+
+        The lines should be checked for validity before generating
+        the regular expressions.
+        """
+        for skip_line in skip_lines:
+            rexpr = re.compile(
+                fnmatch.translate(skip_line[1:].strip() + '*'))
+            self.__skip.append((skip_line, rexpr))
+
+    def __check_line_format(self, skip_lines):
+        """Check if the skip line is given in a valid format.
+
+        Returns the list of valid lines.
+        """
+        valid_lines = []
+        for line in skip_lines:
+            if len(line) < 2 or line[0] not in ['-', '+']:
+                LOG.warning("Skipping malformed skipfile pattern: %s", line)
+                continue
+
+            valid_lines.append(line)
+
+        return valid_lines
+
+    @property
+    def skip_file_lines(self):
+        """List of the lines from the skip file without changes."""
+        return self.__skip_file_lines
+
+    def overwrite_skip_content(self, skip_lines):
+        """Clean out the already collected skip regular expressions
+        and rebuilds the list from the given skip_lines.
+        """
+        self.__skip = []
+        valid_lines = self.__check_line_format(skip_lines)
+        self.__gen_regex(valid_lines)
+
+    def should_skip(self, source):
+        """Check if the given source should be skipped.
+
+        Match the given source path to the processed regex list.
+        """
+        if not self.__skip:
+            return False
+
+        for line, rexpr in self.__skip:
+            if rexpr.match(source):
+                sign = line[0]
+                return sign == '-'
+        return False

--- a/web/server/tests/unit/test_skiplist.py
+++ b/web/server/tests/unit/test_skiplist.py
@@ -1,0 +1,67 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Skip list tests."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import unittest
+
+from codechecker_server.skiplist import SkipListHandler
+
+
+class SkipList(unittest.TestCase):
+    """Skip list related tests."""
+
+    @classmethod
+    def setup_class(cls):
+        """Initialize a checkers list for the tests.
+
+        Order of the lines in the skip file matter!
+        Go from more specific to more global rules like:
+        +*/3pp_other/lib/not_to_skip.cpp
+        -*/3pp_other/*
+        """
+        cls._skip_list = \
+            """
+            -/skip/all/source/in/directory*
+            -/do/not/check/this.file
+            +/dir/check.this.file
+            -/dir/*
+            -*/3pp/to_skip/
+            +*/3pp/not_to_skip/
+            +*/3pp_other/lib/not_to_skip.cpp
+            -*/3pp_other/*
+            """
+
+    def test_skip_absolute_path(self):
+        """Skip rule is an absolute path in the file."""
+        slh = SkipListHandler(self._skip_list)
+
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib1.cpp"))
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib1.h"))
+        self.assertTrue(slh.should_skip(
+            "/skip/all/source/in/directory/lib2.cpp"))
+        self.assertTrue(slh.should_skip("/do/not/check/this.file"))
+        self.assertTrue(slh.should_skip("/dir/main.cpp"))
+        self.assertTrue(slh.should_skip("/dir/lib.cpp"))
+        self.assertTrue(slh.should_skip("/dir/lib2/lib2.cpp"))
+
+        self.assertFalse(slh.should_skip("/dir/check.this.file"))
+
+    def test_skip_relative_path(self):
+        """Skip rule is not an absolute path in the skip file."""
+        slh = SkipListHandler(self._skip_list)
+
+        self.assertTrue(slh.should_skip("/lib/3pp/to_skip/3pp.cpp"))
+        self.assertTrue(slh.should_skip("/lib/3pp_other/lib/skip.cpp"))
+        self.assertTrue(slh.should_skip("/lib/3pp_other/skip_other.cpp"))
+
+        self.assertFalse(slh.should_skip(
+            "/lib/3pp_other/lib/not_to_skip.cpp"))


### PR DESCRIPTION
The skip list hander is moved to the analyzer
and the web parts because both of them use it.
Additional new tests were added.