### PR TITLE
[ldlogger] Allow more than 'CC_LOGGER_MAX_ARGS' in commands.

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-hooks.c
+++ b/analyzer/tools/build-logger/src/ldlogger-hooks.c
@@ -63,8 +63,25 @@ static void tryLog(
   const char* const filename_,
   char* const argv_[], ...)
 {
-  size_t i;
-  const char* loggerArgs[CC_LOGGER_MAX_ARGS];
+  size_t i,argCount,isOnHeap;
+  const char* staticLoggerArgs[CC_LOGGER_MAX_ARGS];
+  const char** largeLoggerArgs;
+  const char** loggerArgs;
+
+  for (i = 0,argCount = 0; argv_[i]; ++i)
+  {
+    argCount++;
+  }
+
+  isOnHeap = argCount >= (CC_LOGGER_MAX_ARGS - 1);
+
+  if(isOnHeap) {
+    largeLoggerArgs = (const char **) malloc(sizeof(char*) * (argCount + 2));
+    loggerArgs = largeLoggerArgs;
+  } else {
+    largeLoggerArgs = NULL;
+    loggerArgs = staticLoggerArgs;
+  }
 
   loggerArgs[0] = filename_;
   for (i = 0; argv_[i]; ++i)
@@ -74,6 +91,9 @@ static void tryLog(
   loggerArgs[i+1] = NULL;
 
   logExec(i+1, loggerArgs);
+
+  if(isOnHeap && largeLoggerArgs != NULL)
+	free(largeLoggerArgs);
 }
 
 __attribute__ ((visibility ("default"))) int execv(const char* filename_, char* const argv_[])

--- a/analyzer/tools/build-logger/src/ldlogger-hooks.c
+++ b/analyzer/tools/build-logger/src/ldlogger-hooks.c
@@ -21,8 +21,6 @@
 
 #include "ldlogger-hooks.h"
 
-#define CC_LOGGER_MAX_ARGS 4096
-
 #define CC_LOGGER_CALL_EXEC(funName_, arglist, ...) \
   tryLog(__VA_ARGS__); \
   { \
@@ -63,9 +61,7 @@ static void tryLog(
   const char* const filename_,
   char* const argv_[], ...)
 {
-  size_t i,argCount,isOnHeap;
-  const char* staticLoggerArgs[CC_LOGGER_MAX_ARGS];
-  const char** largeLoggerArgs;
+  size_t i,argCount;
   const char** loggerArgs;
 
   for (i = 0,argCount = 0; argv_[i]; ++i)
@@ -73,15 +69,7 @@ static void tryLog(
     argCount++;
   }
 
-  isOnHeap = argCount >= (CC_LOGGER_MAX_ARGS - 1);
-
-  if(isOnHeap) {
-    largeLoggerArgs = (const char **) malloc(sizeof(char*) * (argCount + 2));
-    loggerArgs = largeLoggerArgs;
-  } else {
-    largeLoggerArgs = NULL;
-    loggerArgs = staticLoggerArgs;
-  }
+  loggerArgs = (const char **) malloc(sizeof(char*) * (argCount + 2));
 
   loggerArgs[0] = filename_;
   for (i = 0; argv_[i]; ++i)
@@ -92,8 +80,7 @@ static void tryLog(
 
   logExec(i+1, loggerArgs);
 
-  if(isOnHeap && largeLoggerArgs != NULL)
-	free(largeLoggerArgs);
+  free(loggerArgs);
 }
 
 __attribute__ ((visibility ("default"))) int execv(const char* filename_, char* const argv_[])


### PR DESCRIPTION
Currently if the # of arguments is >= CC_LOGGER_MAX_ARGS, the logger segfaults.

This patch uses heap allocated array for arguments,
if the required count is more than CC_LOGGER_MAX_ARGS -1.

Otherwise the static array is utilised.