### PR TITLE
[cfg] Fix migration script generation for config db

### DIFF
--- a/web/server/codechecker_server/migrations/config/env.py
+++ b/web/server/codechecker_server/migrations/config/env.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -14,11 +19,13 @@ except ImportError:
     # Assume we are in the source directory
     import sys
     import os
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 "../build/thrift/v6/gen-py")))
 
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 "..", "..", "..")))
+    server_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                              "..", "..", ".."))
+    root_dir = os.path.join(server_dir, '..', '..')
+
+    sys.path.extend([root_dir, server_dir])
+
     from codechecker_server.database.config_db_model import Base
 
 target_metadata = Base.metadata

--- a/web/server/codechecker_server/migrations/report/env.py
+++ b/web/server/codechecker_server/migrations/report/env.py
@@ -1,6 +1,8 @@
-
-
-
+# -------------------------------------------------------------------------
+#                     The CodeChecker Infrastructure
+#   This file is distributed under the University of Illinois Open Source
+#   License. See LICENSE.TXT for details.
+# -------------------------------------------------------------------------
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool


### PR DESCRIPTION
Running alembic on config database will fail with the following import
error: `ModuleNotFoundError: No module named 'codechecker_common'`.

This commit will fix this problem by adding the root directory to the sys.path.