### PR TITLE
[tu-collector][test][fix] Fix warning in tu-collector test

### DIFF
--- a/tools/tu_collector/tests/project/compile_command.json
+++ b/tools/tu_collector/tests/project/compile_command.json
@@ -6,7 +6,7 @@
 	},
   {
     "directory": "/tmp",
-    "command": "gcc -o /dev/null -std=c++11 main.c",
+    "command": "gcc -o /dev/null -std=c11 main.c",
     "file": "main.c"
   }
 ]


### PR DESCRIPTION
Among the build commands of the tu-collector test files there was
a compilation action which compiled a .c file with -std=c++11 flag.
Such a mix of the languages cause a warning in some compiler on
some platforms.