### PR TITLE
[fix][cmd] Fix empty CodeChecker invocation

### DIFF
--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -46,6 +46,12 @@ class TestCmdline(unittest.TestCase):
         # Get the CodeChecker cmd if needed for the tests.
         self._codechecker_cmd = env.codechecker_cmd()
 
+    def test_no_subcommand(self):
+        """ Call CodeChecker without subcommand. """
+
+        main_cmd = [env.codechecker_cmd()]
+        self.assertEqual(0, run_cmd(main_cmd)[0])
+
     def test_version_help(self):
         """ Test the 'analyzer-version' subcommand. """
 

--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -124,7 +124,10 @@ output.
                 sys.argv.extend(cfg_args)
                 args = parser.parse_args()
 
-        args.func(args)
+        try:
+            args.func(args)
+        except AttributeError:
+            parser.print_help()
 
     except KeyboardInterrupt as kb_err:
         print(str(kb_err))


### PR DESCRIPTION
> Closes #2594

CodeChecker will throw the following exception when no subcommand is
given for the CodeChecker command:
```
Traceback (most recent call last):
  File "/cc_bin/CodeChecker.py", line 127, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

This patch will fix this problem and print the help message instead of
this exception.