### PR TITLE
[Statistics] Replace analyzer option `api-metadata-path` with package option `APIMetadataPath`

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics_collector.py
@@ -137,7 +137,8 @@ class SpecialReturnValueCollector(object):
             return []
         else:
             return ['-Xclang', '-analyzer-config',
-                    '-Xclang', 'api-metadata-path=' + path]
+                    '-Xclang',
+                    'alpha.ericsson.statisticsbased:APIMetadataPath=' + path]
 
     def total(self):
         return self.stats.get('total')
@@ -246,7 +247,8 @@ class ReturnValueCollector(object):
             return []
         else:
             return ['-Xclang', '-analyzer-config',
-                    '-Xclang', 'api-metadata-path=' + path]
+                    '-Xclang',
+                    'alpha.ericsson.statisticsbased:APIMetadataPath=' + path]
 
     def total(self):
         return self.stats.get('total')


### PR DESCRIPTION
Clang 9 enables package options beside analyzer and checker options.
This allows us to use package option instead of analyzer option for
passing the path of the YAML files needed by the statistics-based
checkers. The advantage of this approach is that the plugin now works
with the official Clang 9 release, no patching is needed. Since the
statistics-based checkers are in the same package, the option needs only
to be passed once for the whole analysis.

This patch adjust CodeChecker to work correctly with the new plugin.