### PR TITLE
[cmd] Disable all warnings like checker groups.

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -156,6 +156,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                         compiler_warnings.append('-Wno-' + warning_name)
 
                     continue
+                elif checker_name.startswith('clang-diagnostic'):
+                    checker_name += '*'
 
                 if state == CheckerState.enabled:
                     checkers_cmdline.append(checker_name)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
@@ -30,7 +30,7 @@ class ClangTidyConfigHandler(config_handler.AnalyzerConfigHandler):
         Enable checker, keep description if already set.
         """
         if checker_name.startswith('W') or \
-           checker_name.startswith('clang-diagnostic-'):
+           checker_name.startswith('clang-diagnostic'):
             self.add_checker(checker_name)
 
         super(ClangTidyConfigHandler, self).set_checker_enabled(checker_name,

--- a/analyzer/tests/functional/analyze/test_files/compiler_warning.c
+++ b/analyzer/tests/functional/analyze/test_files/compiler_warning.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+  printf("%d", "hello");
+  int i = 42;
+}


### PR DESCRIPTION
Now the reports starting with clang-diagnostic can be disabled all by
providing this "clang-diagnostic" like a checker group.