### PR TITLE
[cmd] Select which file to analyze from the compile command json

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -226,14 +226,29 @@ used to generate a log file on the fly.""")
                                     "analyzers. USE WISELY AND AT YOUR OWN "
                                     "RISK!")
 
-    analyzer_opts.add_argument('-i', '--ignore', '--skip',
-                               dest="skipfile",
-                               required=False,
-                               default=argparse.SUPPRESS,
-                               help="Path to the Skipfile dictating which "
-                                    "project files should be omitted from "
-                                    "analysis. Please consult the User guide "
-                                    "on how a Skipfile should be laid out.")
+    skip_mode = analyzer_opts.add_mutually_exclusive_group()
+    skip_mode.add_argument('-i', '--ignore', '--skip',
+                           dest="skipfile",
+                           required=False,
+                           default=argparse.SUPPRESS,
+                           help="Path to the Skipfile dictating which project "
+                                "files should be omitted from analysis. "
+                                "Please consult the User guide on how a "
+                                "Skipfile should be laid out.")
+
+    skip_mode.add_argument('--file',
+                           nargs='+',
+                           dest="files",
+                           metavar='FILE',
+                           required=False,
+                           default=argparse.SUPPRESS,
+                           help="Analyze only the given file(s) not the whole "
+                                "compilation database. Absolute directory "
+                                "paths should start with '/', relative "
+                                "directory paths should start with '*' and "
+                                "it can contain path glob pattern. "
+                                "Example: '/path/to/main.cpp', 'lib/*.cpp', "
+                                "*/test*'.")
 
     analyzer_opts.add_argument('--analyzers',
                                nargs='+',
@@ -622,6 +637,7 @@ def main(args):
         # after the call.
         args_to_update = ['quiet',
                           'skipfile',
+                          'files',
                           'analyzers',
                           'add_compiler_defaults',
                           'clangsa_args_cfg_file',

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
@@ -1,0 +1,41 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error simple1" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --file "*/simple1.cpp"
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make multi_error simple1" --output $OUTPUT$ --quiet --analyzers clangsa --file "*/simple1.cpp"
+-----------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - Total analyzed compilation commands: 1
+[] - Skipped compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero]
+  return 2015 / x;
+              ^
+
+Found 1 defect(s) in simple1.cpp
+
+
+----==== Summary ====----
+--------------------------
+Filename    | Report count
+--------------------------
+simple1.cpp |            1
+--------------------------
+-----------------------
+Severity | Report count
+-----------------------
+HIGH     |            1
+-----------------------
+----=================----
+Total number of reports: 1
+----=================----

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -84,7 +84,8 @@ usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q] [-f]
                          [--keep-gcc-include-fixed] [--keep-gcc-intrin]
                          (-b COMMAND | -l LOGFILE) [-j JOBS] [-c]
                          [--compile-uniqueing COMPILE_UNIQUEING]
-                         [--report-hash {context-free}] [-i SKIPFILE]
+                         [--report-hash {context-free}]
+                         [-i SKIPFILE | --file FILE [FILE ...]]
                          [--analyzers ANALYZER [ANALYZER ...]]
                          [--add-compiler-defaults] [--capture-analysis-output]
                          [--saargs CLANGSA_ARGS_CFG_FILE]
@@ -184,6 +185,12 @@ analyzer arguments:
                         Path to the Skipfile dictating which project files
                         should be omitted from analysis. Please consult the
                         User guide on how a Skipfile should be laid out.
+  --file FILE [FILE ...]
+                        Analyze only the given file(s) not the whole
+                        compilation database. Absolute directory paths should
+                        start with '/', relative directory paths should start
+                        with '*' and it can contain path glob pattern.
+                        Example: '/path/to/main.cpp', 'lib/*.cpp', */test*'.
   --analyzers ANALYZER [ANALYZER ...]
                         Run analysis only with the analyzers specified.
                         Currently supported analyzers are: clangsa, clang-
@@ -459,7 +466,9 @@ CodeChecker analyze ../codechecker_myProject_build.log -o my_plists
 below:
 
 ```
-usage: CodeChecker analyze [-h] [-j JOBS] [-i SKIPFILE] -o OUTPUT_PATH
+usage: CodeChecker analyze [-h] [-j JOBS]
+                           [-i SKIPFILE | --file FILE [FILE ...]] -o
+                           OUTPUT_PATH
                            [--compiler-info-file COMPILER_INFO_FILE]
                            [--keep-gcc-include-fixed] [--keep-gcc-intrin]
                            [-t {plist}] [-q] [-c]
@@ -496,6 +505,12 @@ optional arguments:
                         Path to the Skipfile dictating which project files
                         should be omitted from analysis. Please consult the
                         User guide on how a Skipfile should be laid out.
+  --file FILE [FILE ...]
+                        Analyze only the given file(s) not the whole
+                        compilation database. Absolute directory paths should
+                        start with '/', relative directory paths should start
+                        with '*' and it can contain path glob pattern.
+                        Example: '/path/to/main.cpp', 'lib/*.cpp', */test*'.
   -o OUTPUT_PATH, --output OUTPUT_PATH
                         Store the analysis output in the given folder.
   --compiler-info-file COMPILER_INFO_FILE

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -159,6 +159,22 @@ CodeChecker check ./compile_commands.json -i skip.list -o reports
 For more details regarding the skip file format see
 the [user guide](analyzer/user_guide.md#skip).
 
+c) **Select source files from the compilation database**
+You can select which files you would like to analyze from the compilation
+database. This is similar to the skip list feature but can be easier to quickly
+analyze only a few files not the whole compilation database.
+
+Let's assume you have the compilation database in `compile_commands.json`.
+
+```sh
+CodeChecker check ./compile_commands.json -o reports --file "*cmd-find.c"
+```
+
+Absolute directory paths should start with `/`, relative directory paths should
+start with `*` and it can contain path glob pattern. Example:
+`/path/to/main.cpp`, `lib/*.cpp`, `*/test*`.
+
+
 ### Analysis Failures <a name="analysis-failures"></a>
 
 The `reports/failed` folder contains all build-actions that


### PR DESCRIPTION
> Closes #2543

This feature is similar to the skip list feature but can be easier to
quickly analyze only a few files not the whole compile command json.

E.g.: `CodeChecker analyze -o reports compile_command.json --files test.cpp test2.cpp`.