### PR TITLE
Introduce clang version dependent options

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
@@ -1,0 +1,92 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""Clang Static analyzer version dependent arguments."""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import os
+
+
+def get_analyzer_checkers_cmd(clang_version_info, env, plugins,
+                              alpha=True, debug=True):
+    """Return the checkers list which depends on the used clang version.
+
+    plugins should be a list of path to clang plugins (so with checkers)
+
+    Before clang9 alpha and debug checkers were printed by default.
+    Since clang9 there are extra arguments to print the additional checkers.
+    """
+    major_version = clang_version_info.major_version
+    command = []
+
+    for plugin in plugins:
+        command.extend(["-load", plugin])
+
+    command.append("-analyzer-checker-help")
+
+    if alpha and major_version > 8:
+        command.append("-analyzer-checker-help-alpha")
+
+    if debug and major_version > 8:
+        command.append("-analyzer-checker-help-developer")
+
+    return command
+
+
+def ctu_mapping(clang_version_info):
+    """Clang version dependent ctu mapping tool path and mapping file name.
+
+    The path of the mapping tool, which is assumed to be located
+    inside the installed directory of the analyzer. Certain binary
+    distributions can postfix the tool name with the major version
+    number, the number and the tool name being separated by a dash. By
+    default the shorter name is looked up, then if it is not found the
+    postfixed.
+    """
+    if not clang_version_info:
+        LOG.debug("No clang version information."
+                  "Can not detect ctu mapping tool.")
+        return None, None
+
+    old_mapping_tool_name = 'clang-func-mapping'
+    old_mapping_file_name = 'externalFnMap.txt'
+
+    new_mapping_tool_name = 'clang-extdef-mapping'
+    new_mapping_file_name = 'externalDefMap.txt'
+
+    major_version = clang_version_info.major_version
+
+    if major_version > 7:
+        tool_name = new_mapping_tool_name
+        mapping_file = new_mapping_file_name
+    else:
+        tool_name = old_mapping_tool_name
+        mapping_file = old_mapping_file_name
+
+    installed_dir = clang_version_info.installed_dir
+
+    tool_path = os.path.join(installed_dir, tool_name)
+
+    if os.path.isfile(tool_path):
+        return tool_path, mapping_file
+
+    LOG.debug(
+        "Mapping tool '%s' suggested by autodetection is not found in "
+        "directory reported by Clang '%s'. Trying with version-postfixed "
+        "filename...", tool_path, installed_dir)
+
+    postfixed_tool_path = ''.join([tool_path, '-', str(major_version)])
+
+    if os.path.isfile(postfixed_tool_path):
+        return postfixed_tool_path, mapping_file
+
+    LOG.debug(
+        "Postfixed mapping tool '%s' suggested by autodetection is not "
+        "found in directory reported by Clang '%s'.",
+        postfixed_tool_path, installed_dir)
+    return None, None

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -1,0 +1,57 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""Parse the 'clang --version' command output."""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import re
+
+
+class ClangVersionInfo(object):
+    """ClangVersionInfo holds the version information of the used Clang."""
+
+    def __init__(self,
+                 major_version=None,
+                 minor_version=None,
+                 patch_version=None,
+                 installed_dir=None):
+
+        self.major_version = int(major_version)
+        self.minor_version = int(minor_version)
+        self.patch_version = int(patch_version)
+        self.installed_dir = str(installed_dir)
+
+
+class ClangVersionInfoParser(object):
+    """
+    ClangVersionInfoParser is responsible for creating ClangVersionInfo
+    instances from the version output of Clang.
+    """
+
+    def __init__(self):
+        self.clang_version_pattern = (
+            r'clang version (?P<major_version>[0-9]+)'
+            r'\.(?P<minor_version>[0-9]+)\.(?P<patch_version>[0-9]+)')
+
+        self.clang_installed_dir_pattern =\
+            r'InstalledDir: (?P<installed_dir>[^\s]*)'
+
+    def parse(self, version_string):
+        """Try to parse the version string using the predefined patterns."""
+        version_match = re.search(self.clang_version_pattern, version_string)
+        installed_dir_match = re.search(
+            self.clang_installed_dir_pattern, version_string)
+
+        if not version_match or not installed_dir_match:
+            return False
+
+        return ClangVersionInfo(
+            version_match.group('major_version'),
+            version_match.group('minor_version'),
+            version_match.group('patch_version'),
+            installed_dir_match.group('installed_dir'))

--- a/analyzer/tests/unit/test_clang_version_parsing.py
+++ b/analyzer/tests/unit/test_clang_version_parsing.py
@@ -14,8 +14,7 @@ from __future__ import absolute_import
 import unittest
 import os
 
-from codechecker_analyzer.analyzers.clangsa.ctu_autodetection import \
-        ClangVersionInfoParser
+from codechecker_analyzer.analyzers.clangsa import version
 
 
 OLD_PWD = None
@@ -46,7 +45,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         Test that the empty stirng is not a valid version-string.
         """
 
-        parser = ClangVersionInfoParser()
+        parser = version.ClangVersionInfoParser()
         version_info = parser.parse('')
 
         self.assertFalse(version_info, False)
@@ -60,7 +59,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         with open('clang_7_src_version_output') as version_output:
             version_string = version_output.read()
 
-        parser = ClangVersionInfoParser()
+        parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
         self.assertIsNot(version_info, False)
@@ -78,7 +77,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         with open('clang_8_src_version_output') as version_output:
             version_string = version_output.read()
 
-        parser = ClangVersionInfoParser()
+        parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
         self.assertIsNot(version_info, False)
@@ -96,7 +95,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         with open('clang_7_bin_dist_version_output') as version_output:
             version_string = version_output.read()
 
-        parser = ClangVersionInfoParser()
+        parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
         self.assertIsNot(version_info, False)
@@ -114,7 +113,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         with open('clang_9_monorepo_src_version_output') as version_output:
             version_string = version_output.read()
 
-        parser = ClangVersionInfoParser()
+        parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
         self.assertIsNot(version_info, False)


### PR DESCRIPTION
Option names and behaviour can change between clang versions
with the new changes listing of the checkers can be
done based on clang versions

clang9 introduced a change in the listing of the
checker options, alpha and debug checkers require
additional options to list them.