### PR TITLE
[analyzer] Fix test case for has_analyzer_option

### DIFF
--- a/analyzer/tests/functional/host_check/test_host_check.py
+++ b/analyzer/tests/functional/host_check/test_host_check.py
@@ -28,10 +28,11 @@ class Test_has_analyzer_option(unittest.TestCase):
                                    ["-non-existent-feature"]),
             False)
 
-    def test_non_existent_option_binary_throws(self):
-        with self.assertRaises(OSError):
+    def test_non_existent_option_binary(self):
+        self.assertEqual(
             hc.has_analyzer_option("non-existent-binary-Yg4pEna5P7",
-                                   [""])
+                                   [""]),
+            False)
 
     def test_non_existing_congif_option(self):
         self.assertEqual(


### PR DESCRIPTION
OSError is no longer rethrown inside has_analyzer_option method of
host_check.py. Instead, False is returned in case of an error.
The test case is modified to accomodate to this change.