### PR TITLE
[analyzer] aggressive-binary-operation-simplification should be clang version dependent

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
@@ -94,3 +94,20 @@ def ctu_mapping(clang_version_info):
         "found in directory reported by Clang '%s'.",
         postfixed_tool_path, installed_dir)
     return None, None
+
+
+def get_abos_options(clang_version_info):
+    """ Get options to enable aggressive-binary-operation-simplification.
+
+    Returns list of options which enables
+    aggressive-binary-operation-simplification option (which is needed for the
+    iterator checker) if the Clang version is greater then 8.
+    Otherwise returns an empty list.
+    """
+    if clang_version_info and clang_version_info.major_version >= 8:
+        return ['-Xclang',
+                '-analyzer-config',
+                '-Xclang',
+                'aggressive-binary-operation-simplification=true']
+
+    return []

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -34,6 +34,7 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
         self.enable_z3 = False
         self.enable_z3_refutation = False
         self.environ = environ
+        self.version_info = None
 
     def add_checker_config(self, config):
         """

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 import re
+import subprocess
 
 
 class ClangVersionInfo(object):
@@ -55,3 +56,12 @@ class ClangVersionInfoParser(object):
             version_match.group('minor_version'),
             version_match.group('patch_version'),
             installed_dir_match.group('installed_dir'))
+
+
+def get(clang_binary, env=None):
+    """Get and parse the version information from given clang binary."""
+    compiler_version = subprocess.check_output([clang_binary, '--version'],
+                                               env=env)
+    version_parser = ClangVersionInfoParser()
+    version_info = version_parser.parse(compiler_version)
+    return version_info


### PR DESCRIPTION
> Closes #2390 

`aggressive-binary-operation-simplification` option is only available since Clang 8.
This option should not be passed to clang with earlier versions.