### PR TITLE
[doc] Add more example how to use credentials

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -345,7 +345,7 @@ authentication data in `username:password` format.
     "*:8080" : "webserver:1234",
     "localhost" : "local:admin",
     "localhost:6251" : "super:secret",
-    "my.company.org:443": "user:pass"
+    "https://my.company.org:443": "user:pass"
   }
 }
 ```
@@ -392,7 +392,7 @@ Personal tokens can be written instead of the user's password in the
   "credentials": {
     "*" : "global:passphrase",
     "localhost:6251" : "super:22eca8f31ad117e90c371f2e98bcf4c9",
-    "my.company.org:443": "user:pass"
+    "https://my.company.org:443": "user:pass"
   }
 }
 ```

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -337,17 +337,18 @@ After creating the new file open `~/.codechecker.passwords.json`.
 The `credentials` section is used by the client to read pre-saved
 authentication data in `username:password` format.
 
-~~~{.json}
+```json
 {
   "client_autologin" : true,
   "credentials": {
     "*" : "global:passphrase",
     "*:8080" : "webserver:1234",
     "localhost" : "local:admin",
-    "localhost:6251" : "super:secret"
+    "localhost:6251" : "super:secret",
+    "my.company.org:443": "user:pass"
   }
 }
-~~~
+```
 
 Credentials are matched for any particular server at login in the following
 order:
@@ -390,7 +391,8 @@ Personal tokens can be written instead of the user's password in the
   "client_autologin" : true,
   "credentials": {
     "*" : "global:passphrase",
-    "localhost:6251" : "super:22eca8f31ad117e90c371f2e98bcf4c9"
+    "localhost:6251" : "super:22eca8f31ad117e90c371f2e98bcf4c9",
+    "my.company.org:443": "user:pass"
   }
 }
 ```

--- a/web/server/tests/unit/test_credentials.py
+++ b/web/server/tests/unit/test_credentials.py
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+""" Unit tests for the credentials module. """
+
+import unittest
+
+from codechecker_client.credential_manager import simplify_credentials
+
+
+class CredentialsTest(unittest.TestCase):
+    """
+    Testing the credentials.
+    """
+
+    def test_get_auth_string(self):
+        """
+        Get authentication string from the credentials.
+        """
+        credentials = {
+            "client_autologin": True,
+            "credentials": {
+                "*": "global:passphrase",
+                "*:8080": "webserver:1234",
+                "localhost": "local:admin",
+                "localhost:6251": "super:secret",
+                "https://localhost:443/Test": "local1:admin1",
+                "https://myserver.com/Test": "serveruser:serverpassphrase",
+                "https://some.server.com:12345/Product": "user:secretpwd"}}
+
+        # Replace the key of the entries with host:port values.
+        cred_simple = simplify_credentials(credentials["credentials"])
+
+        self.assertIn('*', cred_simple)
+        self.assertIn('*:8080', cred_simple)
+        self.assertIn('localhost', cred_simple)
+        self.assertIn('localhost:6251', cred_simple)
+        self.assertIn('localhost:443', cred_simple)
+        self.assertIn('myserver.com', cred_simple)
+        self.assertIn('some.server.com:12345', cred_simple)


### PR DESCRIPTION
Add a note and a new example for the credentials sections which tells the user not to use protocols when adding new credentials entries.