### PR TITLE
[analyzer] Handle wrong clang version

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -103,6 +103,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         checker_list_args = clang_options.get_analyzer_checkers_cmd(
             cfg_handler,
             alpha=True)
+
+        if not checker_list_args:
+            return []
+
         return parse_clang_help_page(checker_list_args, 'CHECKERS:', environ)
 
     @classmethod
@@ -111,6 +115,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         checker_config_args = clang_options.get_checker_config_cmd(
             cfg_handler,
             alpha=True)
+
+        if not checker_config_args:
+            return []
+
         return parse_clang_help_page(checker_config_args, 'OPTIONS:', environ)
 
     @classmethod

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
@@ -22,6 +22,10 @@ def get_analyzer_checkers_cmd(cfg_handler, alpha=True, debug=True):
     Before clang9 alpha and debug checkers were printed by default.
     Since clang9 there are extra arguments to print the additional checkers.
     """
+    if not cfg_handler.version_info:
+        LOG.debug("No clang version information. Can not get checkers.")
+        return None
+
     command = [cfg_handler.analyzer_binary, "-cc1"]
 
     for plugin in cfg_handler.analyzer_plugins:
@@ -50,6 +54,10 @@ def get_checker_config_cmd(cfg_handler, alpha=True, debug=True):
     """Return the checker config getter command which depends on the used clang
     version.
     """
+    if not cfg_handler.version_info:
+        LOG.debug("No clang version information. Can not get checker configs.")
+        return None
+
     command = [cfg_handler.analyzer_binary, "-cc1"]
 
     for plugin in cfg_handler.analyzer_plugins:


### PR DESCRIPTION
> Closes #2730

If clang was a symlink for example to ccache we tried to get the version
information of this binary. CodeChecker threw an exception in this case.
This commit will handle this use case properly.