### PR TITLE
[server] Fix login form autocompletion

### DIFF
--- a/web/server/www/scripts/login/login.js
+++ b/web/server/www/scripts/login/login.js
@@ -65,8 +65,11 @@ function (declare, cookie, dom, domConstruct, domClass, ioQuery, keys, on,
     _doLogin : function() {
       var that = this;
 
+      var userName = this.txtUser.get('value');
+      var pass = this.txtPass.get('value');
+
       // No username supplied.
-      if (!this.txtUser.value || !this.txtUser.value.trim().length) {
+      if (!userName || !userName.trim().length) {
         domClass.add(that._mbox.domNode, 'mbox-error');
         that._mbox.show("Failed to log in!", "No username supplied.");
         return;
@@ -76,7 +79,7 @@ function (declare, cookie, dom, domConstruct, domClass, ioQuery, keys, on,
       this._standBy.show();
 
       CC_AUTH_SERVICE.performLogin(
-        'Username:Password', this.txtUser.value + ':' + this.txtPass.value,
+        'Username:Password', userName + ':' + pass,
         function (sessionToken) {
           domClass.add(that._mbox.domNode, 'mbox-success');
           that._mbox.show("Successfully logged in!", '');
@@ -270,7 +273,7 @@ function (declare, cookie, dom, domConstruct, domClass, ioQuery, keys, on,
     var loginContainer = new ContentPane({
       region : 'center',
       postCreate : function () {
-         var smallerContainer = domConstruct.create('div', {
+         var smallerContainer = domConstruct.create('form', {
            id : 'login-form'
          }, this.containerNode);
 


### PR DESCRIPTION
In Firefox the login form autocompletion didn't work. The problem was that the `autocomplete` attribute of the `username` input field was set to `off`. In this commit we set it to `on`.

We are also using the `get` function on the input fields to get the values because the value field wasn't set properly in Firefox.