### PR TITLE
[analyzer] Handle two kinds of implicit includes differently

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -113,6 +113,19 @@ def add_arguments_to_parser(parser):
                              "determines whether these should be kept among "
                              "the implicit include paths.")
 
+    parser.add_argument('--keep-gcc-intrin',
+                        dest="keep_gcc_intrin",
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help="There are some implicit include paths which "
+                             "contain GCC-specific header files (those "
+                             "which end with intrin.h). This flag determines "
+                             "whether these should be kept among the implicit "
+                             "include paths. Use this flag if Clang analysis "
+                             "fails with error message related to __builtin "
+                             "symbols.")
+
     parser.add_argument('-t', '--type', '--output-format',
                         dest="output_format",
                         required=False,
@@ -687,6 +700,7 @@ def main(args):
             args.compile_uniqueing,
             compiler_info_file,
             args.keep_gcc_include_fixed,
+            args.keep_gcc_intrin,
             skip_handler,
             pre_analysis_skip_handler,
             ctu_or_stats_enabled,

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -118,6 +118,19 @@ def add_arguments_to_parser(parser):
                              "determines whether these should be kept among "
                              "the implicit include paths.")
 
+    parser.add_argument('--keep-gcc-intrin',
+                        dest="keep_gcc_intrin",
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help="There are some implicit include paths which "
+                             "contain GCC-specific header files (those "
+                             "which end with intrin.h). This flag determines "
+                             "whether these should be kept among the implicit "
+                             "include paths. Use this flag if Clang analysis "
+                             "fails with error message related to __builtin "
+                             "symbols.")
+
     log_args = parser.add_argument_group(
         "log arguments",
         """
@@ -609,7 +622,8 @@ def main(args):
             output_path=output_dir,
             output_format='plist',
             jobs=args.jobs,
-            keep_gcc_include_fixed=args.keep_gcc_include_fixed
+            keep_gcc_include_fixed=args.keep_gcc_include_fixed,
+            keep_gcc_intrin=args.keep_gcc_intrin
         )
         # Some arguments don't have default values.
         # We can't set these keys to None because it would result in an error

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -480,11 +480,38 @@ class OptionParserTest(unittest.TestCase):
         # directory among the implicit include paths. Otherwise this test may
         # fail.
 
-        res = log_parser.parse_options(action, keep_gcc_fix_headers=False)
+        res = log_parser.parse_options(action, keep_gcc_include_fixed=False)
         self.assertFalse(any(map(lambda x: x.endswith('include-fixed'),
                                  res.compiler_includes['c++'])))
-        res = log_parser.parse_options(action, keep_gcc_fix_headers=True)
+        res = log_parser.parse_options(action, keep_gcc_include_fixed=True)
         self.assertTrue(any(map(lambda x: x.endswith('include-fixed'),
+                                res.compiler_includes['c++'])))
+
+    @unittest.skipIf(clangsa.version.get("g++") is not None,
+                     "If gcc or g++ is a symlink to clang this test should be "
+                     "skipped. Option filtering is different for the two "
+                     "compilers. This test is gcc/g++ specific.")
+    def test_compiler_gcc_intrin_headers(self):
+        def contains_intrinsic_headers(dirname):
+            for f in os.listdir(dirname):
+                if f.endswith("intrin.h"):
+                    return True
+            return False
+
+        action = {
+            'file': 'main.cpp',
+            'directory': '',
+            'command': 'g++ main.cpp'
+        }
+
+        # In this test we assume that there will always be a directory
+        # containing ...intrin.h header files. Otherwise this test may fail.
+
+        res = log_parser.parse_options(action, keep_gcc_intrin=False)
+        self.assertFalse(any(map(contains_intrinsic_headers,
+                                 res.compiler_includes['c++'])))
+        res = log_parser.parse_options(action, keep_gcc_intrin=True)
+        self.assertTrue(any(map(contains_intrinsic_headers,
                                 res.compiler_includes['c++'])))
 
     def test_compiler_include_file(self):

--- a/docs/analyzer/gcc_incompatibilities.md
+++ b/docs/analyzer/gcc_incompatibilities.md
@@ -111,6 +111,12 @@ $ gcc -E -x c -v -
  /usr/include
 
 ```
+
+By default the include paths which contain at least one header with `intrin.h`
+postfix are excluded from among the collected paths. If for some reason these
+are needed for the analysis these can be kept with `--keep-gcc-intrin` flag
+after `CodeChecker analyze` and `CodeChecker check` commands.
+
 References:
 * https://software.intel.com/sites/landingpage/IntrinsicsGuide/
 * http://clang.llvm.org/compatibility.html#vector_builtins

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -80,8 +80,8 @@ subcommand.
 
 ```
 usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q] [-f]
-                         [--keep-gcc-include-fixed] (-b COMMAND | -l LOGFILE)
-                         [-j JOBS] [-c]
+                         [--keep-gcc-include-fixed] [--keep-gcc-intrin]
+                         (-b COMMAND | -l LOGFILE) [-j JOBS] [-c]
                          [--compile-uniqueing COMPILE_UNIQUEING]
                          [--report-hash {context-free}] [-i SKIPFILE]
                          [--analyzers ANALYZER [ANALYZER ...]]
@@ -120,6 +120,12 @@ optional arguments:
                         are only used by GCC (include-fixed). This flag
                         determines whether these should be kept among the
                         implicit include paths. (default: False)
+  --keep-gcc-intrin     There are some implicit include paths which contain
+                        GCC-specific header files (those which end with
+                        intrin.h). This flag determines whether these should
+                        be kept among the implicit include paths. Use this
+                        flag if Clang analysis fails with error message
+                        related to __builtin symbols. (default: False)
   --compile-uniqueing COMPILE_UNIQUEING
                         Specify the method the compilation actions in the
                         compilation database are uniqued before analysis. CTU
@@ -411,7 +417,8 @@ below:
 ```
 usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
                            [--compiler-info-file COMPILER_INFO_FILE]
-                           [--keep-gcc-include-fixed] [-t {plist}] [-q] [-c]
+                           [--keep-gcc-include-fixed] [--keep-gcc-intrin]
+                           [-t {plist}] [-q] [-c]
                            [--compile-uniqueing COMPILE_UNIQUEING]
                            [--report-hash {context-free}] [-n NAME]
                            [--analyzers ANALYZER [ANALYZER ...]]
@@ -456,6 +463,12 @@ optional arguments:
                         are only used by GCC (include-fixed). This flag
                         determines whether these should be kept among the
                         implicit include paths. (default: False)
+  --keep-gcc-intrin     There are some implicit include paths which contain
+                        GCC-specific header files (those which end with
+                        intrin.h). This flag determines whether these should
+                        be kept among the implicit include paths. Use this
+                        flag if Clang analysis fails with error message
+                        related to __builtin symbols. (default: False)
   -t {plist}, --type {plist}, --output-format {plist}
                         Specify the format the analysis results should use.
                         (default: plist)
@@ -682,8 +695,9 @@ to collect these so the analysis process can run in the same environment as the
 original build. However, there are some GCC-specific locations (usually with
 name `include-fixed`) which may be incompatible with other compilers and may
 cause failure in analysis. CodeChecker omits these GCC-specific paths from the
-analysis unless `--keep-gcc-include-fixed` flag is given. For further
-information see [GCC incompatibilities](gcc_incompatibilities.md).
+analysis unless `--keep-gcc-include-fixed` or `--keep-gcc-intrin` flag is
+given. For further information see
+[GCC incompatibilities](gcc_incompatibilities.md).
 
 #### Forwarding compiler options <a name="forwarding-compiler-options"></a>
 


### PR DESCRIPTION
There are two kinds of GCC-specific implicit include header files. One
is "include-fixed" and the other are those which contain an ...intrin.h
header files. Until now both of these have been skipped by default and
both could have been kept by --keep-gcc-include-fixed flag during
analysis.

It is clear that ...intrin.h headers are very much GCC-specific, so for
sure these have to be skipped most of the time. These header files
contain some function symbols on vectoriztaion operations (such as
_mm_xor_ps) of which the implementation is an 1-to-1 mapping to a
__buildin... GCC symbol. Of course these built-ins can't be seen by
Clang, however, Clang provides its own headers with the same
_mm_xor_ps-like functions that have some straightforward implementation
(i.e. no __builtin symbols used).

From now --keep-gcc-include-fixed flag keeps only include-fixed
directory from the implicit include path list and not the intrin.h
files. So this commit changes the semantics of this flag. In case
somebody wants to keep intrin.h files (I don't know why would he or she
do that, since these are incomatible with Clang) then --keep-gcc-intrin
can be used.

I don't know what error could occur if include-fixed is always kept by
default. I think this could be the default behavior. Anyway, in these
questions we are always defensive, so using it or not can be the
decision of the user. The only difficulty which remains is what happens
if there are some headers necessary for the analysis in a folder which
contains intrin.h headers too. Currently this case can't be supported.