### PR TITLE
[analyzer][web][dependency] update 3pp python dependencies

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -1,3 +1,3 @@
 lxml==4.5.0
-portalocker==1.1.0
-psutil==5.6.6
+portalocker==1.7.0
+psutil==5.7.0

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -1,7 +1,7 @@
 lxml==4.5.0
 nose==1.3.7
 pycodestyle==2.5.0
-psutil==5.6.6
-portalocker==1.1.0
+psutil==5.7.0
+portalocker==1.7.0
 pylint==2.4.4
 mkdocs==1.0.4

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -1,4 +1,4 @@
 lxml==4.5.0
-portalocker==1.1.0
-psutil==5.6.6
-scan-build==2.0.14
+portalocker==1.7.0
+psutil==5.7.0
+scan-build==2.0.19

--- a/tools/codechecker_report_hash/requirements_py/dev/requirements.txt
+++ b/tools/codechecker_report_hash/requirements_py/dev/requirements.txt
@@ -1,3 +1,3 @@
 nose==1.3.7
-pycodestyle==2.4.0
-pylint==1.9.4
+pycodestyle==2.5.0
+pylint==2.4.4

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,8 +1,8 @@
 lxml==4.5.0
-sqlalchemy==1.3.5
-alembic==0.9.2
-portalocker==1.1.0
-psutil==5.6.6
+sqlalchemy==1.3.16
+alembic==1.4.2
+portalocker==1.7.0
+psutil==5.7.0
 
 codechecker_api==6.26.0
 codechecker_api_shared==6.26.0

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -1,9 +1,9 @@
 lxml==4.5.0
-sqlalchemy==1.3.5
-alembic==0.9.2
-pg8000==1.10.2
-psutil==5.6.6
-portalocker==1.1.0
+sqlalchemy==1.3.16
+alembic==1.4.2
+pg8000==1.15.2
+psutil==5.7.0
+portalocker==1.7.0
 
 codechecker_api==6.26.0
 codechecker_api_shared==6.26.0

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -1,9 +1,9 @@
 lxml==4.5.0
-sqlalchemy==1.3.5
-alembic==0.9.2
-psycopg2-binary==2.7.7
-psutil==5.6.6
-portalocker==1.1.0
+sqlalchemy==1.3.16
+alembic==1.4.2
+psycopg2-binary==2.8.5
+psutil==5.7.0
+portalocker==1.7.0
 
 codechecker_api==6.26.0
 codechecker_api_shared==6.26.0

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,11 +1,11 @@
 lxml==4.5.0
-sqlalchemy==1.3.5
+sqlalchemy==1.3.16
 pycodestyle==2.5.0
-alembic==0.9.2
-psycopg2-binary==2.7.7
-pg8000==1.10.2
-psutil==5.6.6
-portalocker==1.1.0
+alembic==1.4.2
+psycopg2-binary==2.8.5
+pg8000==1.15.2
+psutil==5.7.0
+portalocker==1.7.0
 pylint==2.4.4
 nose==1.3.7
 mockldap==0.3.0

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -1,8 +1,8 @@
 lxml==4.5.0
-alembic==0.9.2
-portalocker==1.1.0
-psutil==5.6.6
-sqlalchemy==1.3.5
+alembic==1.4.2
+portalocker==1.7.0
+psutil==5.7.0
+sqlalchemy==1.3.16
 
 codechecker_api==6.26.0
 codechecker_api_shared==6.26.0

--- a/web/server/codechecker_server/database/database.py
+++ b/web/server/codechecker_server/database/database.py
@@ -499,7 +499,9 @@ class PostgreSQLServer(SQLServer):
                                                          self.database,
                                                          self.user)
 
-        extra_args = {'client_encoding': 'utf8'}
+        extra_args = {}
+        if driver == "psycopg2":
+            extra_args = {'client_encoding': 'utf8'}
         return str(URL('postgresql+' + driver,
                        username=self.user,
                        password=password,


### PR DESCRIPTION
New 3pp versions:
- sqlalchemy 1.3.16
- portalocker 1.7.0
- alembic 1.4.2
- pg8000 1.15.2
- psycopg2-binary 2.8.5
- psutil 5.7.0
- scan-build 2.0.19

client_encoding is a psycopg2 only argument added only if
that driver is used.