### PR TITLE
[analyzer] Add more examples to analyzer --config option

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -304,19 +304,21 @@ def add_arguments_to_parser(parser):
     analyzer_opts.add_argument('--config',
                                dest='config_file',
                                required=False,
-                               help="Allow the configuration from an explicit "
-                                    "JSON based configuration file. The "
-                                    "value of the 'analyzer' key in the "
+                               help="R|Allow the configuration from an "
+                                    "explicit JSON based configuration file. "
+                                    "The value of the 'analyzer' key in the "
                                     "config file will be emplaced as command "
                                     "line arguments. The format of "
-                                    "configuration file is: "
-                                    "{"
-                                    "  \"analyzer\": ["
-                                    "    \"--enable=core.DivideZero\","
-                                    "    \"--enable=core.CallAndMessage\","
-                                    "    \"--clean\""
-                                    "  ]"
-                                    "}.")
+                                    "configuration file is:\n"
+                                    "{\n"
+                                    "  \"analyzer\": [\n"
+                                    "    \"--enable=core.DivideZero\",\n"
+                                    "    \"--enable=core.CallAndMessage\",\n"
+                                    "    \"--report-hash=context-free-v2\",\n"
+                                    "    \"--verbose=debug\",\n"
+                                    "    \"--clean\"\n"
+                                    "  ]\n"
+                                    "}")
 
     analyzer_opts.add_argument('--saargs',
                                dest="clangsa_args_cfg_file",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -318,19 +318,21 @@ used to generate a log file on the fly.""")
     analyzer_opts.add_argument('--config',
                                dest='config_file',
                                required=False,
-                               help="Allow the configuration from an explicit "
-                                    "JSON based configuration file. The "
-                                    "value of the 'analyzer' key in the "
+                               help="R|Allow the configuration from an "
+                                    "explicit JSON based configuration file. "
+                                    "The value of the 'analyzer' key in the "
                                     "config file will be emplaced as command "
                                     "line arguments. The format of "
-                                    "configuration file is: "
-                                    "{"
-                                    "  \"analyzer\": ["
-                                    "    \"--enable=core.DivideZero\","
-                                    "    \"--enable=core.CallAndMessage\","
-                                    "    \"--clean\""
-                                    "  ]"
-                                    "}.")
+                                    "configuration file is:\n"
+                                    "{\n"
+                                    "  \"analyzer\": [\n"
+                                    "    \"--enable=core.DivideZero\",\n"
+                                    "    \"--enable=core.CallAndMessage\",\n"
+                                    "    \"--report-hash=context-free-v2\",\n"
+                                    "    \"--verbose=debug\",\n"
+                                    "    \"--clean\"\n"
+                                    "  ]\n"
+                                    "}")
 
     # TODO: One day, get rid of these. See Issue #36, #427.
     analyzer_opts.add_argument('--saargs',

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -820,10 +820,16 @@ analyzer arguments:
   --config CONFIG_FILE  Allow the configuration from an explicit JSON based
                         configuration file. The value of the 'analyzer' key in
                         the config file will be emplaced as command line
-                        arguments. The format of configuration file is: {
-                        "analyzer": [ "--enable=core.DivideZero", "--
-                        enable=core.CallAndMessage", "--clean" ]}. (default:
-                        ~/.codechecker.json)
+                        arguments. The format of configuration file is:
+                        {
+                          "analyzer": [
+                            "--enable=core.DivideZero",
+                            "--enable=core.CallAndMessage",
+                            "--report-hash=context-free-v2",
+                            "--verbose=debug",
+                            "--clean"
+                          ]
+                        } (default: None)
   --saargs CLANGSA_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang Static Analyzer.
@@ -889,11 +895,13 @@ Lets assume you have a configuration file
   "analyzer": [
     "--enable=core.DivideZero",
     "--enable=core.CallAndMessage",
-    "--clean",
     "--analyzer-config",
     "clangsa:unroll-loops=true",
     "--checker-config",
     "clang-tidy:google-readability-function-size.StatementThreshold=100"
+    "--report-hash", "context-free-v2"
+    "--verbose=debug",
+    "--clean"
   ]
 }
 ```
@@ -903,10 +911,18 @@ If you run the following command:
 CodeChecker analyze compilation.json -o ./reports --config ./codechecker.json
 ```
 then the analyzer parameters from the `codechecker.json` file will be emplaced
-as command line arguments if the `enabled` option in this file is `true`:
+as command line arguments:
 ```sh
-CodeChecker analyze compilation.json -o ./reports --enable=core.DivideZero --enable=core.CallAndMessage --clean
+CodeChecker analyze compilation.json -o ./reports --enable=core.DivideZero --enable=core.CallAndMessage --analyzer-config clangsa:unroll-loops=true --checker-config clang-tidy:google-readability-function-size.StatementThreshold=100 --report-hash context-free-v2 --verbose debug --clean
 ```
+
+Note: Options which require parameters have to be in either of the following
+formats:
+
+- Use equal to separate option and parameter in quotes:
+  `{ "analyzer": [ "--verbose=debug" ] }`
+- Use separated values for option and parameter:
+  `{ "analyzer": [ "--verbose", "debug" ] }`
 
 #### Analyzer and checker config options <a name="analyzer-checker-config-option"></a>
 


### PR DESCRIPTION
Extend the help message of the CodeChecker analyze/check commands, and
improve the user guide with more examples how to use the --config option
of these commands.