### PR TITLE
[server] Fix failed to remove temp directory on server shutdown

### DIFF
--- a/bin/CodeChecker
+++ b/bin/CodeChecker
@@ -81,7 +81,7 @@ def main(subcommand=None):
         try:
             shutil.rmtree(tmp_dir)
         except Exception as ex:
-            if type(ex) != OSError or ex.errno != errno.ENOENT:
+            if not isinstance(ex, OSError) or ex.errno != errno.ENOENT:
                 print('Failed to remove temporary directory: ' + tmp_dir)
                 print('Manual cleanup is required.')
                 print(ex)


### PR DESCRIPTION
Steps to reproduce the problem:
- Start a CodeChecker server
- Stop it by using `Ctrl + C` commands.
- An error message will be printed which says that it failed to remove
temporary directory and manual cleanup is required.

The problem at here that the `_remove_tmp` will be called twice. When it
will be called on the second time, an exception will be thrown because
the file already has been removed. In Python2 an `OSError` was thrown but
in Python3 a `FileNotFoundError` exception will be thrown which inherits
from `OSError`. For this reason we should use `isinstance` to check the
type.