### PR TITLE
[server] Store analyzer version instead of CodeChecker version

### DIFF
--- a/web/server/codechecker_server/api/store_handler.py
+++ b/web/server/codechecker_server/api/store_handler.py
@@ -355,7 +355,7 @@ def addCheckerRun(session, command, name, tag, username,
             failed_sources = res.get('failed_sources')
 
             if analyzer_version:
-                analyzer_version = zlib.compress(version,
+                analyzer_version = zlib.compress(analyzer_version,
                                                  zlib.Z_BEST_COMPRESSION)
 
             compressed_files = None


### PR DESCRIPTION
When storing an analysis result with CodeChecker, on the server
at the detail on which files failed to analyze, the CodeChecker
version "6.9.1" or "6.11.0" is stored, not the analyzer
binaries' own reported version.