### PR TITLE
[makefile] Update codechecker_api dependencies automatically

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -80,7 +80,7 @@ package_vendor: package_dir_structure
 # This target should be used from the top level Makefile to build the package
 # together with the analyzer part. This way we will not build plist-to-html
 # multiple times.
-package_web: package_dir_structure package_userguide package_vendor package_docs
+package_web: check_codechecker_api_version package_dir_structure package_userguide package_vendor package_docs
 
 build_plist_to_html:
 	$(MAKE) -C $(ROOT)/tools/plist_to_html build
@@ -119,6 +119,15 @@ package: package_plist_to_html package_report_hash package_web
 
 	# Copy license file.
 	cp $(ROOT)/LICENSE.TXT $(CC_BUILD_DIR)
+
+# This target will check that 'codecheck_api' and 'codechecker_api_shared'
+# python packages are up to date. If not, it will update these packages
+# and remove the JavaScript package from the vendor directory so the
+# 'package_vendor' target will download the required version.
+check_codechecker_api_version:
+	if ! pip3 install -r ./requirements.txt 2>&1 | grep -q "Requirement already satisfied: codechecker_api"; then \
+		rm -rf $(CC_SERVER)/vendor/codechecker-api-js; \
+	fi
 
 clean_package: clean_userguide clean_plist_to_html
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
> Closes #2724

Add a new make target that will check that `codecheck_api` and `codechecker_api_shared`
python packages are up to date. If not, it will update these packages
and remove the JavaScript package from the vendor directory so the
`package_vendor` target will download the required version.