### PR TITLE
[server][fix] Fix disconnection product after remove

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -866,7 +866,7 @@ class CCSimpleHttpServer(HTTPServer):
         endpoints specified in :endpoints_to_keep.
         """
         [self.remove_product(ep)
-            for ep in self.__products.keys()
+            for ep in list(self.__products)
             if ep not in endpoints_to_keep]
 
 

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -81,7 +81,7 @@ class TestProductConfigShare(unittest.TestCase):
         # Setup a product client to test product API calls which requires root.
         self._root_client = env.setup_product_client(self.test_workspace_main,
                                                      session_token=root_token)
-        self.assertIsNotNone(self._pr_client)
+        self.assertIsNotNone(self._root_client)
 
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace_main)
@@ -212,7 +212,7 @@ class TestProductConfigShare(unittest.TestCase):
         self.assertTrue(self._root_client.removeProduct(p_id),
                         "Main server reported error while removing product.")
 
-        self.assertEqual(len(self._pr_client.getProducts('_second', None)),
+        self.assertEqual(len(self._pr_client_2.getProducts('_second', None)),
                          0,
                          "Secondary server still sees the removed product.")
 


### PR DESCRIPTION
When a product is removed but a server is still connects to this product
we will try to disconnecting it by removing from the local cache.
We will iterate over the `self.__products` dictionary keys and we will
remove this product from the dictionary. In Python 2 it worked but in
Python 3 the following exception was thrown:
```
RuntimeError: dictionary changed size during iteration
```
The problem is that in Python 2 the `keys` makes a copy of the keys
what we can iterate over while modifying the dictionary. In Python 3
`keys` returns an iterator instead of a list. To solve this problem
we will create a force copy from the keys.