### PR TITLE
[analyzer] Fix non existing argument name

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -252,7 +252,7 @@ def perform_analysis(args, skip_handler, context, actions, metadata):
         # Skip list is applied only in pre-analysis
         # if --ctu-collect or --stats-collect  was called explicitly
         if ((ctu_collect and not ctu_analyze)
-                or ("stats_output" in args and args.stats_outptut)):
+                or ("stats_output" in args and args.stats_output)):
             pre_anal_skip_handler = skip_handler
 
         pre_analysis_manager.run_pre_analysis(pre_analyze,


### PR DESCRIPTION
Typo: `stats_outptut` was used instead of `stats_output`.