### PR TITLE
[analyzer] Capture compiler errors as reports

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -335,6 +335,11 @@ def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
 
     LOG.debug("ZIP file written at '%s'", zip_file)
 
+    # In case of compiler errors the error message still needs to be collected
+    # from the standard output by this postprocess phase so we can present them
+    # as CodeChecker reports.
+    rh.postprocess_result()
+
     # Remove files that successfully analyzed earlier on.
     plist_file = result_base + ".plist"
     if os.path.exists(plist_file):

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -26,17 +26,21 @@ LOG = logger.get_logger('system')
 class SeverityMap(Mapping):
     """
     A dictionary which maps checker names to severity levels.
-    If a key is not found in the map and the checker name is a compiler warning
-    it will return severity level of MEDIUM.
+    If a key is not found in the map then it will return MEDIUM severity in
+    case of compiler warnings and CRITICAL in case of compiler errors.
     """
 
     def __init__(self, *args, **kwargs):
         self.store = dict(*args, **kwargs)
 
     def __getitem__(self, key):
-        # Key is not specified in the store and it is a compiler warning.
-        if key not in self.store and key.startswith('clang-diagnostic-'):
-            return "MEDIUM"
+        # Key is not specified in the store and it is a compiler warning
+        # or error.
+        if key not in self.store:
+            if key == 'clang-diagnostic-error':
+                return "CRITICAL"
+            elif key.startswith('clang-diagnostic-'):
+                return "MEDIUM"
 
         return self.store[key] if key in self.store else 'UNSPECIFIED'
 

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -480,7 +480,7 @@ disabled flags starting from the bigger groups and going inwards, e.g.
 certain checkers - such as the 'core' group - is unsupported by the LLVM/Clang
 community, and thus discouraged.
 
-Compiler warnings
+Compiler warnings and errors
 ------------------------------------------------
 Compiler warnings are diagnostic messages that report constructions that are
 not inherently erroneous but that are risky or suggest there may have been an
@@ -493,7 +493,13 @@ enable every 'unused' warnings except 'unused-parameter'. These flags should
 start with a capital 'W' or 'Wno-' prefix followed by the waning name (E.g.:
 '-e Wliteral-conversion', '-d Wno-literal-conversion'). By default '-Wall' and
 '-Wextra' warnings are enabled. For more information see:
-https://clang.llvm.org/docs/DiagnosticsReference.html.""")
+https://clang.llvm.org/docs/DiagnosticsReference.html.
+Sometimes GCC is more permissive than Clang, so it is possible that a specific
+construction doesn't compile with Clang but compiles with GCC. These
+compiler errors are also collected as CodeChecker reports as
+'clang-diagnostic-error'.
+Note that compiler errors and warnings are captured by CodeChecker only if it
+was emitted by clang-tidy.""")
 
     checkers_opts.add_argument('-e', '--enable',
                                dest="enable",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -508,7 +508,7 @@ disabled flags starting from the bigger groups and going inwards, e.g.
 certain checkers - such as the 'core' group - is unsupported by the LLVM/Clang
 community, and thus discouraged.
 
-Compiler warnings
+Compiler warnings and errors
 ------------------------------------------------
 Compiler warnings are diagnostic messages that report constructions that are
 not inherently erroneous but that are risky or suggest there may have been an
@@ -521,7 +521,13 @@ enable every 'unused' warnings except 'unused-parameter'. These flags should
 start with a capital 'W' or 'Wno-' prefix followed by the waning name (E.g.:
 '-e Wliteral-conversion', '-d Wno-literal-conversion'). By default '-Wall' and
 '-Wextra' warnings are enabled. For more information see:
-https://clang.llvm.org/docs/DiagnosticsReference.html.""")
+https://clang.llvm.org/docs/DiagnosticsReference.html.
+Sometimes GCC is more permissive than Clang, so it is possible that a specific
+construction doesn't compile with Clang but compiles with GCC. These
+compiler errors are also collected as CodeChecker reports as
+'clang-diagnostic-error'.
+Note that compiler errors and warnings are captured by CodeChecker only if it
+was emitted by clang-tidy.""")
 
     checkers_opts.add_argument('-e', '--enable',
                                dest="enable",

--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -29,6 +29,8 @@ compiler_warning_wno_group:
 	$(CXX) -w compiler_warning.cpp -Wno-unused -o /dev/null
 compiler_warning_unused:
 	$(CXX) -w compiler_warning.cpp -Wunused -o /dev/null
+compiler_error:
+	$(CXX) -w compiler_error.cpp -o /dev/null
 context_hash:
 	$(CXX) -w context_hash.cpp -o /dev/null
 collision:

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error.output
@@ -1,0 +1,37 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make compiler_error" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy --quiet
+NORMAL#CodeChecker parse $OUTPUT$
+--------------------------------------------------------------------------------
+[] - Starting static analysis ...
+[] - Analyzing compiler_error.cpp with clang-tidy  failed!
+[] - ----==== Summary ====----
+[] - Failed to analyze
+[] -   clang-tidy: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[CRITICAL] compiler_error.cpp:3:11: expected ';' after return statement [clang-diagnostic-error]
+  return 0
+          ^
+
+Found 1 defect(s) in compiler_error.cpp
+
+
+----==== Summary ====----
+---------------------------------
+Filename           | Report count
+---------------------------------
+compiler_error.cpp |            1
+---------------------------------
+-----------------------
+Severity | Report count
+-----------------------
+CRITICAL |            1
+-----------------------
+----=================----
+Total number of reports: 1
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash_clang_tidy.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/context_sensitive_hash_clang_tidy.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make context_hash" --quiet
 NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy
 NORMAL#CodeChecker parse $OUTPUT$ --print-steps
-CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --print-steps --analyer clang-tidy
+CHECK#CodeChecker check --build "make context_hash" --output $OUTPUT$ --quiet --print-steps --analyzers clang-tidy
 --------------------------------------------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -250,7 +250,7 @@ checker configuration:
   checkers in the "core" package is unsupported by the Clang Static Analyzer,
   so they will remain switched on, regardless of the settings.
 
-  Compiler warnings
+  Compiler warnings and errors
   ------------------------------------------------
   Compiler warnings are diagnostic messages that report constructions that are
   not inherently erroneous but that are risky or suggest there may have been an
@@ -264,6 +264,12 @@ checker configuration:
   '-e Wliteral-conversion', '-d Wno-literal-conversion'). By default '-Wall' and
   '-Wextra' warnings are enabled. For more information see:
   https://clang.llvm.org/docs/DiagnosticsReference.html.
+  Sometimes GCC is more permissive than Clang, so it is possible that a specific
+  construction doesn't compile with Clang but compiles with GCC. These
+  compiler errors are also collected as CodeChecker reports as
+  'clang-diagnostic-error'.
+  Note that compiler errors and warnings are captured by CodeChecker only if it
+  was emitted by clang-tidy.
 
   -e checker/group/profile, --enable checker/group/profile
                         Set a checker (or checker group) to BE USED in the
@@ -929,6 +935,13 @@ or you can use the positive form beginning with `W` (e.g.:
 https://clang.llvm.org/docs/DiagnosticsReference.html.
 
 **Note**: by default `-Wall` and `-Wextra` warnings are enabled.
+
+**Node**: In case a file with a compilation error is analyzed then its
+diagnostics appear as `clang-diagnostic-error`. This doesn't refer to a
+compiler warning, but a compilation action which can't be disabled. You can fix
+this only by modifying the source code so it compiles with Clang compiler.
+The `clang-diagnostic-error` reports will always be visible with "critical"
+severity.
 
 
 #### Checker profiles <a name="checker-profiles"></a>

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -158,7 +158,6 @@ def __gather_dependencies(command, build_dir):
     compiler = __determine_compiler(command)
     command = [compiler, '-E', '-M', '-MT', '__dummy'] \
         + command[command.index(compiler) + 1:]
-    print(command)
 
     # Remove empty arguments
     command = [i for i in command if i]

--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -21,17 +21,21 @@ LOG = logger.get_logger('system')
 class SeverityMap(Mapping):
     """
     A dictionary which maps checker names to severity levels.
-    If a key is not found in the map and the checker name is a compiler warning
-    it will return severity level of MEDIUM.
+    If a key is not found in the map then it will return MEDIUM severity in
+    case of compiler warnings and CRITICAL in case of compiler errors.
     """
 
     def __init__(self, *args, **kwargs):
         self.store = dict(*args, **kwargs)
 
     def __getitem__(self, key):
-        # Key is not specified in the store and it is a compiler warning.
-        if key not in self.store and key.startswith('clang-diagnostic-'):
-            return "MEDIUM"
+        # Key is not specified in the store and it is a compiler warning
+        # or error.
+        if key not in self.store:
+            if key == 'clang-diagnostic-error':
+                return "CRITICAL"
+            elif key.startswith('clang-diagnostic-'):
+                return "MEDIUM"
 
         return self.store[key] if key in self.store else 'UNSPECIFIED'
 


### PR DESCRIPTION
There are some constructions which GCC compiles but Clang gives a
compilation error. In case such a compilation error happens, then the
whole translation unit is not analyzed and the users may not be informed
about this. By this change compiler errors also become CodeChecker
reports.