### PR TITLE
[analyzer] Fix missing analyzer binary

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -139,6 +139,11 @@ class Context(object):
             else:
                 env_path = analyzer_env['PATH'] if analyzer_env else None
                 compiler_binary = find_executable(value, env_path)
+                if not compiler_binary:
+                    LOG.warning("'%s' binary can not be found in your PATH!",
+                                value)
+                    continue
+
                 self.__analyzers[name] = os.path.realpath(compiler_binary)
 
     @property

--- a/analyzer/codechecker_analyzer/host_check.py
+++ b/analyzer/codechecker_analyzer/host_check.py
@@ -17,7 +17,7 @@ import tempfile
 
 from codechecker_common.logger import get_logger
 
-LOG = get_logger('analyze')
+LOG = get_logger('analyzer')
 
 
 def check_clang(compiler_bin, env):
@@ -93,7 +93,7 @@ def has_analyzer_option(clang_bin, feature, env=None):
             return proc.returncode == 0
         except OSError:
             LOG.error('Failed to run: "%s"', ' '.join(cmd))
-            raise
+            return False
 
 
 def get_resource_dir(clang_bin, context, env=None):
@@ -123,4 +123,4 @@ def get_resource_dir(clang_bin, context, env=None):
             return None
     except OSError:
         LOG.error('Failed to run: "%s"', ' '.join(cmd))
-        raise
+        return False


### PR DESCRIPTION
If one of the registered analyzer binary (e.g: clang-tidy) was missing
from user host machine, in CodeChecker we tried to get the full binary
path from the user's `PATH` environment variable for this binary by using
the `find_executable` function but it returned with `None` and we tried
to get the `realpath` of it but the parameter of this function cannot be
`None` so we got an exception.

This commit will solve this issue by checking the return value of the
`find_executable` function and if it returned with `None` we will
print a warning message to the user.