### PR TITLE
[gui] Fix different filter option after clicking Back to reports

### DIFF
--- a/web/server/vue-cli/src/views/ReportDetail.vue
+++ b/web/server/vue-cli/src/views/ReportDetail.vue
@@ -17,7 +17,10 @@
               color="primary"
               :to="{ name: 'reports', query: {
                 ...$router.currentRoute.query,
-                'report-id': undefined
+                'report-id': undefined,
+                ...(
+                  reportFilter.reportHash ? {} : { 'report-hash' : undefined }
+                )
               }}"
             >
               <v-icon


### PR DESCRIPTION
> Closes #2840

Steps to reproduce:
- List reports.
- Turn on uniqueing.
- Click on a specific report to inspect it.
- Press "Back to reports" button.

The `report-hash` value from the URL is not removed so the "Report hash filter"
is filled and only that report is listed. We need to remove this filter option
manually if we want to see the original list.

To solve this problem we remove the `report-hash` value from the URL when the
report hash filter is not set.