### PR TITLE
[build-logger] Support debug logging

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -86,7 +86,20 @@ def add_arguments_to_parser(parser):
                         help="Do not print the output of the build tool into "
                              "the output of this command.")
 
-    logger.add_verbose_arguments(parser)
+    parser.add_argument('--verbose',
+                        type=str,
+                        dest='verbose',
+                        choices=logger.CMDLINE_LOG_LEVELS,
+                        default=argparse.SUPPRESS,
+                        help="Set verbosity level. If the value is 'debug' or "
+                             "'debug_analyzer' it will create a "
+                             "'codechecker.logger.debug' debug log file "
+                             "beside the given output file. It will contain "
+                             "debug information of compilation database "
+                             "generation. You can override the location of "
+                             "this file if you set the 'CC_LOGGER_DEBUG_FILE' "
+                             "environment variable to a different file path.")
+
     parser.set_defaults(func=main)
 
 
@@ -102,8 +115,11 @@ def main(args):
         os.remove(args.logfile)
 
     context = analyzer_context.get_context()
+    verbose = args.verbose if 'verbose' in args else None
+
     build_manager.perform_build_command(args.logfile,
                                         args.command,
                                         context,
                                         'keep_link' in args,
-                                        silent='quiet' in args)
+                                        silent='quiet' in args,
+                                        verbose=verbose)

--- a/analyzer/tools/build-logger/Makefile.manual
+++ b/analyzer/tools/build-logger/Makefile.manual
@@ -30,6 +30,7 @@ LDLOGGER_HEADERS =  \
 	src/ldlogger-hooks.h \
 	src/ldlogger-tool.h \
 	src/ldlogger-util.h
+
 LDLOGGER_SOURCES = \
 	src/ldlogger-logger.c \
 	src/ldlogger-tool.c \

--- a/analyzer/tools/build-logger/README.md
+++ b/analyzer/tools/build-logger/README.md
@@ -72,3 +72,6 @@ all relative paths in the compilation commands after
 -iwithprefix, -iwithprefixbefore, -sysroot, --sysroot`
 will be converted to absolute PATH when written into the compilation database.
 
+### `CC_LOGGER_DEBUG_FILE`
+Output file to print log messages. If this environment variable is not
+defined it will do nothing.

--- a/analyzer/tools/build-logger/src/ldlogger-tool.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool.c
@@ -7,6 +7,7 @@
  */
 
 #include "ldlogger-tool.h"
+#include "ldlogger-util.h"
 
 #include <stdlib.h>
 #include <assert.h>
@@ -157,6 +158,13 @@ int loggerCollectActionsByProgName(
   else if (matchToProgramList("CC_LOGGER_JAVAC_LIKE", prog_))
   {
     return loggerJavacParserCollectActions(prog_, argv_, actions_);
+  } else {
+    LOG_INFO("'%s' does not match any program name! Current environment "
+             "variables are: CC_LOGGER_GCC_LIKE (%s), "
+             "CC_LOGGER_JAVAC_LIKE(%s)",
+             prog_,
+             getenv("CC_LOGGER_GCC_LIKE"),
+             getenv("CC_LOGGER_JAVAC_LIKE"))
   }
 
   return 0;

--- a/analyzer/tools/build-logger/src/ldlogger-util.h
+++ b/analyzer/tools/build-logger/src/ldlogger-util.h
@@ -13,6 +13,10 @@
 #include <linux/limits.h>
 #include <string.h>
 
+#define LOG_INFO(...) logPrint("INFO", __FILE__, __LINE__, __VA_ARGS__ );
+#define LOG_WARN(...) logPrint("WARNING", __FILE__, __LINE__, __VA_ARGS__ );
+#define LOG_ERROR(...) logPrint("ERROR", __FILE__, __LINE__, __VA_ARGS__ );
+
 /**
  * Predicts the size of the string after escaping including the closing \0
  * character. For example:
@@ -256,5 +260,37 @@ char* loggerGetFilePathWithoutExt(const char* absPath_);
  */
 char* loggerGetFileName(const char* absPath_, int withoutExt_);
 
-#endif /* __LOGGER_UTIL_H__ */
+/**
+ * Aquire lock for the given log file.
+ * @param logFile_ log file path.
+ * @return -1 on error, lock file descriptor on success.
+ */
+int aquireLock(char const* logFile_);
 
+/**
+ * Remove the given lock.
+ * @param lockFile_ lock file descriptor.
+ */
+void freeLock(int lockFile_);
+
+/**
+ * Print log messages to a file specified by the 'CC_LOGGER_DEBUG_FILE'
+ * environment variable. If this environment variable is not set it will do
+ * nothing.
+ *
+ * @param logLevel_ log level name.
+ * @param fileName_ file name from which the log is coming from.
+ * @param line_ line number at which the log function is called from.
+ * @param fmt_ Message that contains the text to be written to the stream. It
+ *  can optionally contain the follwing format tags:
+ *  - %s: string of characters.
+ *  - %d: signed decimal integer.
+ *  - %a': Array of strings. Two aguments must be passed when using this. The
+ *         first argument is the size of the array and the second argument
+ *         is the array itself.
+ *  These formatted tags will be replaced by the values specified in
+ *  subsequent additional arguments and formatted as requested.
+ */
+void logPrint(char* logLevel_, char* fileName_, int line_, char* fmt_, ...);
+
+#endif /* __LOGGER_UTIL_H__ */

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -8,6 +8,7 @@ export LD_PRELOAD=ldlogger.so
 export LD_LIBRARY_PATH=$logger_dir/lib:$LD_LIBRARY_PATH
 export CC_LOGGER_GCC_LIKE="gcc:g++:clang"
 export CC_LOGGER_FILE=/tmp/logger_test_compilation_database.json
+export CC_LOGGER_DEBUG_FILE=/tmp/logger_test_debug.log
 
 source_file_name=logger_test_source.cpp
 source_file=/tmp/$source_file_name
@@ -28,6 +29,7 @@ EOF
   sed -i -e '$a\' $CC_LOGGER_FILE
 
   diff $reference_file $CC_LOGGER_FILE
+  test -s $CC_LOGGER_DEBUG_FILE
 }
 
 #--- Test functions ---#
@@ -189,6 +191,7 @@ echo "int main() {}" > $source_file
 for func in $(declare -F); do
   if [[ $func =~ test_ ]]; then
     rm -f $CC_LOGGER_FILE
+    rm -rf $CC_LOGGER_DEBUG_FILE
     $func
 
     if [ $? -ne 0 ]; then

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -344,6 +344,17 @@ Example:
 CodeChecker log -o ../codechecker_myProject_build.log -b "make -j2"
 ```
 
+If you run CodeChecker log in verbose mode (`debug` or `debug_analyzer`) it
+will create a 'codechecker.logger.debug' debug log file beside the given output
+file. It will contain debug information of compilation database generation. You
+can override this file if you set the `CC_LOGGER_DEBUG_FILE` environment
+variable to a different file path.
+
+```sh
+export CC_LOGGER_DEBUG_FILE="/path/to/codechecker.debug.log"
+```
+
+
 ### BitBake
 Do the following steps to log compiler calls made by
 [BitBake](https://github.com/openembedded/bitbake) using CodeChecker.


### PR DESCRIPTION
With these changes if the CodeChecker log command will be run in
verbose mode then a new debug log file will be created which will
contain messages related to the build logger.