### PR TITLE
[cmd][web] improve storage performance

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -27,7 +27,7 @@ from codechecker_analyzer import analyzer_context, suppress_handler
 from codechecker_common import arg, logger, plist_parser, util
 from codechecker_common.skiplist_handler import SkipListHandler
 from codechecker_common.source_code_comment_handler import \
-    REVIEW_STATUS_VALUES, SourceCodeCommentHandler
+    REVIEW_STATUS_VALUES, SourceCodeCommentHandler, SpellException
 from codechecker_common.output_formatters import twodim_to_str
 from codechecker_common.report import Report
 
@@ -311,11 +311,18 @@ def skip_report(report_hash, source_file, report_line, checker_name,
 
     sc_handler = SourceCodeCommentHandler()
 
+    src_comment_data = []
     # Check for source code comment.
-    src_comment_data = sc_handler.filter_source_line_comments(
-        source_file,
-        report_line,
-        checker_name)
+    with open(source_file, encoding='utf-8', errors='ignore') as sf:
+        try:
+            src_comment_data = sc_handler.filter_source_line_comments(
+                sf,
+                report_line,
+                checker_name)
+        except SpellException as ex:
+            LOG.warning("%s contains %s",
+                        os.path.basename(source_file),
+                        str(ex))
 
     if not src_comment_data:
         skip = True if src_comment_status_filter and \

--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_suppress_typo.output
@@ -21,7 +21,7 @@ CHECK#CodeChecker check --build "make multi_error_suppress_typo" --output $OUTPU
   return x/0;
           ^
 
-[] - Misspelled review status comment in multi_error_suppress_typo.cpp@9: // codechecker_suppressssss [all] some comment
+[] - multi_error_suppress_typo.cpp contains misspelled review status comment @9: // codechecker_suppressssss [all] some comment
 [LOW] multi_error_suppress_typo.cpp:10:3: Value stored to 'y' is never read [deadcode.DeadStores]
   y = 7;
   ^

--- a/codechecker_common/logger.py
+++ b/codechecker_common/logger.py
@@ -27,7 +27,6 @@ NOTSET = logging.NOTSET
 
 CMDLINE_LOG_LEVELS = ['info', 'debug', 'debug_analyzer']
 
-
 DEBUG_ANALYZER = logging.DEBUG_ANALYZER = 15
 logging.addLevelName(DEBUG_ANALYZER, 'DEBUG_ANALYZER')
 

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -33,6 +33,19 @@ def arg_match(options, args):
     return matched_args
 
 
+def get_linef(fp, line_no):
+    """'fp' should be (readable) file object.
+    Return the line content at line_no or an empty line
+    if there is less lines than line_no.
+    """
+    fp.seek(0)
+    for line in fp:
+        line_no -= 1
+        if line_no == 0:
+            return line
+    return ''
+
+
 def get_line(file_name, line_no, errors='ignore'):
     """
     Return the given line from the file. If line_no is larger than the number

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -30,7 +30,7 @@ from codechecker_common import logger, plist_parser
 from codechecker_common.output_formatters import twodim_to_str
 from codechecker_common.report import Report
 from codechecker_common.source_code_comment_handler import \
-    SourceCodeCommentHandler
+    SourceCodeCommentHandler, SpellException
 from codechecker_report_hash.hash import get_report_path_hash
 
 from codechecker_web.shared import webserver_context
@@ -623,10 +623,17 @@ def handle_diff_results(args):
             bug_line = rep.main['location']['line']
             checker_name = rep.main['check_name']
 
-            src_comment_data = sc_handler.filter_source_line_comments(
-                source_file,
-                bug_line,
-                checker_name)
+            src_comment_data = []
+            with open(source_file, encoding='utf-8', errors='ignore') as sf:
+                try:
+                    src_comment_data = sc_handler.filter_source_line_comments(
+                        sf,
+                        bug_line,
+                        checker_name)
+                except SpellException as ex:
+                    LOG.warning("%s contains %s",
+                                os.path.basename(source_file),
+                                str(ex))
 
             if len(src_comment_data) == 1:
                 suppressed_in_code.append(bughash)

--- a/web/server/tests/unit/test_source_code_comment.py
+++ b/web/server/tests/unit/test_source_code_comment.py
@@ -27,9 +27,21 @@ class SourceCodeCommentTestCase(unittest.TestCase):
         cls.__test_src_dir = os.path.join(
             os.path.dirname(__file__), 'source_code_comment_test_files')
 
-        cls.__tmp_srcfile_1 = os.path.join(cls.__test_src_dir, 'test_file_1')
-        cls.__tmp_srcfile_2 = os.path.join(cls.__test_src_dir, 'test_file_2')
-        cls.__tmp_srcfile_3 = os.path.join(cls.__test_src_dir, 'test_file_3')
+        cls.__tmp_srcfile_1 = open(os.path.join(cls.__test_src_dir,
+                                                'test_file_1'),
+                                   encoding='utf-8', errors="ignore")
+        cls.__tmp_srcfile_2 = open(os.path.join(cls.__test_src_dir,
+                                                'test_file_2'),
+                                   encoding='utf-8', errors="ignore")
+        cls.__tmp_srcfile_3 = open(os.path.join(cls.__test_src_dir,
+                                                'test_file_3'),
+                                   encoding='utf-8', errors="ignore")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.__tmp_srcfile_1.close()
+        cls.__tmp_srcfile_2.close()
+        cls.__tmp_srcfile_3.close()
 
     def test_src_comment_first_line(self):
         """Bug is reported for the first line."""


### PR DESCRIPTION
The speedup is done mainly on the client side after some refactoring:
 - parsing the plist files is done by a process pool in parallel,
   using all the cpu cores on the machine
 - the source files are checked for codechecker review comments
   with a process poll using all the available cores
 - a quick fast check (with a regex) was done to check if there
   are any review comments in a source file and do the more
   time consuming parsing in parallel if there is any
   (this change was done on the server side too)
 - every source file mentioned in the reports should be
   opened only once to check for review comments

The error handling was a bit changed to easier propagate back
the spelling errors.

After some measurements the speedup can be seen if there are
more than ~2000 reports, below that report count there is a
little slowdown because of the extra process poll creation
and management overhead.

improves the storage speed mentioned in #2758