### PR TITLE
less argument processing if skip file used without ctu and stats

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -681,7 +681,8 @@ def skip_cpp(compile_actions, skip_handler):
 def start_workers(actions_map, actions, context, analyzer_config_map,
                   jobs, output_path, skip_handler, metadata,
                   quiet_analyze, capture_analysis_output, timeout,
-                  ctu_reanalyze_on_failure, statistics_data, manager):
+                  ctu_reanalyze_on_failure, statistics_data, manager,
+                  compile_cmd_count):
     """
     Start the workers in the process pool.
     For every build action there is worker which makes the analysis.
@@ -766,9 +767,14 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
     for skp in skipped_actions:
         LOG.debug_analyzer("%s is skipped", skp.source)
 
-    LOG.info("Total analyzed compilation commands: %d", len(analyzed_actions))
-    if skipped_actions:
-        LOG.info("Skipped compilation commands: %d", len(skipped_actions))
+    LOG.info("Total analyzed compilation commands: %d",
+             compile_cmd_count.analyze)
+    # Some compile commands are skipped during log processing, if nothing
+    # is skipped there for pre-analysis step, files will be skipped only
+    # during analysis.
+    if skipped_actions or compile_cmd_count.skipped:
+        LOG.info("Skipped compilation commands: %d",
+                 compile_cmd_count.skipped + len(skipped_actions))
 
     LOG.info("----=================----")
     if not os.listdir(success_dir):

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -131,7 +131,8 @@ def __get_statistics_data(args, manager):
     return statistics_data
 
 
-def perform_analysis(args, skip_handler, context, actions, metadata):
+def perform_analysis(args, skip_handler, context, actions, metadata,
+                     compile_cmd_count):
     """
     Perform static analysis via the given (or if not, all) analyzers,
     in the given analysis context for the supplied build actions.
@@ -287,7 +288,8 @@ def perform_analysis(args, skip_handler, context, actions, metadata):
                                        else None,
                                        ctu_reanalyze_on_failure,
                                        statistics_data,
-                                       manager)
+                                       manager,
+                                       compile_cmd_count)
         LOG.info("Analysis finished.")
         LOG.info("To view results in the terminal use the "
                  "\"CodeChecker parse\" command.")

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1073,11 +1073,15 @@ def parse_unique_log(compilation_database,
                      keep_gcc_fix_headers=False,
                      analysis_skip_handler=None,
                      pre_analysis_skip_handler=None,
+                     ctu_or_stats_enabled=False,
                      env=None):
     """
     This function reads up the compilation_database
-    and returns with a list of build actions that is prepared for clang
-    execution. That means that gcc specific parameters are filtered out
+    and returns with a list of build actions that is
+    prepared (uniqued and skipped) for clang execution together
+    with the number of skipped compile commands.
+
+    That means that gcc specific parameters are filtered out
     and gcc built in targets and include paths are added.
     It also filters out duplicate compilation actions based on the
     compile_uniqueing parameter.
@@ -1111,7 +1115,8 @@ def parse_unique_log(compilation_database,
                              during analysis
     pre_analysis_skip_handler -- skip handler for files wich should be skipped
                                  during pre analysis
-
+    ctu_or_stats_enabled -- ctu or statistics based analysis was enabled
+                            influences the behavior which files are skipped.
     env -- Is the environment where a subprocess call should be executed.
     """
     try:
@@ -1127,14 +1132,20 @@ def parse_unique_log(compilation_database,
             build_action_uniqueing = CompileActionUniqueingType.SOURCE_REGEX
             uniqueing_re = re.compile(compile_uniqueing)
 
+        skipped_cmp_cmd_count = 0
+
         for entry in extend_compilation_database_entries(compilation_database):
             # Skip parsing the compilaton commands if it should be skipped
             # at both analysis phases (pre analysis and analysis).
             full_path = os.path.join(entry["directory"], entry["file"])
+
+            # Skipping of the compile commands is done differently if no
+            # CTU or statistics related feature was enabled.
             if analysis_skip_handler \
-                    and analysis_skip_handler.should_skip(full_path) \
-                    and pre_analysis_skip_handler \
-                    and pre_analysis_skip_handler.should_skip(full_path):
+                and analysis_skip_handler.should_skip(full_path) \
+                and (not ctu_or_stats_enabled or pre_analysis_skip_handler
+                     and pre_analysis_skip_handler.should_skip(full_path)):
+                skipped_cmp_cmd_count += 1
                 continue
 
             action = parse_options(entry,
@@ -1193,7 +1204,7 @@ def parse_unique_log(compilation_database,
             json.dump(ImplicitCompilerInfo.get(), f)
 
         LOG.debug('Parsing log file done.')
-        return list(uniqued_build_actions.values())
+        return list(uniqued_build_actions.values()), skipped_cmp_cmd_count
 
     except (ValueError, KeyError, TypeError) as ex:
         if not compilation_database:

--- a/analyzer/tests/functional/analyze_and_parse/test_files/context_free_hash.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/context_free_hash.output
@@ -12,7 +12,7 @@ CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --
 [] - Successfully analyzed
 [] -   clangsa: 1
 [] -   clang-tidy: 1
-[] - Total analyzed compilation commands: 2
+[] - Total analyzed compilation commands: 1
 [] - ----=================----
 [] - Analysis finished.
 [] - To view results in the terminal use the "CodeChecker parse" command.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash.output
@@ -12,7 +12,7 @@ CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --
 [] - Successfully analyzed
 [] -   clangsa: 1
 [] -   clang-tidy: 1
-[] - Total analyzed compilation commands: 2
+[] - Total analyzed compilation commands: 1
 [] - ----=================----
 [] - Analysis finished.
 [] - To view results in the terminal use the "CodeChecker parse" command.

--- a/analyzer/tests/unit/test_buildcmd_escaping.py
+++ b/analyzer/tests/unit/test_buildcmd_escaping.py
@@ -86,7 +86,7 @@ class BuildCmdTestNose(unittest.TestCase):
         compile_cmd = self.compiler + \
             ' -DDEBUG \'-DMYPATH="/this/some/path/"\''
 
-        comp_actions = log_parser.\
+        comp_actions, _ = log_parser.\
             parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
 
         for comp_action in comp_actions:
@@ -112,7 +112,7 @@ class BuildCmdTestNose(unittest.TestCase):
         If the escaping fails the source file will not compile.
         """
         compile_cmd = self.compiler + ''' '-DMYPATH=\"/some/other/path\"' '''
-        comp_actions = log_parser.\
+        comp_actions, _ = log_parser.\
             parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
 
         for comp_action in comp_actions:

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -73,8 +73,9 @@ class LogParserTest(unittest.TestCase):
         # option_parser, so here we aim for a non-failing stalemate of the
         # define being considered a file and ignored, for now.
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -92,8 +93,9 @@ class LogParserTest(unittest.TestCase):
         # Logfile contains -DVARIABLE="some value"
         # and --target=x86_64-linux-gnu.
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -104,8 +106,9 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -121,8 +124,9 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -133,8 +137,9 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -154,8 +159,9 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -166,8 +172,9 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
         self.assertEqual(build_action.lang, 'c++')
@@ -196,8 +203,9 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -M /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions,
-                                                    self.__this_dir)
+        build_actions, _ = \
+            log_parser.parse_unique_log(preprocessor_actions,
+                                        self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-M' not in build_actions[0].original_command)
         self.assertTrue('-E' not in build_actions[0].original_command)
@@ -212,8 +220,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions,
-                                                    self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions,
+                                                       self.__this_dir)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-MD' in build_actions[0].original_command)
 
@@ -228,8 +236,8 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -E -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions = log_parser.parse_unique_log(preprocessor_actions,
-                                                    self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions,
+                                                       self.__this_dir)
         self.assertEqual(len(build_actions), 0)
 
     def test_include_rel_to_abs(self):
@@ -238,8 +246,9 @@ class LogParserTest(unittest.TestCase):
         """
         logfile = os.path.join(self.__test_files, "include.json")
 
-        build_action = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser.\
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
         self.assertEqual(build_action.analyzer_options[0], '-I')
@@ -288,7 +297,7 @@ class LogParserTest(unittest.TestCase):
         analysis_skip = skiplist_handler.SkipListHandler(skip_list)
         pre_analysis_skip = skiplist_handler.SkipListHandler(skip_list)
 
-        build_actions = log_parser.\
+        build_actions, _ = log_parser.\
             parse_unique_log(cmp_cmd_json, self.__this_dir,
                              analysis_skip_handler=analysis_skip,
                              pre_analysis_skip_handler=pre_analysis_skip)
@@ -319,7 +328,7 @@ class LogParserTest(unittest.TestCase):
         analysis_skip = skiplist_handler.SkipListHandler(skip_list)
         pre_analysis_skip = skiplist_handler.SkipListHandler(pre_skip_list)
 
-        build_actions = log_parser.\
+        build_actions, _ = log_parser.\
             parse_unique_log(cmp_cmd_json, self.__this_dir,
                              analysis_skip_handler=analysis_skip,
                              pre_analysis_skip_handler=pre_analysis_skip)
@@ -331,7 +340,7 @@ class LogParserTest(unittest.TestCase):
         self.assertEqual(build_actions[0].original_command, keep['command'])
 
     def test_skip_no_pre_from_parse(self):
-        """Keep everything pre analysis needs it, no skipping there."""
+        """Keep everything pre analysis needs it in ctu or statistics mode."""
         cmp_cmd_json = [
             {"directory": "/tmp/lib1",
              "command": "g++ /tmp/lib1/a.cpp",
@@ -349,9 +358,10 @@ class LogParserTest(unittest.TestCase):
         analysis_skip = skiplist_handler.SkipListHandler(skip_list)
         pre_analysis_skip = skiplist_handler.SkipListHandler("")
 
-        build_actions = log_parser.\
+        build_actions, _ = log_parser.\
             parse_unique_log(cmp_cmd_json, self.__this_dir,
                              analysis_skip_handler=analysis_skip,
+                             ctu_or_stats_enabled=True,
                              pre_analysis_skip_handler=pre_analysis_skip)
 
         self.assertEqual(len(build_actions), 3)
@@ -375,7 +385,7 @@ class LogParserTest(unittest.TestCase):
         analysis_skip = skiplist_handler.SkipListHandler("")
         pre_analysis_skip = skiplist_handler.SkipListHandler(skip_list)
 
-        build_actions = log_parser.\
+        build_actions, _ = log_parser.\
             parse_unique_log(cmp_cmd_json, self.__this_dir,
                              analysis_skip_handler=analysis_skip,
                              pre_analysis_skip_handler=pre_analysis_skip)
@@ -400,8 +410,9 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_action = log_parser. \
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser. \
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertEqual(build_action.analyzer_options[0], '-DVARIABLE=some')
 
@@ -422,8 +433,9 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_action = log_parser. \
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)[0]
+        build_actions, _ = log_parser. \
+            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+        build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertEqual(build_action.source, self.src_file_path)
@@ -455,7 +467,7 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_actions = log_parser. \
+        build_actions, _ = log_parser. \
             parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
 
         self.assertEqual(len(build_actions), 2)


### PR DESCRIPTION
if a skip file is used but no pre analysis step is executed
the pre analysis skip handler will not be used.

In the analyze.py the statistics collector flag
status was only checked if the ctu_phases was in the args.
The two of them should be checked independently because
stats and ctu can be executed independently.
stats can be enabled even if ctu is not enabled.