### PR TITLE
[server] Fix printing product statuses

### DIFF
--- a/web/server/codechecker_server/cmd/server.py
+++ b/web/server/codechecker_server/cmd/server.py
@@ -429,7 +429,8 @@ def print_prod_status(prod_status):
         db_status_msg = database_status.db_status_msg.get(db_status)
         if schema_ver == package_ver:
             schema_ver += " (up to date)"
-        rows.append([k, db_status_msg, db_location, schema_ver, package_ver])
+        rows.append([k, db_status_msg, db_location, str(schema_ver),
+                     package_ver])
 
     prod_status = output_formatters.twodim_to_str('table',
                                                   header,


### PR DESCRIPTION
There is a problem with the server when we do the following:
- Start a web server by using postgresql database.
- Add a new product by using sqlite database.
- Remove the sqlite database.
- Restart the server.
- The following exception will be thrown:
```
output_formatters.py", line 114, in twodim_to_table
    str_parts.append(print_string.format(*line))
TypeError: unsupported format string passed to NoneType.__format__
```

The problem at here that the schema version will be None and we try to
print it in a format string: "{0:0}.format(schema_ver)". To solve this
problem we will convert the schema version to string before print.