### PR TITLE
Implicit include path handling

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -102,16 +102,15 @@ def add_arguments_to_parser(parser):
                              "specified file rather than invoke the compiler "
                              "executable.")
 
-    parser.add_argument('--skip-gcc-fix-include',
-                        dest="skip_gcc_fix_include",
+    parser.add_argument('--keep-gcc-include-fixed',
+                        dest="keep_gcc_include_fixed",
                         required=False,
                         action='store_true',
                         default=False,
-                        help="DEPRECATED. There are some implicit include "
-                             "paths which are only used by GCC "
-                             "(include-fixed). This flag determines whether "
-                             "these should be skipped from the implicit "
-                             "include paths.")
+                        help="There are some implicit include paths which are "
+                             "only used by GCC (include-fixed). This flag "
+                             "determines whether these should be kept among "
+                             "the implicit include paths.")
 
     parser.add_argument('-t', '--type', '--output-format',
                         dest="output_format",
@@ -593,7 +592,7 @@ def main(args):
             report_dir,
             args.compile_uniqueing,
             compiler_info_file,
-            args.skip_gcc_fix_include)
+            args.keep_gcc_include_fixed)
 
     if not actions:
         LOG.info("No analysis is required.\nThere were no compilation "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -108,16 +108,15 @@ def add_arguments_to_parser(parser):
                              "incrementally update defect reports for source "
                              "files that were analysed.)")
 
-    parser.add_argument('--skip-gcc-fix-include',
-                        dest="skip_gcc_fix_include",
+    parser.add_argument('--keep-gcc-include-fixed',
+                        dest="keep_gcc_include_fixed",
                         required=False,
                         action='store_true',
                         default=False,
-                        help="DEPRECATED. There are some implicit include "
-                             "paths which are only used by GCC "
-                             "(include-fixed). This flag determines whether "
-                             "these should be skipped from the implicit "
-                             "include paths.")
+                        help="There are some implicit include paths which are "
+                             "only used by GCC (include-fixed). This flag "
+                             "determines whether these should be kept among "
+                             "the implicit include paths.")
 
     log_args = parser.add_argument_group(
         "log arguments",
@@ -592,7 +591,7 @@ def main(args):
             output_path=output_dir,
             output_format='plist',
             jobs=args.jobs,
-            skip_gcc_fix_include=args.skip_gcc_fix_include
+            keep_gcc_include_fixed=args.keep_gcc_include_fixed
         )
         # Some arguments don't have default values.
         # We can't set these keys to None because it would result in an error

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -391,12 +391,12 @@ class OptionParserTest(unittest.TestCase):
         # directory among the implicit include paths. Otherwise this test may
         # fail.
 
-        res = log_parser.parse_options(action, skip_gcc_fix_headers=False)
-        self.assertTrue(any(map(lambda x: x.endswith('include-fixed'),
-                                res.compiler_includes['c++'])))
-        res = log_parser.parse_options(action, skip_gcc_fix_headers=True)
+        res = log_parser.parse_options(action, keep_gcc_fix_headers=False)
         self.assertFalse(any(map(lambda x: x.endswith('include-fixed'),
                                  res.compiler_includes['c++'])))
+        res = log_parser.parse_options(action, keep_gcc_fix_headers=True)
+        self.assertTrue(any(map(lambda x: x.endswith('include-fixed'),
+                                res.compiler_includes['c++'])))
 
     def test_compiler_include_file(self):
         action = {

--- a/docs/analyzer/gcc_incompatibilities.md
+++ b/docs/analyzer/gcc_incompatibilities.md
@@ -46,6 +46,21 @@ Consequently, Clang (from version 3.8) skips the `include-fixed` include path
 even if it is built with GCC and configured to use GCC's libstdc++
 (https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-3.8/+bug/1573778).
 
+The practical difficulty in CodeChecker is that we're appending the implicit
+include paths of the compiler which is used during the comiplation of the
+analyzed project in the logging phase. The reason of this is that we'd like to
+see the same build environment during the analysis. However, Clang also has its
+own implicit include paths. These are almost the same of GCC's paths except for
+`include-fixed` directories because these are GCC specific. Unfortunately some
+projects require the additiion of these paths but some do not. So
+`--keep-gcc-include-fixed` flag can control whether we should keep these during
+the analysis. There is another unanswered question: currently the GCC implicit
+include paths are added with `-isystem` flag. This appends the paths _before_
+the analyzer Clang's implicit paths. However, we could also use
+`-isystem-after` which appends them _after_ Clang's paths. According to our
+experiences `-isystem` has to be used otherwise we get compilation error during
+the analysis.
+
 References:
 * https://www.gnu.org/software/autogen/fixinc.html
 * https://android.googlesource.com/toolchain/gcc/+/master/gcc-4.8.3/fixincludes/README

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -79,7 +79,7 @@ subcommand.
 
 ```
 usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q] [-f]
-                         [--skip-gcc-fix-include] (-b COMMAND | -l LOGFILE)
+                         [--keep-gcc-include-fixed] (-b COMMAND | -l LOGFILE)
                          [-j JOBS] [-c]
                          [--compile-uniqueing COMPILE_UNIQUEING]
                          [--report-hash {context-free}] [-i SKIPFILE]
@@ -114,10 +114,10 @@ optional arguments:
                         coming from files not affected by the analysis, and
                         only incrementally update defect reports for source
                         files that were analysed.)
-  --skip-gcc-fix-include
-                        DEPRECATED. There are some implicit include paths which
+  --keep-gcc-include-fixed
+                        There are some implicit include paths which
                         are only used by GCC (include-fixed). This flag
-                        determines whether these should be skipped from the
+                        determines whether these should be kept among the
                         implicit include paths. (default: False)
   --compile-uniqueing COMPILE_UNIQUEING
                         Specify the method the compilation actions in the
@@ -410,7 +410,7 @@ below:
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
                            [--compiler-info-file COMPILER_INFO_FILE]
-                           [--skip-gcc-fix-include] [-t {plist}] [-q] [-c]
+                           [--keep-gcc-include-fixed] [-t {plist}] [-q] [-c]
                            [--compile-uniqueing COMPILE_UNIQUEING]
                            [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]
@@ -450,10 +450,10 @@ optional arguments:
                         Read the compiler includes and target from the
                         specified file rather than invoke the compiler
                         executable.
-  --skip-gcc-fix-include
-                        DEPRECATED. There are some implicit include paths which
+  --keep-gcc-include-fixed
+                        There are some implicit include paths which
                         are only used by GCC (include-fixed). This flag
-                        determines whether these should be skipped from the
+                        determines whether these should be kept among the
                         implicit include paths. (default: False)
   -t {plist}, --type {plist}, --output-format {plist}
                         Specify the format the analysis results should use.
@@ -641,10 +641,14 @@ If you want to run the analysis with a specific compiler configuration
 instead of the auto-detection you can pass that to the
 `--compiler-info-file compiler_info.json` parameter.
 
-There are some implicit include paths (for example those which contain
-`include-fixed` directory) which are used only by GCC. By default CodeChecker
-doesn't collect them if `--skip-gcc-fix-include` flag is given. For
-further information see [GCC incompatibilities](gcc_incompatibilities.md).
+There are some standard locations which compilers use in order to find standard
+header files. These paths are hard-coded in GCC compiler. CodeChecker is able
+to collect these so the analysis process can run in the same environment as the
+original build. However, there are some GCC-specific locations (usually with
+name `include-fixed`) which may be incompatible with other compilers and may
+cause failure in analysis. CodeChecker omits these GCC-specific paths from the
+analysis unless `--keep-gcc-include-fixed` flag is given. For further
+information see [GCC incompatibilities](gcc_incompatibilities.md).
 
 #### Forwarding compiler options <a name="forwarding-compiler-options"></a>
 


### PR DESCRIPTION
--skip-gcc-fix-include flag has been renamed to
--keep-gcc-include-fixed. The goal of this flag is to add the GCC
specific include-fixed directories to the analyzer command.

When determining implicit include paths of a compiler, the result
list is affected by -nostdinc and -nostdinc++ flags.

There was a bug in the addition of implicit include paths: there
were some -isystem flags added without a path as parameter.