### PR TITLE
[travis] Fix travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
 before_install:
     # Download macOS specific extra dependencies.
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/llvm-mirror/clang.git ~/llvm --branch master --single-branch --depth 1; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update-reset; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install doxygen; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm@8; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install thrift@0.9; fi


### PR DESCRIPTION
Travis failed on the OSX test cases on with the following error message:
.../kernel_require.rb:55:in `require': cannot load such file --
active_support/core_ext/object/blank (LoadError)

Solution: https://stackoverflow.com/questions/54888582/ruby-cannot-load-such-file-active-support-core-ext-object-blank