### PR TITLE
[ld-logger] Improve debug messages

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-logger.c
+++ b/analyzer/tools/build-logger/src/ldlogger-logger.c
@@ -150,7 +150,7 @@ static void logProgramArgs(
 
   if (!loggerMakePathAbs(".", workingDir, 1))
   {
-    LOG_WARN("Failed to convert current directory to absolute path!")
+    LOG_WARN("Failed to convert current directory to absolute path!");
     return;
   }
 
@@ -163,7 +163,7 @@ static void logProgramArgs(
   }
   else
   {
-    LOG_WARN("Failed to convert argument vector to a NULL terminated list!")
+    LOG_WARN("Failed to convert argument vector to a NULL terminated list!");
     return;
   }
 

--- a/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool-gcc.c
@@ -548,8 +548,13 @@ int loggerGccParserCollectActions(
   }
   else if (responseFile = getResponseFile(&action->arguments))
   {
+    LOG_INFO("Processing response file: %s", responseFile);
     loggerVectorAdd(&action->sources, responseFile);
     loggerVectorAdd(actions_, action);
+  }
+  else
+  {
+    LOG_WARN("No souce file was found.");
   }
 
   return 1;

--- a/analyzer/tools/build-logger/src/ldlogger-tool.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool.c
@@ -164,7 +164,7 @@ int loggerCollectActionsByProgName(
              "CC_LOGGER_JAVAC_LIKE(%s)",
              prog_,
              getenv("CC_LOGGER_GCC_LIKE"),
-             getenv("CC_LOGGER_JAVAC_LIKE"))
+             getenv("CC_LOGGER_JAVAC_LIKE"));
   }
 
   return 0;


### PR DESCRIPTION
- Print debug messages when no source file found when processing a command
or when processing a response file.
- Terminate log print expressions with `;`.