### PR TITLE
[analyzer] Create reports on compiler failure only in case of Clang Tidy

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/result_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/result_handler.py
@@ -9,6 +9,7 @@
 Result handler for Clang Static Analyzer.
 """
 
+import os
 
 from codechecker_common.logger import get_logger
 from codechecker_report_hash.hash import HashType, replace_report_hash
@@ -28,6 +29,7 @@ class ResultHandlerClangSA(ResultHandler):
         Override the context sensitive issue hash in the plist files to
         context insensitive if it is enabled during analysis.
         """
-        if self.report_hash_type in ['context-free', 'context-free-v2']:
+        if self.report_hash_type in ['context-free', 'context-free-v2'] and \
+                os.path.exists(self.analyzer_result_file):
             replace_report_hash(self.analyzer_result_file,
                                 HashType.CONTEXT_FREE)


### PR DESCRIPTION
In case of compiler errors Clang Tidy analyzer will create reports
(plist files) from the standard output. Previously if we enabled the
Clang SA analyzer too and we used one of the context free hashes we
tried to open the plist file and override the report hashes in it
but no plist file was created by this analyzer. So an exception was
thrown that the plist file does not exist. This commit will handle
this use case too.