### PR TITLE
Removing MallocOverflow throws too many FPs

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -29,7 +29,7 @@
         "alpha.cplusplus.UninitializedObject" : ["sensitive", "extreme"],
         "alpha.security.ArrayBound" : ["extreme","security"],
         "alpha.security.ArrayBoundV2" : ["extreme","security"],
-        "alpha.security.MallocOverflow" : ["sensitive", "extreme","security"],
+        "alpha.security.MallocOverflow" : ["extreme","security"],
         "alpha.security.MmapWriteExec" : ["sensitive", "extreme","security"],
         "alpha.security.ReturnPtrRange" : ["sensitive", "extreme","security"],
         "alpha.security.taint.TaintPropagation" : ["sensitive", "extreme","security"],


### PR DESCRIPTION
So removing it from the sensitive profile.