### PR TITLE
[doc] Remove template scripts section from gerrit docs

### DIFF
--- a/docs/jenkins_gerrit_integration.md
+++ b/docs/jenkins_gerrit_integration.md
@@ -29,7 +29,6 @@ Table of Contents
 =================
 * [Gerrit requirements](#gerrit-requirements)
 * [Jenkins requirements](#jenkins-requirements)
-* [Template Scripts](#template-scripts)
 * [Gerrit Trigger plugin setup](#gerrit-plugin-setup)
 * [Configuring the Jenkins job](#configuring-the-jenkins-job)
     * [Source Code Managament](#jenkins-source-code-management)
@@ -69,15 +68,6 @@ Requirements of the Jenkins machine
 * Python >= 2.7
 * Access to Gerrit (i.e. proper firewall settings)
 
-# Template scripts <a name="template-scripts"></a>
-
-You can find template scripts
-in the [/scripts/gerrit_jenkins](/scripts/gerrit_jenkins) directory:
-
-* [create_skipfile.py](/scripts/gerrit_jenkins/create_skipfile.py): Converts
-Gerrit Review changed files `json` to CodeChecker skipfile.
-* [parse_output_parser.py](/scripts/gerrit_jenkins/parse_output_parser.py):
-Generates Gerrit Review json' from CodeChecker parse\'s output. 
 
 # Gerrit Trigger plugin setup <a name="gerrit-plugin-setup"></a>
 If Gerrit Trigger plugin is installed correctly, its settings


### PR DESCRIPTION
> Closes #2667

Template scripts are removed when we implemented the gerrit output format
support for CodeChecker cmd diff command but the userguide still mentioned
these files. This commit will remove this section from the user guide.