### PR TITLE
[server] Handle empty auth string on login

### DIFF
--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -77,6 +77,11 @@ class ThriftAuthHandler(object):
 
     @timeit
     def performLogin(self, auth_method, auth_string):
+        if not auth_string:
+            raise codechecker_api_shared.ttypes.RequestFailed(
+                codechecker_api_shared.ttypes.ErrorCode.AUTH_DENIED,
+                "No credentials supplied. Refusing authentication!")
+
         if auth_method == "Username:Password":
             user_name, _ = auth_string.split(':', 1)
             LOG.info("'%s' logged in.", user_name)

--- a/web/tests/functional/authentication/test_authentication.py
+++ b/web/tests/functional/authentication/test_authentication.py
@@ -55,6 +55,9 @@ class DictAuth(unittest.TestCase):
             auth_client.performLogin("Username:Password", "invalid:invalid")
             print("Invalid credentials gave us a token!")
 
+        with self.assertRaises(RequestFailed):
+            auth_client.performLogin("Username:Password", None)
+
         # A non-authenticated session should return an empty user.
         user = auth_client.getLoggedInUser()
         self.assertEqual(user, "")


### PR DESCRIPTION
It is possible that the `performLogin` function will be called by a different
client and when no auth string is given we will get the following exception:
```
CodeChecker/lib/python3/codechecker_server/api/authentication.py", line 86, in performLogin
    user_name, _ = auth_string.split(':', 1)
AttributeError: 'NoneType' object has no attribute 'split'
```
To solve this problem we will raise an exception that no credentials
are supplied.