### PR TITLE
[server] Filter out deduplicates from metadata.json

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2905,11 +2905,10 @@ class ThriftRequestHandler(object):
 
                 command = ''
                 if len(check_commands) == 1:
-                    command = ' '.join(check_commands[0])
+                    command = list(check_commands)[0]
                 elif len(check_commands) > 1:
                     command = "multiple analyze calls: " + \
-                              '; '.join([' '.join(com)
-                                         for com in check_commands])
+                              '; '.join(check_commands)
 
                 durations = 0
                 if check_durations:

--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -79,8 +79,8 @@ class MetadataInfoParser(object):
 
     def __get_metadata_info_v2(self, metadata_dict):
         """ Get metadata information from the new version format json file. """
-        cc_version = []
-        check_commands = []
+        cc_version = set()
+        check_commands = set()
         check_durations = []
         analyzer_statistics = {}
         checkers = {}
@@ -88,10 +88,10 @@ class MetadataInfoParser(object):
         tools = metadata_dict.get('tools', {})
         for tool in tools:
             if tool['name'] == 'codechecker' and 'version' in tool:
-                cc_version.append(tool['version'])
+                cc_version.add(tool['version'])
 
             if 'command' in tool:
-                check_commands.append(tool['command'])
+                check_commands.add(' '.join(tool['command']))
 
             if 'timestamps' in tool:
                 check_durations.append(

--- a/web/server/tests/unit/metadata_test_files/v2_multiple.json
+++ b/web/server/tests/unit/metadata_test_files/v2_multiple.json
@@ -51,6 +51,17 @@
       }
     },
     {
+      "name": "codechecker",
+      "version": "6.11 (930440d6a6cae80f615146547f4b169c7629d558)",
+      "command": [
+        "CodeChecker.py",
+        "analyze",
+        "-o",
+        "/path/to/reports",
+        "/path/to/build.json"
+      ]
+    },
+    {
       "name": "cppcheck",
       "analyzer_statistics": {
         "failed": 0,

--- a/web/server/tests/unit/test_metadata_parser.py
+++ b/web/server/tests/unit/test_metadata_parser.py
@@ -149,7 +149,7 @@ class MetadataInfoParserTest(unittest.TestCase):
 
         self.assertEqual(len(check_commands), 1)
         self.assertEqual(' '.join(metadata_cc_info['check_commands']),
-                         ' '.join(check_commands[0]))
+                         list(check_commands)[0])
 
         self.assertEqual(metadata_cc_info['analysis_duration'][0],
                          check_durations[0])
@@ -170,7 +170,6 @@ class MetadataInfoParserTest(unittest.TestCase):
             checkers = self.__parser.get_metadata_info(metadata_multiple)
 
         self.assertEqual(len(check_commands), 2)
-        check_commands = [' '.join(c) for c in check_commands]
         for command in metadata_multiple_info['check_commands']:
             self.assertTrue(command in check_commands)
 
@@ -192,7 +191,6 @@ class MetadataInfoParserTest(unittest.TestCase):
             checkers = self.__parser.get_metadata_info(metadata_multiple)
 
         self.assertEqual(len(check_commands), 2)
-        check_commands = [' '.join(c) for c in check_commands]
         for command in metadata_mult_cppcheck_info['check_commands']:
             self.assertTrue(command in check_commands)
 


### PR DESCRIPTION
Mutliple reports directory can be given for the CodeChecker store command.
We will get metadata.json files from each report directory, we will merge
them together. The problem is that on the server we will put all the
version information to a list not a set so if all the report directory
were analyzed with the same CodeChecker version we will show the same version
multiple times.
This patch will use a set to filter out such duplicates in the version and
in the check command too.