### PR TITLE
keep all flags if the analyzer is the same as the compiler

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -59,7 +59,11 @@ class ClangVersionInfoParser(object):
 
 
 def get(clang_binary, env=None):
-    """Get and parse the version information from given clang binary."""
+    """Get and parse the version information from given clang binary
+
+    Should return False for getting the version
+    information not from a clang compiler.
+    """
     compiler_version = subprocess.check_output([clang_binary, '--version'],
                                                env=env)
     version_parser = ClangVersionInfoParser()

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import sys
 
-from codechecker_analyzer import analyzer, analyzer_context, arg
+from codechecker_analyzer import analyzer, analyzer_context, arg, env
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.buildlog import log_parser
 
@@ -632,6 +632,10 @@ def main(args):
                 or ("stats_output" in args and args.stats_output)):
             pre_analysis_skip_handler = skip_handler
 
+    context = analyzer_context.get_context()
+    analyzer_env = env.extend(context.path_env_extra,
+                              context.ld_lib_path_extra)
+
     # Parse the JSON CCDBs and retrieve the compile commands.
     actions = []
     for log_file in args.logfile:
@@ -647,7 +651,8 @@ def main(args):
             compiler_info_file,
             args.keep_gcc_include_fixed,
             skip_handler,
-            pre_analysis_skip_handler)
+            pre_analysis_skip_handler,
+            analyzer_env)
 
     if not actions:
         LOG.info("No analysis is required.\nThere were no compilation "
@@ -661,7 +666,6 @@ def main(args):
         json.dump(actions, f,
                   cls=log_parser.CompileCommandEncoder)
 
-    context = analyzer_context.get_context()
     metadata = {'action_num': len(actions),
                 'command': sys.argv,
                 'versions': {

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -151,8 +151,8 @@ class TestAnalyze(unittest.TestCase):
         with open(info_File, 'r') as f:
             try:
                 data = json.load(f)
-                self.assertEquals(len(data), 2)
-                self.assertTrue("clang++" in data)
+                self.assertEquals(len(data), 1)
+                # For clang we do not collect anything.
                 self.assertTrue("g++" in data)
             except ValueError:
                 self.fail("json.load should successfully parse the file %s"

--- a/analyzer/tests/unit/ctu_autodetection_test_files/gcc_version
+++ b/analyzer/tests/unit/ctu_autodetection_test_files/gcc_version
@@ -1,0 +1,4 @@
+gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
+Copyright (C) 2017 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/analyzer/tests/unit/test_clang_version_parsing.py
+++ b/analyzer/tests/unit/test_clang_version_parsing.py
@@ -121,3 +121,13 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         self.assertEqual(version_info.minor_version, 0)
         self.assertEqual(version_info.patch_version, 0)
         self.assertEqual(version_info.installed_dir, '/path/to/clang/bin')
+
+    def test_built_from_gcc(self):
+        """ Test if parsing a gcc version info returns False. """
+
+        with open('gcc_version') as version_output:
+            version_string = version_output.read()
+
+        parser = version.ClangVersionInfoParser()
+        version_info = parser.parse(version_string)
+        self.assertIs(version_info, False)


### PR DESCRIPTION
If clang compiler is used to build and to analyze a project
do not filter the compiler options, keep them all.

The compiler installed dir and major versions are compared
to detect if the same clang is used for compilation and
analysis.

clang and clang++ are handled as they were the same binaries.

if the compiler is the same as the analyzer only a minimal
compiler option filtering is done.

- source, output and other files are removed from the compile command
- include paths are converted to absolute path required for the reports
- preprocessor flags are filtered out (the same way as for gcc/g++)

The list of filtered preprocessor flags is extended to remove -MD, -MG
options.

__collect_clang_compile_opts was introduced to
collect all the compile options should be run at
last everything should be filtered out earlier

__collect_compile_opts was split up
so the include path modification and the option filtering
is done separately, because the include path modification
is required for clang but the filtering not

resolves #2382
