### PR TITLE
[analyzer] Fix failure zip

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -315,7 +315,7 @@ def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
         zip_file,
         map(lambda path: os.path.join(action.directory, path), other_files))
 
-    with zipfile.ZipFile(zip_file, 'w') as archive:
+    with zipfile.ZipFile(zip_file, 'a') as archive:
         LOG.debug("[ZIP] Writing analyzer STDOUT to /stdout")
         archive.writestr("stdout", rh.analyzer_stdout)
 
@@ -552,15 +552,15 @@ def check(check_data):
 
         source_file_name = os.path.basename(action.source)
 
+        # Remove the previously generated error file.
+        if os.path.exists(zip_file):
+            os.remove(zip_file)
+
+        # Remove the previously generated CTU error file.
+        if os.path.exists(ctu_zip_file):
+            os.remove(ctu_zip_file)
+
         if rh.analyzer_returncode == 0:
-            # Remove the previously generated error file.
-            if os.path.exists(zip_file):
-                os.remove(zip_file)
-
-            # Remove the previously generated CTU error file.
-            if os.path.exists(ctu_zip_file):
-                os.remove(ctu_zip_file)
-
             handle_success(rh, result_file, result_base,
                            skip_handler, capture_analysis_output,
                            success_dir)

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -284,7 +284,6 @@ class TestAnalyze(unittest.TestCase):
         # We expect a failure archive to be in the failed directory.
         failed_files = os.listdir(failed_dir)
         self.assertEquals(len(failed_files), 1)
-        self.assertIn("failure.c", failed_files[0])
 
         fail_zip = os.path.join(failed_dir, failed_files[0])
 


### PR DESCRIPTION
In the analysis manager we used `tu_collector` to create failed zip
but after it added source files to the zip we opened this zip file
again in write mode to add some files but it cleared the zip so
the collected source files were removed from the zip.

To solve this problem we need to open the zip file in append mode.