### PR TITLE
[cmd] Logging enabled checkers at the beginning of analysis

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -10,6 +10,7 @@ Prepare and start different analysis types
 """
 
 
+from collections import defaultdict
 from multiprocessing.managers import SyncManager
 import os
 import shlex
@@ -240,6 +241,8 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
     check_env = env.extend(context.path_env_extra,
                            context.ld_lib_path_extra)
 
+    enabled_checkers = defaultdict(list)
+
     # Save some metadata information.
     for analyzer in analyzers:
         metadata_info = {
@@ -254,11 +257,15 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
             state, _ = data
             metadata_info['checkers'].update({
                 check: state == CheckerState.enabled})
+            enabled_checkers[analyzer].append(check)
 
         version = config_map[analyzer].get_version(check_env)
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info
+
+    LOG.info("Enabled checkers:\n%s", '\n'.join(
+        k + ': ' + ', '.join(v) for k, v in enabled_checkers.items()))
 
     if 'makefile' in args and args.makefile:
         statistics_data = __get_statistics_data(args)

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -890,7 +890,9 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        self.assertEqual(out.count('hicpp-use-nullptr'), 1)
+        # First it's printed as the member of enabled checkers at the beginning
+        # of the output. Second it is printed as a found report.
+        self.assertEqual(out.count('hicpp-use-nullptr'), 2)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clang-tidy", "-o", self.report_dir,
@@ -909,7 +911,9 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        self.assertEqual(out.count('hicpp-use-nullptr'), 2)
+        # First it's printed as the member of enabled checkers at the beginning
+        # of the output. Second and third it is printed as a found report.
+        self.assertEqual(out.count('hicpp-use-nullptr'), 3)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clangsa", "-o", self.report_dir,
@@ -927,7 +931,9 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        self.assertEqual(out.count('UninitializedObject'), 1)
+        # First it's printed as the member of enabled checkers at the beginning
+        # of the output. Second it is printed as a found report.
+        self.assertEqual(out.count('UninitializedObject'), 2)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clangsa", "-o", self.report_dir,
@@ -947,7 +953,9 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        self.assertEqual(out.count('UninitializedObject'), 0)
+        # It is printed as the member of enabled checkers, but it gives no
+        # report.
+        self.assertEqual(out.count('UninitializedObject'), 1)
 
     def test_invalid_compilation_database(self):
         """ Warn in case of an invalid enabled checker. """

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -168,7 +168,12 @@ class AnalyzeParseTestCase(
         post_processed_output = []
         skip_prefixes = ["[] - Analysis length:",
                          "[] - Previous analysis results",
-                         "[] - Skipping input file"]
+                         "[] - Skipping input file",
+                         # Enabled checkers are listed in the beginning of
+                         # analysis.
+                         "[] - Enabled checkers:",
+                         "clang-tidy:",
+                         "clangsa:"]
         for line in output:
             # replace timestamps
             line = re.sub(r'\[\w+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}\]',


### PR DESCRIPTION
The list of applied checkers can be configured by -e, -d flags,
CodeChecker config files, etc. It is hard to see which checkers are
actually enabled during the analysis. Now the enabled checkers are
listed at the beginning of the analysis.