### PR TITLE
store cppcheck plist reports (generate hash)

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -30,6 +30,7 @@ from codechecker_client import client as libclient
 from codechecker_common import logger
 from codechecker_common import util
 from codechecker_common import plist_parser
+from codechecker_common import report as common_report
 from codechecker_common.output_formatters import twodim_to_str
 from codechecker_common.source_code_comment_handler import \
     SourceCodeCommentHandler
@@ -233,6 +234,14 @@ def assemble_zip(inputs, zip_file, client):
 
         try:
             files, reports = plist_parser.parse_plist_file(plist_file)
+
+            # CppCheck generates a '0' value for the bug hash.
+            # In case all of the reports in a plist file contain only
+            # a hash with '0' value oeverwrite the hash values in the
+            # plist report files with a context free hash value.
+            rep_hash = [rep.report_hash == '0' for rep in reports]
+            if all(rep_hash):
+                common_report.use_context_free_hashes(plist_file)
 
             for f in files:
                 if not os.path.isfile(f):

--- a/web/tests/functional/cppcheck/__init__.py
+++ b/web/tests/functional/cppcheck/__init__.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+
+"""Setup for the package tests."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import multiprocessing
+import os
+import shutil
+
+from libtest import codechecker
+from libtest import env
+
+# Stopping event for CodeChecker server.
+__STOP_SERVER = multiprocessing.Event()
+
+# Test workspace initialized at setup for cppcheck tests.
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for the tests then start the server."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('cppcheck')
+
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+    # Configuration options.
+    codechecker_cfg = {
+        'suppress_file': None,
+        'skip_list_file': None,
+        'check_env': env.test_env(TEST_WORKSPACE),
+        'workspace': TEST_WORKSPACE,
+        'checkers': [],
+        'reportdir': os.path.join(TEST_WORKSPACE, 'reports'),
+        'test_project': 'cppcheck'
+    }
+
+    # Start or connect to the running CodeChecker server and get connection
+    # details.
+    print("This test uses a CodeChecker server... connecting...")
+    server_access = codechecker.start_or_get_server()
+    server_access['viewer_product'] = 'cppcheck'
+    codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
+
+    # Extend the checker configuration with the server access.
+    codechecker_cfg.update(server_access)
+
+    # Export the test configuration to the workspace.
+    env.export_test_cfg(TEST_WORKSPACE, {'codechecker_cfg': codechecker_cfg})
+
+
+def teardown_package():
+    """Clean up after the test."""
+
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
+    global TEST_WORKSPACE
+
+    check_env = env.import_test_cfg(TEST_WORKSPACE)[
+        'codechecker_cfg']['check_env']
+    codechecker.remove_test_package_product(TEST_WORKSPACE, check_env)
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/web/tests/functional/cppcheck/test_cppcheck.py
+++ b/web/tests/functional/cppcheck/test_cppcheck.py
@@ -1,0 +1,77 @@
+#
+# -----------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -----------------------------------------------------------------------------
+"""
+cppcheck tests.
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+
+from libtest import env
+from libtest import plist_test
+
+
+class CppCheck(unittest.TestCase):
+    """
+    Test storage of cppcheck reports
+    """
+
+    def setUp(self):
+
+        # Get the test workspace used to cppcheck tests.
+        self._test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + self._test_workspace)
+
+        self._test_cfg = env.import_test_cfg(self._test_workspace)
+
+    def test_cppcheck_report_storage(self):
+        """ In the stored report not the default zero hash should be used. """
+
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+
+        report_dir = os.path.join(test_dir, 'test_proj')
+
+        codechecker_cfg = self._test_cfg['codechecker_cfg']
+
+        # Copy report files to a temporary directory not to modify the
+        # files in the repository.
+        # Report files will be overwritten during the tests.
+        temp_workspace = os.path.join(codechecker_cfg['workspace'],
+                                      'test_proj')
+        shutil.copytree(report_dir, temp_workspace)
+
+        report_file = os.path.join(temp_workspace, 'divide_zero.plist')
+        # Convert file paths to absolute in the report.
+        plist_test.prefix_file_path(report_file, temp_workspace)
+
+        run_name = 'cppcheck'
+        store_cmd = [env.codechecker_cmd(), 'store', '--name', run_name,
+                     # Use the 'Default' product.
+                     '--url', env.parts_to_url(codechecker_cfg),
+                     temp_workspace]
+
+        out = subprocess.check_output(store_cmd)
+        print(out)
+        query_cmd = [env.codechecker_cmd(), 'cmd', 'results', run_name,
+                     # Use the 'Default' product.
+                     '--url', env.parts_to_url(codechecker_cfg), '-o', 'json']
+
+        out = subprocess.check_output(query_cmd)
+        print(out)
+        reports = json.loads(out)
+        self.assertEquals(len(reports), 5)
+        # The stored hash should not be "0".
+        for report in reports:
+            self.assertNotEquals(report['bugHash'], "0")

--- a/web/tests/functional/cppcheck/test_proj/Makefile
+++ b/web/tests/functional/cppcheck/test_proj/Makefile
@@ -1,0 +1,5 @@
+
+all: analyze
+
+analyze:
+	cppcheck --enable=all --plist-output=. .

--- a/web/tests/functional/cppcheck/test_proj/divide_zero.cpp
+++ b/web/tests/functional/cppcheck/test_proj/divide_zero.cpp
@@ -1,0 +1,19 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+// core.DivideZero (C, C++, ObjC)
+// Check for division by zero.
+#include "lib.h"
+
+void test1(int z) {
+  if (z == 0)
+    int x = 1 / z; // warn
+}
+
+void test2{
+  int x = 1;
+  div(x)
+}

--- a/web/tests/functional/cppcheck/test_proj/divide_zero.plist
+++ b/web/tests/functional/cppcheck/test_proj/divide_zero.plist
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>clang_version</key>
+<string>cppcheck version 1.90 dev</string>
+ <key>files</key>
+ <array>
+  <string>divide_zero.cpp</string>
+  <string>lib.h</string>
+ </array>
+ <key>diagnostics</key>
+ <array>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>11</integer>
+      <key>col</key><integer>13</integer>
+      <key>file</key><integer>1</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>13</integer>
+         <key>file</key><integer>1</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>13</integer>
+         <key>file</key><integer>1</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Division by zero</string>
+     <key>message</key>
+     <string>Division by zero</string>
+    </dict>
+   </array>
+   <key>description</key><string>Division by zero.</string>
+   <key>category</key><string>error</string>
+   <key>type</key><string>Division by zero.</string>
+   <key>check_name</key><string>zerodiv</string>
+   <!-- This hash is experimental and going to change! -->
+   <key>issue_hash_content_of_line_in_context</key><string>0</string>
+  <key>issue_context_kind</key><string></string>
+  <key>issue_context</key><string></string>
+  <key>issue_hash_function_offset</key><string></string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>11</integer>
+   <key>col</key><integer>13</integer>
+   <key>file</key><integer>1</integer>
+  </dict>
+  </dict>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>12</integer>
+      <key>col</key><integer>9</integer>
+      <key>file</key><integer>0</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>12</integer>
+         <key>col</key><integer>9</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>12</integer>
+         <key>col</key><integer>9</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Assuming that condition 'z==0' is not redundant</string>
+     <key>message</key>
+     <string>Assuming that condition 'z==0' is not redundant</string>
+    </dict>
+    <dict>
+     <key>kind</key><string>control</string>
+     <key>edges</key>
+      <array>
+       <dict>
+        <key>start</key>
+         <array>
+          <dict>
+           <key>line</key><integer>12</integer>
+           <key>col</key><integer>9</integer>
+           <key>file</key><integer>0</integer>
+          </dict>
+          <dict>
+           <key>line</key><integer>12</integer>
+           <key>col</key><integer>9</integer>
+           <key>file</key><integer>0</integer>
+          </dict>
+         </array>
+        <key>end</key>
+         <array>
+          <dict>
+           <key>line</key><integer>13</integer>
+           <key>col</key><integer>15</integer>
+           <key>file</key><integer>0</integer>
+          </dict>
+          <dict>
+           <key>line</key><integer>13</integer>
+           <key>col</key><integer>15</integer>
+           <key>file</key><integer>0</integer>
+          </dict>
+         </array>
+       </dict>
+      </array>
+    </dict>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>13</integer>
+      <key>col</key><integer>15</integer>
+      <key>file</key><integer>0</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>13</integer>
+         <key>col</key><integer>15</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>13</integer>
+         <key>col</key><integer>15</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Division by zero</string>
+     <key>message</key>
+     <string>Division by zero</string>
+    </dict>
+   </array>
+   <key>description</key><string>Either the condition 'z==0' is redundant or there is division by zero at line 13.</string>
+   <key>category</key><string>warning</string>
+   <key>type</key><string>Either the condition 'z==0' is redundant or there is division by zero at line 13.</string>
+   <key>check_name</key><string>zerodivcond</string>
+   <!-- This hash is experimental and going to change! -->
+   <key>issue_hash_content_of_line_in_context</key><string>0</string>
+  <key>issue_context_kind</key><string></string>
+  <key>issue_context</key><string></string>
+  <key>issue_hash_function_offset</key><string></string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>13</integer>
+   <key>col</key><integer>15</integer>
+   <key>file</key><integer>0</integer>
+  </dict>
+  </dict>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>11</integer>
+      <key>col</key><integer>9</integer>
+      <key>file</key><integer>1</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>9</integer>
+         <key>file</key><integer>1</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>9</integer>
+         <key>file</key><integer>1</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Variable 'y' is assigned a value that is never used.</string>
+     <key>message</key>
+     <string>Variable 'y' is assigned a value that is never used.</string>
+    </dict>
+   </array>
+   <key>description</key><string>Variable 'y' is assigned a value that is never used.</string>
+   <key>category</key><string>style</string>
+   <key>type</key><string>Variable 'y' is assigned a value that is never used.</string>
+   <key>check_name</key><string>unreadVariable</string>
+   <!-- This hash is experimental and going to change! -->
+   <key>issue_hash_content_of_line_in_context</key><string>0</string>
+  <key>issue_context_kind</key><string></string>
+  <key>issue_context</key><string></string>
+  <key>issue_hash_function_offset</key><string></string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>11</integer>
+   <key>col</key><integer>9</integer>
+   <key>file</key><integer>1</integer>
+  </dict>
+  </dict>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>13</integer>
+      <key>col</key><integer>11</integer>
+      <key>file</key><integer>0</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>13</integer>
+         <key>col</key><integer>11</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>13</integer>
+         <key>col</key><integer>11</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Variable 'x' is assigned a value that is never used.</string>
+     <key>message</key>
+     <string>Variable 'x' is assigned a value that is never used.</string>
+    </dict>
+   </array>
+   <key>description</key><string>Variable 'x' is assigned a value that is never used.</string>
+   <key>category</key><string>style</string>
+   <key>type</key><string>Variable 'x' is assigned a value that is never used.</string>
+   <key>check_name</key><string>unreadVariable</string>
+   <!-- This hash is experimental and going to change! -->
+   <key>issue_hash_content_of_line_in_context</key><string>0</string>
+  <key>issue_context_kind</key><string></string>
+  <key>issue_context</key><string></string>
+  <key>issue_hash_function_offset</key><string></string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>13</integer>
+   <key>col</key><integer>11</integer>
+   <key>file</key><integer>0</integer>
+  </dict>
+  </dict>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>11</integer>
+      <key>col</key><integer>0</integer>
+      <key>file</key><integer>0</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>0</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>11</integer>
+         <key>col</key><integer>0</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>The function 'test1' is never used.</string>
+     <key>message</key>
+     <string>The function 'test1' is never used.</string>
+    </dict>
+   </array>
+   <key>description</key><string>The function 'test1' is never used.</string>
+   <key>category</key><string>style</string>
+   <key>type</key><string>The function 'test1' is never used.</string>
+   <key>check_name</key><string>unusedFunction</string>
+   <!-- This hash is experimental and going to change! -->
+   <key>issue_hash_content_of_line_in_context</key><string>0</string>
+  <key>issue_context_kind</key><string></string>
+  <key>issue_context</key><string></string>
+  <key>issue_hash_function_offset</key><string></string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>11</integer>
+   <key>col</key><integer>0</integer>
+   <key>file</key><integer>0</integer>
+  </dict>
+  </dict>
+ </array>
+</dict>
+</plist>

--- a/web/tests/functional/cppcheck/test_proj/lib.h
+++ b/web/tests/functional/cppcheck/test_proj/lib.h
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+
+// core.DivideZero (C, C++, ObjC)
+// Check for division by zero.
+
+void div(int x) {
+  int y = x % 0; // warn
+}


### PR DESCRIPTION
cppcheck can generate plist reports but no bug identifier
hash is generated. A 0 value is generated by cppcheck as a bug hash.
This change allows to generate the report hash if the plist report
contains onl results where all the hashes are 0.

The generated report hash will be written to the plist report files.