### PR TITLE
check the limit value for every api endpoint

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -93,6 +93,10 @@ def verify_limit_range(limit):
     Max is returned if the value is larger than max.
     """
     max_query_limit = constants.MAX_QUERY_SIZE
+
+    if not limit:
+        return max_query_limit
+
     if limit > max_query_limit:
         LOG.warning('Query limit %d was larger than max query limit %d, '
                     'setting limit to %d',
@@ -1271,6 +1275,9 @@ class ThriftRequestHandler(object):
           counts will be calculated for all of the available runs.
         """
         self.__require_access()
+
+        limit = verify_limit_range(limit)
+
         results = []
         with DBSession(self.__Session) as session:
             filter_expression = process_report_filter(session, report_filter)
@@ -1762,6 +1769,9 @@ class ThriftRequestHandler(object):
           will be used as a baseline excluding the runs in compare data.
         """
         self.__require_access()
+
+        limit = verify_limit_range(limit)
+
         results = []
         with DBSession(self.__Session) as session:
             diff_hashes = None
@@ -1868,6 +1878,9 @@ class ThriftRequestHandler(object):
           will be used as a baseline excluding the runs in compare data.
         """
         self.__require_access()
+
+        limit = verify_limit_range(limit)
+
         results = {}
         with DBSession(self.__Session) as session:
             diff_hashes = None
@@ -1974,6 +1987,9 @@ class ThriftRequestHandler(object):
           will be used as a baseline excluding the runs in compare data.
         """
         self.__require_access()
+
+        limit = verify_limit_range(limit)
+
         results = {}
         with DBSession(self.__Session) as session:
             if cmp_data:


### PR DESCRIPTION
For some api endpoints no limit checking was done wich should be done.
The value of the limit was not checked if not set it could be None,
set the value to max query limit if no limit was set.