### PR TITLE
[cmd] Use report object to trim path prefixes at parse command

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -179,9 +179,6 @@ class PlistToPlaintextFormatter(object):
                 last_report_event = report.bug_path[-1]
                 source_file = \
                     report.files[last_report_event['location']['file']]
-                trimmed_source_file = \
-                    util.trim_path_prefixes(source_file,
-                                            self._trim_path_prefixes)
 
                 report_line = last_report_event['location']['line']
                 report_hash = \
@@ -198,6 +195,12 @@ class PlistToPlaintextFormatter(object):
 
                 if skip:
                     continue
+
+                if self._trim_path_prefixes:
+                    report.trim_path_prefixes(self._trim_path_prefixes)
+
+                trimmed_source_file = \
+                    report.files[last_report_event['location']['file']]
 
                 file_stats[f_path] += 1
                 severity = self.__severity_map.get(checker_name)
@@ -269,14 +272,11 @@ class PlistToPlaintextFormatter(object):
                     for index, event in enumerate(events):
                         output.write(index_format % (index + 1))
                         source_file = report.files[event['location']['file']]
-                        trimmed_source_file = \
-                            util.trim_path_prefixes(source_file,
-                                                    self._trim_path_prefixes)
                         output.write(
                             self.__format_bug_event(None,
                                                     None,
                                                     event,
-                                                    trimmed_source_file))
+                                                    source_file))
                         output.write('\n')
                 output.write('\n')
 


### PR DESCRIPTION
Earlier a `trim_path_prefixes` method was introduced in the `Report` class
which can be used at the parse command to trim path prefixes.