### PR TITLE
[analyzer] Compiler errors as reports can be disabled.

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -29,6 +29,7 @@ from codechecker_common.logger import get_logger
 from . import gcc_toolchain
 
 from .analyzers import analyzer_types
+from .analyzers.config_handler import CheckerState
 from .analyzers.clangsa.analyzer import ClangSA
 from .analyzers.clangsa.statistics_collector import SpecialReturnValueCollector
 
@@ -323,7 +324,10 @@ def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
     # In case of compiler errors the error message still needs to be collected
     # from the standard output by this postprocess phase so we can present them
     # as CodeChecker reports.
-    rh.postprocess_result()
+    checks = source_analyzer.config_handler.checks()
+    state = checks.get('clang-diagnostic-error', (CheckerState.default, ''))[0]
+    if state != CheckerState.disabled:
+        rh.postprocess_result()
 
     # Remove files that successfully analyzed earlier on.
     plist_file = result_base + ".plist"

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
@@ -27,7 +27,8 @@ class ClangTidyConfigHandler(config_handler.AnalyzerConfigHandler):
         """
         Enable checker, keep description if already set.
         """
-        if checker_name.startswith("Wno-") or checker_name.startswith("W"):
+        if checker_name.startswith('W') or \
+           checker_name.startswith('clang-diagnostic-'):
             self.add_checker(checker_name)
 
         super(ClangTidyConfigHandler, self).set_checker_enabled(checker_name,

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error_disabled.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_error_disabled.output
@@ -1,0 +1,21 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make compiler_error" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy --quiet --disable clang-diagnostic-error
+NORMAL#CodeChecker parse $OUTPUT$
+--------------------------------------------------------------------------------
+[] - Starting static analysis ...
+[] - Analyzing compiler_error.cpp with clang-tidy  failed!
+[] - ----==== Summary ====----
+[] - Failed to analyze
+[] -   clang-tidy: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+
+----==== Summary ====----
+----=================----
+Total number of reports: 0
+----=================----

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -934,14 +934,14 @@ or you can use the positive form beginning with `W` (e.g.:
 `--enable Wliteral-conversion`). For more information see:
 https://clang.llvm.org/docs/DiagnosticsReference.html.
 
-**Note**: by default `-Wall` and `-Wextra` warnings are enabled.
+A warning can be referred in both formats: `-d Wunused-parameter` and
+`-d clang-diagnostic-unused-parameter` are the same.
 
-**Node**: In case a file with a compilation error is analyzed then its
-diagnostics appear as `clang-diagnostic-error`. This doesn't refer to a
-compiler warning, but a compilation action which can't be disabled. You can fix
-this only by modifying the source code so it compiles with Clang compiler.
-The `clang-diagnostic-error` reports will always be visible with "critical"
-severity.
+`clang-diagnostic-error` is a special one, since it doesn't refer a warning but
+a compilation error. This is enabled by default and will be stored as a
+critical severity bug.
+
+**Note**: by default `-Wall` and `-Wextra` warnings are enabled.
 
 
 #### Checker profiles <a name="checker-profiles"></a>


### PR DESCRIPTION
In an earlier commit (#2652) a new feature has been introduced: compiler
errors can be captured as CodeChecker reports. The corresponding checker
name is clang-diagnostic-error. This type of report couldn't have been
disabled. In this commit these can be disabled too.

Warnings can be enabled and disabled as CodeChecker reports as well. For
example the warning about unused variables can be disabled by
-d Wunused-variable. This warning is captured as
clang-diagnostic-unused-variable and now this can be also disabled as
-d clang-diagnostic-unused-variable.