### PR TITLE
for plistlib the file needs to be opened in binary mode

### DIFF
--- a/analyzer/tests/unit/test_remove_report_from_plist.py
+++ b/analyzer/tests/unit/test_remove_report_from_plist.py
@@ -66,7 +66,7 @@ class TestRemoveReportFromPlist(unittest.TestCase):
                   encoding="utf-8", errors="ignore") as skip_file:
             skip_handler = skiplist_handler.SkipListHandler(skip_file.read())
 
-        with open('x.plist', 'r') as plist_data:
+        with open('x.plist', 'rb') as plist_data:
             data = remove_report_from_plist(plist_data, skip_handler)
 
         with open('keep_only_empty.expected.plist', 'rb') as plist_file:


### PR DESCRIPTION
Without lxml in plistlib the plist parsing will fail
if the plist file was not opened in binary mode.