### PR TITLE
[fix][gui] Rename source component

### DIFF
--- a/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
+++ b/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
@@ -132,8 +132,17 @@ export default {
   },
 
   methods: {
-    saveSourceComponent() {
+    async saveSourceComponent() {
       if (!this.$refs.form.validate()) return;
+
+      // Remove the original component because the user would like to change
+      // the name.
+      if (this.sourceComponent &&
+          this.sourceComponent.name !== this.component.name
+      ) {
+        await ccService.getClient().removeSourceComponent(
+          this.sourceComponent.name, handleThriftError);
+      }
 
       const component = this.component;
       ccService.getClient().addSourceComponent(component.name,


### PR DESCRIPTION
> Closes #2846

When editing a source component the initial source component will not be
renamed but a new source component will be saved. To solve this problem
we remove the original component and create a new component.