### PR TITLE
Fix CLI

### DIFF
--- a/codechecker_common/output_formatters.py
+++ b/codechecker_common/output_formatters.py
@@ -57,7 +57,7 @@ def twodim_to_rows(lines):
     # Count the column width.
     widths = []
     for line in lines:
-        for i, size in enumerate([len(x) for x in line]):
+        for i, size in enumerate([len(str(x)) for x in line]):
             while i >= len(widths):
                 widths.append(0)
             if size > widths[i]:

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -16,7 +16,7 @@ import getpass
 import datetime
 import sys
 
-from codeCheckerDBAccess_v6 import ttypes
+from codechecker_api.codeCheckerDBAccess_v6 import ttypes
 
 from codechecker_client import cmd_line_client
 from codechecker_client import product_client


### PR DESCRIPTION
I hit two Python errors in my recent usage, the first one blocking use of `CodeChecker cmd` (and producing warnings on other commands), fixed in the first commit, and the second blocking use of `CodeChecker cmd .... -o rows`, fixed in the second commit.