### PR TITLE
clang searches for builtin includes relative to the binary

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -245,9 +245,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
-            env.extend_analyzer_cmd_with_resource_dir(
-                analyzer_cmd, config.compiler_resource_dir)
-
             analyzer_cmd.extend(
                 self.buildaction.compiler_includes[compile_lang])
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
@@ -12,8 +12,6 @@ from __future__ import absolute_import
 
 import shlex
 
-from codechecker_analyzer.env import extend_analyzer_cmd_with_resource_dir
-
 from .. import analyzer_base
 from ..flag import has_flag
 
@@ -30,13 +28,11 @@ def get_compile_command(action, config, source='', output=''):
             action.target[compile_lang] != "":
         cmd.append("--target=" + action.target[compile_lang])
 
-    extend_analyzer_cmd_with_resource_dir(cmd,
-                                          config.compiler_resource_dir)
-
     cmd.extend(action.compiler_includes[compile_lang])
     cmd.append('-c')
     if not has_flag('-x', cmd):
         cmd.extend(['-x', action.lang])
+
     cmd.extend(config.analyzer_extra_arguments)
     cmd.extend(action.analyzer_options)
     if output:

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
@@ -21,8 +21,6 @@ import re
 
 from codechecker_common.logger import get_logger
 
-from codechecker_analyzer.env import extend_analyzer_cmd_with_resource_dir
-
 from ..flag import has_flag
 
 LOG = get_logger('analyzer')
@@ -77,9 +75,6 @@ def build_stat_coll_cmd(action, config, source):
 
     if not has_flag('-std', cmd) and not has_flag('--std', cmd):
         cmd.append(action.compiler_standard.get(compile_lang, ""))
-
-    extend_analyzer_cmd_with_resource_dir(cmd,
-                                          config.compiler_resource_dir)
 
     cmd.extend(action.compiler_includes.get(compile_lang, []))
 

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -144,9 +144,6 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
-            env.extend_analyzer_cmd_with_resource_dir(
-                analyzer_cmd, config.compiler_resource_dir)
-
             analyzer_cmd.extend(
                 self.buildaction.compiler_includes[compile_lang])
 

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -75,45 +75,6 @@ def extend(path_env_extra, ld_lib_path_extra):
     return new_env
 
 
-def extend_analyzer_cmd_with_resource_dir(analyzer_cmd,
-                                          compiler_resource_dir):
-    """
-    GCC and Clang handles the certain compiler intrinsics for specific
-    instruction sets (like SSE, AVX) differently.  They have their own set of
-    macros in a bunch of include files (e.g. xmmintrin.h) in the include dir
-    of the resource dir of the compiler.  Since we execute the analysis with
-    Clang we must ensure that theses resource headers are included from the
-    proper place. One option to do this is the usage of -resource-dir.  On the
-    other hand, to make the analysis work we also have to add the default
-    includes of the original compiler (which maybe a GCC cross compiler).  We
-    add these default includes of the original compiler with -isystem.
-
-    Our empirical results show that -resource_dir has lower priority than
-    -isystem.  Unfortunately in Clang the implementation about resource
-    includes is very messy, it is merged with the handling of the upcoming
-    modules feature from C++20.  The corresponding functions from Clang:
-        clang::ApplyHeaderSearchOptions
-        HeaderSearch::LookupFile
-        DirectoryLookup::LookupFile.
-    Based on our emprical results, the only solution is to add the resource
-    includes with -isystem before adding the system headers of the original
-    compiler. Since we don't use the -resource_dir switch, it is more explicit
-    and describes our intentions more cleanly if we just simply disable the
-    inludes from the resource dir.
-    """
-    if not compiler_resource_dir:
-        return
-
-    resource_inc = compiler_resource_dir
-    # Resource include path must end with "/include".
-    basename = os.path.basename(os.path.normpath(resource_inc))
-    if basename != 'include':
-        resource_inc = os.path.join(resource_inc, "include")
-
-    analyzer_cmd.extend(['-nobuiltininc',
-                         '-isystem', resource_inc])
-
-
 def replace_env_var(cfg_file):
     """
     Returns a replacement function which can be used in RegEx functions such as

--- a/docs/README.md
+++ b/docs/README.md
@@ -187,6 +187,10 @@ binaries you intend to use.
 },
 ```
 
+Make sure that the required include paths are at the right place!
+Clang based tools search by default for [builtin-includes](https://clang.llvm.org/docs/LibTooling.html#builtin-includes) in a path relative to the tool binary.
+`$(dirname /path/to/tool)/../lib/clang/8.0.0/include`
+
 ## Setting up the environment in your Terminal
 
 These steps must always be taken in a new command prompt you wish to execute


### PR DESCRIPTION
adding the the resource dir manually might mess up the
include path order, let clang manage it, the builtin
include files should be at the righ place relative
to the clang binaries.

See:
https://clang.llvm.org/docs/LibTooling.html#libtooling-builtin-includes