### PR TITLE
adding all sei-cert checkers to the security profile

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -74,11 +74,20 @@
         "unix",
         "valist"
       ],
-      "security": [
-        "alpha.security",
+      "security":[
+        "alpha.core.PointerSub",
+        "alpha.core.PointerArithm",
+        "alpha.core.Conversion",
+        "alpha.core.CastToStruct",
+        "alpha.cplusplus.PlacementNew",
+        "option.cplusplus.VirtualCall",
         "alpha.unix.Chroot",
-        "apiModeling",
-        "security.insecureAPI"
+        "alpha.security",
+        "alpha.unix.cstring.OutOfBounds",
+        "alpha.unix.cstring.BufferOverlap",
+        "alpha.unix.PthreadLock",
+        "alpha.unix.Stream",
+        "option.cplusplus.VirtualCall"
       ],
       "portability": [
         "apiModeling",
@@ -240,7 +249,16 @@
         "performance"
       ],
       "security": [
-        "cert"
+        "cert",
+        "bugprone-exception-escape",
+        "bugprone-undefined-memory-manipulation",
+        "bugprone-use-after-move",
+        "bugprone-narrowing-conversions",
+        "bugprone-suspicious-memset-usage",
+        "bugprone-sizeof-expression",
+        "cppcoreguidelines-slicing",
+        "bugprone-unhandled-self-assignment",
+        "bugprone-macro-repeated-side-effects"
       ],
       "portability": [
         "bugprone-misplaced-widening",


### PR DESCRIPTION
Updating the security profile with all chekcers that have relevant findings on the Sei cert test suite.
Many of them are alpha.
Finding counts on our open source projects are indicated below
     
       "security":[
        "alpha.core.PointerSub",0
        "alpha.core.PointerArithm",0
        "alpha.core.Conversion", 44
        "alpha.core.CastToStruct",0
        "alpha.cplusplus.PlacementNew",0
        "option.cplusplus.VirtualCall",35
        "alpha.unix.Chroot",0
        "alpha.security.ReturnPtrRange",9
        "alpha.security.MallocOverflow",19
        "alpha.security.taint.TaintPropagation",4
        "alpha.security.ArrayBound",0
        "alpha.security.ArrayBoundV2"0,
        "alpha.unix.cstring.OutOfBounds",53
        "alpha.unix.cstring.BufferOverlap",0
        "alpha.unix.PthreadLock",12
        "alpha.unix.Stream",218(!)
        "alpha.ericsson.cpp.InvariablePtrBranch",0
        "alpha.ericsson.IncompatiblePointerCast",0
        "alpha.ericsson.cpp.IteratorMismatch",4
        "option.cplusplus.VirtualCall"35
      ],

      
     "security": [
        "cert",
        "bugprone-exception-escape",  -11 
        "bugprone-undefined-memory-manipulation",  0
        "bugprone-use-after-move",1
        "bugprone-narrowing-conversions", 2425!!
        "bugprone-suspicious-memset-usage", 0
        "bugprone-sizeof-expression", 128
        "cppcoreguidelines-slicing", 29
        "bugprone-unhandled-self-assignment", 7
        "bugprone-macro-repeated-side-effects" 0
      ],
