### PR TITLE
[fix][doc] osx install guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -184,7 +184,7 @@ virtualenv -p /usr/bin/python3 .
 ```
 
 ## Mac OS X
-For installation instructions for Mac OS X see [Mac OS X Installation Guide](installation_macosx.md) documentation. 
+For installation instructions for Mac OS X see [Mac OS X Installation Guide](install_macosx.md) documentation.
 
 ## Docker
 To run CodeChecker server in Docker see the [Docker](web/docker.md) documentation.

--- a/docs/install_macosx.md
+++ b/docs/install_macosx.md
@@ -1,4 +1,4 @@
-#Mac OS X Installation Guide
+# Mac OS X Installation Guide
 
 In OSX environment the intercept-build tool from
 [scan-build](https://github.com/rizsotto/scan-build) is used to log the


### PR DESCRIPTION
- broken link from the readme
- missing space from the markdown heading

resolves #2811