### PR TITLE
[server] Fix empty review status message

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1383,7 +1383,7 @@ class ThriftRequestHandler(object):
 
             review_status.status = review_status_str(status)
             review_status.author = user
-            review_status.message = message.encode('utf8')
+            review_status.message = message.encode('utf8') if message else b''
             review_status.date = datetime.now()
             session.add(review_status)
 

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -77,7 +77,7 @@ class TestReviewStatus(unittest.TestCase):
         success = self._cc_client.changeReviewStatus(
             bug.reportId,
             status,
-            '')
+            None)
 
         self.assertTrue(success)
         logging.debug("Bug review status changed successfully")


### PR DESCRIPTION
If we called the `changeReviewStatus` API function where the message
was `None` the server trown an error which said that we can not call
`encode` function on None. This commit will handle the use case when
no review status message is given for this API function.