### PR TITLE
detect -MG as a precompilation flag

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -203,7 +203,7 @@ COMPILE_OPTIONS_MERGED = [
 COMPILE_OPTIONS_MERGED = \
     re.compile('(' + '|'.join(COMPILE_OPTIONS_MERGED) + ')')
 
-PRECOMPILATION_OPTION = re.compile('-(E|M[T|Q|F|J|P|V|M]*)$')
+PRECOMPILATION_OPTION = re.compile('-(E|M[G|T|Q|F|J|P|V|M]*)$')
 
 
 def filter_compiler_includes_extra_args(compiler_flags):


### PR DESCRIPTION
The -M flag is used for dependency generation.
-MG assumes missing header files are generated files and adds them to the
dependency list without raising an error.