### PR TITLE
[config] Remove duplicated entry from the checker severity map

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -245,7 +245,6 @@
   "misc-move-constructor-init":                                 "MEDIUM",
   "misc-move-forwarding-reference":                             "MEDIUM",
   "misc-multiple-statement-macro":                              "MEDIUM",
-  "misc-non-private-member-variables-in-classes":               "LOW",
   "misc-new-delete-overloads":                                  "MEDIUM",
   "misc-noexcept-move-constructor":                             "MEDIUM",
   "misc-non-copyable-objects":                                  "HIGH",


### PR DESCRIPTION
`misc-non-private-member-variables-in-classes` checker is defined multiple times
in the `checker_severity_map.json` file. This commit will keep only one.