### PR TITLE
[analyzer] Always generate valid log file

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -118,8 +118,15 @@ def main(args):
     logger.setup_logger(args.verbose if 'verbose' in args else None)
 
     args.logfile = os.path.realpath(args.logfile)
-    if os.path.exists(args.logfile):
-        os.remove(args.logfile)
+
+    # It is possible that the log file will not be created or it will be empty
+    # for example when the build command is an empty string or when there is no
+    # compiler command to log. For this reason we will create this log file if
+    # it does not exist and we will insert an empty array to it, so it will be
+    # a valid json file.
+    with open(args.logfile, 'w',
+              encoding="utf-8", errors="ignore") as logfile:
+        logfile.write("[\n]")
 
     context = analyzer_context.get_context()
     verbose = args.verbose if 'verbose' in args else None

--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -8,7 +8,7 @@
 This module tests the CodeChecker command line.
 """
 
-
+import json
 import os
 import subprocess
 import unittest
@@ -93,3 +93,19 @@ class TestCmdline(unittest.TestCase):
 
         analyzers_cmd = [env.codechecker_cmd(), 'analyzers']
         self.assertEqual(0, run_cmd(analyzers_cmd)[0])
+
+    def test_log_empty_build_command(self):
+        """ Logging empty build command result will be a valid json file. """
+
+        log_file = os.path.join(self.test_workspace, 'build.json')
+
+        analyzers_cmd = [env.codechecker_cmd(), 'log',
+                         '-b', '',
+                         '-o', log_file]
+        out = run_cmd(analyzers_cmd)
+        print(out)
+
+        self.assertTrue(os.path.exists(log_file))
+        with open(log_file,
+                  encoding="utf-8", errors="ignore") as log_f:
+            self.assertFalse(json.load(log_f))

--- a/analyzer/tools/build-logger/src/ldlogger-logger.c
+++ b/analyzer/tools/build-logger/src/ldlogger-logger.c
@@ -101,11 +101,6 @@ static void writeActions(FILE* stream_, char const* wd_, const LoggerVector* act
   long fsize;
   int entryCount = 0;
 
-  if (actions_->size <= 0)
-  {
-    return;
-  }
-
   fseek(stream_, 0L, SEEK_END);
   fsize = ftell(stream_);
   if (fsize == 0)

--- a/analyzer/tools/build-logger/test/test_logger.sh
+++ b/analyzer/tools/build-logger/test/test_logger.sh
@@ -50,7 +50,9 @@ function test_compiler_path2 {
 
   if [ -n $compiler ]; then
     CC_LOGGER_GCC_LIKE="/g++-" bash -c "$compiler $source_file"
-    test ! -s $CC_LOGGER_FILE
+
+    echo -ne "[\n]" > $reference_file
+    diff $reference_file $CC_LOGGER_FILE
   fi
 }
 
@@ -183,6 +185,13 @@ function test_source_abs {
   grep -- "$source_file" $CC_LOGGER_FILE &> /dev/null
 }
 
+function test_valid_json {
+  bash -c "gcc 2>/dev/null"
+  echo -ne "[\n]" > $reference_file
+
+  diff $reference_file $CC_LOGGER_FILE
+}
+
 
 #--- Run tests ---#
 
@@ -202,4 +211,4 @@ for func in $(declare -F); do
   fi
 done
 
-rm a.out
+rm -f a.out


### PR DESCRIPTION
It is possible that the log file will not be created or it will be empty
for example when the build command is an empty string or when there is no
compiler command to log. For this reason we will create this log file if
it does not exist at the beginning of the logging phase and we will insert
an empty array to it, to make sure that it will be a valid json file.