### PR TITLE
[tu-collector] Recognize CCache in build command

### DIFF
--- a/tools/tu_collector/tests/project/compile_command.json
+++ b/tools/tu_collector/tests/project/compile_command.json
@@ -8,5 +8,10 @@
     "directory": "/tmp",
     "command": "gcc -o /dev/null -std=c11 main.c",
     "file": "main.c"
+  },
+  {
+    "directory": "/tmp",
+    "command": "ccache gcc -o /dev/null -std=c11 hello.c",
+    "file": "hello.c"
   }
 ]

--- a/tools/tu_collector/tests/project/hello.c
+++ b/tools/tu_collector/tests/project/hello.c
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------------
+//                     The CodeChecker Infrastructure
+//   This file is distributed under the University of Illinois Open Source
+//   License. See LICENSE.TXT for details.
+// -----------------------------------------------------------------------------
+#include <stdio.h>
+
+int main()
+{
+
+}

--- a/tools/tu_collector/tests/tu_collector_test.py
+++ b/tools/tu_collector/tests/tu_collector_test.py
@@ -52,9 +52,15 @@ class TUCollectorTest(unittest.TestCase):
         os.remove(zip_file_name)
 
         self.assertTrue(
+            any(map(lambda path: path.endswith(os.path.join('/', 'main.c')),
+                    files)))
+        self.assertTrue(
             any(map(lambda path: path.endswith(os.path.join('/', 'main.cpp')),
                     files)))
         self.assertTrue(
             any(map(lambda path: path.endswith(os.path.join('/', 'vector')),
+                    files)))
+        self.assertTrue(
+            any(map(lambda path: path.endswith(os.path.join('/', 'hello.c')),
                     files)))
         self.assertIn('compilation_database.json', files)


### PR DESCRIPTION
When the build command compiles with CCache, the tu-collector tries to
use it as preprocessor in order to gather the files of the translation
unit. This fails the TU collection, so in this commit we find the
original compiler.