### PR TITLE
[makefile] Fix cleaning vendor directory

### DIFF
--- a/web/server/vendor/Makefile
+++ b/web/server/vendor/Makefile
@@ -176,4 +176,4 @@ clean_vendor:
 	rm -rf jquery
 	rm -rf marked
 	rm -rf thrift
-	rm -rf codechecker_api_js
+	rm -rf codechecker-api-js


### PR DESCRIPTION
We tried to remove a wrong directory called `codechecker_api_js` on
`clean_vendor` makefile target instead of `codechecker-api-js`.
This commit solves this problem and removes the correct directory.