### PR TITLE
[cmd] Support Code Climate format for parse command

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -246,6 +246,31 @@ class AnalyzeParseTestCase(
         self.assertIn('notes', res)
         self.assertTrue(res['notes'])
 
+    def test_codeclimate_output(self):
+        """ Test parse codeclimate output. """
+        test_project_notes = os.path.join(self.test_workspaces['NORMAL'],
+                                          "test_files", "notes")
+        extract_cmd = ['CodeChecker', 'parse', "-e", "codeclimate",
+                       test_project_notes,
+                       '--trim-path-prefix', test_project_notes]
+
+        out, _ = call_command(extract_cmd, cwd=self.test_dir, env=self.env)
+        res = json.loads(out)
+
+        self.assertEqual(res, [{
+            'type': 'issue',
+            'check_name': 'alpha.clone.CloneChecker',
+            'description': 'Duplicate code detected',
+            'categories': ['Bug Risk'],
+            'fingerprint': '3d15184f38c5fa57e479b744fe3f5035',
+            'location': {
+                'path': 'notes.cpp',
+                'lines': {
+                    'begin': 3
+                }
+            }
+        }])
+
     def test_invalid_plist_file(self):
         """ Test parsing invalid plist file. """
         invalid_plist_file = os.path.join(self.test_workspaces['NORMAL'],

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1064,9 +1064,10 @@ Statistics analysis feature arguments:
 `parse` prints analysis results to the standard output.
 
 ```
-usage: CodeChecker parse [-h] [-t {plist}] [-e {html,json}] [-o OUTPUT_PATH]
-                         [-c] [--suppress SUPPRESS] [--export-source-suppress]
-                         [--print-steps] [-i SKIPFILE]
+usage: CodeChecker parse [-h] [-t {plist}] [-e {html,json,codeclimate}]
+                         [-o OUTPUT_PATH] [-c] [--suppress SUPPRESS]
+                         [--export-source-suppress] [--print-steps]
+                         [-i SKIPFILE]
                          [--trim-path-prefix [TRIM_PATH_PREFIX [TRIM_PATH_PREFIX ...]]]
                          [--verbose {info,debug,debug_analyzer}]
                          file/folder [file/folder ...]
@@ -1114,8 +1115,12 @@ optional arguments:
                         Set verbosity level.
 
 export arguments:
-  -e {html,json}, --export {html,json}
-                        Specify extra output format type. (default: None)
+  -e {html,json,codeclimate}, --export {html,json,codeclimate}
+                        Specify extra output format type.
+                        'codeclimate' format can be used for Code Climate and
+                        for GitLab integration. For more information see:
+                        https://github.com/codeclimate/platform/blob/master/sp
+                        ec/analyzers/SPEC.md#data-types (default: None)
   -o OUTPUT_PATH, --output OUTPUT_PATH
                         Store the output in the given folder.
   -c, --clean           DEPRECATED. Delete output results stored in the output


### PR DESCRIPTION
> Part of the #2661.

Introducing `codeclimate` json output format for the `CodeChecker parse` command
which will make the CodeChecker Gitlab integration much easier.