### PR TITLE
[analyzer] Fix plist file name collision

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
@@ -85,10 +85,15 @@ class ResultHandler(object, metaclass=ABCMeta):
         if not self.__result_file:
             analyzed_file_name = os.path.basename(self.analyzed_source_file)
 
-            build_info = str(self.buildaction.analyzer_type) + '_' + \
+            source_file = os.path.normpath(
+                os.path.join(self.buildaction.directory,
+                             self.analyzed_source_file))
+
+            build_info = source_file + '_' + \
                 self.buildaction.original_command
 
             out_file_name = analyzed_file_name + '_' + \
+                str(self.buildaction.analyzer_type) + '_' + \
                 hashlib.md5(build_info.encode(errors='ignore')).hexdigest() \
                 + '.plist'
 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -31,3 +31,5 @@ compiler_warning_unused:
 	$(CXX) -w compiler_warning.cpp -Wunused -o /dev/null
 context_hash:
 	$(CXX) -w context_hash.cpp -o /dev/null
+collision:
+	$(CXX) -w filename_collision/main.cpp filename_collision/a/f.cpp filename_collision/b/f.cpp -o /dev/null

--- a/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision.output
@@ -1,0 +1,45 @@
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/3] clangsa analyzed f.cpp successfully.
+[] - [2/3] clangsa analyzed main.cpp successfully.
+[] - [3/3] clangsa analyzed f.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clangsa: 3
+[] - Total analyzed compilation commands: 3
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+Found no defects in main.cpp
+[HIGH] f.cpp:3:9: Dereference of undefined pointer value [core.NullDereference]
+    *pb = 42;
+        ^
+
+Found 1 defect(s) in f.cpp
+
+[HIGH] f.cpp:3:9: Dereference of undefined pointer value [core.NullDereference]
+    *pa = 42;
+        ^
+
+Found 1 defect(s) in f.cpp
+
+
+----==== Summary ====----
+-----------------------
+Filename | Report count
+-----------------------
+f.cpp    |            1
+f.cpp    |            1
+-----------------------
+-----------------------
+Severity | Report count
+-----------------------
+HIGH     |            2
+-----------------------
+----=================----
+Total number of reports: 2
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/a/f.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/a/f.cpp
@@ -1,0 +1,4 @@
+void f_a() {
+    int* pa;
+    *pa = 42;
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/b/f.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/b/f.cpp
@@ -1,0 +1,4 @@
+void f_b() {
+    int* pb;
+    *pb = 42;
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/main.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/filename_collision/main.cpp
@@ -1,0 +1,7 @@
+extern void f_a();
+extern void f_b();
+
+int main() {
+  f_a();
+  f_b();
+}


### PR DESCRIPTION
> Closes #2435 

Source files with equal filename generates and overwrites the
filename.plist result file during analysis step. The main problem
is that the filename hash generation contains only the filename and
not the file path.
This commit will solve this problem and include the buildaction
directory (removes the users home directory from the path) to the
filename hash.