### PR TITLE
do not parse the compile command if not needed later

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -579,6 +579,16 @@ def main(args):
 
     report_dir = args.output_path
 
+    # Skip list is applied only in pre-analysis
+    # if --ctu-collect or --stats-collect was called explicitly.
+    pre_analysis_skip_handler = None
+    if 'ctu_phases' in args:
+        ctu_collect = args.ctu_phases[0]
+        ctu_analyze = args.ctu_phases[1]
+        if ((ctu_collect and not ctu_analyze)
+                or ("stats_output" in args and args.stats_output)):
+            pre_analysis_skip_handler = skip_handler
+
     # Parse the JSON CCDBs and retrieve the compile commands.
     actions = []
     for log_file in args.logfile:
@@ -592,7 +602,9 @@ def main(args):
             report_dir,
             args.compile_uniqueing,
             compiler_info_file,
-            args.keep_gcc_include_fixed)
+            args.keep_gcc_include_fixed,
+            skip_handler,
+            pre_analysis_skip_handler)
 
     if not actions:
         LOG.info("No analysis is required.\nThere were no compilation "

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -14,6 +14,7 @@ import unittest
 
 from codechecker_analyzer.buildlog import log_parser
 from codechecker_common.util import load_json_or_empty
+from codechecker_common import skiplist_handler
 
 
 class LogParserTest(unittest.TestCase):
@@ -253,3 +254,117 @@ class LogParserTest(unittest.TestCase):
         flags = ["-I", "/usr/include", "--sysroot=/usr/mysysroot"]
         filtered = log_parser.filter_compiler_includes_extra_args(flags)
         self.assertEqual(filtered, ["--sysroot=/usr/mysysroot"])
+
+    def test_skip_everything_from_parse(self):
+        """Same skip file for pre analysis and analysis. Skip everything."""
+        cmp_cmd_json = [
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/a.cpp",
+             "file": "a.cpp"},
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/b.cpp",
+             "file": "b.cpp"},
+            {"directory": "/tmp/lib2",
+             "command": "g++ /tmp/lib2/a.cpp",
+             "file": "a.cpp"}]
+
+        skip_list = """
+        -*/lib1/*
+        -*/lib2/*
+        """
+        analysis_skip = skiplist_handler.SkipListHandler(skip_list)
+        pre_analysis_skip = skiplist_handler.SkipListHandler(skip_list)
+
+        build_actions = log_parser.\
+            parse_unique_log(cmp_cmd_json, self.__this_dir,
+                             analysis_skip_handler=analysis_skip,
+                             pre_analysis_skip_handler=pre_analysis_skip)
+
+        self.assertEqual(len(build_actions), 0)
+
+    def test_skip_all_in_pre_from_parse(self):
+        """Pre analysis skips everything but keep build action for analysis."""
+        cmp_cmd_json = [
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/a.cpp",
+             "file": "a.cpp"},
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/b.cpp",
+             "file": "b.cpp"},
+            {"directory": "/tmp/lib2",
+             "command": "g++ /tmp/lib2/a.cpp",
+             "file": "a.cpp"}]
+
+        keep = cmp_cmd_json[2]
+
+        skip_list = """
+        -*/lib1/*
+        """
+        pre_skip_list = """
+        -*
+        """
+        analysis_skip = skiplist_handler.SkipListHandler(skip_list)
+        pre_analysis_skip = skiplist_handler.SkipListHandler(pre_skip_list)
+
+        build_actions = log_parser.\
+            parse_unique_log(cmp_cmd_json, self.__this_dir,
+                             analysis_skip_handler=analysis_skip,
+                             pre_analysis_skip_handler=pre_analysis_skip)
+
+        self.assertEqual(len(build_actions), 1)
+
+        source_file = os.path.join(keep['directory'], keep['file'])
+        self.assertEqual(build_actions[0].source, source_file)
+        self.assertEqual(build_actions[0].original_command, keep['command'])
+
+    def test_skip_no_pre_from_parse(self):
+        """Keep everything pre analysis needs it, no skipping there."""
+        cmp_cmd_json = [
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/a.cpp",
+             "file": "a.cpp"},
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/b.cpp",
+             "file": "b.cpp"},
+            {"directory": "/tmp/lib2",
+             "command": "g++ /tmp/lib2/a.cpp",
+             "file": "a.cpp"}]
+
+        skip_list = """
+        -*/lib1/*
+        """
+        analysis_skip = skiplist_handler.SkipListHandler(skip_list)
+        pre_analysis_skip = skiplist_handler.SkipListHandler("")
+
+        build_actions = log_parser.\
+            parse_unique_log(cmp_cmd_json, self.__this_dir,
+                             analysis_skip_handler=analysis_skip,
+                             pre_analysis_skip_handler=pre_analysis_skip)
+
+        self.assertEqual(len(build_actions), 3)
+
+    def test_skip_no_pre_from_parse(self):
+        """Keep everything for analysis, no skipping there."""
+        cmp_cmd_json = [
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/a.cpp",
+             "file": "a.cpp"},
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/b.cpp",
+             "file": "b.cpp"},
+            {"directory": "/tmp/lib2",
+             "command": "g++ /tmp/lib2/a.cpp",
+             "file": "a.cpp"}]
+
+        skip_list = """
+        -*/lib1/*
+        """
+        analysis_skip = skiplist_handler.SkipListHandler("")
+        pre_analysis_skip = skiplist_handler.SkipListHandler(skip_list)
+
+        build_actions = log_parser.\
+            parse_unique_log(cmp_cmd_json, self.__this_dir,
+                             analysis_skip_handler=analysis_skip,
+                             pre_analysis_skip_handler=pre_analysis_skip)
+
+        self.assertEqual(len(build_actions), 3)


### PR DESCRIPTION
If the compilation command is not needed by any other
later step (pre-analysis, actual analysis) do not
parse it.

resolves #2396