### PR TITLE
match for multiple digit clang versions in tests

### DIFF
--- a/scripts/test/check_clang.py
+++ b/scripts/test/check_clang.py
@@ -43,7 +43,7 @@ def get_version(output):
     """
     Return the version information from the command output.
     """
-    version_regex = r"version \b(?P<major>[0-9])+(?:\.[0-9]+)?(?:\.[0-9]+)?\b"
+    version_regex = r"version \b(?P<major>[0-9]+)(?:\.[0-9]+)?(?:\.[0-9]+)?\b"
     version_matcher = re.compile(version_regex)
     match = version_matcher.search(output)
     if match:


### PR DESCRIPTION
in case the current latest clang master branch (v10.0.0) is used
during the tests the regex did not match the double digit major version
and failed to run the tests