### PR TITLE
[fix] Fix hiding tooltip of the source component filter item

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/filter/SelectFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/SelectFilter.js
@@ -190,6 +190,10 @@ function (declare, dom, Standby, ContentPane, Tooltip, FilterBase,
           tooltip : that.getTooltip ? that.getTooltip(value) : null,
           options : options,
           onClick : function () {
+            if (this.options.description) {
+              Tooltip.hide(this.domNode);
+            }
+
             that.deselect(value);
             that.notifyOthers();
             this.destroy();


### PR DESCRIPTION
If we set a new source component filter and we move the mouse over
this item a tooltip will be shown. If I remove this filter the tooltip
will not be removed and it will be visible constantly.

This commit solves this problem and hides the tooltip when the source
component filter item is being removed.