### PR TITLE
[fix] Fix tidyargs file encoding

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -298,7 +298,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             host_check.get_resource_dir(clang_bin, context)
 
         try:
-            with open(args.tidy_args_cfg_file, 'rb') as tidy_cfg:
+            with open(args.tidy_args_cfg_file, 'r', encoding='utf-8',
+                      errors='ignore') as tidy_cfg:
                 handler.analyzer_extra_arguments = \
                     re.sub(r'\$\((.*?)\)', env.replace_env_var,
                            tidy_cfg.read().strip())

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -465,6 +465,70 @@ class TestAnalyze(unittest.TestCase):
         self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
 
+    def test_tidyargs_saargs(self):
+        """
+        Test tidyargs and saargs config files
+        """
+        build_json = os.path.join(self.test_workspace, "build_extra_args.json")
+        report_dir = os.path.join(self.test_workspace, "reports_extra_args")
+        source_file = os.path.join(self.test_dir, "extra_args.c")
+        tidyargs_file = os.path.join(self.test_dir, "tidyargs")
+        saargs_file = os.path.join(self.test_dir, "saargs")
+
+        build_log = [{"directory": self.test_dir,
+                      "command": "cc -c " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w',
+                  encoding="utf-8", errors="ignore") as outfile:
+            json.dump(build_log, outfile)
+
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "-o", report_dir, "--tidyargs", tidyargs_file]
+
+        process = subprocess.Popen(
+            analyze_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.test_workspace,
+            encoding="utf-8",
+            errors="ignore")
+        process.communicate()
+
+        process = subprocess.Popen(
+            [self._codechecker_cmd, "parse", report_dir],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.test_workspace,
+            encoding="utf-8",
+            errors="ignore")
+        out, _ = process.communicate()
+
+        self.assertIn("division by zero", out)
+
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "-o", report_dir, "--saargs", saargs_file]
+        process = subprocess.Popen(
+            analyze_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.test_workspace,
+            encoding="utf-8",
+            errors="ignore")
+        process.communicate()
+
+        process = subprocess.Popen(
+            [self._codechecker_cmd, "parse", report_dir],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.test_workspace,
+            encoding="utf-8",
+            errors="ignore")
+        out, _ = process.communicate()
+
+        self.assertIn("Dereference of null pointer", out)
+
     def unique_json_helper(self, unique_json, is_a, is_b, is_s):
         with open(unique_json,
                   encoding="utf-8", errors="ignore") as json_file:

--- a/analyzer/tests/functional/analyze/test_files/extra_args.c
+++ b/analyzer/tests/functional/analyze/test_files/extra_args.c
@@ -1,0 +1,11 @@
+int main()
+{
+  #ifdef TIDYARGS
+  int i = 1 / 0;
+  #endif
+
+  #ifdef SAARGS
+  int* p = 0;
+  *p = 42;
+  #endif
+}

--- a/analyzer/tests/functional/analyze/test_files/saargs
+++ b/analyzer/tests/functional/analyze/test_files/saargs
@@ -1,0 +1,1 @@
+-DSAARGS

--- a/analyzer/tests/functional/analyze/test_files/tidyargs
+++ b/analyzer/tests/functional/analyze/test_files/tidyargs
@@ -1,0 +1,1 @@
+--extra-arg=-DTIDYARGS


### PR DESCRIPTION
The content of tidyargs file is given to re.sub() function which doesn't
accept binary strings.