### PR TITLE
[analyzer] Sort report lines for files

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -17,6 +17,7 @@ import io
 import json
 import math
 import os
+from operator import itemgetter
 import sys
 import traceback
 
@@ -710,12 +711,14 @@ def main(args):
     if file_stats:
         vals = [[os.path.basename(k), v] for k, v in
                 dict(file_stats).items()]
+        vals.sort(key=itemgetter(0))
         keys = ['Filename', 'Report count']
         table = twodim_to_str('table', keys, vals, 1, True)
         print(table)
 
     if severity_stats:
         vals = [[k, v] for k, v in dict(severity_stats).items()]
+        vals.sort(key=itemgetter(0))
         keys = ['Severity', 'Report count']
         table = twodim_to_str('table', keys, vals, 1, True)
         print(table)

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 import hashlib
 import io
 import os
+from operator import itemgetter
 import re
 import sys
 import shutil
@@ -895,12 +896,14 @@ def handle_diff_results(args):
         if file_stats:
             vals = [[os.path.basename(k), v] for k, v in
                     dict(file_stats).items()]
+            vals.sort(key=itemgetter(0))
             keys = ['Filename', 'Report count']
             table = twodim_to_str('table', keys, vals, 1, True)
             print(table)
 
         if severity_stats:
             vals = [[k, v] for k, v in dict(severity_stats).items()]
+            vals.sort(key=itemgetter(0))
             keys = ['Severity', 'Report count']
             table = twodim_to_str('table', keys, vals, 1, True)
             print(table)


### PR DESCRIPTION
During the report generation the file list is in no determinate order
when the results counts otherwise match. This change sorts the result
lines based on the base name of the file.