### PR TITLE
[server] Fix exception in massStoreRun api

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2985,6 +2985,11 @@ class ThriftRequestHandler(object):
                                   sec_to_wait_after_failure)
                         time.sleep(sec_to_wait_after_failure)
                         sec_to_wait_after_failure *= 2
+        except Exception as ex:
+            LOG.error("Failed to store results: %s", ex)
+            import traceback
+            traceback.print_exc()
+            raise
         finally:
             # In any case if the "try" block's execution began, a run lock must
             # exist, which can now be removed, as storage either completed

--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -126,7 +126,7 @@ class MetadataInfoParser(object):
         # detection status. To solve this problem we will return with an empty
         # checker set. This way detection statuses will be calculated properly
         # but OFF and UNAVAILABLE checker statuses will never be used.
-        num_of_report_dir = metadata_dict.get('num_of_report_dir')
+        num_of_report_dir = metadata_dict.get('num_of_report_dir', 0)
         if num_of_report_dir > 1:
             checkers = {}
 


### PR DESCRIPTION
- When the `num_of_report_dir` does not exist in the metadata we tried to
compare NoneType with a number, but Python3 will throw an exception in this case.
This commit will return 0 by default if this key doesn't exist in the metadata.
- This patch also print traceback to the server in case of exception.