### PR TITLE
[cmd] Fix parsing invalid plist file

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -246,3 +246,19 @@ class AnalyzeParseTestCase(
 
         self.assertIn('notes', res)
         self.assertTrue(res['notes'])
+
+    def test_invalid_plist_file(self):
+        """ Test parsing invalid plist file. """
+        invalid_plist_file = os.path.join(self.test_workspaces['NORMAL'],
+                                          "test_files", "invalid.plist")
+        with open(invalid_plist_file, "w+",
+                  encoding="utf-8",
+                  errors="ignore") as invalid_plist_f:
+            invalid_plist_f.write("Invalid plist file.")
+
+        extract_cmd = ['CodeChecker', 'parse',
+                       invalid_plist_file]
+
+        out, _ = call_command(extract_cmd, cwd=self.test_dir, env=self.env)
+
+        self.assertTrue("Invalid plist file" in out)

--- a/codechecker_common/plist_parser.py
+++ b/codechecker_common/plist_parser.py
@@ -81,8 +81,14 @@ class LXMLPlistParser(plistlib._PlistParser):
         self.parser = XMLParser(target=self.event_handler)
 
     def parse(self, fileobj):
-        from lxml.etree import parse
-        parse(fileobj, self.parser)
+        from lxml.etree import parse, XMLSyntaxError
+
+        try:
+            parse(fileobj, self.parser)
+        except XMLSyntaxError as ex:
+            LOG.error("Invalid plist file '%s': %s", fileobj.name, ex)
+            return
+
         return self.root
 
 
@@ -144,6 +150,9 @@ def parse_plist_file(path, source_root=None, allow_plist_update=True):
     try:
         with open(path, 'rb') as plist_file_obj:
             plist = parse_plist(plist_file_obj)
+
+        if not plist:
+            return files, reports
 
         files = plist['files']
 


### PR DESCRIPTION
> Closes #2598

Give a better log message when the user parses an invalid plist file.