### PR TITLE
fix standalone package builder script py2 -> py3

### DIFF
--- a/scripts/build/wrap_binary_in_venv.py
+++ b/scripts/build/wrap_binary_in_venv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """
 Create a wrapper for a runnable file which requires a certain virtualenv to
 provide its dependencies. The wrapper implicitly uses the virtual environment,


### PR DESCRIPTION
Still the python2 interpreter was used to execute
the script.