### PR TITLE
[gui][fix] Set cmpData to null when no newcheck filter is set

### DIFF
--- a/web/server/vue-cli/src/store/modules/base-filter.js
+++ b/web/server/vue-cli/src/store/modules/base-filter.js
@@ -13,6 +13,11 @@ const getters = {
     return state.reportFilter;
   },
   getCmpData(state) {
+    // If only the diff type is set we will return with null to identify that
+    // no compare data is set.
+    if (state.cmpData && !state.cmpData.runIds && !state.cmpData.runTag)
+      return null;
+
     return state.cmpData;
   }
 };


### PR DESCRIPTION
Set cmpData API parameters to null when only the diff type is set and no
newcheck filter (run ids, tags) is set.