### PR TITLE
[report-converter] Metadata

### DIFF
--- a/tools/report-converter/README.md
+++ b/tools/report-converter/README.md
@@ -33,7 +33,9 @@ make package
 
 ## Usage
 ```sh
-usage: report-converter [-h] -o OUTPUT_DIR -t TYPE [-c] [-v] file
+usage: report-converter [-h] -o OUTPUT_DIR -t TYPE [--meta [META [META ...]]]
+                        [-c] [-v]
+                        file
 
 Creates a CodeChecker report directory from the given code analyzer output
 which can be stored to a CodeChecker web server.
@@ -51,6 +53,12 @@ optional arguments:
                         Currently supported output types are: asan, clang-
                         tidy, cppcheck, eslint, fbinfer, golint, msan,
                         pyflakes, pylint, spotbugs, tsan, tslint, ubsan.
+  --meta [META [META ...]]
+                        Metada information which will be stored alongside the
+                        run when the created report directory will be stored
+                        to a running CodeChecker server. It has the following
+                        format: key=value. Valid key values are:
+                        analyzer_command, analyzer_version.
   -c, --clean           Delete files stored in the output directory.
   -v, --verbose         Set verbosity level.
 

--- a/tools/report-converter/tests/functional/cmdline/test_cmdline.py
+++ b/tools/report-converter/tests/functional/cmdline/test_cmdline.py
@@ -8,8 +8,10 @@
 This module tests the report-converter tool.
 """
 
-
+import json
+import os
 import subprocess
+import tempfile
 import unittest
 
 
@@ -20,3 +22,33 @@ class TestCmdline(unittest.TestCase):
         """ Get help for report-converter tool. """
         ret = subprocess.call(['report-converter', '--help'])
         self.assertEqual(0, ret)
+
+    def test_metadata(self):
+        """ Generate metadata for CodeChecker server. """
+        analyzer_version = "x.y.z"
+        analyzer_command = "golint simple.go"
+
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        test_file = os.path.join(test_dir, "test_files", "simple.out")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ret = subprocess.call(['report-converter', '-t', 'golint',
+                                   '-o', tmp_dir, test_file, '--meta',
+                                   'analyzer_version=' + analyzer_version,
+                                   'analyzer_command=' + analyzer_command])
+            self.assertEqual(0, ret)
+
+            metadata_file = os.path.join(tmp_dir, "metadata.json")
+            self.assertTrue(os.path.exists(metadata_file))
+
+            with open(metadata_file, 'r',
+                      encoding="utf-8", errors="ignore") as metadata_f:
+                metadata = json.load(metadata_f)
+
+                self.assertEqual(metadata['version'], 2)
+                self.assertEqual(metadata['num_of_report_dir'], 1)
+                self.assertEqual(len(metadata['tools']), 1)
+
+                tool = metadata['tools'][0]
+                self.assertEqual(tool['name'], "golint")
+                self.assertEqual(tool['version'], analyzer_version)
+                self.assertEqual(tool['command'], analyzer_command)

--- a/tools/report-converter/tests/functional/cmdline/test_files/Makefile
+++ b/tools/report-converter/tests/functional/cmdline/test_files/Makefile
@@ -1,0 +1,2 @@
+all:
+	golint ./files/simple.go > simple.out

--- a/tools/report-converter/tests/functional/cmdline/test_files/files/simple.go
+++ b/tools/report-converter/tests/functional/cmdline/test_files/files/simple.go
@@ -1,0 +1,5 @@
+package pgk
+
+type T int
+
+var Y, Z int

--- a/tools/report-converter/tests/functional/cmdline/test_files/simple.out
+++ b/tools/report-converter/tests/functional/cmdline/test_files/simple.out
@@ -1,0 +1,2 @@
+./files/simple.go:3:6: exported type T should have comment or be unexported
+./files/simple.go:5:5: exported var Z should have its own declaration


### PR DESCRIPTION
Provide metada information which will be stored alongside the run when the
created report directory will be stored to a running CodeChecker server.
It has the following format: `key=value`. Valid key values are:
`analyzer_command`, `analyzer_version`.