### PR TITLE
[report-converter] Write metada info into the plist files

### DIFF
--- a/tools/report-converter/codechecker_report_converter/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/__init__.py
@@ -3,3 +3,6 @@
 #   This file is distributed under the University of Illinois Open Source
 #   License. See LICENSE.TXT for details.
 # -------------------------------------------------------------------------
+
+__title__ = "report-converter"
+__version__ = "0.1.0"

--- a/tools/report-converter/setup.py
+++ b/tools/report-converter/setup.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 
 import setuptools
+import codechecker_report_converter
 
 with open("README.md", "r", encoding="utf-8", errors="ignore") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="report-converter",
-    version="0.1.0",
+    name=codechecker_report_converter.__title__,
+    version=codechecker_report_converter.__version__,
     author='CodeChecker Team (Ericsson)',
     description="Parse and create HTML files from one or more '.plist' "
                 "result files.",

--- a/tools/report-converter/tests/unit/asan_output_test_files/asan.plist
+++ b/tools/report-converter/tests/unit/asan_output_test_files/asan.plist
@@ -91,5 +91,20 @@
 	<array>
 		<string>files/asan.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>asan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/cppcheck_output_test_files/divide_zero.expected.plist
+++ b/tools/report-converter/tests/unit/cppcheck_output_test_files/divide_zero.expected.plist
@@ -60,5 +60,20 @@
   </dict>
   </dict>
  </array>
+ <key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>cppcheck</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/eslint_output_test_files/reports.expected.plist
+++ b/tools/report-converter/tests/unit/eslint_output_test_files/reports.expected.plist
@@ -214,5 +214,20 @@
 	<array>
 		<string>files/index.js</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>eslint</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/golint_output_test_files/simple.expected.plist
+++ b/tools/report-converter/tests/unit/golint_output_test_files/simple.expected.plist
@@ -91,5 +91,20 @@
 	<array>
 		<string>files/simple.go</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>golint</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/infer_output_test_files/NullDereference.java.plist
+++ b/tools/report-converter/tests/unit/infer_output_test_files/NullDereference.java.plist
@@ -304,5 +304,20 @@
 	<array>
 		<string>files/NullDereference.java</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>fbinfer</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/infer_output_test_files/dead_store.cpp.plist
+++ b/tools/report-converter/tests/unit/infer_output_test_files/dead_store.cpp.plist
@@ -69,5 +69,20 @@
 	<array>
 		<string>files/dead_store.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>fbinfer</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/msan_output_test_files/msan.plist
+++ b/tools/report-converter/tests/unit/msan_output_test_files/msan.plist
@@ -90,5 +90,20 @@
 	<array>
 		<string>files/msan.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>msan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/pyflakes_output_test_files/simple.expected.plist
+++ b/tools/report-converter/tests/unit/pyflakes_output_test_files/simple.expected.plist
@@ -132,5 +132,20 @@
 	<array>
 		<string>files/simple.py</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>pyflakes</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/pylint_output_test_files/simple.expected.plist
+++ b/tools/report-converter/tests/unit/pylint_output_test_files/simple.expected.plist
@@ -255,5 +255,20 @@
 	<array>
 		<string>files/simple.py</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>pylint</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.plist
+++ b/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.plist
@@ -257,5 +257,20 @@
 	<array>
 		<string>files/Assign.java</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>spotbugs</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/test_asan_parser.py
+++ b/tools/report-converter/tests/unit/test_asan_parser.py
@@ -64,6 +64,9 @@ class ASANAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = 'files/asan.cpp'
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         self.assertEqual(res, exp)
 
 

--- a/tools/report-converter/tests/unit/test_clang_tidy_parser.py
+++ b/tools/report-converter/tests/unit/test_clang_tidy_parser.py
@@ -362,6 +362,9 @@ class ClangTidyAnalyzerResultTestCase(unittest.TestCase):
         with open(expected_plist, mode='rb') as pfile:
             exp = plistlib.load(pfile)
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         self.assertEqual(res, exp)
 
     def test_empty1(self):

--- a/tools/report-converter/tests/unit/test_cppcheck_parser.py
+++ b/tools/report-converter/tests/unit/test_cppcheck_parser.py
@@ -61,6 +61,9 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'divide_zero.expected.plist')
         with open(plist_file, mode='rb') as pfile:
@@ -77,6 +80,9 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
                                   'divide_zero_cppcheck.plist')
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
+
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
 
         plist_file = os.path.join(self.test_files,
                                   'divide_zero.expected.plist')

--- a/tools/report-converter/tests/unit/test_eslint_parser.py
+++ b/tools/report-converter/tests/unit/test_eslint_parser.py
@@ -65,6 +65,9 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = os.path.join('files', 'index.js')
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'reports.expected.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_golint_parser.py
+++ b/tools/report-converter/tests/unit/test_golint_parser.py
@@ -65,6 +65,9 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = os.path.join('files', 'simple.go')
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'simple.expected.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_infer_parser.py
+++ b/tools/report-converter/tests/unit/test_infer_parser.py
@@ -63,6 +63,9 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'dead_store.cpp.plist')
         with open(plist_file, mode='rb') as pfile:
@@ -84,6 +87,9 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                   'dead_store.cpp_fbinfer.plist')
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
+
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
 
         plist_file = os.path.join(self.test_files,
                                   'dead_store.cpp.plist')
@@ -107,6 +113,9 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'NullDereference.java.plist')
         with open(plist_file, mode='rb') as pfile:
@@ -129,6 +138,9 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
 
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
+
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
 
         plist_file = os.path.join(self.test_files,
                                   'NullDereference.java.plist')

--- a/tools/report-converter/tests/unit/test_msan_parser.py
+++ b/tools/report-converter/tests/unit/test_msan_parser.py
@@ -65,6 +65,9 @@ class MSANPListConverterTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = 'files/msan.cpp'
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         self.assertEqual(res, exp)
 
 

--- a/tools/report-converter/tests/unit/test_pyflakes_parser.py
+++ b/tools/report-converter/tests/unit/test_pyflakes_parser.py
@@ -65,6 +65,9 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = os.path.join('files', 'simple.py')
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'simple.expected.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_pylint_parser.py
+++ b/tools/report-converter/tests/unit/test_pylint_parser.py
@@ -65,6 +65,9 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = os.path.join('files', 'simple.py')
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'simple.expected.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_spotbugs_parser.py
+++ b/tools/report-converter/tests/unit/test_spotbugs_parser.py
@@ -77,6 +77,9 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
         with open(plist_file, mode='rb') as pfile:
             res = plistlib.load(pfile)
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'assign.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_tsan_parser.py
+++ b/tools/report-converter/tests/unit/test_tsan_parser.py
@@ -65,6 +65,9 @@ class TSANAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = 'files/tsan.cpp'
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         self.assertEqual(res, exp)
 
 

--- a/tools/report-converter/tests/unit/test_tslint_parser.py
+++ b/tools/report-converter/tests/unit/test_tslint_parser.py
@@ -65,6 +65,9 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'][0] = os.path.join('files', 'index.ts')
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         plist_file = os.path.join(self.test_files,
                                   'reports.expected.plist')
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/test_ubsan_parser.py
+++ b/tools/report-converter/tests/unit/test_ubsan_parser.py
@@ -64,6 +64,9 @@ class UBSANPListConverterTestCase(unittest.TestCase):
             # Use relative path for this test.
             res['files'] = source_files
 
+            self.assertTrue(res['metadata']['generated_by']['version'])
+            res['metadata']['generated_by']['version'] = "x.y.z"
+
         with open(expected_plist, mode='rb') as pfile:
             exp = plistlib.load(pfile)
 

--- a/tools/report-converter/tests/unit/tidy_output_test_files/tidy1.plist
+++ b/tools/report-converter/tests/unit/tidy_output_test_files/tidy1.plist
@@ -108,5 +108,20 @@
 	<array>
 		<string>files/test.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>clang-tidy</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/tidy_output_test_files/tidy2.plist
+++ b/tools/report-converter/tests/unit/tidy_output_test_files/tidy2.plist
@@ -270,5 +270,20 @@
 	<array>
 		<string>files/test2.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>clang-tidy</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/tidy_output_test_files/tidy3_cpp.plist
+++ b/tools/report-converter/tests/unit/tidy_output_test_files/tidy3_cpp.plist
@@ -67,5 +67,20 @@
 	<array>
 		<string>files/test3.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>clang-tidy</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/tidy_output_test_files/tidy3_hh.plist
+++ b/tools/report-converter/tests/unit/tidy_output_test_files/tidy3_hh.plist
@@ -360,5 +360,20 @@
 		<string>files/test3.hh</string>
 		<string>files/test3.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>clang-tidy</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/tsan_output_test_files/tsan.plist
+++ b/tools/report-converter/tests/unit/tsan_output_test_files/tsan.plist
@@ -157,5 +157,20 @@
 	<array>
 		<string>files/tsan.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>tsan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/tslint_output_test_files/reports.expected.plist
+++ b/tools/report-converter/tests/unit/tslint_output_test_files/reports.expected.plist
@@ -91,5 +91,20 @@
 	<array>
 		<string>files/index.ts</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>tslint</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/ubsan_output_test_files/ubsan1.plist
+++ b/tools/report-converter/tests/unit/ubsan_output_test_files/ubsan1.plist
@@ -50,5 +50,20 @@
 	<array>
 		<string>files/ubsan1.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>ubsan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/tools/report-converter/tests/unit/ubsan_output_test_files/ubsan2.plist
+++ b/tools/report-converter/tests/unit/ubsan_output_test_files/ubsan2.plist
@@ -91,5 +91,20 @@
 	<array>
 		<string>files/ubsan2.cpp</string>
 	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>ubsan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Write the following metada information to the plist files created by the
`report-converter` tool:
- analyzer name
- name and version number of the tool which generated the plist files.