### PR TITLE
[fix][ldlogger] the ldlogger binary was built to 32bit instead of 64bit

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -86,12 +86,19 @@ package_ld_logger:
 	cd $(CC_BUILD_DIR) && \
 	ln -sf ../ld_logger/bin/ldlogger bin/ldlogger
 
+define LOGGER_BUILD_ERROR_MSG
+Failed to compile logger for 32bit and 64bit targets please check if
+gcc-multilib is installed if both targets are needed or set the
+BUILD_LOGGER_64_BIT_ONLY=YES environment variable for a 64bit only build.
+endef
+
+export LOGGER_BUILD_ERROR_MSG
 build_ld_logger:
-  ifeq ($(BUILD_LOGGER_64_BIT_ONLY),YES)
-		$(MAKE) -C tools/build-logger -f Makefile.manual pack64bit 2> /dev/null
-  else
-		$(MAKE) -C tools/build-logger -f Makefile.manual 2> /dev/null
-  endif
+ifeq ($(BUILD_LOGGER_64_BIT_ONLY),YES)
+	$(MAKE) -C tools/build-logger -f Makefile.manual pack64bit_only 2> /dev/null
+else
+	$(MAKE) -C tools/build-logger -f Makefile.manual 2> /dev/null || (echo "$$LOGGER_BUILD_ERROR_MSG" && false)
+endif
 
 # NOTE: extra spaces are allowed and ignored at the beginning of the
 # conditional directive line, but a tab is not allowed.

--- a/analyzer/tools/build-logger/Makefile.manual
+++ b/analyzer/tools/build-logger/Makefile.manual
@@ -65,17 +65,33 @@ pack64bit: 64bit packbin
 	done
 	rm -f ldlogger_64.so
 
+pack64bit_only: 64bit_only packbin64
+	for x8664dir in 'x86_64'; do \
+		mkdir -p $(LIB_DIR)/$$x8664dir ; \
+		cp ldlogger_64.so $(LIB_DIR)/$$x8664dir/ldlogger.so ; \
+	done
+	rm -f ldlogger_64.so
+
 # pack binary
 packbin:
 	mkdir -p $(BIN_DIR)
 	cp ldlogger $(BIN_DIR)
 	rm -f ldlogger
 
+# pack binary
+packbin64:
+	mkdir -p $(BIN_DIR)
+	cp ldlogger64 $(BIN_DIR)/ldlogger
+	rm -f ldlogger64
+
 # Build only 32 bit lib
 32bit: ldlogger ldlogger_32.so
 
 # Build only 64 bit lib
 64bit: ldlogger ldlogger_64.so
+
+# Build only 64 bit lib and logger
+64bit_only: ldlogger64 ldlogger_64.so
 
 # Cleaner rule
 clean:
@@ -85,6 +101,10 @@ clean:
 # ldlogger executable
 ldlogger: $(LDLOGGER_SOURCES) $(LDLOGGER_HEADERS)
 	$(CC) -m32 $(CPPFLAGS) $(CFLAGS) -D__LOGGER_MAIN__ $(LDFLAGS) $(LDLOGGER_SOURCES) -o $@
+
+# ldlogger executable
+ldlogger64: $(LDLOGGER_SOURCES) $(LDLOGGER_HEADERS)
+	$(CC) -m64 $(CPPFLAGS) $(CFLAGS) -D__LOGGER_MAIN__ $(LDFLAGS) $(LDLOGGER_SOURCES) -o $@
 
 # ldlogger lib 32
 ldlogger_32.so: $(LDLOGGER_LIB_SOURCES) $(LDLOGGER_LIB_HEADERS)


### PR DESCRIPTION
 The ldlogger binary was built into a 32bit executable even if only the
 64bit build was configured during the build.

resolves #2790