### PR TITLE
Remove SimpleStream checker from sensitive profile

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -52,7 +52,6 @@
         "alpha.unix.BlockInCriticalSection",
         "alpha.unix.Chroot",
         "alpha.unix.PthreadLock",
-        "alpha.unix.SimpleStream",
         "alpha.unix.Stream",
         "alpha.unix.cstring.NotNullTerminated",
         "alpha.unix.cstring.OutOfBounds",


### PR DESCRIPTION
This checker is only a demo checker.
The real checker is alpha.unix.SimpleStream