### PR TITLE
[clang-tidy] Display errors from all non-system headers

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -167,7 +167,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.extend(config.analyzer_extra_arguments)
 
-            if config.checker_config != '{}':
+            if config.checker_config and config.checker_config != '{}':
                 analyzer_cmd.append('-config=' + config.checker_config)
 
             analyzer_cmd.append(self.source_file)
@@ -345,7 +345,11 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                 # No clang tidy config file was given in the command line.
                 LOG.debug_analyzer(aerr)
 
-        if not handler.checker_config:
+        # 'take-config-from-directory' is a special option which let the user
+        # to use the '.clang-tidy' config files. It will disable analyzer and
+        # checker configuration options.
+        if not handler.checker_config and \
+                analyzer_config.get('take-config-from-directory') != 'true':
             handler.checker_config = json.dumps(analyzer_config)
 
         check_env = env.extend(context.path_env_extra,

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -347,7 +347,11 @@ def add_arguments_to_parser(parser):
                                     "The collection of the options can be "
                                     "printed with "
                                     "'CodeChecker analyzers "
-                                    "--analyzer-config'.")
+                                    "--analyzer-config'. To disable the "
+                                    "default behaviour of this option you can "
+                                    "use the "
+                                    "'clang-tidy:take-config-from-directory="
+                                    "true' option.")
 
     analyzer_opts.add_argument('--checker-config',
                                dest='checker_config',

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -341,7 +341,7 @@ def add_arguments_to_parser(parser):
     analyzer_opts.add_argument('--analyzer-config',
                                dest='analyzer_config',
                                nargs='*',
-                               default=argparse.SUPPRESS,
+                               default=["clang-tidy:HeaderFilterRegex=.*"],
                                help="Analyzer configuration options in the "
                                     "following format: analyzer:key=value. "
                                     "The collection of the options can be "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -356,7 +356,7 @@ used to generate a log file on the fly.""")
     analyzer_opts.add_argument('--analyzer-config',
                                dest='analyzer_config',
                                nargs='*',
-                               default=argparse.SUPPRESS,
+                               default=["clang-tidy:HeaderFilterRegex=.*"],
                                help="Analyzer configuration options in the "
                                     "forllowing format: analyzer:key=value. "
                                     "The collection of the options can be "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -358,11 +358,15 @@ used to generate a log file on the fly.""")
                                nargs='*',
                                default=["clang-tidy:HeaderFilterRegex=.*"],
                                help="Analyzer configuration options in the "
-                                    "forllowing format: analyzer:key=value. "
+                                    "following format: analyzer:key=value. "
                                     "The collection of the options can be "
                                     "printed with "
                                     "'CodeChecker analyzers "
-                                    "--analyzer-config'.")
+                                    "--analyzer-config'. To disable the "
+                                    "default behaviour of this option you can "
+                                    "use the "
+                                    "'clang-tidy:take-config-from-directory="
+                                    "true' option.")
 
     analyzer_opts.add_argument('--checker-config',
                                dest='checker_config',

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -228,7 +228,8 @@ analyzer arguments:
                         Analyzer configuration options in the following format:
                         analyzer:key=value. The collection of the options can
                         be printed with 'CodeChecker analyzers
-                        --analyzer-config'.
+                        --analyzer-config'. (default: ['clang-
+                        tidy:HeaderFilterRegex=.*'])
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:
                         analyzer:key=value. The collection of the options can
@@ -818,7 +819,8 @@ analyzer arguments:
                         Analyzer configuration options in the following format:
                         analyzer:key=value. The collection of the options can
                         be printed with 'CodeChecker analyzers
-                        --analyzer-config'.
+                        --analyzer-config'. (default: ['clang-
+                        tidy:HeaderFilterRegex=.*'])
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:
                         analyzer:key=value. The collection of the options can

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -225,10 +225,12 @@ analyzer arguments:
                         'CodeChecker analyzers --dump-config clang-tidy'
                         command.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
-                        Analyzer configuration options in the following format:
-                        analyzer:key=value. The collection of the options can
-                        be printed with 'CodeChecker analyzers
-                        --analyzer-config'. (default: ['clang-
+                        Analyzer configuration options in the following
+                        format: analyzer:key=value. The collection of the
+                        options can be printed with 'CodeChecker analyzers
+                        --analyzer-config'. To disable the default behaviour
+                        of this option you can use the 'clang-tidy:take-
+                        config-from-directory=true' option. (default: ['clang-
                         tidy:HeaderFilterRegex=.*'])
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:
@@ -816,10 +818,12 @@ analyzer arguments:
                         'CodeChecker analyzers --dump-config clang-tidy'
                         command.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
-                        Analyzer configuration options in the following format:
-                        analyzer:key=value. The collection of the options can
-                        be printed with 'CodeChecker analyzers
-                        --analyzer-config'. (default: ['clang-
+                        Analyzer configuration options in the following
+                        format: analyzer:key=value. The collection of the
+                        options can be printed with 'CodeChecker analyzers
+                        --analyzer-config'. To disable the default behaviour
+                        of this option you can use the 'clang-tidy:take-
+                        config-from-directory=true' option. (default: ['clang-
                         tidy:HeaderFilterRegex=.*'])
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -377,6 +377,7 @@ int main()
         # as OFF.
         cfg = dict(self._codechecker_cfg)
         cfg['checkers'] = ['-d', 'modernize']
+        cfg['analyzer_config'] = ['clang-tidy:take-config-from-directory=true']
 
         self._create_source_file(1)
         self._create_clang_tidy_cfg_file(['-*', 'hicpp-*', 'modernize-*'])

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -66,6 +66,7 @@ class TestReportFilter(unittest.TestCase):
              'core.StackAddrEscapeBase': 3,
              'cplusplus.NewDelete': 5,
              'deadcode.DeadStores': 6,
+             'misc-definitions-in-headers': 2,
              'unix.Malloc': 1}
 
         self.run2_checkers = \
@@ -74,22 +75,23 @@ class TestReportFilter(unittest.TestCase):
              'core.NullDereference': 4,
              'cplusplus.NewDelete': 5,
              'deadcode.DeadStores': 6,
+             'misc-definitions-in-headers': 2,
              'unix.MismatchedDeallocator': 1}
 
         self.run1_sev_counts = {Severity.UNSPECIFIED: 3,
-                                Severity.MEDIUM: 1,
+                                Severity.MEDIUM: 3,
                                 Severity.LOW: 6,
                                 Severity.HIGH: 24}
 
-        self.run2_sev_counts = {Severity.MEDIUM: 1,
+        self.run2_sev_counts = {Severity.MEDIUM: 3,
                                 Severity.LOW: 6,
                                 Severity.HIGH: 24}
 
         self.run1_detection_counts = \
-            {DetectionStatus.NEW: 34}
+            {DetectionStatus.NEW: 36}
 
         self.run2_detection_counts = \
-            {DetectionStatus.NEW: 31}
+            {DetectionStatus.NEW: 33}
 
         self.run1_files = \
             {'file_to_be_skipped.cpp': 2,
@@ -101,9 +103,9 @@ class TestReportFilter(unittest.TestCase):
              'divide_zero_duplicate.cpp': 2,
              'has a space.cpp': 1,
              'skip_header.cpp': 1,
-             'skip.h': 1,
+             'skip.h': 2,
              'path_begin.cpp': 2,
-             'path_end.h': 2
+             'path_end.h': 3
              }
 
         self.run2_files = \
@@ -115,9 +117,9 @@ class TestReportFilter(unittest.TestCase):
              'file_to_be_skipped.cpp': 2,
              'has a space.cpp': 1,
              'skip_header.cpp': 1,
-             'skip.h': 1,
+             'skip.h': 2,
              'path_begin.cpp': 2,
-             'path_end.h': 2
+             'path_end.h': 3
              }
 
     def test_run1_all_checkers(self):
@@ -525,6 +527,7 @@ class TestReportFilter(unittest.TestCase):
                'core.NullDereference': 4,
                'core.DivideZero': 10,
                'deadcode.DeadStores': 6,
+               'misc-definitions-in-headers': 2,
                'unix.Malloc': 1}
         self.assertDictEqual(new, checkers_dict)
 

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -212,7 +212,7 @@ class TestReportFilter(unittest.TestCase):
                                                              None,
                                                              None)
 
-        self.assertEqual(run_result_count, 65)
+        self.assertEqual(run_result_count, 69)
 
         run_results = self._cc_client.getRunResults(self._runids,
                                                     run_result_count,

--- a/web/tests/functional/skip/__init__.py
+++ b/web/tests/functional/skip/__init__.py
@@ -132,7 +132,7 @@ def _generate_skip_list_file(skip_list_file):
     """
     skip_list_content = ["-*randtable.c", "-*blocksort.c", "-*huffman.c",
                          "-*decompress.c", "-*crctable.c",
-                         "-*file_to_be_skipped.cpp",
+                         "-*file_to_be_skipped.cpp", "-*path_end.h",
                          "-*skip.h"]
     print('Skip list file content: ' + skip_list_file)
     print('\n'.join(skip_list_content))

--- a/web/tests/functional/skip/test_skip.py
+++ b/web/tests/functional/skip/test_skip.py
@@ -64,7 +64,7 @@ class TestSkip(unittest.TestCase):
         run_results = get_all_run_results(self._cc_client, runid)
         self.assertIsNotNone(run_results)
 
-        skipped_files = ["file_to_be_skipped.cpp", "skip.h"]
+        skipped_files = ["file_to_be_skipped.cpp", "skip.h", "path_end.h"]
 
         test_proj_res = self._testproject_data[self._clang_to_test]['bugs']
         skipped = [x for x in test_proj_res if x['file'] in skipped_files]

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -217,6 +217,11 @@ def check_and_store(codechecker_cfg, test_project_name, test_project_path,
     if clean:
         check_cmd.extend(['--clean'])
 
+    analyzer_config = codechecker_cfg.get('analyzer_config')
+    if analyzer_config:
+        check_cmd.append('--analyzer-config')
+        check_cmd.extend(analyzer_config)
+
     check_cmd.extend(codechecker_cfg['checkers'])
 
     try:

--- a/web/tests/projects/cpp/project_info.json
+++ b/web/tests/projects/cpp/project_info.json
@@ -31,19 +31,21 @@
             { "file": "null_dereference.cpp", "line": 29, "checker": "deadcode.DeadStores", "hash": "98db15ea41ba255ba5e98d5ed35b5037" },
             { "file": "path_end.h", "line": 9, "checker": "core.DivideZero", "hash": "4073351ef6106178688407bc3c4aa6ae" },
             { "file": "path_end.h", "line": 9, "checker": "core.DivideZero", "hash": "4073351ef6106178688407bc3c4aa6ae" },
+            { "file": "path_end.h", "line": 7, "checker": "misc-definitions-in-headers", "hash": "682eed27e6a1ff49414d7e2f057cf113" },
             { "file": "stack_address_escape.cpp", "line": 15, "checker": "core.StackAddrEscapeBase", "hash": "023c73b32cc68a04b8cafd2fe1839cad" },
             { "file": "stack_address_escape.cpp", "line": 18, "checker": "core.StackAddrEscapeBase", "hash": "afb5b4e0f6ed01dff585689bcf458a7e" },
             { "file": "stack_address_escape.cpp", "line": 25, "checker": "core.StackAddrEscapeBase", "hash": "ab4781a0c24cd271c0da36b8b8ed0dc0" },
             { "file": "skip_header.cpp", "line": 15, "checker": "core.DivideZero", "hash": "6323bb2b22ffeff5c265eb14ae402d29" },
             { "file": "skip.h", "line": 8, "checker": "core.DivideZero", "hash": "269d82a20d38f23bbf730a2cf1d1668b" },
+            { "file": "skip.h", "line": 7, "checker": "misc-definitions-in-headers", "hash": "3fa3c4f09e3bb769a68e377bd5ab3222" },
             { "file": "path_begin.cpp", "line": 12, "checker": "core.DivideZero", "hash": "73e6a2e1091295da065a6527f8540366" },
             { "file": "path_begin.cpp", "line": 18, "checker": "core.DivideZero", "hash": "73e6a2e1091295da065a6527f8540366" }
         ],
-        "filter_severity_levels": [{"MEDIUM": 1}, {"LOW": 6}, {"HIGH": 24}, {"STYLE": 0}, {"UNSPECIFIED": 3}, {"CRITICAL": 0}],
+        "filter_severity_levels": [{"MEDIUM": 3}, {"LOW": 6}, {"HIGH": 24}, {"STYLE": 0}, {"UNSPECIFIED": 3}, {"CRITICAL": 0}],
         "filter_checker_id": [{"*unix*": 1}, {"core*": 22}, {"*DeadStores": 6}],
         "filter_filepath": [{"*null*": 5}],
         "filter_filepath_case_insensitive": [{"*null*": 5}, {"*nULl*": 5}, {"*NULL*": 5}, {"*Null*": 5}],
-        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 34}, {"FALSE_POSITIVE": 0}, {"INTENTIONAL": 0}],
+        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 36}, {"FALSE_POSITIVE": 0}, {"INTENTIONAL": 0}],
         "diff_res_types_filter": [{"deadcode.DeadStores": 6},  {"cplusplus.NewDelete": 5}, {"unix.Malloc": 1}]
     }
 }


### PR DESCRIPTION
Use `-header-filter=.*` to display errors from all non-system headers.