### PR TITLE
[server] Fix storing analyze command

### DIFF
--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -33,7 +33,7 @@ class MetadataInfoParser(object):
         checkers = {}
 
         if 'command' in metadata_dict:
-            check_commands.append(metadata_dict['command'])
+            check_commands.append(' '.join(metadata_dict['command']))
         if 'timestamps' in metadata_dict:
             check_durations.append(
                 float(metadata_dict['timestamps']['end'] -

--- a/web/server/tests/unit/test_metadata_parser.py
+++ b/web/server/tests/unit/test_metadata_parser.py
@@ -128,7 +128,7 @@ class MetadataInfoParserTest(unittest.TestCase):
 
         self.assertEqual(len(check_commands), 1)
         self.assertEqual(' '.join(metadata_cc_info['check_commands']),
-                         ' '.join(check_commands[0]))
+                         check_commands[0])
 
         self.assertEqual(metadata_cc_info['analysis_duration'][0],
                          check_durations[0])


### PR DESCRIPTION
In case of old version metadata the analyze command needs to be joined
together before putting it to a list otherwise the database will throw an
exception that we try to insert a list instead of string.