### PR TITLE
[gui] Fix adding product with postgresql database

### DIFF
--- a/web/server/vue-cli/src/components/Product/ProductConfigForm.vue
+++ b/web/server/vue-cli/src/components/Product/ProductConfigForm.vue
@@ -95,7 +95,7 @@
         />
 
         <v-text-field
-          v-model="dbConnection.username"
+          v-model="dbUserName"
           label="User name"
           name="db-username"
           prepend-icon="mdi-account-outline"
@@ -103,7 +103,7 @@
         />
 
         <v-text-field
-          v-model="dbConnection.password"
+          v-model="dbPassword"
           type="password"
           label="Password"
           name="db-password"
@@ -166,6 +166,31 @@ export default {
     dbConnection() {
       return this.productConfig.connection;
     },
+
+    dbUserName: {
+      get() {
+        if (!this.productConfig.connection.username_b64) return "";
+
+        return window.atob(this.productConfig.connection.username_b64);
+      },
+      set(value) {
+        this.productConfig.connection.username_b64 =
+          value.length ? window.btoa(value) : null;
+      }
+    },
+
+    dbPassword: {
+      get() {
+        if (!this.productConfig.connection.password_b64) return "";
+
+        return window.atob(this.productConfig.connection.password_b64);
+      },
+      set(value) {
+        this.productConfig.connection.password_b64 =
+          value.length ? window.btoa(value) : null;
+      }
+    },
+
     description: {
       get() {
         if (!this.productConfig.description_b64) return "";
@@ -177,6 +202,7 @@ export default {
           value.length ? window.btoa(value) : null;
       }
     },
+
     displayName: {
       get() {
         if (!this.productConfig.displayedName_b64) return "";


### PR DESCRIPTION
Database user name and password are not set properly when adding a new
product with PostgreSQL database. These values should be encoded to base64
on the client side before sending to the server. Also wrong field names were
used: username instead of username_b64 and password instead of password_b64.