### PR TITLE
[doc] Adding some documentation to ld-logger

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -28,6 +28,13 @@ def get_argparser_ctor_args():
     argparse.ArgumentParser (either directly or as a subparser).
     """
 
+    is_intercept = check_intercept(os.environ)
+    ldlogger_settings = "\nld-logger can be fine-tuned with some " \
+        "environment variables. For details see the following " \
+        "documentation: " \
+        "https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/" \
+        "build-logger/README.md#usage" if not is_intercept else ''
+
     return {
         'prog': 'CodeChecker log',
         'formatter_class': argparse.ArgumentDefaultsHelpFormatter,
@@ -37,8 +44,8 @@ def get_argparser_ctor_args():
                        "compilation steps. These steps are written to the "
                        "output file in a JSON format.\n\nAvailable build "
                        "logger tool that will be used is '" +
-                       ('intercept-build' if check_intercept(os.environ)
-                        else 'ld-logger') + "'.",
+                       ('intercept-build' if is_intercept
+                        else 'ld-logger') + "'." + ldlogger_settings,
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/analyzer/tools/build-logger/README.md
+++ b/analyzer/tools/build-logger/README.md
@@ -17,8 +17,10 @@ Set the following environment variables:
 export LD_PRELOAD=ldlogger.so
 export LD_LIBRARY_PATH=`pwd`/build/lib:$LD_LIBRARY_PATH
 export CC_LOGGER_GCC_LIKE="gcc:g++:clang"
-#The output compilation JSON file
+# The output compilation JSON file.
 export CC_LOGGER_FILE=`pwd`/compilation.json
+# Log linker build actions to the JSON file. Optional. Default: false
+export CC_LOGGER_KEEP_LINK=true
 ~~~~~~~
 
 then when you call `gcc` from a sub-shell (e.g. as a part of a Make build process),
@@ -75,3 +77,13 @@ will be converted to absolute PATH when written into the compilation database.
 ### `CC_LOGGER_DEBUG_FILE`
 Output file to print log messages. If this environment variable is not
 defined it will do nothing.
+
+### `CC_LOGGER_KEEP_LINK`
+This environment variable is optional. If its value is not `true` then object
+files will be removed from the build action. For example in case of this build
+command: `gcc main.c object1.o object2.so` the `object1.o` and `object2.so`
+will be removed and only `gcc main.c` will be captured. If only object files
+are provided to the compiler then the complete build action will be thrown
+away. This means that build actions which only perform linking will not be
+captured. We consider a file as object file if its extension is `.o`, `.so` or
+`.a`.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -301,7 +301,10 @@ usage: CodeChecker log [-h] -o LOGFILE -b COMMAND [-q]
 
 Runs the given build command and records the executed compilation steps. These
 steps are written to the output file in a JSON format. Available build logger
-tool that will be used is '...'.
+tool that will be used is '...'. ld-logger can be fine-tuned with some
+environment variables. For details see the following documentation:
+https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/build-
+logger/README.md#usage
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -364,6 +367,11 @@ variable to a different file path.
 ```sh
 export CC_LOGGER_DEBUG_FILE="/path/to/codechecker.debug.log"
 ```
+
+With `CC_LOGGER_KEEP_LINK` environment variable you can set whether linking
+build actions (i.e. those which don't perform compilation but contain only
+object files as input) should be captured. For further details see
+[this documentation](/analyzer/tools/build-logger/README.md).
 
 
 ### Change user inside the build command


### PR DESCRIPTION
The documentation of LD_LOGGER_KEEP_LINK was missing.
Fixes #2617