### PR TITLE
[server] Fix source code comment regex

### DIFF
--- a/codechecker_common/source_code_comment_handler.py
+++ b/codechecker_common/source_code_comment_handler.py
@@ -90,7 +90,7 @@ class SourceCodeCommentHandler(object):
         # Check for codechecker source code comment.
         comment_markers = '|'.join(self.source_code_comment_markers)
         pattern = r'^\s*(?P<status>' + comment_markers + r')' \
-                  + r'\s*\[\s*(?P<checkers>(.*))\s*\]\s*(?P<comment>.*)$'
+                  + r'\s*\[\s*(?P<checkers>[^\]]*)\s*\]\s*(?P<comment>.*)$'
 
         ptn = re.compile(pattern)
         res = re.match(ptn, formatted)

--- a/web/server/tests/unit/source_code_comment_test_files/test_file_1
+++ b/web/server/tests/unit/source_code_comment_test_files/test_file_1
@@ -60,7 +60,7 @@ void test_func(int num){ // line 57
 }
 
 // codechecker_suppress [ my_checker_1 ]
-// áúőóüöáé ▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬
+// áúőóüöáé [▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬]
 void test_func(int num){ // line 64
     // wrong formatted suppress comment
     cout << "test func"  << endl;

--- a/web/server/tests/unit/test_source_code_comment.py
+++ b/web/server/tests/unit/test_source_code_comment.py
@@ -182,7 +182,7 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         self.assertEqual(len(source_line_comments), 1)
 
         expected = {'checkers': {'my_checker_1'},
-                    'message': u"áúőóüöáé ▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬",
+                    'message': u"áúőóüöáé [▬▬▬▬▬▬▬▬▬▬ஜ۩۞۩ஜ▬▬▬▬▬▬▬▬▬▬]",
                     'status': 'false_positive'}
         self.assertDictEqual(expected, source_line_comments[0])
 


### PR DESCRIPTION
If the message of the source code comment contained a closing square
bracket (`]`) the source code comment parsing regex behaved badly.

For example on the following source code comment
`codechecker_suppress [ my_checker ] t[x] is null` the parsed checker
name was `my_checker ] t[x` instead of `my_checker`.

This commit will fix the regex, so the first closing square bracket
will mark the end of the checker name list.