### PR TITLE
[web] New filter options for CodeChecker cmd runs command

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -765,6 +765,24 @@ optional arguments:
                         you have run_1_a_name, run_2_b_name, run_2_c_name,
                         run_3_d_name then "run_2* run_3_d_name" shows the last
                         three runs.
+  --all-before-run RUN_NAME
+                        Get all runs that were stored to the server BEFORE the
+                        specified one.
+  --all-after-run RUN_NAME
+                        Get all runs that were stored to the server AFTER the
+                        specified one.
+  --all-after-time TIMESTAMP
+                        Get all analysis runs that were stored to the server
+                        AFTER the given timestamp. The format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
+  --all-before-time TIMESTAMP
+                        Get all analysis runs that were stored to the server
+                        BEFORE the given timestamp. The format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
 ```
 
 ### List of run histories (`history`) <a name="cmd-history"></a>

--- a/web/api/v6/report_server.thrift
+++ b/web/api/v6/report_server.thrift
@@ -290,9 +290,13 @@ typedef list<CommentData> CommentDataList
  * If exactMatch field is True it will use exact match for run names.
  */
 struct RunFilter {
-  1: list<i64>    ids,        // IDs of the runs.
-  2: list<string> names,      // Part of the run name.
-  3: bool         exactMatch  // If it's True it will use an exact match for run names.
+  1: list<i64>       ids,        // IDs of the runs.
+  2: list<string>    names,      // Part of the run name.
+  3: bool            exactMatch, // If it's True it will use an exact match for run names.
+  4: optional i64    beforeTime, // Filter runs that were stored to the server BEFORE this time.
+  5: optional i64    afterTime,  // Filter runs that were stored to the server AFTER this time.
+  6: optional string beforeRun,  // Filter runs that were stored to the server BEFORE this one.
+  7: optional string afterRun,   // Filter runs that were stored to the server AFTER this one.
 }
 
 // CompareData is used as an optinal argument for multiple API calls.
@@ -491,7 +495,8 @@ service codeCheckerDBAccess {
 
   // Remove run from the database.
   // PERMISSION: PRODUCT_STORE
-  bool removeRun(1: i64 runId)
+  bool removeRun(1: i64 runId,
+                 2: optional RunFilter runFilter)
                  throws (1: codechecker_api_shared.RequestFailed requestError),
 
   // PERMISSION: PRODUCT_STORE

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -505,7 +505,7 @@ def __register_delete(parser):
     group.add_argument('-n', '--name',
                        type=str,
                        nargs='+',
-                       dest="name",
+                       dest="names",
                        metavar='RUN_NAME',
                        default=argparse.SUPPRESS,
                        help="Full name(s) of the analysis run or runs to "
@@ -933,22 +933,64 @@ def __register_runs(parser):
     Add argparse subcommand parser for the "list runs by run name" action.
     """
 
-    parser.add_argument('-n', '--name',
-                        type=str,
-                        nargs='*',
-                        dest="names",
-                        metavar='RUN_NAME',
-                        default=argparse.SUPPRESS,
-                        required=False,
-                        help="Names of the analysis runs. If this argument is "
-                             "not supplied it will show all runs. This has "
-                             "the  following format: \"<run_name_1> "
-                             "<run_name_2> <run_name_3>\" where run names can "
-                             "contain multiple * quantifiers which matches "
-                             "any number of characters (zero or more). So if "
-                             "you have run_1_a_name, run_2_b_name, "
-                             "run_2_c_name, run_3_d_name then \"run_2* "
-                             "run_3_d_name\" shows the last three runs.")
+    group = parser.add_mutually_exclusive_group(required=False)
+
+    group.add_argument('-n', '--name',
+                       type=str,
+                       nargs='*',
+                       dest="names",
+                       metavar='RUN_NAME',
+                       default=argparse.SUPPRESS,
+                       required=False,
+                       help="Names of the analysis runs. If this argument is "
+                            "not supplied it will show all runs. This has "
+                            "the  following format: \"<run_name_1> "
+                            "<run_name_2> <run_name_3>\" where run names can "
+                            "contain multiple * quantifiers which matches "
+                            "any number of characters (zero or more). So if "
+                            "you have run_1_a_name, run_2_b_name, "
+                            "run_2_c_name, run_3_d_name then \"run_2* "
+                            "run_3_d_name\" shows the last three runs.")
+
+    group.add_argument('--all-before-run',
+                       type=str,
+                       dest="all_before_run",
+                       metavar='RUN_NAME',
+                       default=argparse.SUPPRESS,
+                       help="Get all runs that were stored to the server "
+                            "BEFORE the specified one.")
+
+    group.add_argument('--all-after-run',
+                       type=str,
+                       dest="all_after_run",
+                       metavar='RUN_NAME',
+                       default=argparse.SUPPRESS,
+                       help="Get all runs that were stored to the server "
+                            "AFTER the specified one.")
+
+    group.add_argument('--all-after-time',
+                       type=valid_time,
+                       dest="all_after_time",
+                       metavar='TIMESTAMP',
+                       default=argparse.SUPPRESS,
+                       help="Get all analysis runs that were stored to "
+                            "the server AFTER the given timestamp. The "
+                            "format of TIMESTAMP is "
+                            "'year:month:day:hour:minute:second' (the "
+                            "\"time\" part can be omitted, in which case "
+                            "midnight (00:00:00) is used).")
+
+    group.add_argument('--all-before-time',
+                       type=valid_time,
+                       dest="all_before_time",
+                       metavar='TIMESTAMP',
+                       default=argparse.SUPPRESS,
+                       help="Get all analysis runs that were stored to "
+                            "the server BEFORE the given timestamp. The "
+                            "format of TIMESTAMP is "
+                            "'year:month:day:hour:minute:second' (the "
+                            "\"time\" part can be omitted, in which case "
+                            "midnight (00:00:00) is used).")
 
 
 def __register_run_histories(parser):

--- a/web/client/codechecker_client/thrift_helper.py
+++ b/web/client/codechecker_client/thrift_helper.py
@@ -76,7 +76,7 @@ class ThriftClientHelper(object):
         pass
 
     @ThriftClientCall
-    def removeRun(self, run_id):
+    def removeRun(self, run_id, run_filter):
         pass
 
     @ThriftClientCall

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -389,7 +389,7 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
           });
 
           that.deleteRunIds.forEach(function (runId) {
-            CC_SERVICE.removeRun(runId, function () {}).fail(
+            CC_SERVICE.removeRun(runId, null, function () {}).fail(
             function (jsReq, status, exc) {
               new Dialog({
                 title : 'Failure!',

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -131,7 +131,7 @@ int main()
 
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
-            self._cc_client.removeRun(run_id)
+            self._cc_client.removeRun(run_id, None)
 
         # Check the first file version
         self._create_source_file(0)
@@ -287,7 +287,7 @@ int main()
             run_id = max(map(lambda run: run.runId, runs))
 
             # Remove the run.
-            self._cc_client.removeRun(run_id)
+            self._cc_client.removeRun(run_id, None)
 
         self._create_source_file(0)
 
@@ -326,7 +326,7 @@ int main()
             run_id = max(map(lambda run: run.runId, runs))
 
             # Remove the run.
-            self._cc_client.removeRun(run_id)
+            self._cc_client.removeRun(run_id, None)
 
         cfg = dict(self._codechecker_cfg)
 

--- a/web/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/web/tests/functional/report_viewer_api/test_hash_clash.py
@@ -91,7 +91,7 @@ class HashClash(unittest.TestCase):
         run_id = runs[0].runId
 
         # Remove the run.
-        self._report.removeRun(run_id)
+        self._report.removeRun(run_id, None)
 
     def _reports_for_latest_run(self):
         runs = self._report.getRunData(None, None, 0, None)

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -98,7 +98,7 @@ class RemoveRunResults(unittest.TestCase):
         self.assertEqual(res_count, 0)
 
         # Remove the run.
-        self._cc_client.removeRun(run_id)
+        self._cc_client.removeRun(run_id, None)
 
         # Check that we removed all results from the run.
         res = self._cc_client.getRunResultCount([run_id], None, None)


### PR DESCRIPTION
* Extend Thrift API to be able to filter runs on multiple conditions.
* Add the same filter command line options to the `CodeChecker cmd runs`
  as the `CodeChecker cmd del` command.
* Add new test cases.