### PR TITLE
add missing lxml dependency to the analyzer

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -1,2 +1,3 @@
+lxml==4.3.4
 portalocker==1.1.0
 psutil==5.2.2


### PR DESCRIPTION
Using lxml can increase the plist parsing speed
the dependency was missing the requirements.txt.
It was listed at the dev and osx requirements.