### PR TITLE
[analyzer] Remove EXPERIMENTAL tag from the statistics-based feature

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -387,7 +387,7 @@ Cross-TU analysis. By default, no CTU analysis is run when
 
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
-            "EXPERIMENTAL statistics analysis feature arguments",
+            "Statistics analysis feature arguments",
             """
 These arguments are only available if the Clang Static Analyzer supports
 Statistics-based analysis (e.g. statisticsCollector.ReturnValueCheck,
@@ -397,8 +397,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store',
                                default=argparse.SUPPRESS,
                                dest='stats_output',
-                               help="EXPERIMENTAL feature. "
-                                    "Perform the first, 'collect' phase of "
+                               help="Perform the first, 'collect' phase of "
                                     "Statistical analysis. This phase "
                                     "generates extra files needed by "
                                     "statistics analysis, and "
@@ -412,8 +411,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store',
                                default=argparse.SUPPRESS,
                                dest='stats_dir',
-                               help="EXPERIMENTAL feature. "
-                                    "Use the previously generated statistics "
+                               help="Use the previously generated statistics "
                                     "results for the analysis from the given "
                                     "'<STATS_DIR>'.")
 
@@ -421,8 +419,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store_true',
                                default=argparse.SUPPRESS,
                                dest='stats_enabled',
-                               help="EXPERIMENTAL feature. "
-                                    "Perform both phases of "
+                               help="Perform both phases of "
                                     "Statistical analysis. This phase "
                                     "generates extra files needed by "
                                     "statistics analysis and enables "
@@ -434,8 +431,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                default="10",
                                type=int,
                                dest='stats_min_sample_count',
-                               help="EXPERIMENTAL feature. "
-                                    "Minimum number of samples (function call"
+                               help="Minimum number of samples (function call"
                                     " occurrences) to be collected"
                                     " for a statistics to be relevant "
                                     "'<MIN-SAMPLE-COUNT>'.")
@@ -445,8 +441,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                default="0.85",
                                type=float,
                                dest='stats_relevance_threshold',
-                               help="EXPERIMENTAL feature. "
-                                    "The minimum ratio of calls of function "
+                               help="The minimum ratio of calls of function "
                                     "f that must have a certain property "
                                     "property to consider it true for that "
                                     "function (calculated as calls "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -408,7 +408,7 @@ is called.""")
 
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
-            "EXPERIMENTAL statistics analysis feature arguments",
+            "Statistics analysis feature arguments",
             """
 These arguments are only available if the Clang Static Analyzer supports
 Statistics-based analysis (e.g. statisticsCollector.ReturnValueCheck,
@@ -418,8 +418,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store',
                                default=argparse.SUPPRESS,
                                dest='stats_output',
-                               help="EXPERIMENTAL feature. "
-                                    "Perform the first, 'collect' phase of "
+                               help="Perform the first, 'collect' phase of "
                                     "Statistical analysis. This phase "
                                     "generates extra files needed by "
                                     "statistics analysis, and "
@@ -433,8 +432,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store',
                                default=argparse.SUPPRESS,
                                dest='stats_dir',
-                               help="EXPERIMENTAL feature. "
-                                    "Use the previously generated statistics "
+                               help="Use the previously generated statistics "
                                     "results for the analysis from the given "
                                     "'<STATS_DIR>'.")
 
@@ -442,8 +440,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                action='store_true',
                                default=argparse.SUPPRESS,
                                dest='stats_enabled',
-                               help="EXPERIMENTAL feature. "
-                                    "Perform both phases of "
+                               help="Perform both phases of "
                                     "Statistical analysis. This phase "
                                     "generates extra files needed by "
                                     "statistics analysis and enables "
@@ -455,8 +452,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                default="10",
                                type=int,
                                dest='stats_min_sample_count',
-                               help="EXPERIMENTAL feature. "
-                                    "Minimum number of samples (function call"
+                               help="Minimum number of samples (function call"
                                     " occurrences) to be collected"
                                     " for a statistics to be relevant.")
 
@@ -465,8 +461,7 @@ statisticsCollector.SpecialReturnValue checkers are available).""")
                                default="0.85",
                                type=float,
                                dest='stats_relevance_threshold',
-                               help="EXPERIMENTAL feature. "
-                                    "The minimum ratio of calls of function "
+                               help="The minimum ratio of calls of function "
                                     "f that must have a certain property "
                                     "property to consider it true for that "
                                     "function (calculated as calls "

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -904,36 +904,34 @@ These options are only visible in `analyze` if the experimental
 statistical analysis support is present.
 
 ```
-EXPERIMENTAL statistics analysis feature arguments:
+Statistics analysis feature arguments:
   These arguments are only available if the Clang Static Analyzer supports
   Statistics-based analysis (e.g. statisticsCollector.ReturnValueCheck,
   statisticsCollector.SpecialReturnValue checkers are available).
 
   --stats-collect STATS_OUTPUT, --stats-collect STATS_OUTPUT
-                        EXPERIMENTAL feature. Perform the first, 'collect'
-                        phase of Statistical analysis. This phase generates
-                        extra files needed by statistics analysis, and puts
-                        them into '<STATS_OUTPUT>'. NOTE: If this argument is
-                        present, CodeChecker will NOT execute the analyzers!
+                        Perform the first, 'collect' phase of Statistical
+                        analysis. This phase generates extra files needed by
+                        statistics analysis, and puts them into
+                        '<STATS_OUTPUT>'. NOTE: If this argument is present,
+                        CodeChecker will NOT execute the analyzers!
   --stats-use STATS_DIR, --stats-use STATS_DIR
-                        EXPERIMENTAL feature. Use the previously generated
-                        statistics results for the analysis from the given
-                        '<STATS_DIR>'.
-  --stats               EXPERIMENTAL feature. Perform both phases of
-                        Statistical analysis. This phase generates extra files
-                        needed by statistics analysis and enables the
-                        statistical checkers. No need to enable them
-                        explicitly.
+                        Use the previously generated statistics results for
+                        the analysis from the given '<STATS_DIR>'.
+  --stats               Perform both phases of Statistical analysis. This
+                        phase generates extra files needed by statistics
+                        analysis and enables the statistical checkers. No
+                        need to enable them explicitly.
  --stats-min-sample-count STATS_MIN_SAMPLE_COUNT, --stats-min-sample-count STATS_MIN_SAMPLE_COUNT
-                        EXPERIMENTAL feature. Minimum number of samples
-                        (function call occurrences) to be collected for a
-                        statistics to be relevant.(default: 10)
+                        Minimum number of samples (function call occurrences)
+                        to be collected for a statistics to be relevant.
+                        (default: 10)
   --stats-relevance-threshold STATS_RELEVANCE_THRESHOLD, --stats-relevance-threshold STATS_RELEVANCE_THRESHOLD
-                        EXPERIMENTAL feature. The minimum ratio of
-                        calls of function f that must have a certain property
-                        to consider it true for that function (calculated as calls 
-                        with a property/all calls). CodeChecker will warn for calls 
-                        of f that do not have that property.(default: 0.85)
+                        The minimum ratio of calls of function f that must
+                        have a certain property to consider it true for that
+                        function (calculated as calls  with a property/all
+                        calls). CodeChecker will warn for calls of f that do
+                        not have that property.(default: 0.85)
  
 ```
 


### PR DESCRIPTION
The statistics-based feature proved stable enough to remove the
EXPERIMENTAL flag from it. Flag is now removed from help texts and
docs.