### PR TITLE
bump up version to v6.11.1

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -34,7 +34,7 @@ PROJECT_NAME           = "CodeChecker"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 6.11.0
+PROJECT_NUMBER         = 6.11.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/analyzer/config/analyzer_version.json
+++ b/analyzer/config/analyzer_version.json
@@ -2,6 +2,6 @@
     "version": {
         "major" : "6",
         "minor" : "11",
-        "revision" : "0"
+        "revision" : "1"
     }
 }

--- a/web/config/web_version.json
+++ b/web/config/web_version.json
@@ -2,6 +2,6 @@
     "version": {
         "major" : "6",
         "minor" : "11",
-        "revision" : "0"
+        "revision" : "1"
     }
 }


### PR DESCRIPTION
increment version on the new upcoming release branch 

The few commits already merged to v6.11.0 should be cherry picked to the new release-v6.11.1 branch after the version is updated.