### PR TITLE
Do not count a number of skipped actions in progress log

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -697,7 +697,7 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
             sys.exit(128 + signum)
 
     signal.signal(signal.SIGINT, signal_handler)
-
+    actions, skipped_actions = skip_cpp(actions, skip_handler)
     # Start checking parallel.
     checked_var = multiprocessing.Value('i', 1)
     actions_num = multiprocessing.Value('i', len(actions))
@@ -723,8 +723,6 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
     # Construct analyzer env.
     analyzer_environment = env.extend(context.path_env_extra,
                                       context.ld_lib_path_extra)
-
-    actions, skipped_actions = skip_cpp(actions, skip_handler)
 
     analyzed_actions = [(actions_map,
                          build_action,
@@ -770,6 +768,8 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
         LOG.debug_analyzer("%s is skipped", skp.source)
 
     LOG.info("Total analyzed compilation commands: %d", len(analyzed_actions))
+    if skipped_actions:
+        LOG.info("Skipped compilation commands: %d", len(skipped_actions))
 
     LOG.info("----=================----")
     if not os.listdir(success_dir):

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped.output
@@ -6,11 +6,12 @@ CHECK#CodeChecker check --build "make multi_error simple1" --output $OUTPUT$ --q
 [] - Starting build ...
 [] - Build finished successfully.
 [] - Starting static analysis ...
-[] - [1/2] clangsa analyzed simple1.cpp successfully.
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
 [] - ----==== Summary ====----
 [] - Successfully analyzed
 [] -   clangsa: 1
 [] - Total analyzed compilation commands: 1
+[] - Skipped compilation commands: 1
 [] - ----=================----
 [] - Analysis finished.
 [] - To view results in the terminal use the "CodeChecker parse" command.


### PR DESCRIPTION
Sample:

Before:
```
[1/2] clangsa analyzed simple1.cpp successfully.
```
After:
```
[1/1] clangsa analyzed simple1.cpp successfully.
```