### PR TITLE
Fix ld_logger crash

### DIFF
--- a/analyzer/tools/build-logger/Makefile.manual
+++ b/analyzer/tools/build-logger/Makefile.manual
@@ -16,7 +16,7 @@ CC = gcc
 # Preprocessor flags
 CPPFLAGS = -D_GNU_SOURCE
 # C flags
-CFLAGS = -std=c89 -ansi -pedantic -Wall -Wextra -O2
+CFLAGS = -std=c99 -pedantic -Wall -Wextra -O2
 # Linker flags
 LDFLAGS =
 # Flags for ldlogger lib

--- a/analyzer/tools/build-logger/src/ldlogger-hooks.c
+++ b/analyzer/tools/build-logger/src/ldlogger-hooks.c
@@ -65,7 +65,6 @@ static void tryLog(
 {
   size_t i;
   const char* loggerArgs[CC_LOGGER_MAX_ARGS];
-  char* ldpreload;
 
   loggerArgs[0] = filename_;
   for (i = 0; argv_[i]; ++i)
@@ -74,7 +73,7 @@ static void tryLog(
   }
   loggerArgs[i+1] = NULL;
 
-  logExec(i+1, (char* const*) loggerArgs);
+  logExec(i+1, loggerArgs);
 }
 
 __attribute__ ((visibility ("default"))) int execv(const char* filename_, char* const argv_[])

--- a/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
@@ -321,7 +321,7 @@ int loggerGccParserCollectActions(
          * TODO: According to a GCC warning the -x flag has no effect when it
          * is placed after the last input file to be compiled.
          */
-        const char* l = current[2] ? current[2] : argv_[i + 1];
+        const char* l = current[2] ? current + 2 : argv_[i + 1];
         if (strcmp(l, "c") == 0 || strcmp(l, "c-header") == 0)
           lang = C;
         else if (strcmp(l, "c++") == 0 || strcmp(l, "c++-header") == 0)
@@ -337,7 +337,7 @@ int loggerGccParserCollectActions(
       {
         loggerFileInitFromPath(
           &action->output,
-          current[2] ? current[2] : argv_[i + 1]);
+          current[2] ? current + 2 : argv_[i + 1]);
       }
     }
     else


### PR DESCRIPTION
The logger contained a crash based on a type conversion bug.