### PR TITLE
[cmd] Fix credential manager

### DIFF
--- a/web/client/codechecker_client/credential_manager.py
+++ b/web/client/codechecker_client/credential_manager.py
@@ -34,7 +34,7 @@ def simplify_credentials(credentials):
     removed if these are given.
     """
     host_entry_pattern = re.compile(
-        r'^(?P<protocol>http[s]?://)*(?P<host>[\w.\*]+):*(?P<port>\d+)*'
+        r'^(?P<protocol>http[s]?://)*(?P<host>[^:\/\s]+):*(?P<port>\d+)*'
         r'/*(?P<product>\w+)*$')
 
     ret = {}


### PR DESCRIPTION
Saved credentials are not worked properly when the url contained a special
non word character. For example: `https://codechecker-demo.cloudapp.azure.com/`