### PR TITLE
Upgrade thrift from 0.9.1/2 to 0.11.0. Clean rebuild required.

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,4 +3,4 @@ sqlalchemy==1.3.5
 alembic==0.9.2
 portalocker==1.1.0
 psutil==5.2.2
-thrift==0.9.1
+thrift==0.11.0

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -2,6 +2,6 @@ lxml==4.3.4
 sqlalchemy==1.3.5
 alembic==0.9.2
 pg8000==1.10.2
-thrift==0.9.1
+thrift==0.11.0
 psutil==5.2.2
 portalocker==1.1.0

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -2,6 +2,6 @@ lxml==4.3.4
 sqlalchemy==1.3.5
 alembic==0.9.2
 psycopg2-binary==2.7.7
-thrift==0.9.1
+thrift==0.11.0
 psutil==5.2.2
 portalocker==1.1.0

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -4,7 +4,7 @@ pycodestyle==2.4.0
 alembic==0.9.2
 psycopg2-binary==2.7.7
 pg8000==1.10.2
-thrift==0.9.1
+thrift==0.11.0
 psutil==5.2.2
 portalocker==1.1.0
 pylint==1.9.4

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -3,4 +3,4 @@ alembic==0.9.2
 portalocker==1.1.0
 psutil==5.2.2
 sqlalchemy==1.3.5
-thrift==0.9.1
+thrift==0.11.0

--- a/web/server/vendor/Makefile
+++ b/web/server/vendor/Makefile
@@ -2,7 +2,7 @@ VENDOR_DIR = $(shell pwd)
 BUILD_DIR = $(VENDOR_DIR)/build
 
 # Git tag versions of external dependencies.
-THRIFT_VERSION = 0.9.2
+THRIFT_VERSION = 0.11.0
 CODEMIRROR_VERSION = 5.25.0
 JSPLUMB_VERSION = 2.2.0
 MARKED_VERSION = v0.3.3


### PR DESCRIPTION
Fixes failure to build/run on Debian Buster. (See my note on #1827)