### PR TITLE
[analyzer] mark the --ctu-reanalyze-on-failure flag deprecated

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -166,6 +166,13 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
     Additionally, insert statistical information into the metadata dict.
     """
 
+    ctu_reanalyze_on_failure = 'ctu_reanalyze_on_failure' in args and \
+        args.ctu_reanalyze_on_failure
+    if ctu_reanalyze_on_failure:
+        LOG.warning("Usage of a DEPRECATED FLAG!\n"
+                    "The --ctu-reanalyze-on-failure flag will be removed "
+                    "in the upcoming releases!")
+
     analyzers = args.analyzers if 'analyzers' in args \
         else analyzer_types.supported_analyzers
     analyzers, _ = analyzer_types.check_supported_analyzers(
@@ -322,9 +329,6 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
 
     if 'stats_dir' in args and args.stats_dir:
         statistics_data = manager.dict({'stats_out_dir': args.stats_dir})
-
-    ctu_reanalyze_on_failure = 'ctu_reanalyze_on_failure' in args and \
-        args.ctu_reanalyze_on_failure
 
     if ctu_analyze or statistics_data or (not ctu_analyze and not ctu_collect):
 

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -476,7 +476,8 @@ Cross-TU analysis. By default, no CTU analysis is run when
                               action='store_true',
                               dest='ctu_reanalyze_on_failure',
                               default=argparse.SUPPRESS,
-                              help="If Cross-TU analysis is enabled and fails "
+                              help="DEPRECATED. The flag will be removed. "
+                                   "If Cross-TU analysis is enabled and fails "
                                    "for some reason, try to re analyze the "
                                    "same translation unit without "
                                    "Cross-TU enabled.")

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -480,7 +480,8 @@ is called.""")
                               action='store_true',
                               dest='ctu_reanalyze_on_failure',
                               default=argparse.SUPPRESS,
-                              help="If Cross-TU analysis is enabled and "
+                              help="DEPRECATED. The flag will be removed. "
+                                   "If Cross-TU analysis is enabled and "
                                    "fails for some reason, try to re analyze "
                                    "the same translation unit without "
                                    "Cross-TU enabled.")

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1265,9 +1265,11 @@ cross translation unit analysis arguments:
                         analysis, using already available extra files in
                         '<OUTPUT_DIR>/ctu-dir'. (These files will not be
                         cleaned up in this mode.)
-  --ctu-on-the-fly      If specified, the 'collect' phase will not create the
-                        extra AST dumps, but rather analysis will be run with
-                        an in-memory recompilation of the source files.
+  --ctu-reanalyze-on-failure
+                        DEPRECATED. The flag will be removed. If Cross-TU
+                        analysis is enabled and fails for some reason, try to
+                        re analyze the same translation unit without Cross-TU
+                        enabled.
 ```
 
 ### Statistical analysis mode <a name="statistical"></a>


### PR DESCRIPTION
The ctu analysis is much stable now. The plan is
to remove this feature. First mark the flag as deprecated.