### PR TITLE
[gui] Reduce API requests at diff type filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/NewcheckDiffTypeFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/NewcheckDiffTypeFilter.vue
@@ -92,7 +92,7 @@ export default {
     fetchItems() {
       this.loading = true;
 
-      if (!this.cmpData) {
+      if (!this.cmpData || !(this.cmpData.runIds || this.cmpData.runTag)) {
         this.loading = false;
         return Promise.resolve([]);
       }


### PR DESCRIPTION
We call the `getRunResultCount` API function for each diff type to get
diff type filter items even when no run ids or run tags are set. With this
patch we will call these API functions only if the run ids or run tags filters
are set.