### PR TITLE
[doc] Refactoring doc of supported analyzers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -281,7 +281,14 @@ If you have Clang `3.7` installed you might see the following warning message:
    support bug identifier hash generation currently.
 
 # Code Analyzers supported by CodeChecker
-For now CodeChecker supports only `C/C++` related analyzers:
+CodeChecker can only execute two main `C/C++` static analyzer tools:
+- [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/)
+- [Clang Static Analyzer](https://clang-analyzer.llvm.org/)
+
+However it can store the results of other analyzer tools in the database.
+So it can be used as a generic tool for visualizing analyzer results.
+
+For now CodeChecker supports the storage of the following analyzers results:
 
 | Language       | Analyzer     |
 | -------------- |--------------|
@@ -290,8 +297,10 @@ For now CodeChecker supports only `C/C++` related analyzers:
 |                | [Cppcheck](/tools/report-converter/README.md#cppcheck)    |
 |                | [Clang Sanitizers](supported_code_analyzers.md#clang-sanitizers)    |
 
-We are planning to support multiple analyzers of different programming
-languages. For more detailed information [see](supported_code_analyzers.md).
+We are planning to support the storage of the results created by other
+analyzers for different languages (Java, Python ...). For more detailed
+information check out the
+[supported code analyzers](supported_code_analyzers.md) documentation.
 
 # Useful Documentation
 

--- a/docs/supported_code_analyzers.md
+++ b/docs/supported_code_analyzers.md
@@ -4,11 +4,11 @@ CodeChecker can execute two main `C/C++` static analyzer tools:
 - [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/)
 - [Clang Static Analyzer](https://clang-analyzer.llvm.org/)
 
-We are planning to support more analyzer tools by creating a separate converter
-tool which can be used to convert the output of different code analyzer tools
-to a CodeChecker result directory which can be stored to a CodeChecker server.
+We have created a separate [converter tool](/tools/report-converter) which
+can be used to convert the output of different source code analyzer tools to a
+CodeChecker result directory which can be stored to a CodeChecker server.
 
-| Language       | Analyzer     | Supported by CodeChecker |
+| Language       | Analyzer     | Support storage of analyzer results |
 | -------------- |--------------|---------------------|
 | **C/C++**      | [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/)  | ✓ |
 |                | [Clang Static Analyzer](https://clang-analyzer.llvm.org/)    | ✓ |
@@ -30,7 +30,7 @@ to a CodeChecker result directory which can be stored to a CodeChecker server.
 |                | [go-critic](https://github.com/go-critic/go-critic)    | ✗ |
 
 ## Clang Sanitizers
-| Name         | Supported by CodeChecker |
+| Name         | Support storage of analyzer results |
 |--------------|---------------------|
 | [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)    | ✓ |
 | [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)    | ✓ |


### PR DESCRIPTION
> Closes #2555

Highligh in the documentation that CodeChecker can only execute ClangSA
and Clang Tidy analyzers but supports the storage of multiple analyzer
results.