### PR TITLE
[server] Improvement in a slow query preventing timeout

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -211,8 +211,18 @@ def process_report_filter(session, report_filter):
         AND.append(or_(*OR))
 
     if report_filter.reportHash:
-        OR = [Report.bug_id.ilike(conv(rh))
-              for rh in report_filter.reportHash]
+        OR = []
+        no_joker = []
+
+        for rh in report_filter.reportHash:
+            if '*' in rh:
+                OR.append(Report.bug_id.ilike(conv(rh)))
+            else:
+                no_joker.append(rh)
+
+        if no_joker:
+            OR.append(Report.bug_id.in_(no_joker))
+
         AND.append(or_(*OR))
 
     if report_filter.severity:


### PR DESCRIPTION
Earlier the "CodeChecker cmd diff..." command assembled an SQL query which
contained case insensitive pattern matching on the bug hashes with potential
joker characters. The number of these pattern matches is proportional to the
number of reports. This query could cause a timeout in the underlying SQL
server. The solution is checking equality instead of pattern matching.