### PR TITLE
[plist2html] Print total number of reports in plist-to-html

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -715,36 +715,6 @@ def main(args):
         rep_stats = report_stats.get('reports')
         report_count += rep_stats.get("report_count", 0)
 
-    print("\n----==== Summary ====----")
-    if file_stats:
-        vals = [[os.path.basename(k), v] for k, v in
-                dict(file_stats).items()]
-        vals.sort(key=itemgetter(0))
-        keys = ['Filename', 'Report count']
-        table = twodim_to_str('table', keys, vals, 1, True)
-        print(table)
-
-    if severity_stats:
-        vals = [[k, v] for k, v in dict(severity_stats).items()]
-        vals.sort(key=itemgetter(0))
-        keys = ['Severity', 'Report count']
-        table = twodim_to_str('table', keys, vals, 1, True)
-        print(table)
-
-    print("----=================----")
-    print("Total number of reports: {}".format(report_count))
-    print("----=================----")
-
-    if file_change:
-        changed_files = '\n'.join([' - ' + f for f in file_change])
-        LOG.warning("The following source file contents changed since the "
-                    "latest analysis:\n%s\nMultiple reports were not "
-                    "shown and skipped from the statistics. Please "
-                    "analyze your project again to update the "
-                    "reports!", changed_files)
-
-    os.chdir(original_cwd)
-
     # Create index.html and statistics.html for the generated html files.
     if html_builder:
         html_builder.create_index_html(args.output_path)
@@ -755,3 +725,33 @@ def main(args):
 
         print('\nTo view the results in a browser run:\n> firefox {0}'.format(
             os.path.join(args.output_path, 'index.html')))
+    else:
+        print("\n----==== Summary ====----")
+        if file_stats:
+            vals = [[os.path.basename(k), v] for k, v in
+                    dict(file_stats).items()]
+            vals.sort(key=itemgetter(0))
+            keys = ['Filename', 'Report count']
+            table = twodim_to_str('table', keys, vals, 1, True)
+            print(table)
+
+        if severity_stats:
+            vals = [[k, v] for k, v in dict(severity_stats).items()]
+            vals.sort(key=itemgetter(0))
+            keys = ['Severity', 'Report count']
+            table = twodim_to_str('table', keys, vals, 1, True)
+            print(table)
+
+        print("----=================----")
+        print("Total number of reports: {}".format(report_count))
+        print("----=================----")
+
+    if file_change:
+        changed_files = '\n'.join([' - ' + f for f in file_change])
+        LOG.warning("The following source file contents changed since the "
+                    "latest analysis:\n%s\nMultiple reports were not "
+                    "shown and skipped from the statistics. Please "
+                    "analyze your project again to update the "
+                    "reports!", changed_files)
+
+    os.chdir(original_cwd)

--- a/tools/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/tools/plist_to_html/plist_to_html/PlistToHtml.py
@@ -250,6 +250,12 @@ class HtmlBuilder(object):
                      errors='ignore') as html_output:
             html_output.write(content)
 
+        print("\n----==== Summary ====----")
+
+        print("----=================----")
+        print("Total number of reports: {}".format(num_of_reports))
+        print("----=================----")
+
         print("\n----======== Statistics ========----")
         statistics_rows = [
             ["Number of processed plist files", num_of_plist_files],


### PR DESCRIPTION
> Closes #2539

Running `CodeChecker parse -e html reports -o html_reports` will convert
the reports to html but the `Total number of reports: 0` even if there
were reports. This commit will fix this and will print the number of reports
and summary header in the source code of the `plist-to-html` tool and not in
the CodeChecker parse command.