### PR TITLE
[config] Remove unused entries from config file

### DIFF
--- a/config/package_layout.json
+++ b/config/package_layout.json
@@ -35,8 +35,6 @@
     "ld_logger_lib_path": "ld_logger/lib",
     "plist_to_html_bin": "bin/plist-to-html",
     "plist_to_html_dist_path": "lib/python2.7/plist_to_html/static",
-    "checkers_severity_map_file": "config/checker_severity_map.json",
-    "gdb_config_file": "config/gdbScript.gdb",
-    "ctu_func_map_cmd": "clang-func-mapping"
+    "checkers_severity_map_file": "config/checker_severity_map.json"
   }
 }


### PR DESCRIPTION
Remove `ctu_func_map_cmd` and `gdb_config_file` entries from
the `package_layout.json` config file because we do not use
these anymore.