### PR TITLE
[server] Serve static files in docs directory as non product

### DIFF
--- a/web/server/codechecker_server/routing.py
+++ b/web/server/codechecker_server/routing.py
@@ -19,6 +19,7 @@ from codechecker_web.shared.version import SUPPORTED_VERSIONS
 # which should not be considered as a product route.
 NON_PRODUCT_ENDPOINTS = ['index.html',
                          'images',
+                         'docs',
                          'live',
                          'ready']
 

--- a/web/server/vue-cli/config/webpack.dev.js
+++ b/web/server/vue-cli/config/webpack.dev.js
@@ -45,7 +45,10 @@ module.exports = merge(common, {
       ]
     },
     proxy: [{
-      context: CC_SERVICE_ENDPOINTS.map(endpoint => `**/${endpoint}`),
+      context: [
+        ...CC_SERVICE_ENDPOINTS.map(endpoint => `**/${endpoint}`),
+        "/docs/**"
+      ],
       target: CC_THRIFT_API_HOST + ':' + CC_THRIFT_API_PORT,
       changeOrigin: true,
       secure: false


### PR DESCRIPTION
We put generated documentation files under the docs dir. If the user
would like to see these files we need to mark docs directory as non
product endpoint. This way if the user opens for example
`{host}:{port}/docs/checker_md_docs/core_division_by_zero.md` in his browser
the md file will be served by the server instead of index.html.