### PR TITLE
refactor how the analyzer configs are passed for each process

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -163,7 +163,7 @@ def is_ctu_active(source_analyzer):
         source_analyzer.is_ctu_enabled()
 
 
-def prepare_check(action, analyzer_config_map, output_dir,
+def prepare_check(action, analyzer_config, output_dir,
                   severity_map, skip_handler, statistics_data,
                   disable_ctu=False):
     """
@@ -175,7 +175,7 @@ def prepare_check(action, analyzer_config_map, output_dir,
     # Create a source analyzer.
     source_analyzer = \
         analyzer_types.construct_analyzer(action,
-                                          analyzer_config_map)
+                                          analyzer_config)
 
     if disable_ctu:
         # WARNING! can be called only on ClangSA
@@ -452,7 +452,7 @@ def check(check_data):
 
     skiplist handler is None if no skip file was configured.
     """
-    actions_map, action, context, analyzer_config_map, \
+    actions_map, action, context, analyzer_config, \
         output_dir, skip_handler, quiet_output_on_stdout, \
         capture_analysis_output, analysis_timeout, \
         analyzer_environment, ctu_reanalyze_on_failure, \
@@ -468,8 +468,11 @@ def check(check_data):
 
         result_file = ''
 
+        if analyzer_config is None:
+            raise Exception("Analyzer configuration is missing.")
+
         source_analyzer, analyzer_cmd, rh, reanalyzed = \
-            prepare_check(action, analyzer_config_map,
+            prepare_check(action, analyzer_config,
                           output_dir, context.severity_map,
                           skip_handler, statistics_data)
 
@@ -587,7 +590,7 @@ def check(check_data):
                 # Try to reanalyze with CTU disabled.
                 source_analyzer, analyzer_cmd, rh, reanalyzed = \
                     prepare_check(action,
-                                  analyzer_config_map,
+                                  analyzer_config,
                                   output_dir,
                                   context.severity_map,
                                   skip_handler,
@@ -718,7 +721,7 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
     analyzed_actions = [(actions_map,
                          build_action,
                          context,
-                         analyzer_config_map,
+                         analyzer_config_map.get(build_action.analyzer_type),
                          output_path,
                          skip_handler,
                          quiet_analyze,

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -248,7 +248,6 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
     manager = SyncManager()
     manager.start(__mgr_init)
 
-    config_map = manager.dict(config_map)
     actions_map = create_actions_map(actions, manager)
 
     # Setting to not None value will enable statistical analysis features.
@@ -276,14 +275,20 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
                 or ("stats_output" in args and args.stats_output)):
             pre_anal_skip_handler = skip_handler
 
-        pre_analysis_manager.run_pre_analysis(pre_analyze,
-                                              context,
-                                              config_map,
-                                              args.jobs,
-                                              pre_anal_skip_handler,
-                                              ctu_data,
-                                              statistics_data,
-                                              manager)
+        clangsa_config = config_map.get(ClangSA.ANALYZER_NAME)
+
+        if clangsa_config is not None:
+            pre_analysis_manager.run_pre_analysis(pre_analyze,
+                                                  context,
+                                                  clangsa_config,
+                                                  args.jobs,
+                                                  pre_anal_skip_handler,
+                                                  ctu_data,
+                                                  statistics_data,
+                                                  manager)
+        else:
+            LOG.error("Can not run pre analysis without clang "
+                      "static analyzer configuration.")
 
     if 'stats_output' in args and args.stats_output:
         return

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -167,15 +167,13 @@ def check_supported_analyzers(analyzers, context):
 
 
 def construct_analyzer(buildaction,
-                       analyzer_config_map):
+                       analyzer_config):
     try:
         analyzer_type = buildaction.analyzer_type
-        # Get the proper config handler for this analyzer type.
-        config_handler = analyzer_config_map.get(analyzer_type)
 
         LOG.debug_analyzer('Constructing %s analyzer.', analyzer_type)
         if analyzer_type in supported_analyzers:
-            analyzer = supported_analyzers[analyzer_type](config_handler,
+            analyzer = supported_analyzers[analyzer_type](analyzer_config,
                                                           buildaction)
         else:
             analyzer = None

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -28,13 +28,14 @@ from .analyzers.clangsa.analyzer import ClangSA
 LOG = get_logger('analyzer')
 
 
-def collect_statistics(action, source, config, environ, statistics_data):
+def collect_statistics(action, source, clangsa_config,
+                       environ, statistics_data):
     """
     Run the statistics collection command and save the
     stdout and stderr to a file.
     """
     cmd, can_collect = statistics_collector.build_stat_coll_cmd(action,
-                                                                config,
+                                                                clangsa_config,
                                                                 source)
 
     if not can_collect:
@@ -82,7 +83,7 @@ def init_worker(checked_num, action_num):
 
 def pre_analyze(params):
 
-    action, context, analyzer_config_map, skip_handler, \
+    action, context, clangsa_config, skip_handler, \
         ctu_data, statistics_data = params
 
     analyzer_environment = env.extend(context.path_env_extra,
@@ -101,8 +102,6 @@ def pre_analyze(params):
              progress_checked_num.value,
              progress_actions.value, source_filename)
 
-    config = analyzer_config_map.get(ClangSA.ANALYZER_NAME)
-
     try:
         if ctu_data:
             LOG.debug("running CTU pre analysis")
@@ -111,12 +110,12 @@ def pre_analyze(params):
 
             triple_arch = \
                 ctu_triple_arch.get_triple_arch(action, action.source,
-                                                config,
+                                                clangsa_config,
                                                 analyzer_environment)
             ctu_manager.generate_ast(triple_arch, action, action.source,
-                                     config, analyzer_environment)
+                                     clangsa_config, analyzer_environment)
             ctu_manager.map_functions(triple_arch, action, action.source,
-                                      config, analyzer_environment,
+                                      clangsa_config, analyzer_environment,
                                       ctu_func_map_cmd,
                                       ctu_temp_fnmap_folder)
 
@@ -130,7 +129,7 @@ def pre_analyze(params):
             LOG.debug("running statistics pre analysis")
             collect_statistics(action,
                                action.source,
-                               config,
+                               clangsa_config,
                                analyzer_environment,
                                statistics_data)
 
@@ -140,7 +139,7 @@ def pre_analyze(params):
         raise
 
 
-def run_pre_analysis(actions, context, analyzer_config_map,
+def run_pre_analysis(actions, context, clangsa_config,
                      jobs, skip_handler, ctu_data, statistics_data, manager):
     """
     Run multiple pre analysis jobs before the actual analysis.
@@ -185,7 +184,7 @@ def run_pre_analysis(actions, context, analyzer_config_map,
     try:
         collect_actions = [(build_action,
                             context,
-                            analyzer_config_map,
+                            clangsa_config,
                             skip_handler,
                             ctu_data,
                             statistics_data)


### PR DESCRIPTION
No sync manager is required anymore. The configs were already
shared in a read only way. A configuration change in one process
should not influence the config in another.
Every process will get its own local configuration instance in
the new setup and can modify it if needed.

Every configuration change which could influence the analysis
should be done before the worker pool starts the analysis jobs.

The refactoring was done to fix a hardly reproducible
problem with the sared configuration values between processes.

For some reason the socket belonging to the SyncManager was closed
by the SyncManager even if data was tried to be sent to be shared
between the processes.

  File "<string>", line 2, in get
  File ".../python3.8.2/multiprocessing/managers.py", line 844, in _callmethod
    conn.send((self._id, methodname, args, kwds))
  File ".../python3.8.2/multiprocessing/connection.py", line 215, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
  File ".../python3.8.2/multiprocessing/connection.py", line 434, in _send_bytes
    self._send(header + buf)
  File ".../python3.8.2/multiprocessing/connection.py", line 380, in _send
    n = write(self._handle, buf)
TypeError: an integer is required (got type NoneType)

One other thing which could cause this problem could have been the
shares SyncManager between two multiprocessing pools (pre analysis,
and the normal analysis), but that was not validated.