### PR TITLE
do not convert to absolute path the files after -include

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -672,8 +672,8 @@ def __collect_compile_opts(flag_iterator, details):
         # TODO: If Clang will be extended with an extra analyzer option in
         # order to print these absolute paths natively, this conversion will
         # not be necessary.
-        flags_with_path = ['-I', '-idirafter', '-imacros', '-imultilib',
-                           '-include', '-iquote', '-isysroot', '-isystem',
+        flags_with_path = ['-I', '-idirafter', '-imultilib',
+                           '-iquote', '-isysroot', '-isystem',
                            '-iwithprefix', '-iwithprefixbefore', '-sysroot',
                            '--sysroot']
         if flag in flags_with_path:


### PR DESCRIPTION
File path after the -include flag should not be converted to absolute path.
Only the flags with include path directories should be converted.
If every other include directory flag is set properly the
file set by -include should be found too.

Resolves #2440