### PR TITLE
[analyzer] Exit with error code on invalid compilation database

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -854,7 +854,9 @@ def main(args):
     analyzer_env = env.extend(context.path_env_extra,
                               context.ld_lib_path_extra)
 
-    compile_commands = load_json_or_empty(args.logfile, default={})
+    compile_commands = load_json_or_empty(args.logfile)
+    if compile_commands is None:
+        sys.exit(1)
 
     # Number of all the compilation commands in the parsed log files,
     # logged by the logger.

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -948,3 +948,26 @@ class TestAnalyze(unittest.TestCase):
         out, _ = process.communicate()
 
         self.assertEqual(out.count('UninitializedObject'), 0)
+
+    def test_invalid_compilation_database(self):
+        """ Warn in case of an invalid enabled checker. """
+        build_json = os.path.join(self.test_workspace, "build_corrupted.json")
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "-o", self.report_dir]
+
+        with open(build_json, 'w',
+                  encoding="utf-8", errors="ignore") as outfile:
+            outfile.write("Corrupted JSON file!")
+
+        print(analyze_cmd)
+        process = subprocess.Popen(
+            analyze_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.test_dir,
+            encoding="utf-8",
+            errors="ignore")
+
+        process.communicate()
+
+        self.assertEqual(process.returncode, 1)


### PR DESCRIPTION
Exit with error code if the compilation database given to the CodeChecker analyze
command is an invalid json file.