### PR TITLE
[fix] OSError exception was not handled if a binary is missing from PATH

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -987,8 +987,8 @@ def parse_options(compilation_db_entry,
         try:
             compiler_version_info = \
                 get_clangsa_version_func(details['compiler'], env)
-        except subprocess.CalledProcessError as cerr:
-            LOG.error('Failed to get and parse clang version: %s',
+        except (subprocess.CalledProcessError, OSError) as cerr:
+            LOG.error('Failed to get and parse version of: %s',
                       details['compiler'])
             LOG.error(cerr)
             compiler_version_info = False


### PR DESCRIPTION
Handle the error when the logged compiler binary is missing from the PATH.