### PR TITLE
convert the source file to abs path if CC_LOGGER_ABS_PATH is set

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
@@ -433,7 +433,17 @@ int loggerGccParserCollectActions(
         {
           if (strcmp(srcExts[i], ext) == 0)
           {
-            loggerVectorAddUnique(&action->sources, loggerStrDup(current),
+            char newPath[PATH_MAX];
+
+            if (getenv("CC_LOGGER_ABS_PATH"))
+            {
+              loggerMakePathAbs(current, newPath, 0);
+            }
+            else
+            {
+              strcpy(newPath, current);
+            }
+            loggerVectorAddUnique(&action->sources, loggerStrDup(newPath),
               (LoggerCmpFuc) &strcmp);
             break;
           }

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -9,7 +9,8 @@ export LD_LIBRARY_PATH=$logger_dir/lib:$LD_LIBRARY_PATH
 export CC_LOGGER_GCC_LIKE="gcc:g++:clang"
 export CC_LOGGER_FILE=/tmp/logger_test_compilation_database.json
 
-source_file=/tmp/logger_test_source.cpp
+source_file_name=logger_test_source.cpp
+source_file=/tmp/$source_file_name
 response_file=/tmp/logger_test_source.cpp.rsp
 reference_file=/tmp/logger_test_reference.json
 
@@ -174,6 +175,12 @@ function test_include_abs3 {
   CC_LOGGER_ABS_PATH=1 bash -c "gcc -isystem=hello $source_file"
   grep -- "-isystem=/.*hello" $CC_LOGGER_FILE &> /dev/null
 }
+
+function test_source_abs {
+  CC_LOGGER_ABS_PATH=1 bash -c "cd /tmp && gcc $source_file_name"
+  grep -- "$source_file" $CC_LOGGER_FILE &> /dev/null
+}
+
 
 #--- Run tests ---#
 


### PR DESCRIPTION
with this change not only the include paths but the source file
path is converted to absolute path in the compile command database.