### PR TITLE
[server] Fix update comments

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1594,7 +1594,7 @@ class ThriftRequestHandler(object):
                         self.__add_comment(comment.bug_hash,
                                            system_comment_msg,
                                            CommentKindValue.SYSTEM)
-                session.add(system_comment)
+                    session.add(system_comment)
 
                 comment.message = content.encode('utf-8')
                 session.add(comment)


### PR DESCRIPTION
When a comment was updated and the message wasn't changed we didn't
create a system comment object but we tried to use this variable later
so the following exception was thrown:
`local variable 'system_comment' referenced before assignment`
There was a bad indentantion in the source code and this commit fixes that.