### PR TITLE
replace StackAddressEscape checker in analyzer tests

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.cpp
@@ -1,14 +1,14 @@
-int* foo() {
+int foo() {
   int x = 42;
-  return &x;
+  return x/0;
 }
 
 int main() {
   int y;
 
   y = 7;
-  int* x = foo();
+  int x = foo();
   y = 10;
 
-  return y + *x;
+  return y + x;
 }

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.en1.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.en1.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --enable core.StackAddressEscape --disable deadcode.DeadStores
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --enable core.DivideZero --disable deadcode.DeadStores
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --analyzers clangsa --enable core.StackAddressEscape --disable deadcode.DeadStores
+CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --analyzers clangsa --enable core.DivideZero --disable deadcode.DeadStores
 -----------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.
@@ -17,9 +17,9 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
+[HIGH] multi_error.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
 
 Found 1 defect(s) in multi_error.cpp
 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.en2.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.en2.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --disable core.StackAddressEscape --enable deadcode.DeadStores
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --disable core.DivideZero -d core.UndefinedBinaryOperatorResult -d core.uninitialized.UndefReturn -d core.uninitialized.Assign --enable deadcode.DeadStores
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --analyzers clangsa --disable core.StackAddressEscape --enable deadcode.DeadStores
+CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --analyzers clangsa --disable core.DivideZero -d core.UndefinedBinaryOperatorResult -d core.uninitialized.UndefReturn -d core.uninitialized.Assign --enable deadcode.DeadStores
 -----------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.output
@@ -17,9 +17,9 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
+[HIGH] multi_error.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
 
 [LOW] multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.steps.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error.steps.output
@@ -17,14 +17,14 @@ CHECK#CodeChecker check --build "make multi_error" --output $OUTPUT$ --quiet --a
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
-  Report hash: 9b976691ee1dbc182ca89ecfcae5c8db
+[HIGH] multi_error.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
+  Report hash: 901a68a2ecb36a9221296fa65b53dec7
   Steps:
-    1, multi_error.cpp:10:12: Calling 'foo'
+    1, multi_error.cpp:10:11: Calling 'foo'
     2, multi_error.cpp:1:1: Entered call from 'main'
-    3, multi_error.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller
+    3, multi_error.cpp:3:11: Division by zero
 
 [LOW] multi_error.cpp:9:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress.cpp
@@ -1,6 +1,6 @@
-int* foo() {
+int foo() {
   int x = 42;
-  return &x;
+  return x/0;
 }
 
 int main() {
@@ -8,8 +8,8 @@ int main() {
 
   // codechecker_suppress [all] some comment
   y = 7;
-  int* x = foo();
+  int x = foo();
   y = 10;
 
-  return y + *x;
+  return y + x;
 }

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress.output
@@ -17,9 +17,9 @@ CHECK#CodeChecker check --build "make multi_error_suppress" --output $OUTPUT$ --
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error_suppress.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
+[HIGH] multi_error_suppress.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
 
 Found 1 defect(s) in multi_error_suppress.cpp
 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_cstyle.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_cstyle.cpp
@@ -1,6 +1,6 @@
-int* foo() {
+int foo() {
   int x = 42;
-  return &x;
+  return x/0;
 }
 
 int main() {
@@ -8,8 +8,8 @@ int main() {
 
   /* codechecker_suppress [all] some comment */
   y = 7;
-  int* x = foo();
+  int x = foo();
   y = 10;
 
-  return y + *x;
+  return y + x;
 }

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_cstyle.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_cstyle.output
@@ -17,9 +17,9 @@ CHECK#CodeChecker check --build "make multi_error_suppress_cstyle" --output $OUT
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error_suppress_cstyle.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
+[HIGH] multi_error_suppress_cstyle.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
 
 Found 1 defect(s) in multi_error_suppress_cstyle.cpp
 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.cpp
@@ -1,6 +1,6 @@
-int* foo() {
+int foo() {
   int x = 42;
-  return &x;
+  return x/0;
 }
 
 int main() {
@@ -8,8 +8,8 @@ int main() {
 
   // codechecker_suppressssss [all] some comment
   y = 7;
-  int* x = foo();
+  int x = foo();
   y = 10;
 
-  return y + *x;
+  return y + x;
 }

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
@@ -17,9 +17,9 @@ CHECK#CodeChecker check --build "make multi_error_suppress_typo" --output $OUTPU
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] multi_error_suppress_typo.cpp:3:3: Address of stack memory associated with local variable 'x' returned to caller [core.StackAddressEscape]
-  return &x;
-  ^
+[HIGH] multi_error_suppress_typo.cpp:3:11: Division by zero [core.DivideZero]
+  return x/0;
+          ^
 
 [] - Misspelled review status comment in multi_error_suppress_typo.cpp@9: // codechecker_suppressssss [all] some comment
 [LOW] multi_error_suppress_typo.cpp:10:3: Value stored to 'y' is never read [deadcode.DeadStores]


### PR DESCRIPTION
There is a bug in clang9 where the core.StackAddressEscape
checker reports the results as core.StackAddrEscapeBase
to be able to run the tests with newer clang versions
the StackAddressEscape checker was replaced by the
DivideZero checker in the analyzer tests.