### PR TITLE
bump up the minimal required clang version

### DIFF
--- a/scripts/test/check_clang.py
+++ b/scripts/test/check_clang.py
@@ -15,8 +15,8 @@ import subprocess
 import sys
 
 # clang an clang tidy versions to run the tests
-_CLANG_MIN_VERSION = {"major": 7, "minor": 0}
-_TIDY_MIN_VERSION = {"major": 7, "minor": 0}
+_CLANG_MIN_VERSION = {"major": 9, "minor": 0}
+_TIDY_MIN_VERSION = {"major": 9, "minor": 0}
 
 
 def eprint(*args, **kwargs):


### PR DESCRIPTION
the minimal required clang version to run the tests
is clang v9