### PR TITLE
[server] improve endpoint handling

### DIFF
--- a/web/server/codechecker_server/routing.py
+++ b/web/server/codechecker_server/routing.py
@@ -126,6 +126,8 @@ def split_client_POST_request(path):
 
         return None, version_tag, remainder
 
+    return None, None, None
+
 
 def is_protected_GET_entrypoint(path):
     """

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -362,6 +362,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
         try:
             product_endpoint, api_ver, request_endpoint = \
                 routing.split_client_POST_request(self.path)
+            if product_endpoint is None and api_ver is None and\
+                    request_endpoint is None:
+                raise Exception("Invalid request endpoint path.")
 
             product = None
             if product_endpoint:

--- a/web/server/tests/unit/test_request_routing.py
+++ b/web/server/tests/unit/test_request_routing.py
@@ -48,10 +48,10 @@ class request_routingTest(unittest.TestCase):
         Test if the server properly splits query addresses for POST.
         """
 
-        # The splitter returns None as these are invalid paths.
+        # The splitter returns (None, None, None) as these are invalid paths.
         # It is the server code's responsibility to give a 404 Not Found.
-        self.assertIsNone(POST(''))
-        self.assertIsNone(POST('CodeCheckerService'))
+        self.assertEqual(POST(''), (None, None, None))
+        self.assertEqual(POST('CodeCheckerService'), (None, None, None))
 
         # Raise an exception if URL is malformed, such as contains a
         # product-endpoint-like component which is badly encoded version


### PR DESCRIPTION
"TypeError: 'NoneType' object is not iterable" exception was thrown
by the server if an invalid product endpoint was in the url.
In that case the split_client_POST_request function returned
only one None which could not be unpacked to multiple values
at the caller.