### PR TITLE
[server] Remove only filtered reports

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2299,6 +2299,9 @@ class ThriftRequestHandler(object):
 
                 session.commit()
                 session.close()
+
+                LOG.info("The following reports were removed by '%s': %s",
+                         self.__get_username(), reports_to_delete)
             except Exception as ex:
                 session.rollback()
                 LOG.error("Database cleanup failed.")

--- a/web/server/vue-cli/src/components/Report/ReportFilter/RemoveFilteredReports.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/RemoveFilteredReports.vue
@@ -33,12 +33,14 @@
 <script>
 import { ccService, handleThriftError } from "@cc-api";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import BaseFilterMixin from "./Filters/BaseFilter.mixin";
 
 export default {
   name: "RemoveFileteredReports",
   components: {
     ConfirmDialog
   },
+  mixins: [ BaseFilterMixin ],
   data() {
     return {
       dialog: false

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -251,6 +251,7 @@
         <v-list-item-content>
           <remove-filtered-reports
             class="mt-4"
+            :namespace="namespace"
             @update="updateAllFilters"
           />
         </v-list-item-content>


### PR DESCRIPTION
Unfortunately in the RemoveFilteredReports component the filter variables (runIds,
reportFilter, cmpData) weren't initalized properly so everything in the product were
removed. This commit will initalize this component with these variables and it
also add some logs on the server side about the remove event.