### PR TITLE
[web] Set minial node requirement

### DIFF
--- a/web/server/vue-cli/.npmrc
+++ b/web/server/vue-cli/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -83,6 +83,9 @@
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2"
   },
+  "engines": {
+    "node": ">=10.0"
+  },
   "jest": {
     "moduleFileExtensions": [
       "js",


### PR DESCRIPTION
This commit sets the minimal required node version to >=v10.0.0. If the
node version in the user's machine is older, npm install will terminate
and give a proper error message.