### PR TITLE
[doc] Fix daily script

### DIFF
--- a/docs/script_daily.md
+++ b/docs/script_daily.md
@@ -66,7 +66,7 @@ DIFF_CMD=$(cat << END \
 # Assume that there are new bugs introduced, unless proven otherwise.
 echo -n "1" > "${WORKSPACE}/was_output.txt"
 
-eval "${DIFF_CMD}" | while read -r line
+eval "${DIFF_CMD}" 2>&1 | while read -r line
   do
     # If CodeChecker says there aren't new bugs, don't introduce them.
     if [[ "$line" =~ "- No results" ]]


### PR DESCRIPTION
Log output of the diff command was redirected to the stderr if the output type is not table (See: #1534).

In this case the `No results` line was not in the output so we though that we found some bugs.

Redirecting the `stderr` to `stdout` will solve this problem.