### PR TITLE
[store] Keep plist file valid when replacing report hash

### DIFF
--- a/tools/codechecker_report_hash/codechecker_report_hash/hash.py
+++ b/tools/codechecker_report_hash/codechecker_report_hash/hash.py
@@ -308,8 +308,7 @@ def replace_report_hash(plist_file, hash_type=HashType.CONTEXT_FREE):
                 report_hash = get_report_hash(diag, file_path, hash_type)
                 diag['issue_hash_content_of_line_in_context'] = report_hash
 
-            if plist['diagnostics']:
-                plistlib.dump(plist, pfile)
+            plistlib.dump(plist, pfile)
 
     except (TypeError, AttributeError) as err:
         LOG.warning('Failed to process plist file: %s wrong file format?',

--- a/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
+++ b/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
@@ -5,17 +5,15 @@
 # -----------------------------------------------------------------------------
 
 """ Unit tests for the CodeChecker report hash. """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import plistlib
 import unittest
 import shutil
+import tempfile
 
 from codechecker_report_hash.hash import get_report_hash, \
-    get_report_path_hash, HashType
+    get_report_path_hash, HashType, replace_report_hash
 
 
 class CodeCheckerReportHashTest(unittest.TestCase):
@@ -106,3 +104,19 @@ class CodeCheckerReportHashTest(unittest.TestCase):
             actual_report_hash = diag['issue_hash_content_of_line_in_context']
             self.assertEqual(path_hash,
                              expected_path_hash[actual_report_hash])
+
+    def test_replace_report_hash_in_empty_plist(self):
+        """ Test replacing hash in an empty plist file. """
+        with tempfile.NamedTemporaryFile("wb+",
+                                         suffix='.plist') as empty_plist_file:
+            content = {'diagnostics': [], 'files': []}
+            plistlib.dump(content, empty_plist_file)
+            empty_plist_file.flush()
+            empty_plist_file.seek(0)
+
+            replace_report_hash(empty_plist_file.name, HashType.CONTEXT_FREE)
+            empty_plist_file.flush()
+            empty_plist_file.seek(0)
+
+            # Check that plist file is not empty.
+            self.assertNotEqual(empty_plist_file.read(), b'')

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -232,6 +232,10 @@ def assemble_zip(inputs, zip_file, client):
 
         try:
             files, reports = plist_parser.parse_plist_file(plist_file)
+
+            if not reports:
+                return missing_files, source_file_mod_times
+
             # CppCheck generates a '0' value for the bug hash.
             # In case all of the reports in a plist file contain only
             # a hash with '0' value oeverwrite the hash values in the


### PR DESCRIPTION
- Do not call the replace_report_hash function when the plist file
does not contain any diagnostic.
- Keep the plist file valid when replacing report hash and the plist
file does not contain any diagnostic.
- Add new unit test case which test that the plist file will be valid
after calling the replace_report_hash function on it.