### PR TITLE
[fix][cmd] Faster diff command + utf8 bugfix

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1722,7 +1722,7 @@ class ThriftRequestHandler(object):
                 sourcefile = session.query(File).get(lines_in_file.fileId)
                 cont = session.query(FileContent).get(sourcefile.content_hash)
                 lines = zlib.decompress(
-                    cont.content).decode('utf-8').split('\n')
+                    cont.content).decode('utf-8', 'ignore').split('\n')
                 for line in lines_in_file.lines:
                     content = '' if len(lines) < line else lines[line - 1]
                     if encoding == Encoding.BASE64:


### PR DESCRIPTION
In case of plain text output the diff command queries the file contents from
the server. However the source code lines were queried to all reports again and
again. Of course always the same content was returned.

This commit also contains a minor bugfix: if a source file contains a special
character then the utf8 decoder function crashed.