### PR TITLE
[server] Implement understanding IPv6 listen addresses

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -290,7 +290,9 @@ optional arguments:
                         (default: /home/<username>/.codechecker)
   --host LISTEN_ADDRESS
                         The IP address or hostname of the server on which it
-                        should listen for connections. (default: localhost)
+                        should listen for connections. For IPv6 listening,
+                        specify an IPv6 address, such as "::1". (default:
+                        localhost)
   -v PORT, --view-port PORT, -p PORT, --port PORT
                         The port which will be used as listen port for the
                         server. (default: 8001)
@@ -298,7 +300,7 @@ optional arguments:
                         possible not only by browsers and clients running
                         locally, but to everyone, who can access the server
                         over the Internet. (Equivalent to specifying '--host
-                        ""'.) (default: False)
+                        "::"'.) (default: False)
   --skip-db-cleanup     Skip performing cleanup jobs on the database like
                         removing unused files.
   --verbose {info,debug,debug_analyzer}

--- a/web/server/codechecker_server/cmd/server.py
+++ b/web/server/codechecker_server/cmd/server.py
@@ -101,7 +101,9 @@ def add_arguments_to_parser(parser):
                         default="localhost",
                         required=False,
                         help="The IP address or hostname of the server on "
-                             "which it should listen for connections.")
+                             "which it should listen for connections. "
+                             "For IPv6 listening, specify an IPv6 address, "
+                             "such as \"::1\".")
 
     # TODO: -v/--view-port is too verbose. The server's -p/--port is used
     # symmetrically in 'CodeChecker cmd' anyways.
@@ -124,7 +126,7 @@ def add_arguments_to_parser(parser):
                              "will be possible not only by browsers and "
                              "clients running locally, but to everyone, who "
                              "can access the server over the Internet. "
-                             "(Equivalent to specifying '--host \"\"'.)")
+                             "(Equivalent to specifying '--host \"::\"'.)")
 
     parser.add_argument('--skip-db-cleanup',
                         dest="skip_db_cleanup",
@@ -349,11 +351,11 @@ def add_arguments_to_parser(parser):
         if set(arg_match(options)) == set(options):
             parser.error("argument --not-host-only: not allowed with "
                          "argument --host, as it is a shortcut to --host "
-                         "\"\"")
+                         "\"::\"")
         else:
             # Apply the shortcut.
             if arg_match(['--not-host-only']):
-                args.listen_address = ""  # Listen on every interface.
+                args.listen_address = "::"  # Listen on every interface.
 
             # --not-host-only is just a shortcut optstring, no actual use
             # is intended later on.

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -200,17 +200,30 @@ class RequestHandler(SimpleHTTPRequestHandler):
 
         SimpleHTTPRequestHandler.end_headers(self)
 
+    @staticmethod
+    def _get_client_host_port(address):
+        """
+        Returns the host and port of the request's address, and whether it
+        was an IPv6 address.
+        """
+        if len(address) == 2:
+            return address[0], address[1], False
+        if len(address) == 4:
+            return address[0], address[1], True
+
+        raise IndexError("Invalid address tuple given.")
+
     def do_GET(self):
         """
         Handles the browser access (GET requests).
         """
-
+        client_host, client_port, is_ipv6 = \
+            RequestHandler._get_client_host_port(self.client_address)
         self.auth_session = self.__check_session_cookie()
         username = self.auth_session.user if self.auth_session else 'Anonymous'
-        LOG.debug("%s:%s -- [%s] GET %s", self.client_address[0],
-                  str(self.client_address[1]),
-                  self.auth_session.user if self.auth_session else 'Anonymous',
-                  self.path)
+        LOG.debug("%s:%s -- [%s] GET %s",
+                  client_host if not is_ipv6 else '[' + client_host + ']',
+                  client_port, username, self.path)
 
         product_endpoint, path = routing.split_client_GET_request(self.path)
 
@@ -389,10 +402,12 @@ class RequestHandler(SimpleHTTPRequestHandler):
         """
         Handles POST queries, which are usually Thrift messages.
         """
-
-        client_host, client_port = self.client_address
+        client_host, client_port, is_ipv6 = \
+            RequestHandler._get_client_host_port(self.client_address)
         self.auth_session = self.__check_session_cookie()
-        LOG.info("%s:%s -- [%s] POST %s", client_host, str(client_port),
+        LOG.info("%s:%s -- [%s] POST %s",
+                 client_host if not is_ipv6 else '[' + client_host + ']',
+                 client_port,
                  self.auth_session.user if self.auth_session else "Anonymous",
                  self.path)
 
@@ -746,6 +761,7 @@ class CCSimpleHttpServer(HTTPServer):
     """
 
     daemon_threads = False
+    address_family = socket.AF_INET  # IPv4
 
     def __init__(self,
                  server_address,
@@ -952,6 +968,17 @@ class CCSimpleHttpServer(HTTPServer):
             if ep not in endpoints_to_keep]
 
 
+class CCSimpleHttpServerIPv6(CCSimpleHttpServer):
+    """
+    CodeChecker HTTP simple server that listens over an IPv6 socket.
+    """
+
+    address_family = socket.AF_INET6
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 def __make_root_file(root_file):
     """
     Generate a root username and password SHA. This hash is saved to the
@@ -1049,23 +1076,31 @@ def start_server(config_directory, package_data, port, config_sql_server,
         LOG.error("The server's configuration file is invalid!")
         sys.exit(1)
 
-    http_server = CCSimpleHttpServer(server_addr,
-                                     RequestHandler,
-                                     config_directory,
-                                     config_sql_server,
-                                     skip_db_cleanup,
-                                     package_data,
-                                     context,
-                                     check_env,
-                                     manager)
+    server_clazz = CCSimpleHttpServer
+    if ':' in server_addr[0]:
+        # IPv6 address specified for listening.
+        # FIXME: Python>=3.8 automatically handles IPv6 if ':' is in the bind
+        # address, see https://bugs.python.org/issue24209.
+        server_clazz = CCSimpleHttpServerIPv6
+
+    http_server = server_clazz(server_addr,
+                               RequestHandler,
+                               config_directory,
+                               config_sql_server,
+                               skip_db_cleanup,
+                               package_data,
+                               context,
+                               check_env,
+                               manager)
 
     def signal_handler(signum, frame):
         """
         Handle SIGTERM to stop the server running.
         """
-        LOG.info("Shutting down the WEB server on [%s:%d].",
-                 listen_address, port)
-
+        LOG.info("Shutting down the WEB server on [%s:%d]",
+                 '[' + listen_address + ']'
+                 if server_clazz is CCSimpleHttpServerIPv6 else listen_address,
+                 port)
         http_server.terminate()
         sys.exit(128 + signum)
 
@@ -1089,7 +1124,9 @@ def start_server(config_directory, package_data, port, config_sql_server,
         LOG.debug(ex.strerror)
 
     LOG.info("Server waiting for client requests on [%s:%d]",
-             listen_address, port)
+             '[' + listen_address + ']'
+             if server_clazz is CCSimpleHttpServerIPv6 else listen_address,
+             port)
 
     def unregister_handler(pid):
         """

--- a/web/server/tests/unit/test_url_understanding.py
+++ b/web/server/tests/unit/test_url_understanding.py
@@ -43,6 +43,8 @@ class product_urlTest(unittest.TestCase):
             self.assertEqual(sname, name)
 
         test("localhost", 8001, "Default")
+        test("[::1]", 8001, "Default")
+        test("[f000:baa5::f00d]", 8080, "Foo")
         test("localhost", 8002, "MyProduct")
         test("another.server", 80, "CodeChecker", "http")
         test("very-secure.another.server", 443, "CodeChecker", "https")
@@ -81,6 +83,8 @@ class product_urlTest(unittest.TestCase):
             self.assertEqual(sname, name)
 
         test("localhost", "Default")
+        test("[::1]", "Default")
+        test("[f000:baa5::f00d]", "Default")
         test("otherhost", "awesome123", "http")
 
         # 8080/MyProduct as if 8080 was a host name.
@@ -112,6 +116,9 @@ class product_urlTest(unittest.TestCase):
             # HTTPS, localhost, 443, and "foobar.baz:1234" product name.
             split_product_url("https://foobar.bar:1234")
 
+        with self.assertRaises(ValueError):
+            split_product_url("http://::1:8080/Default")
+
     def testFullServerURL(self):
         """
         Whole server URL understanding.
@@ -137,6 +144,12 @@ class product_urlTest(unittest.TestCase):
         self.assertEqual(shost, 'someserver')
         self.assertEqual(sport, 1234)
 
+        sprotocol, shost, sport = \
+            split_server_url('http://[::1]:1234/Product')
+        self.assertEqual(sprotocol, 'http')
+        self.assertEqual(shost, '[::1]')
+        self.assertEqual(sport, 1234)
+
     def testHostname(self):
         """
         Understanding only a hostname specified for server URLs.
@@ -150,6 +163,7 @@ class product_urlTest(unittest.TestCase):
             self.assertEqual(sport, expected_port(protocol, None))
 
         test("codechecker")  # Port: 8001
+        test("[::1]")  # Port: 8001
         test("codechecker", "http")  # Port: 80
         test("codechecker.local")  # Port: 8001
         test("www.example.org", "https")  # Port: 443
@@ -167,3 +181,6 @@ class product_urlTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             split_server_url("whatever://whatev.er")
+
+        with self.assertRaises(ValueError):
+            split_server_url("http://::1:8081")


### PR DESCRIPTION
> Properly fixes #2708.

Adds support to listen on IPv6 addresses, if the user requests.

    $ CodeChecker server  # as if started with --host localhost
    $ netstat -tlp | grep 8001
    tcp        0      0 localhost:8001          0.0.0.0:*               LISTEN      30020/python3


    $ CodeChecker server --host ::1
    $ netstat -tlp | grep 8001
    tcp6       0      0 ip6-localhost:8001      [::]:*                  LISTEN      29734/python3

    $ CodeChecker server --not-host-only  # now equal to: --host ::
    $ netstat -tlp | grep 8001
    tcp6       0      0 [::]:8001               [::]:*                  LISTEN      30860/python3

An IPv6 listening socket on all interfaces (`::`) also listens on all IPv4 interfaces (`0.0.0.0`), so there is no need to bind two sockets for most normal operation.
All IPv4 addresses are also IPv6 addresses in the form of `::ffff:255.255.255.255`, as per [RFC 2373 §2.2](https://tools.ietf.org/html/rfc2373#section-2.2).

IPv6 has been available in the Linux kernel since 2.6 (~2001), on OS/X from 2006 and in Windows since Window XP, so there is no need to make it a conditional thing.