### PR TITLE
[analyzer] Fix unknown -fno-extended-identifiers clang option

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -83,6 +83,7 @@ IGNORED_OPTIONS_GCC = [
     '-fipa-sra',
     '-fno-aggressive-loop-optimizations',
     '-fno-delete-null-pointer-checks',
+    '-fno-extended-identifiers',
     '-fno-jump-table',
     '-fno-keep-static-consts',
     '-fno-strength-reduce',


### PR DESCRIPTION
> Closes #2819

The GCC compiler flag `-fno-extended-identifiers` is not supported by clang.