### PR TITLE
[analyzer] Fix analyzer --file option

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -651,8 +651,9 @@ def __get_skip_handler(args):
 
     if 'files' in args:
         # Creates a skip file where all source files will be skipped except
-        # the given source files.
+        # the given source files and all the header files.
         skip_files = ['+{0}'.format(f) for f in args.files]
+        skip_files.extend(['+/*.h', '+/*.H', '+/*.tcc'])
         skip_files.append('-*')
 
         skip_file_content = "\n".join(skip_files)

--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -2,6 +2,8 @@ multi_error_suppress:
 	$(CXX) -w multi_error_suppress.cpp -o /dev/null
 multi_error_suppress_cstyle:
 	$(CXX) -w multi_error_suppress_cstyle.cpp -o /dev/null
+multi_error_skipped_in_cmd:
+	$(CXX) -w multi_error_skipped_in_cmd.cpp -o /dev/null
 multi_error_suppress_typo:
 	$(CXX) -w multi_error_suppress_typo.cpp -o /dev/null
 multi_error:

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.HPP
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.HPP
@@ -1,0 +1,8 @@
+#ifndef MULTI_ERROR_SKIPPED_IN_CMD_HPP
+#define MULTI_ERROR_SKIPPED_IN_CMD_HPP
+
+void bar() {
+  sizeof(42);
+}
+
+#endif

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.cpp
@@ -1,0 +1,9 @@
+#include "multi_error_skipped_in_cmd.h"
+#include "multi_error_skipped_in_cmd.HPP"
+
+int main()
+{
+  foo();
+
+  sizeof(42);
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.h
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.h
@@ -1,0 +1,8 @@
+#ifndef MULTI_ERROR_SKIPPED_IN_CMD_H
+#define MULTI_ERROR_SKIPPED_IN_CMD_H
+
+void foo() {
+  sizeof(42);
+}
+
+#endif

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
@@ -1,15 +1,15 @@
-NORMAL#CodeChecker log --output $LOGFILE$ --build "make multi_error simple1" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --file "*/simple1.cpp"
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make tidy_check multi_error_skipped_in_cmd" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy --file "*/multi_error_skipped_in_cmd.cpp" -d clang-diagnostic-unused-value -d misc-definitions-in-headers
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make multi_error simple1" --output $OUTPUT$ --quiet --analyzers clangsa --file "*/simple1.cpp"
+CHECK#CodeChecker check --build "make tidy_check multi_error_skipped_in_cmd" --output $OUTPUT$ --analyzers clang-tidy --quiet --file "*/multi_error_skipped_in_cmd.cpp" -d clang-diagnostic-unused-value -d misc-definitions-in-headers
 -----------------------------------------------
 [] - Starting build ...
 [] - Build finished successfully.
 [] - Starting static analysis ...
-[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - [1/1] clang-tidy analyzed multi_error_skipped_in_cmd.cpp successfully.
 [] - ----==== Summary ====----
 [] - Successfully analyzed
-[] -   clangsa: 1
+[] -   clang-tidy: 1
 [] - Total analyzed compilation commands: 1
 [] - Skipped compilation commands: 1
 [] - ----=================----
@@ -18,24 +18,38 @@ CHECK#CodeChecker check --build "make multi_error simple1" --output $OUTPUT$ --q
 [] - To store results use the "CodeChecker store" command.
 [] - See --help and the user guide for further options about parsing and storing the reports.
 [] - ----=================----
-[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero]
-  return 2015 / x;
-              ^
+[HIGH] multi_error_skipped_in_cmd.cpp:8:3: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
+  sizeof(42);
+  ^
 
-Found 1 defect(s) in simple1.cpp
+Found 1 defect(s) in multi_error_skipped_in_cmd.cpp
+
+[HIGH] multi_error_skipped_in_cmd.HPP:5:3: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
+  sizeof(42);
+  ^
+
+Found 1 defect(s) in multi_error_skipped_in_cmd.HPP
+
+[HIGH] multi_error_skipped_in_cmd.h:5:3: suspicious usage of 'sizeof(K)'; did you mean 'K'? [bugprone-sizeof-expression]
+  sizeof(42);
+  ^
+
+Found 1 defect(s) in multi_error_skipped_in_cmd.h
 
 
 ----==== Summary ====----
---------------------------
-Filename    | Report count
---------------------------
-simple1.cpp |            1
---------------------------
+---------------------------------------------
+Filename                       | Report count
+---------------------------------------------
+multi_error_skipped_in_cmd.HPP |            1
+multi_error_skipped_in_cmd.cpp |            1
+multi_error_skipped_in_cmd.h   |            1
+---------------------------------------------
 -----------------------
 Severity | Report count
 -----------------------
-HIGH     |            1
+HIGH     |            3
 -----------------------
 ----=================----
-Total number of reports: 1
+Total number of reports: 3
 ----=================----


### PR DESCRIPTION
When `--file` option was given to the CodeChecker analyze or check commands
at the backround a skip handler was created which included only the given
source file and skipped everything. The problem was when we found reports
in header files we skipped these reports too.
With this patch we will not skip results from the header files.