### PR TITLE
[WIP] Use the default checkers suggested by ClangSA

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -160,9 +160,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd = [config.analyzer_binary, '--analyze',
                             # Do not warn about the unused gcc/g++ arguments.
-                            '-Qunused-arguments',
-                            # Turn off clang hardcoded checkers list.
-                            '--analyzer-no-default-checks']
+                            '-Qunused-arguments']
 
             for plugin in config.analyzer_plugins:
                 analyzer_cmd.extend(["-Xclang", "-plugin",
@@ -190,12 +188,14 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                     analyzer_cmd.extend(cfg)
 
             # Config handler stores which checkers are enabled or disabled.
-            for checker_name, value in config.checks().items():
-                enabled, _ = value
-                if enabled:
+            checker_handler = config.checker_handler()
+            for checker_name, value in checker_handler.checkers().items():
+                state, _ = value
+
+                if state.is_enabled():
                     analyzer_cmd.extend(['-Xclang',
                                          '-analyzer-checker=' + checker_name])
-                else:
+                elif state.is_disabled():
                     analyzer_cmd.extend(['-Xclang',
                                          '-analyzer-disable-checker=' +
                                          checker_name])

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -22,6 +22,132 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('system')
 
 
+class CheckerHandling(object):
+    """
+    The possible states of a checker from perspective of handling it inside
+    CodeChecker. The Checker can either be implicitly handled, and be in the
+    AUTO state, or explicitly managed. Explicit handling could result in the
+    checker being either ENABLED or DISABLED state.
+
+    TODO: This should be implemented as an enum in Python 3.
+    """
+
+    AUTO, ENABLED, DISABLED = range(0, 3)
+
+    def __init__(self):
+        self.__value = CheckerHandling.AUTO
+
+    def is_enabled(self):
+        return self.__value == CheckerHandling.ENABLED
+
+    def set_enabled(self):
+        self.__value = CheckerHandling.ENABLED
+        return self
+
+    def is_disabled(self):
+        return self.__value == CheckerHandling.DISABLED
+
+    def set_disabled(self):
+        self.__value = CheckerHandling.DISABLED
+        return self
+
+    def is_auto(self):
+        return self.__value == CheckerHandling.AUTO
+
+    def set_auto(self):
+        self.__value = CheckerHandling.AUTO
+        return self
+
+    def __str__(self):
+        return ['automatic', 'enabled', 'disabled'][self.__value]
+
+
+class Checker(object):
+    def __init__(self, name, description=None):
+        self.name = name
+        self.description = description
+
+
+class CheckerHandler(object):
+    """
+    CheckerHandler class is used to store available checkers, every one of
+    which can have a state of being explicitly enabled, explicitly disabled or
+    implicitly handled.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        # The key is the checker name, the value is a Checker.
+        self.__checkers = collections.OrderedDict()
+
+    def register_checker(self, name, description=None, state=None):
+        """
+        Make a checker available. By default the checkers handling is set to
+        implicit. If there exists a checker that is already available this
+        method does not no modifications.
+
+        Arguments:
+        name -- name of the checker. type: string
+        description -- description of the checker. type: string
+        state -- handling status of the checker. type: CheckerHandling
+        """
+
+        # Checker is added with implicit handling by default.
+        if state is None:
+            state = CheckerHandling().set_auto()
+
+        if name not in self.__checkers:
+            self.__checkers[name] = (state, Checker(name, description))
+
+    def _set_handling_for_matching(self, target_name, handling):
+        """
+        Set the handling of checkers those name either starts or ends with
+        target_name to the category specified by handling.
+        """
+
+        for checker_entry in self.__checkers.items():
+            checker_name, checker = checker_entry
+            if checker_name.startswith(target_name) or \
+               checker_name.endswith(target_name):
+                self.__checkers[checker_name] = (handling, checker)
+
+    def enable_matching_checkers(self, target_name):
+        """
+        Explicitly enable checkers those name either starts or ends with
+        target_name.
+        """
+
+        self._set_handling_for_matching(target_name,
+                                        CheckerHandling().set_enabled())
+
+    def disable_matching_checkers(self, target_name):
+        """
+        Explicitly disable checkers those name either starts or ends with
+        target_name.
+        """
+
+        self._set_handling_for_matching(target_name,
+                                        CheckerHandling().set_disabled())
+
+    def automate_matching_checkers(self, target_name):
+        """
+        Make the handling of checkers those name either starts or ends with
+        target_name implicit.
+        """
+
+        self._set_handling_for_matching(target_name,
+                                        CheckerHandling().set_auto())
+
+    def checkers(self):
+        """
+        Returns a collections of tuples keyed by checker names. Every tuple has
+        the enabled state of type CheckerHandling as the first element, and the
+        checker object of type Checker as the second.
+        """
+        return self.__checkers
+
+
 class AnalyzerConfigHandler(object):
     """
     Handle the checker configurations and enabled disabled checkers lists.
@@ -37,11 +163,7 @@ class AnalyzerConfigHandler(object):
         self.checker_config = ''
         self.report_hash = None
 
-        # The key is the checker name, the value is a tuple.
-        # False if disabled (should be by default).
-        # True if checker is enabled.
-        # (False/True, 'checker_description')
-        self.__available_checkers = collections.OrderedDict()
+        self.__available_checkers = CheckerHandler()
 
     @property
     def analyzer_plugins(self):
@@ -58,26 +180,9 @@ class AnalyzerConfigHandler(object):
                             and f.endswith(".so")]
         return analyzer_plugins
 
-    def add_checker(self, checker_name, enabled, description):
+    def checker_handler(self):
         """
-        Add additional checker.
-        Tuple of (checker_name, True or False).
-        """
-        self.__available_checkers[checker_name] = (enabled, description)
-
-    def set_checker_enabled(self, checker_name, enabled=True):
-        """
-        Enable checker, keep description if already set.
-        """
-        for ch_name, values in self.__available_checkers.items():
-            if ch_name.startswith(checker_name) or \
-               ch_name.endswith(checker_name):
-                _, description = values
-                self.__available_checkers[ch_name] = (enabled, description)
-
-    def checks(self):
-        """
-        Return the checkers.
+        Return the configuration for checkers.
         """
         return self.__available_checkers
 
@@ -85,7 +190,7 @@ class AnalyzerConfigHandler(object):
         """
         Generate all applicable name variations from the given checker list.
         """
-        checker_names = (name for name in self.__available_checkers)
+        checker_names = self.checker_handler().checkers().keys()
         reserved_names = []
 
         for name in checker_names:
@@ -114,9 +219,12 @@ class AnalyzerConfigHandler(object):
         analyzer-retrieved checker list.
         """
 
-        # By default disable all checkers.
+        handler = self.checker_handler()
+
+        # By default all checkers are in the AUTO state. This means that the
+        # analysis framework should decide to whether use the checker or not.
         for checker_name, description in checkers:
-            self.add_checker(checker_name, False, description)
+            handler.register_checker(checker_name, description)
 
         # Set default enabled or disabled checkers, based on the config file.
         if checker_config:
@@ -130,22 +238,22 @@ class AnalyzerConfigHandler(object):
                 # Turn default checkers on.
                 for checker_name, profile_list in checker_config.items():
                     if 'default' in profile_list:
-                        self.set_checker_enabled(checker_name)
+                        handler.enable_matching_checkers(checker_name)
 
         # If enable_all is given, almost all checkers should be enabled.
         if enable_all:
-            for checker_name, enabled in checkers:
+            for checker_name, _ in checkers:
                 if not checker_name.startswith("alpha.") and \
                         not checker_name.startswith("debug.") and \
                         not checker_name.startswith("osx."):
                     # There are a few exceptions, though, which still need to
                     # be manually enabled by the user: alpha and debug.
-                    self.set_checker_enabled(checker_name)
+                    handler.enable_matching_checkers(checker_name)
 
                 if checker_name.startswith("osx.") and \
                         platform.system() == 'Darwin':
                     # OSX checkers are only enable-all'd if we are on OSX.
-                    self.set_checker_enabled(checker_name)
+                    handler.enable_matching_checkers(checker_name)
 
         # Set user defined enabled or disabled checkers from the command line.
         if cmdline_checkers:
@@ -154,7 +262,7 @@ class AnalyzerConfigHandler(object):
             # (It is used to check if a profile name is valid.)
             reserved_names = self.__gen_name_variations()
 
-            for identifier, enabled in cmdline_checkers:
+            for identifier, state in cmdline_checkers:
 
                 # The identifier is a profile name.
                 if identifier in available_profiles:
@@ -175,9 +283,15 @@ class AnalyzerConfigHandler(object):
                                         in checker_config.items()
                                         if profile_name in profile_list)
                     for checker_name in profile_checkers:
-                        self.set_checker_enabled(checker_name, enabled)
+                        if state:
+                            handler.enable_matching_checkers(checker_name)
+                        else:
+                            handler.disable_matching_checkers(checker_name)
 
                 # The identifier is a checker(-group) name.
                 else:
                     checker_name = identifier
-                    self.set_checker_enabled(checker_name, enabled)
+                    if state:
+                        handler.enable_matching_checkers(checker_name)
+                    else:
+                        handler.disable_matching_checkers(checker_name)


### PR DESCRIPTION
The `--analyzer-no-default-checks` option is no longer passed to Clang,
so the default-enabled checkers are picked. Also no checkers are explicitly
disabled by CodeChecker.