### PR TITLE
[gui] Fix delete run

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
+++ b/web/server/www/scripts/codecheckerviewer/ListOfRuns.js
@@ -101,7 +101,7 @@ function (declare, dom, ObjectStore, Store, Deferred, topic, Dialog, Button,
       var runFilter = new CC_OBJECTS.RunFilter();
       runFilter.ids = [ id ];
 
-      CC_SERVICE.getRunData(runFilter, 1, 0, function (runDataList) {
+      CC_SERVICE.getRunData(runFilter, 1, 0, null, function (runDataList) {
         if (typeof runDataList === 'string') {
           deferred.reject('Failed to get run ' + id + ': ' + runDataList);
         } else {


### PR DESCRIPTION
> Closes #2473 

The server side run sort feature changed the Thrift API and introduced a
new paramter for `getRunData` function. In the `ListOfRuns.js` file
we forgot to change this function call in one place so the browser
is thrown the following exception:
codeCheckerDBAccess.js:102 Uncaught TypeError: this.sortMode.write is not a function

This commit fix the `getRunData` function call in the GUI's code.