### PR TITLE
[server] Fix source component update

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2362,7 +2362,7 @@ class ThriftRequestHandler(object):
             user = self.__auth_session.user if self.__auth_session else None
 
             if component:
-                component.value = value
+                component.value = value.encode('utf-8')
                 component.description = description
                 component.user = user
             else:


### PR DESCRIPTION
On component update the following exception was thrown:
```
a bytes-like object is required, not 'str'
```
We forgot to encode the component value when we moved to Python 3 so
this commit will solve this problem.