### PR TITLE
[analyzer] Exit with an error code if the logfile does not exist

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -679,12 +679,8 @@ def main(args):
             logfile = args.logfile
 
         # --- Step 2.: Perform the analysis.
-        if not os.path.exists(logfile):
-            raise OSError("The specified logfile '" + logfile + "' does not "
-                          "exist.")
-
         analyze_args = argparse.Namespace(
-            logfile=[logfile],
+            logfile=logfile,
             output_path=output_dir,
             output_format='plist',
             jobs=args.jobs,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -578,7 +578,7 @@ usage: CodeChecker analyze [-h] [-j JOBS]
                            [-e checker/group/profile]
                            [-d checker/group/profile] [--enable-all]
                            [--verbose {info,debug,debug_analyzer}]
-                           logfile [logfile ...]
+                           logfile
 
 Use the previously created JSON Compilation Database to perform an analysis on
 the project, outputting analysis results in a machine-readable format.


### PR DESCRIPTION
- If the log file does not exist we will print an error message and
exit with an error code.
- If multiple log files were given to the CodeChecker analyze command,
we print an error message that it is not supported yet and we exit
with an error code. Instead of this we can just remove the multiple
log files support from the argument parser so the user will not be
able to give multiple log files for this command.