### PR TITLE
[server] Fix run history tag filter

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2112,6 +2112,9 @@ class ThriftRequestHandler(object):
             if run_ids:
                 tag_q = tag_q.filter(RunHistory.run_id.in_(run_ids))
 
+            if report_filter and report_filter.runTag:
+                tag_q = tag_q.filter(RunHistory.id.in_(report_filter.runTag))
+
             tag_q = tag_q.subquery()
 
             q = session.query(tag_q.c.run_history_id,


### PR DESCRIPTION
- Filter run history tags on the server side instead of client side.
- Previously the `runTag` attribute of the `ReportFilter` data was set
  to list of strings when the user set a tag filter and refreshed the page.
  This way the thrift api was thrown an exception. To solve this issue we will
  always set this attribute to list of tag ids.