### PR TITLE
[analyzer] Do not load plugins when CC_ANALYZERS_FROM_PATH is used

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -245,6 +245,10 @@ class Context(object):
 
     @property
     def checker_plugin(self):
+        # Do not load the plugin because it might be incompatible.
+        if env.is_analyzer_from_path():
+            return None
+
         return os.path.join(self._package_root, 'plugin')
 
     @property

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -149,13 +149,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                             # Turn off clang hardcoded checkers list.
                             '--analyzer-no-default-checks']
 
-            # Do not load the plugin because it might be incompatible.
-            if not env.is_analyzer_from_path():
-                for plugin in config.analyzer_plugins:
-                    analyzer_cmd.extend(["-Xclang", "-plugin",
-                                         "-Xclang", "checkercfg",
-                                         "-Xclang", "-load",
-                                         "-Xclang", plugin])
+            for plugin in config.analyzer_plugins:
+                analyzer_cmd.extend(["-Xclang", "-plugin",
+                                     "-Xclang", "checkercfg",
+                                     "-Xclang", "-load",
+                                     "-Xclang", plugin])
 
             analyzer_mode = 'plist-multi-file'
             analyzer_cmd.extend(['-Xclang',

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -49,7 +49,7 @@ class AnalyzerConfigHandler(object):
         Full path of the analyzer plugins.
         """
         plugin_dir = self.analyzer_plugins_dir
-        if not os.path.exists(plugin_dir):
+        if not plugin_dir or not os.path.exists(plugin_dir):
             return []
 
         analyzer_plugins = [os.path.join(plugin_dir, f)


### PR DESCRIPTION
Do not load the plugin when `CC_ANALYZERS_FROM_PATH` is turned on because
it might be incompatible.