### PR TITLE
Do not apply skip list to CTU pre-analysis

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -247,11 +247,19 @@ def perform_analysis(args, skip_handler, context, actions, metadata):
 
         pre_analyze = [a for a in actions
                        if a.analyzer_type == ClangSA.ANALYZER_NAME]
+        pre_anal_skip_handler = None
+
+        # Skip list is applied only in pre-analysis
+        # if --ctu-collect or --stats-collect  was called explicitly
+        if ((ctu_collect and not ctu_analyze)
+                or ("stats_output" in args and args.stats_outptut)):
+            pre_anal_skip_handler = skip_handler
+
         pre_analysis_manager.run_pre_analysis(pre_analyze,
                                               context,
                                               config_map,
                                               args.jobs,
-                                              skip_handler,
+                                              pre_anal_skip_handler,
                                               ctu_data,
                                               statistics_data,
                                               manager)

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -924,7 +924,6 @@ class CompileActionUniqueingType(object):
 def parse_unique_log(compilation_database,
                      report_dir,
                      compile_uniqueing="none",
-                     skip_handler=None,
                      compiler_info_file=None,
                      skip_gcc_fix_headers=False):
     """
@@ -948,9 +947,6 @@ def parse_unique_log(compilation_database,
     compile_uniqueing -- Compilation database uniqueing mode.
                          If there are more than one compile commands for a
                          target file, only a single one is kept.
-    skip_handler -- A SkipListHandler object which helps to skip build actions
-                    that shouldn't be analyzed. The build actions described by
-                    this handler will not be the part of the result list.
     compiler_info_file -- compiler_info.json. If exists, it will be used for
                     analysis.
     skip_gcc_fix_headers -- There are some implicit include paths which are
@@ -972,9 +968,6 @@ def parse_unique_log(compilation_database,
             uniqueing_re = re.compile(compile_uniqueing)
 
         for entry in compilation_database:
-            if skip_handler and skip_handler.should_skip(entry['file']):
-                LOG.debug("SKIPPING FILE %s", entry['file'])
-                continue
             action = parse_options(entry,
                                    compiler_info_file,
                                    skip_gcc_fix_headers)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -592,7 +592,6 @@ def main(args):
             load_json_or_empty(log_file),
             report_dir,
             args.compile_uniqueing,
-            skip_handler,
             compiler_info_file,
             args.skip_gcc_fix_include)
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -547,6 +547,11 @@ Every other file where the path contains `/myproject` except the files in the
 
 The provided *shell-style* pattern is converted to a regex with the [fnmatch.translate](https://docs.python.org/2/library/fnmatch.html#fnmatch.translate).
 
+Please note that when `-i SKIPFILE` is used along with `--stats` or 
+`--ctu` the skip list will be ignored in the pre-analysis phase. This means
+that statistics and ctu-pre-analysis will be created for *all* files in the
+*compilation database*.
+
 ### Analyzer configuration <a name="analyzer-configuration"></a>
 
 ```


### PR DESCRIPTION
> Closes #2299 

Don't apply the skip list to CTU and statistical pre-analysis
by default, because it makes the analysis broken.
Skip list can be applied explicitly for these phases
if analyze is called with --ctu-collect or --stats-collect

skip list will not be used in the pre-analysis phase if only --ctu or --statistics parameter is given.