### PR TITLE
Logger absolute include paths

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-util.c
+++ b/analyzer/tools/build-logger/src/ldlogger-util.c
@@ -115,6 +115,11 @@ char* shellEscapeStr(const char* str_, char* buff_)
   return buff_;
 }
 
+int startsWith(const char* str_, const char* prefix_)
+{
+  return strstr(str_, prefix_) == str_;
+}
+
 char* loggerMakePathAbs(const char* path_, char* resolved_, int mustExist_)
 {
   assert(resolved_ && "resolved_ must be not NULL!");
@@ -350,6 +355,14 @@ void loggerVectorErase(LoggerVector* vec_, size_t index_)
   }
 
   vec_->size -= 1;
+}
+
+void loggerVectorReplace(LoggerVector* vec_, size_t index_, void* data_)
+{
+  if (vec_->dataFree)
+    vec_->dataFree(vec_->data[index_]);
+
+  vec_->data[index_] = data_;
 }
 
 char* loggerStrDup(const char* str_)

--- a/analyzer/tools/build-logger/src/ldlogger-util.h
+++ b/analyzer/tools/build-logger/src/ldlogger-util.h
@@ -49,6 +49,11 @@ char* shellEscapeStr(const char* str_, char* buff_);
 char* loggerMakePathAbs(const char* path_, char* resolved_, int mustExist_);
 
 /**
+ * The function returns true if str_ starts with prefix_.
+ */
+int startsWith(const char* str_, const char* prefix_);
+
+/**
  * Typedef for free function for a vector.
  */
 typedef void (*LoggerFreeFuc)(void*);
@@ -162,15 +167,24 @@ int loggerVectorAddUnique(LoggerVector* vec_, void* data_, LoggerCmpFuc cmp_);
 /**
  * Removes (and frees) an item from the vector.
  *
- * @param vec_ a vector struct (must be not NULL).
- * @parma index_ an item index.
+ * @param vec_ a vector struct (must not be NULL).
+ * @param index_ an item index.
  */
 void loggerVectorErase(LoggerVector* vec_, size_t index_);
 
 /**
+ * Replaces the item in the vector at the given position.
+ *
+ * @param vec_ a vector struct (must not be NULL).
+ * @param index_ an item index.
+ * @param data_ the new data to insert.
+ */
+void loggerVectorReplace(LoggerVector* vec_, size_t index_, void* data_);
+
+/**
  * Finds an element using the given comparation fuction.
  *
- * @param vec_ a vector struct (must be not NULL).
+ * @param vec_ a vector struct (must not be NULL).
  * @param data_ an item.
  * @param cmp_ a comparation function.
  * @return SIZE_MAX if the element not found otherwise the item`s index.

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -160,6 +160,21 @@ function test_compiler_abs {
     "$source_file"
 }
 
+function test_include_abs1 {
+  CC_LOGGER_ABS_PATH=1 bash -c "gcc -Ihello $source_file"
+  grep -- -I/.*hello $CC_LOGGER_FILE &> /dev/null
+}
+
+function test_include_abs2 {
+  CC_LOGGER_ABS_PATH=1 bash -c "gcc -I hello $source_file"
+  grep -- "-I /.*hello" $CC_LOGGER_FILE &> /dev/null
+}
+
+function test_include_abs3 {
+  CC_LOGGER_ABS_PATH=1 bash -c "gcc -isystem=hello $source_file"
+  grep -- "-isystem=/.*hello" $CC_LOGGER_FILE &> /dev/null
+}
+
 #--- Run tests ---#
 
 echo "int main() {}" > $source_file


### PR DESCRIPTION
Some paths are converted to absolute path in the build command by
the logger if CC_LOGGER_ABS_PATH=1 given.

resolves #2447