### PR TITLE
[server] Fix comment update

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/CommentView.js
+++ b/web/server/www/scripts/codecheckerviewer/CommentView.js
@@ -133,8 +133,9 @@ function (declare, dom, style, topic, Memory, Observable, ConfirmDialog,
             CC_SERVICE.updateComment(that.cId, newContent);
           } catch (ex) { util.handleThriftException(ex); }
 
-          that._message.replace(/(?:\r\n|\r|\n)/g, '<br>')
-              .set('content', newContent);
+          that._message.set('content',
+            newContent.replace(/(?:\r\n|\r|\n)/g, '<br>'));
+
           that._editDialog.hide();
         }
       });


### PR DESCRIPTION
> Closes #2264

When we opened a bug which had a comment and we clicked on the edit button, changed the comment message and pressed the `Save` button nothing happened. The problem was that we tried to call the `replace` function on the dojo `ContentPane` object not on the content itself (See #2262). With this commit we fix this problem.