### PR TITLE
ld_logger improvement

### DIFF
--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -30,6 +30,26 @@ EOF
 
 #--- Test functions ---#
 
+function test_compiler_path1 {
+  IFS=':' read -ra my_array <<< $PATH
+  compiler=$(find ${my_array[@]} -name g++-* -print -quit)
+
+  if [ -n $compiler ]; then
+    CC_LOGGER_GCC_LIKE="g++-" bash -c "$compiler $source_file"
+    assert_json "$source_file" $compiler
+  fi
+}
+
+function test_compiler_path2 {
+  IFS=':' read -ra my_array <<< $PATH
+  compiler=$(find ${my_array[@]} -name g++-* -print -quit)
+
+  if [ -n $compiler ]; then
+    CC_LOGGER_GCC_LIKE="/g++-" bash -c "$compiler $source_file"
+    test ! -s $CC_LOGGER_FILE
+  fi
+}
+
 function test_simple {
   bash -c "g++ $source_file"
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -313,6 +313,23 @@ For example (default):
 export CC_LOGGER_GCC_LIKE="gcc:g++:clang"
 ```
 
+This colon separated list may contain compiler names or paths. In case an
+element of this list contains at least one slash (/) character then this is
+considered a path. The logger will capture only those build actions which have
+this postfix:
+
+```sh
+export CC_LOGGER_GCC_LIKE="gcc:/bin/g++"
+
+# "gcc" has to be infix of the compiler's name because it contains no slash.
+# "/bin/g++" has to be postfix of the compiler's path because it contains slash.
+
+my/gcc/compiler/g++ main.cpp  # Not captured because there is no match.
+my/gcc/compiler/gcc-7 main.c  # Captured because "gcc" is infix of "gcc-7".
+/usr/bin/g++ main.cpp         # Captured because "/bin/g++" is postfix of the compiler path.
+/usr/bin/g++-7 main.cpp       # Not captured because "/bin/g++" is not postfix of the compiler path.
+```
+
 Example:
 
 ```sh


### PR DESCRIPTION
In case a compiler in CC_LOGGER_?_LIKE environment variable contains
slash (/) character, then we assume that this is a postfix of a
compiler's path. Otherwise we check if it is the infix of the compiler
name like in case of the original behavior.

Fixes #2315