### PR TITLE
open plist file in binary mode

### DIFF
--- a/analyzer/tests/unit/test_remove_report_from_plist.py
+++ b/analyzer/tests/unit/test_remove_report_from_plist.py
@@ -52,7 +52,7 @@ class TestRemoveReportFromPlist(unittest.TestCase):
                   encoding="utf-8", errors="ignore") as skip_file:
             skip_handler = skiplist_handler.SkipListHandler(skip_file.read())
 
-        with open('x.plist', 'r') as plist_data:
+        with open('x.plist', 'rb') as plist_data:
             data = remove_report_from_plist(plist_data, skip_handler)
 
         with open('skip_all_header.expected.plist', 'rb') as plist_file:


### PR DESCRIPTION
If the builtin plistlib is used (because lxml is missing)
to parse the plist files it expects that the files will be open
in binary mode.