### PR TITLE
[fix] Fix row output type in command line

### DIFF
--- a/codechecker_common/output_formatters.py
+++ b/codechecker_common/output_formatters.py
@@ -66,7 +66,7 @@ def twodim_to_rows(lines):
     # Generate the format string to pad the columns.
     print_string = " "
     for i, width in enumerate(widths):
-        if i == 0 or i == len(widths) - 1:
+        if i == 0 or i == len(widths) - 1 or width == 0:
             print_string += "{" + str(i) + "} "
         else:
             print_string += "{" + str(i) + ":" + str(width) + "} "

--- a/web/tests/functional/cmdline/test_cmdline.py
+++ b/web/tests/functional/cmdline/test_cmdline.py
@@ -119,6 +119,17 @@ class TestCmdline(unittest.TestCase):
         self.assertEqual(0, ret)
         self.assertEqual(1, len(json.loads(res)))
 
+    def test_runs_row(self):
+        """ Test cmd row output type. """
+        env = self._test_config['codechecker_cfg']['check_env']
+
+        res_cmd = [self._codechecker_cmd, 'cmd', 'runs',
+                   '-o', 'rows', '-n', 'test_files1*',
+                   '--url', str(self.server_url)]
+        ret, _, _ = run_cmd(res_cmd, env=env)
+
+        self.assertEqual(0, ret)
+
     def test_run_update(self):
         """ Test to update run name from the command line. """
 


### PR DESCRIPTION
In the format specification `0` means fill default to `0` and align to `=`.
If the format string looks like `{i:0}`, we will get the following error
message: '=' alignment not allowed in string format specifier.
For this reason we do not put `:0` in the format specification.