### PR TITLE
[CI] Fix travis error code handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,12 +135,15 @@ script:
       make package &&
       make -C tools/plist_to_html test &&
       if [[ "$CC_MODULE" = "analyzer" ]]; then
-        BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer test_unit test_functional test_tu_collector;
+        BUILD_DIR=$TRAVIS_BUILD_DIR/build make -C analyzer \
+          test_unit \
+          test_functional \
+          test_tu_collector &&
         if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
           make -C analyzer test_build_logger
         fi
       elif [[ ! -z "$DATABASE" ]]; then
-        make -C web test_matrix_${DATABASE};
+        make -C web test_matrix_${DATABASE}
       else
-        make test;
+        make test
       fi


### PR DESCRIPTION
Currently if an analysis is performed on a linux platform, the results of
functional, unit and tu_collector tests are ignored, and the job can
succeed even if the tests failed. This modification makes sure that the job
is only successful if every test passes.