### PR TITLE
[fix] Bugfix in HTML generator in parse command

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -670,7 +670,7 @@ def main(args):
         element will be a list of source code comments related to the actual
         report.
         """
-        report = Report(None, diag['path'], files)
+        report = Report({'check_name': checker_name}, diag['path'], files)
         path_hash = get_report_path_hash(report)
         if path_hash in processed_path_hashes:
             LOG.debug("Skip report because it is a deduplication of an "


### PR DESCRIPTION
The checker name is needed so the hash function can compute a hash for the
report. If this checker name is not the member of the Report object then hash
generation crashes.