### PR TITLE
[analyzer] Fix encoding string when genering hash

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import
 
 from collections import defaultdict
 import argparse
+import codecs
 import io
 import json
 import math
@@ -36,6 +37,13 @@ from codechecker_common.report import Report, get_report_path_hash
 from codechecker_common.source_code_comment_handler import skip_suppress_status
 
 LOG = logger.get_logger('system')
+
+
+# Print to the console without UnicodeEncodeErrors. For more information see:
+# https://chase-seibert.github.io/blog/2014/01/12/python-unicode-console-output.html
+# TODO: This should be removed when we move to Python 3.
+sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+sys.stderr = codecs.getwriter('utf8')(sys.stderr)
 
 
 class PlistToPlaintextFormatter(object):

--- a/codechecker_common/report.py
+++ b/codechecker_common/report.py
@@ -29,6 +29,12 @@ from codechecker_common.util import get_line
 LOG = get_logger('report')
 
 
+def str_to_hash(string_to_hash, errors='ignore'):
+    """ Encodes the given string and generates a hash from it. """
+    string_hash = string_to_hash.encode(encoding="utf-8", errors=errors)
+    return hashlib.md5(string_hash).hexdigest()
+
+
 def generate_report_hash(path, source_file, check_name):
     """
     !!! Compatible with the old hash before v6.0
@@ -147,8 +153,7 @@ def generate_report_hash(path, source_file, check_name):
                 col_num = loc['col']
                 hash_content.append(str(col_num))
 
-        string_to_hash = '|||'.join(hash_content)
-        return hashlib.md5(string_to_hash.encode()).hexdigest()
+        return str_to_hash('|||'.join(hash_content))
 
     except Exception as ex:
         LOG.error("Hash generation failed")
@@ -228,8 +233,7 @@ def generate_report_hash_no_bugpath(main_section, source_file):
                         str(from_col),
                         str(until_col)]
 
-        string_to_hash = '|||'.join(hash_content)
-        return hashlib.md5(string_to_hash.encode()).hexdigest()
+        return str_to_hash('|||'.join(hash_content))
 
     except Exception as ex:
         LOG.error("Hash generation failed")
@@ -259,7 +263,7 @@ def get_report_path_hash(report, files):
         LOG.error(events)
 
     LOG.debug(report_path_hash)
-    return hashlib.md5(report_path_hash.encode()).hexdigest()
+    return str_to_hash(report_path_hash)
 
 
 class Report(object):

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 import base64
+import codecs
 import logging
 import os
 import re
@@ -160,7 +161,8 @@ class RunResults(unittest.TestCase):
             file_content1 = file_data.fileContent
             self.assertIsNotNone(file_content1)
 
-            with open(run_res.checkedFile) as source_file:
+            with codecs.open(run_res.checkedFile, 'r', 'UTF-8',
+                             'replace') as source_file:
                 file_content2 = source_file.read()
 
             self.assertEqual(file_content1, file_content2)
@@ -172,6 +174,7 @@ class RunResults(unittest.TestCase):
             file_content1_b64 = base64.b64decode(file_data_b64.fileContent)
             self.assertIsNotNone(file_content1_b64)
 
+            file_content2 = codecs.encode(file_content2, 'utf-8')
             self.assertEqual(file_content1_b64, file_content2)
 
         logging.debug('got ' + str(len(run_results)) + ' files')

--- a/web/tests/projects/cpp/new_delete.cpp
+++ b/web/tests/projects/cpp/new_delete.cpp
@@ -34,7 +34,7 @@ void test2() {
 void test3() {
   int *p = new int;
   delete p;
-  delete p; // warn: attempt to free released
+  delete p; // warn: attempt to free released °
 }
 
 void test4() {


### PR DESCRIPTION
> Closes #2454

When the source line contained a non ascii character where a checker reported a bug the hash generation failed. To solve this problem we encode the string to `utf-8` and ignore the errors.