### PR TITLE
[gui] Set limit and query when getting filter items

### DIFF
--- a/web/server/www/scripts/codecheckerviewer/filter/SelectFilter.js
+++ b/web/server/www/scripts/codecheckerviewer/filter/SelectFilter.js
@@ -256,7 +256,12 @@ function (declare, dom, Standby, ContentPane, Tooltip, FilterBase,
       if (!selectedItemLen) return;
 
       var that = this;
-      var opt = { filter : selectedItems };
+      var opt = {
+        filter: selectedItems,
+        limit: this._filterTooltip.defaultQueryFilterSize,
+        query: selectedItems
+      };
+
       this._standBy.show();
       this.getItems(opt).then(function (items) {
         that._filterTooltip.reset(items);


### PR DESCRIPTION
There was a bug in the UI when we set a file path filter for example
to `*` and we reloaded the page. Unfortunately we forgot to set the limit
and query parameters so it tried to get all the items from the server
which can be really large and a browser can be freezed.
This commit will solve this problem.