### PR TITLE
[doc] Documentation about CC_SEVERITY_MAP_FILE environment variable

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -36,6 +36,8 @@ def get_argparser_ctor_args():
     argparse.ArgumentParser (either directly or as a subparser).
     """
 
+    package_root = analyzer_context.get_context().package_root
+
     return {
         'prog': 'CodeChecker analyze',
         'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
@@ -55,6 +57,8 @@ environment variables:
                            is set you can configure the plugin directory of the
                            Clang Static Analyzer by using this environment
                            variable.
+  CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
+                           Default: {}
 
 
 issue hashes:
@@ -98,7 +102,8 @@ checker is renamed.
 
 Compilation databases can be created by instrumenting your project's build via
 'CodeChecker log'. To transform the results of the analysis to a human-friendly
-format, please see the commands 'CodeChecker parse' or 'CodeChecker store'.""",
+format, please see the commands 'CodeChecker parse' or 'CodeChecker store'.
+""".format(os.path.join(package_root, 'config', 'checker_severity_map.json')),
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -32,6 +32,8 @@ def get_argparser_ctor_args():
     argparse.ArgumentParser (either directly or as a subparser).
     """
 
+    package_root = analyzer_context.get_context().package_root
+
     return {
         'prog': 'CodeChecker check',
         'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
@@ -52,6 +54,8 @@ environment variables:
                            is set you can configure the plugin directory of the
                            Clang Static Analyzer by using this environment
                            variable.
+  CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
+                           Default: {}
 
 
 issue hashes:
@@ -100,7 +104,8 @@ analysis results, see 'CodeChecker parse'. 'CodeChecker check' exposes a
 wrapper calling these three commands in succession. Please make sure your build
 command actually builds the files -- it is advised to execute builds on empty
 trees, aka. after a 'make clean', as CodeChecker only analyzes files that had
-been used by the build system.""",
+been used by the build system.
+""".format(os.path.join(package_root, 'config', 'checker_severity_map.json')),
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -359,6 +359,8 @@ def get_argparser_ctor_args():
     argparse.ArgumentParser (either directly or as a subparser).
     """
 
+    package_root = analyzer_context.get_context().package_root
+
     return {
         'prog': 'CodeChecker parse',
         'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
@@ -369,6 +371,12 @@ Parse and pretty-print the summary and results from one or more
 'codechecker-analyze' result files. Bugs which are commented by using
 "false_positive", "suppress" and "intentional" source code comments will not be
 printed by the `parse` command.""",
+
+        'epilog': """
+environment variables:
+  CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
+                         Default: {}
+""".format(os.path.join(package_root, 'config', 'checker_severity_map.json')),
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -364,6 +364,8 @@ environment variables:
                            is set you can configure the plugin directory of the
                            Clang Static Analyzer by using this environment
                            variable.
+  CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
+                           Default: <package>/config/checker_severity_map.json
 
 issue hashes:
 - By default the issue hash calculation method for 'Clang Static Analyzer' is
@@ -793,9 +795,14 @@ optional arguments:
                         Set verbosity level.
 
 environment variables:
-  CC_ANALYZERS_FROM_PATH       Set to `yes` or `1` to enforce taking the
-                               analyzers from the `PATH` instead of the given
-                               binaries.
+  CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
+                           from the `PATH` instead of the given binaries.
+  CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
+                           is set you can configure the plugin directory of the
+                           Clang Static Analyzer by using this environment
+                           variable.
+  CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
+                           Default: <package>/config/checker_severity_map.json
 ```
 
 
@@ -1441,6 +1448,10 @@ export arguments:
                         directory. (By default, it would keep output files and
                         overwrites only those that belongs to a plist file
                         given by the input argument. (default: True)
+
+environment variables:
+  CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
+                         Default: <package>/config/checker_severity_map.json
 ```
 
 For example, if the analysis was run like:


### PR DESCRIPTION
CodeChecker analye|check|parse commands also support
CC_SEVERITY_MAP_FILE environment variable and this was not documented on
their help page.