### PR TITLE
fixed 'CodeChecker parse --print-steps' filename bug

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -243,6 +243,9 @@ class PlistToPlaintextFormatter(object):
                     for index, event in enumerate(events):
                         output.write(index_format % (index + 1))
                         source_file = report.files[event['location']['file']]
+                        trimmed_source_file = \
+                            util.trim_path_prefixes(source_file,
+                                                    self._trim_path_prefixes)
                         output.write(
                             self.__format_bug_event(None,
                                                     None,


### PR DESCRIPTION
> Closes #2358 

Fixed the bug where 'CodeChecker parse --print-steps' shows incorrect file names for some steps when the report ranges across multiple translation units.