### PR TITLE
[web] Store multiple report directories with one command

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -12,6 +12,7 @@ from abc import ABCMeta
 import collections
 import os
 import platform
+import subprocess
 import sys
 
 from codechecker_common.logger import get_logger
@@ -72,6 +73,23 @@ class AnalyzerConfigHandler(object, metaclass=ABCMeta):
                             if os.path.isfile(os.path.join(plugin_dir, f))
                             and f.endswith(".so")]
         return analyzer_plugins
+
+    def get_version(self, env=None):
+        """ Get analyzer version information. """
+        version = [self.analyzer_binary, '--version']
+        try:
+            output = subprocess.check_output(version,
+                                             env=env,
+                                             universal_newlines=True,
+                                             encoding="utf-8",
+                                             errors="ignore")
+            return output
+        except (subprocess.CalledProcessError, OSError) as oerr:
+            LOG.warning("Failed to get analyzer version: %s",
+                        ' '.join(version))
+            LOG.warning(oerr)
+
+        return None
 
     def add_checker(self, checker_name, description=None, state=None):
         """

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -457,10 +457,17 @@ def parse(plist_file, metadata_dict, rh, file_report_map):
 
     LOG.debug("Parsing input file '%s'", plist_file)
 
-    if 'result_source_files' in metadata_dict and \
-            plist_file in metadata_dict['result_source_files']:
+    result_source_files = {}
+    if 'result_source_files' in metadata_dict:
+        result_source_files = metadata_dict['result_source_files']
+    else:
+        for tool in metadata_dict.get('tools', {}):
+            result_src_files = tool.get('result_source_files', {})
+            result_source_files.update(result_src_files.items())
+
+    if plist_file in result_source_files:
         analyzed_source_file = \
-            metadata_dict['result_source_files'][plist_file]
+            result_source_files[plist_file]
 
         if analyzed_source_file not in file_report_map:
             file_report_map[analyzed_source_file] = []

--- a/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash_clang_tidy.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash_clang_tidy.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make context_hash" --quiet
 NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy
 NORMAL#CodeChecker parse $OUTPUT$ --print-steps
-CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --print-steps --analyer clang-tidy
+CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --print-steps --analyzers clang-tidy
 --------------------------------------------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -173,6 +173,8 @@ database.
 positional arguments:
   file/folder           The analysis result files and/or folders containing
                         analysis results which should be parsed and printed.
+                        If multiple report directories are given, OFF and
+                        UNAVAILABLE detection statuses will not be available.
                         (default: /home/<username>/.codechecker/reports)
 
 optional arguments:

--- a/web/client/codechecker_client/metadata.py
+++ b/web/client/codechecker_client/metadata.py
@@ -1,0 +1,71 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Helpers to manage metadata.json file.
+"""
+
+from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json_or_empty
+
+LOG = get_logger('system')
+
+
+def metadata_v1_to_v2(metadata_dict):
+    """ Convert old version metadata to a new version format. """
+
+    if 'version' in metadata_dict and metadata_dict['version'] >= 2:
+        return metadata_dict
+
+    ret = {'version': 2, 'tools': []}
+    tool = {
+        'name': 'codechecker',
+        'version': metadata_dict.get('versions', {}).get('codechecker'),
+        'command': metadata_dict.get('command'),
+        'output_path': metadata_dict.get('output_path'),
+        'skipped': metadata_dict.get('skipped'),
+        'timestamps': metadata_dict.get('timestamps'),
+        'working_directory': metadata_dict.get('working_directory'),
+        'analyzers': {},
+        'result_source_files': metadata_dict.get('result_source_files')}
+
+    for analyzer_name in sorted(metadata_dict['checkers'].keys()):
+        checkers = metadata_dict['checkers'][analyzer_name]
+        if not isinstance(checkers, dict):
+            checkers = {checker_name: True for checker_name in checkers}
+
+        analyzer_stats = metadata_dict.get('analyzer_statistics', {})
+
+        tool['analyzers'][analyzer_name] = {
+            'checkers': checkers,
+            'analyzer_statistics': analyzer_stats.get(analyzer_name, {})}
+
+    ret["tools"].append(tool)
+
+    return ret
+
+
+def merge_metadata_json(metadata_files, num_of_report_dir=1):
+    """ Merge content of multiple metadata files and return it as json. """
+
+    if not metadata_files:
+        return {}
+
+    ret = {
+        'version': 2,
+        'num_of_report_dir': num_of_report_dir,
+        'tools': []}
+
+    for metadata_file in metadata_files:
+        try:
+            metadata_dict = load_json_or_empty(metadata_file, {})
+            metadata = metadata_v1_to_v2(metadata_dict)
+            for tool in metadata['tools']:
+                ret['tools'].append(tool)
+        except Exception as ex:
+            LOG.warning('Failed to parse %s file with the following error: %s',
+                        metadata_file, str(ex))
+
+    return ret

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -50,6 +50,7 @@ from ..database.run_db_model import \
     AnalyzerStatistic, Report, ReviewStatus, File, Run, RunHistory, \
     RunLock, Comment, BugPathEvent, BugReportPoint, \
     FileContent, SourceComponent, ExtendedReportData
+from ..metadata import MetadataInfoParser
 from ..tmp import TemporaryDirectory
 
 from .db import DBSession, escape_like
@@ -2816,8 +2817,9 @@ class ThriftRequestHandler(object):
 
                 run_history_time = datetime.now()
 
+                metadata_parser = MetadataInfoParser()
                 check_commands, check_durations, cc_version, statistics, \
-                    checkers = store_handler.metadata_info(metadata_file)
+                    checkers = metadata_parser.get_metadata_info(metadata_file)
 
                 command = ''
                 if len(check_commands) == 1:

--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -1,0 +1,150 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
+"""
+Helpers to parse metadata.json file.
+"""
+
+from abc import ABCMeta
+import os
+
+
+from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json_or_empty
+
+LOG = get_logger('system')
+
+
+class MetadataInfoParser(object):
+    """ Metadata info parser. """
+
+    __metaclass__ = ABCMeta
+
+    def __get_metadata_info_v1(self, metadata_dict):
+        """ Get metadata information from the old version json file. """
+        check_commands = []
+        check_durations = []
+        cc_version = None
+        analyzer_statistics = {}
+        checkers = {}
+
+        if 'command' in metadata_dict:
+            check_commands.append(metadata_dict['command'])
+        if 'timestamps' in metadata_dict:
+            check_durations.append(
+                float(metadata_dict['timestamps']['end'] -
+                      metadata_dict['timestamps']['begin']))
+
+        # Get CodeChecker version.
+        cc_version = metadata_dict.get('versions', {}).get('codechecker')
+
+        # Get analyzer statistics.
+        analyzer_statistics = metadata_dict.get('analyzer_statistics', {})
+
+        # Get analyzer checkers.
+        checkers = metadata_dict.get('checkers', {})
+
+        return check_commands, check_durations, cc_version, \
+            analyzer_statistics, checkers
+
+    def __insert_analyzer_statistics(self, source, dest, analyzer_name):
+        """ Insert stats from source to dest of the given analyzer. """
+        if not source:
+            return
+
+        if analyzer_name in dest:
+            dest[analyzer_name]['failed'] += source['failed']
+            dest[analyzer_name]['failed_sources'].extend(
+                source['failed_sources'])
+            dest[analyzer_name]['successful'] += source['successful']
+            dest[analyzer_name]['version'].update([source['version']])
+        else:
+            dest[analyzer_name] = source
+            dest[analyzer_name]['version'] = set([source['version']])
+
+    def __insert_checkers(self, source, dest, analyzer_name):
+        """ Insert checkers from source to dest of the given analyzer. """
+        if analyzer_name in dest:
+            d_chks = dest[analyzer_name]
+            for checker in source:
+                if checker in d_chks and source[checker] != d_chks[checker]:
+                    LOG.warning('Different checker statuses for %s', checker)
+                dest[analyzer_name][checker] = source[checker]
+        else:
+            dest[analyzer_name] = source
+
+    def __get_metadata_info_v2(self, metadata_dict):
+        """ Get metadata information from the new version format json file. """
+        cc_version = []
+        check_commands = []
+        check_durations = []
+        analyzer_statistics = {}
+        checkers = {}
+
+        tools = metadata_dict.get('tools', {})
+        for tool in tools:
+            if tool['name'] == 'codechecker' and 'version' in tool:
+                cc_version.append(tool['version'])
+
+            if 'command' in tool:
+                check_commands.append(tool['command'])
+
+            if 'timestamps' in tool:
+                check_durations.append(
+                    float(tool['timestamps']['end'] -
+                          tool['timestamps']['begin']))
+
+            if 'analyzers' in tool:
+                for analyzer_name, analyzer_info in tool['analyzers'].items():
+                    self.__insert_analyzer_statistics(
+                        analyzer_info.get('analyzer_statistics', {}),
+                        analyzer_statistics,
+                        analyzer_name)
+
+                    self.__insert_checkers(
+                        analyzer_info.get('checkers', {}),
+                        checkers,
+                        analyzer_name)
+            else:
+                self.__insert_analyzer_statistics(
+                    tool.get('analyzer_statistics', {}),
+                    analyzer_statistics,
+                    tool['name'])
+
+                self.__insert_checkers(tool.get('checkers', {}),
+                                       checkers,
+                                       tool['name'])
+
+        # FIXME: if multiple report directories are stored created by different
+        # codechecker versions there can be multiple results with OFF detection
+        # status. If additional reports are stored created with cppcheck all
+        # the cppcheck analyzer results will be marked with unavailable
+        # detection status. To solve this problem we will return with an empty
+        # checker set. This way detection statuses will be calculated properly
+        # but OFF and UNAVAILABLE checker statuses will never be used.
+        num_of_report_dir = metadata_dict.get('num_of_report_dir')
+        if num_of_report_dir > 1:
+            checkers = {}
+
+        cc_version = '; '.join(cc_version) if cc_version else None
+
+        for analyzer in analyzer_statistics:
+            analyzer_statistics[analyzer]['version'] = \
+                '; '.join(analyzer_statistics[analyzer]['version'])
+
+        return check_commands, check_durations, cc_version, \
+            analyzer_statistics, checkers
+
+    def get_metadata_info(self, metadata_file):
+        """ Get metadata information from the given file. """
+        if not os.path.isfile(metadata_file):
+            return [], [], None, {}, {}
+
+        metadata_dict = load_json_or_empty(metadata_file, {})
+
+        if 'version' in metadata_dict:
+            return self.__get_metadata_info_v2(metadata_dict)
+        else:
+            return self.__get_metadata_info_v1(metadata_dict)

--- a/web/server/tests/unit/metadata_test_files/v1.json
+++ b/web/server/tests/unit/metadata_test_files/v1.json
@@ -1,0 +1,50 @@
+{
+  "action_num": 1,
+  "analyzer_statistics": {
+    "clang-tidy": {
+      "failed": 0,
+      "failed_sources": [],
+      "successful": 10,
+      "version": "LLVM version 7.0.0"
+    },
+    "clangsa": {
+      "failed": 0,
+      "failed_sources": [],
+      "successful": 1,
+      "version": "clang version 7.0.0"
+    }
+  },
+  "checkers": {
+    "clang-tidy": {
+      "abseil-string-find-startswith": false,
+      "bugprone-use-after-move": true
+    },
+    "clangsa": {
+      "alpha.clone.CloneChecker": false,
+      "deadcode.DeadStores": true
+    }
+  },
+  "command": [
+    "CodeChecker.py",
+    "analyze",
+    "-o",
+    "/path/to/reports",
+    "/path/to/build.json"
+  ],
+  "output_path": "/path/to/reports",
+  "result_source_files": {
+    "/path/to/reports/main.cpp_cd2085addd2b226005b7f9cf1827c082.plist": "/path/to/main.cpp",
+    "/path/to/reports/reports/main.cpp_ed1ce6c18431138a19465e60aa69a4ba.plist": "/path/to/main.cpp"
+  },
+  "skipped": 0,
+  "timestamps": {
+    "begin": 1571297867,
+    "end": 1571297868
+  },
+  "versions": {
+    "clang": "clang version 7.0.0",
+    "clang-tidy": "LLVM version 7.0.0",
+    "codechecker": "6.11 (930440d6a6cae80f615146547f4b169c7629d558)"
+  },
+  "working_directory": "/path/to/workspace"
+}

--- a/web/server/tests/unit/metadata_test_files/v2.json
+++ b/web/server/tests/unit/metadata_test_files/v2.json
@@ -1,0 +1,54 @@
+{
+  "version": 2,
+  "num_of_report_dir": 1,
+  "tools": [
+    {
+      "name": "codechecker",
+      "version": "6.11 (930440d6a6cae80f615146547f4b169c7629d558)",
+      "command": [
+        "CodeChecker.py",
+        "analyze",
+        "-o",
+        "/path/to/reports",
+        "/path/to/build.json"
+      ],
+      "output_path": "/path/to/reports",
+      "skipped": 0,
+      "timestamps": {
+        "begin": 1571297867,
+        "end": 1571297868
+      },
+      "working_directory": "/path/to/workspace",
+      "analyzers": {
+        "clang-tidy": {
+          "checkers": {
+            "abseil-string-find-startswith": false,
+            "bugprone-use-after-move": true
+          },
+          "analyzer_statistics": {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 10,
+            "version": "LLVM version 7.0.0"
+          }
+        },
+        "clangsa": {
+          "checkers": {
+            "alpha.clone.CloneChecker": false,
+            "deadcode.DeadStores": true
+          },
+          "analyzer_statistics": {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 1,
+            "version": "clang version 7.0.0"
+          }
+        }
+      },
+      "result_source_files": {
+        "/path/to/reports/main.cpp_cd2085addd2b226005b7f9cf1827c082.plist": "/path/to/main.cpp",
+        "/path/to/reports/reports/main.cpp_ed1ce6c18431138a19465e60aa69a4ba.plist": "/path/to/main.cpp"
+      }
+    }
+  ]
+}

--- a/web/server/tests/unit/metadata_test_files/v2_multiple.json
+++ b/web/server/tests/unit/metadata_test_files/v2_multiple.json
@@ -1,0 +1,68 @@
+{
+  "version": 2,
+  "num_of_report_dir": 2,
+  "tools": [
+    {
+      "name": "codechecker",
+      "version": "6.11 (930440d6a6cae80f615146547f4b169c7629d558)",
+      "command": [
+        "CodeChecker.py",
+        "analyze",
+        "-o",
+        "/path/to/reports",
+        "/path/to/build.json"
+      ],
+      "output_path": "/path/to/reports",
+      "skipped": 0,
+      "timestamps": {
+        "begin": 1571297867,
+        "end": 1571297868
+      },
+      "working_directory": "/path/to/workspace",
+      "analyzers": {
+        "clang-tidy": {
+          "checkers": {
+            "abseil-string-find-startswith": false,
+            "bugprone-use-after-move": true
+          },
+          "analyzer_statistics": {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 10,
+            "version": "LLVM version 7.0.0"
+          }
+        },
+        "clangsa": {
+          "checkers": {
+            "alpha.clone.CloneChecker": false,
+            "deadcode.DeadStores": true
+          },
+          "analyzer_statistics": {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 1,
+            "version": "clang version 7.0.0"
+          }
+        }
+      },
+      "result_source_files": {
+        "/path/to/reports/main.cpp_cd2085addd2b226005b7f9cf1827c082.plist": "/path/to/main.cpp",
+        "/path/to/reports/reports/main.cpp_ed1ce6c18431138a19465e60aa69a4ba.plist": "/path/to/main.cpp"
+      }
+    },
+    {
+      "name": "cppcheck",
+      "analyzer_statistics": {
+        "failed": 0,
+        "failed_sources": [],
+        "successful": 1,
+        "version": "Cppcheck 1.87"
+      },
+      "command": ["cppcheck", "/path/to/main.cpp"],
+      "timestamps": {
+        "begin": 1571297867,
+        "end": 1571297868
+      }
+    }
+  ]
+}

--- a/web/server/tests/unit/metadata_test_files/v2_multiple_cppcheck.json
+++ b/web/server/tests/unit/metadata_test_files/v2_multiple_cppcheck.json
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "num_of_report_dir": 2,
+  "tools": [
+    {
+      "name": "cppcheck",
+      "checkers": {},
+      "analyzer_statistics": {
+        "failed": 0,
+        "failed_sources": [],
+        "successful": 1,
+        "version": "Cppcheck 1.87"
+      },
+      "command": ["cppcheck", "/path/to/main.cpp"],
+      "timestamps": {
+        "begin": 1571297867,
+        "end": 1571297868
+      }
+    },
+    {
+      "name": "cppcheck",
+      "checkers": {},
+      "analyzer_statistics": {
+        "failed": 0,
+        "failed_sources": [],
+        "successful": 1,
+        "version": "Cppcheck 1.86"
+      },
+      "command": ["cppcheck", "-I", "/path/to/include", "/path/to/main.cpp"],
+      "timestamps": {
+        "begin": 1571297867,
+        "end": 1571297868
+      }
+    }
+  ]
+}

--- a/web/server/tests/unit/test_metadata_merge.py
+++ b/web/server/tests/unit/test_metadata_merge.py
@@ -1,0 +1,221 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Unit tests for the metadata merge. """
+
+import json
+import os
+from tempfile import mkdtemp
+import shutil
+import unittest
+
+from codechecker_client.metadata import metadata_v1_to_v2, merge_metadata_json
+
+
+class MetadataMergeTest(unittest.TestCase):
+    """ Test for merging multiple metadata.json file. """
+
+    def test_metadata_v1_to_v2(self):
+        """ Test to convert v1 version format metadata to v2 format. """
+        metadata = {
+            "action_num": 1,
+            "checkers": {
+                "clang-tidy": ["a"],
+                "clangsa": {"b": False}
+            },
+            "command": ["CodeChecker", "analyze"],
+            "failed": {},
+            "output_path": "/path/to/reports",
+            "result_source_files": {
+                "/path/to/reports/main.cpp_cd.plist": "/path/to/main.cpp",
+                "/path/to/reports/main.cpp_ed.plist": "/path/to/main.cpp"
+            },
+            "skipped": 1,
+            "successful": {
+                "clang-tidy": 1,
+                "clangsa": 1
+            },
+            "timestamps": {
+                "begin": 1571728770,
+                "end": 1571728771
+            },
+            "versions": {
+                "clang": "clang version 5.0.1",
+                "clang-tidy": "LLVM version 5.0.1",
+                "codechecker": "6.5.1 (fd2df38)"
+            },
+            "working_directory": "/path/to/workspace"
+        }
+
+        expected = {
+            "version": 2,
+            "tools": [{
+                "name": "codechecker",
+                "version": "6.5.1 (fd2df38)",
+                "command": ["CodeChecker", "analyze"],
+                "output_path": "/path/to/reports",
+                "skipped": 1,
+                "timestamps": {
+                    "begin": 1571728770,
+                    "end": 1571728771
+                },
+                "working_directory": "/path/to/workspace",
+                "analyzers": {
+                    "clang-tidy": {
+                        "checkers": {"a": True},
+                        "analyzer_statistics": {}
+                    },
+                    "clangsa": {
+                        "checkers": {"b": False},
+                        "analyzer_statistics": {}
+                    }
+                },
+                "result_source_files": {
+                    "/path/to/reports/main.cpp_cd.plist": "/path/to/main.cpp",
+                    "/path/to/reports/main.cpp_ed.plist": "/path/to/main.cpp"
+                },
+            }]
+        }
+
+        res = metadata_v1_to_v2(metadata)
+        self.assertEqual(res, expected)
+
+    def test_merge_metadata(self):
+        """ Test merging multiple metadata files. """
+        metadata_v1 = {
+            "action_num": 1,
+            "checkers": {
+                "clang-tidy": ["a"],
+                "clangsa": {"b": False}
+            },
+            "command": ["CodeChecker", "analyze"],
+            "failed": {},
+            "output_path": "/path/to/reports",
+            "result_source_files": {
+                "/path/to/reports/main.cpp_cd.plist": "/path/to/main.cpp",
+                "/path/to/reports/main.cpp_ed.plist": "/path/to/main.cpp"
+            },
+            "skipped": 1,
+            "successful": {
+                "clang-tidy": 1,
+                "clangsa": 1
+            },
+            "timestamps": {
+                "begin": 1571728770,
+                "end": 1571728771
+            },
+            "versions": {
+                "clang": "clang version 5.0.1",
+                "clang-tidy": "LLVM version 5.0.1",
+                "codechecker": "6.5.1 (fd2df38)"
+            },
+            "working_directory": "/path/to/workspace"
+        }
+
+        metadata_v2 = {
+            "version": 2,
+            'num_of_report_dir': 1,
+            "tools": [{
+                "name": "cppcheck",
+                "analyzer_statistics": {
+                    "failed": 0,
+                    "failed_sources": [],
+                    "successful": 1,
+                    "version": "Cppcheck 1.87"
+                },
+                "command": ["cppcheck", "/path/to/main.cpp"],
+                "timestamps": {
+                    "begin": 1571297867,
+                    "end": 1571297868
+                }
+            }]
+        }
+
+        metadata_v3 = {
+            "version": 2,
+            'num_of_report_dir': 1,
+            "tools": [{
+                "name": "cppcheck",
+                "command": ["cppcheck", "/path/to/main2.cpp"],
+                "timestamps": {
+                    "begin": 1571297867,
+                    "end": 1571297868
+                }
+            }]
+        }
+
+        expected = {
+            "version": 2,
+            'num_of_report_dir': 2,
+            "tools": [{
+                "name": "codechecker",
+                "version": "6.5.1 (fd2df38)",
+                "command": ["CodeChecker", "analyze"],
+                "output_path": "/path/to/reports",
+                "skipped": 1,
+                "timestamps": {
+                    "begin": 1571728770,
+                    "end": 1571728771
+                },
+                "working_directory": "/path/to/workspace",
+                "analyzers": {
+                    "clang-tidy": {
+                        "checkers": {"a": True},
+                        "analyzer_statistics": {}
+                    },
+                    "clangsa": {
+                        "checkers": {"b": False},
+                        "analyzer_statistics": {}
+                    }
+                },
+                "result_source_files": {
+                    "/path/to/reports/main.cpp_cd.plist": "/path/to/main.cpp",
+                    "/path/to/reports/main.cpp_ed.plist": "/path/to/main.cpp"
+                }},
+                {
+                    "name": "cppcheck",
+                    "analyzer_statistics": {
+                        "failed": 0,
+                        "failed_sources": [],
+                        "successful": 1,
+                        "version": "Cppcheck 1.87"
+                    },
+                    "command": ["cppcheck", "/path/to/main.cpp"],
+                    "timestamps": {
+                        "begin": 1571297867,
+                        "end": 1571297868
+                    }
+                },
+                {
+                    "name": "cppcheck",
+                    "command": ["cppcheck", "/path/to/main2.cpp"],
+                    "timestamps": {
+                        "begin": 1571297867,
+                        "end": 1571297868
+                    }
+                }]
+        }
+
+        try:
+            metadata_dir = mkdtemp()
+
+            mf_1 = os.path.join(metadata_dir, 'm1.json')
+            mf_2 = os.path.join(metadata_dir, 'm2.json')
+            mf_3 = os.path.join(metadata_dir, 'm3.json')
+
+            with open(mf_1, 'w', encoding='utf-8', errors='ignore') as f1:
+                f1.write(json.dumps(metadata_v1, indent=2))
+
+            with open(mf_2, 'w', encoding='utf-8', errors='ignore') as f2:
+                f2.write(json.dumps(metadata_v2, indent=2))
+
+            with open(mf_3, 'w', encoding='utf-8', errors='ignore') as f3:
+                f3.write(json.dumps(metadata_v3, indent=2))
+
+            res = merge_metadata_json([mf_1, mf_2, mf_3], 2)
+            self.assertEqual(res, expected)
+        finally:
+            shutil.rmtree(metadata_dir)

--- a/web/server/tests/unit/test_metadata_parser.py
+++ b/web/server/tests/unit/test_metadata_parser.py
@@ -1,0 +1,216 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Unit tests for the metadata parser. """
+
+import os
+import unittest
+
+from codechecker_server.metadata import MetadataInfoParser
+
+
+metadata_cc_info = {
+    'check_commands': [
+        'CodeChecker.py analyze -o /path/to/reports /path/to/build.json'
+    ],
+    'analysis_duration': [1.0],
+    'cc_version': '6.11 (930440d6a6cae80f615146547f4b169c7629d558)',
+    'analyzer_statistics': {
+        'clangsa': {
+            'successful': 1,
+            'failed': 0,
+            'version': 'clang version 7.0.0',
+            'failed_sources': []
+        },
+        'clang-tidy': {
+            'successful': 10,
+            'failed': 0,
+            'version': 'LLVM version 7.0.0',
+            'failed_sources': []
+        }
+    },
+    'checkers': {
+        'clangsa': {
+            'alpha.clone.CloneChecker': False,
+            'deadcode.DeadStores': True
+        },
+        'clang-tidy': {
+            'bugprone-use-after-move': True,
+            'abseil-string-find-startswith': False
+        }
+    }
+}
+
+metadata_multiple_info = {
+    'check_commands': [
+        'CodeChecker.py analyze -o /path/to/reports /path/to/build.json',
+        'cppcheck /path/to/main.cpp'
+    ],
+    'analysis_duration': [1.0, 1.0],
+    'cc_version': '6.11 (930440d6a6cae80f615146547f4b169c7629d558)',
+    'analyzer_statistics': {
+        'clangsa': {
+            'successful': 1,
+            'failed': 0,
+            'version': 'clang version 7.0.0',
+            'failed_sources': []
+        },
+        'clang-tidy': {
+            'successful': 10,
+            'failed': 0,
+            'version': 'LLVM version 7.0.0',
+            'failed_sources': []
+        },
+        'cppcheck': {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 1,
+            "version": "Cppcheck 1.87"
+        }
+    },
+    'checkers': {
+        'clangsa': {
+            'alpha.clone.CloneChecker': False,
+            'deadcode.DeadStores': True
+        },
+        'clang-tidy': {
+            'bugprone-use-after-move': True,
+            'abseil-string-find-startswith': False
+        },
+        'cppcheck': {}
+    }
+}
+
+
+metadata_mult_cppcheck_info = {
+    'check_commands': [
+        'cppcheck /path/to/main.cpp',
+        'cppcheck -I /path/to/include /path/to/main.cpp'
+    ],
+    'analysis_duration': [1.0, 1.0],
+    'cc_version': None,
+    'analyzer_statistics': {
+        'cppcheck': {
+            "failed": 0,
+            "failed_sources": [],
+            "successful": 2,
+            "version": "Cppcheck 1.87"
+        }
+    },
+    'checkers': {
+        'cppcheck': {}
+    }
+}
+
+
+class MetadataInfoParserTest(unittest.TestCase):
+    """ Testing metadata parser. """
+
+    @classmethod
+    def setup_class(self):
+        """ Initialize the metadata parser and test files. """
+        self.__parser = MetadataInfoParser()
+
+        # Already generated plist files for the tests.
+        self.__metadata_test_files = os.path.join(
+            os.path.dirname(__file__), 'metadata_test_files')
+
+    def test_metadata_info_v1(self):
+        """ Get metadata info for old version format json file. """
+        metadata_v1 = os.path.join(self.__metadata_test_files, 'v1.json')
+        check_commands, check_durations, cc_version, analyzer_statistics, \
+            checkers = self.__parser.get_metadata_info(metadata_v1)
+
+        self.assertEqual(len(check_commands), 1)
+        self.assertEqual(' '.join(metadata_cc_info['check_commands']),
+                         ' '.join(check_commands[0]))
+
+        self.assertEqual(metadata_cc_info['analysis_duration'][0],
+                         check_durations[0])
+
+        self.assertEqual(metadata_cc_info['cc_version'], cc_version)
+
+        self.assertDictEqual(metadata_cc_info['analyzer_statistics'],
+                             analyzer_statistics)
+
+        self.assertDictEqual(metadata_cc_info['checkers'],
+                             checkers)
+
+    def test_metadata_info_v2(self):
+        """ Get metadata info for new version format json. """
+        metadata_v2 = os.path.join(self.__metadata_test_files, 'v2.json')
+        check_commands, check_durations, cc_version, analyzer_statistics, \
+            checkers = self.__parser.get_metadata_info(metadata_v2)
+
+        self.assertEqual(len(check_commands), 1)
+        self.assertEqual(' '.join(metadata_cc_info['check_commands']),
+                         ' '.join(check_commands[0]))
+
+        self.assertEqual(metadata_cc_info['analysis_duration'][0],
+                         check_durations[0])
+
+        self.assertEqual(metadata_cc_info['cc_version'], cc_version)
+
+        self.assertDictEqual(metadata_cc_info['analyzer_statistics'],
+                             analyzer_statistics)
+
+        self.assertDictEqual(metadata_cc_info['checkers'],
+                             checkers)
+
+    def test_multiple_metadata_info(self):
+        """ Get metadata info from multiple analyzers. """
+        metadata_multiple = os.path.join(self.__metadata_test_files,
+                                         'v2_multiple.json')
+        check_commands, check_durations, cc_version, analyzer_statistics, \
+            checkers = self.__parser.get_metadata_info(metadata_multiple)
+
+        self.assertEqual(len(check_commands), 2)
+        check_commands = [' '.join(c) for c in check_commands]
+        for command in metadata_multiple_info['check_commands']:
+            self.assertTrue(command in check_commands)
+
+        self.assertEqual(int(sum(metadata_multiple_info['analysis_duration'])),
+                         int(sum(check_durations)))
+
+        self.assertEqual(metadata_multiple_info['cc_version'], cc_version)
+
+        self.assertDictEqual(metadata_multiple_info['analyzer_statistics'],
+                             analyzer_statistics)
+
+        self.assertDictEqual(checkers, {})
+
+    def test_multiple_cppcheck_metadata_info(self):
+        """ Get metadata info from multiple cppcheck analyzers. """
+        metadata_multiple = os.path.join(self.__metadata_test_files,
+                                         'v2_multiple_cppcheck.json')
+        check_commands, check_durations, cc_version, analyzer_statistics, \
+            checkers = self.__parser.get_metadata_info(metadata_multiple)
+
+        self.assertEqual(len(check_commands), 2)
+        check_commands = [' '.join(c) for c in check_commands]
+        for command in metadata_mult_cppcheck_info['check_commands']:
+            self.assertTrue(command in check_commands)
+
+        self.assertEqual(
+            int(sum(metadata_mult_cppcheck_info['analysis_duration'])),
+            int(sum(check_durations)))
+
+        self.assertEqual(metadata_mult_cppcheck_info['cc_version'], cc_version)
+
+        expected_stats = metadata_mult_cppcheck_info['analyzer_statistics']
+        expected_cppcheck_stats = expected_stats['cppcheck']
+        cppcheck_stats = analyzer_statistics['cppcheck']
+
+        self.assertEqual(expected_cppcheck_stats['failed'],
+                         cppcheck_stats['failed'])
+
+        self.assertEqual(len(expected_cppcheck_stats['failed_sources']),
+                         len(cppcheck_stats['failed_sources']))
+
+        self.assertEqual(expected_cppcheck_stats['successful'],
+                         cppcheck_stats['successful'])
+
+        self.assertDictEqual(checkers, {})

--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -269,6 +269,8 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
               checkCommand = 'Unavailable!';
             }
 
+            checkCommand = checkCommand.replace(/; /g, '<br/>');
+
             that._dialog.set('title', 'Check command');
             that._dialog.set('content', checkCommand);
             that._dialog.show();

--- a/web/server/www/scripts/codecheckerviewer/RunHistory.js
+++ b/web/server/www/scripts/codecheckerviewer/RunHistory.js
@@ -163,6 +163,8 @@ function (declare, ObjectStore, Store, Deferred, DataGrid, Dialog, ContentPane,
               checkCommand = 'Unavailable!';
             }
 
+            checkCommand = checkCommand.replace(/; /g, '<br/>');
+
             that._dialog.set('title', 'Check command');
             that._dialog.set('content', checkCommand);
             that._dialog.show();


### PR DESCRIPTION
* Allow the user to store multiple report directories with one `CodeChecker store` command.
* New metadata.json format.
* Tests for parsing and merging metadata.json files.