### PR TITLE
[db] Add index for content hash column on files table

### DIFF
--- a/web/server/codechecker_server/database/run_db_model.py
+++ b/web/server/codechecker_server/database/run_db_model.py
@@ -168,7 +168,8 @@ class File(Base):
     content_hash = Column(String,
                           ForeignKey('file_contents.content_hash',
                                      deferrable=True,
-                                     initially="DEFERRED", ondelete='CASCADE'))
+                                     initially="DEFERRED", ondelete='CASCADE'),
+                          index=True)
 
     __table_args__ = (UniqueConstraint('filepath', 'content_hash'),)
 

--- a/web/server/codechecker_server/migrations/report/versions/2185167f8568_content_hash_index_for_files.py
+++ b/web/server/codechecker_server/migrations/report/versions/2185167f8568_content_hash_index_for_files.py
@@ -1,0 +1,23 @@
+"""content hash index for files
+
+Revision ID: 2185167f8568
+Revises: 5f8a443a51e5
+Create Date: 2020-07-28 16:02:01.131126
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2185167f8568'
+down_revision = '5f8a443a51e5'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index(op.f('ix_files_content_hash'), 'files', ['content_hash'], unique=False)
+
+def downgrade():
+    op.drop_index(op.f('ix_files_content_hash'), table_name='files')


### PR DESCRIPTION
If we use PostgreSQL database and we set the query timeout to 2 minutes the
database cleanup will be timed out when the server tries to remove unused
files and the database is to big.
The reason is that the database sequentially scanned the database to look
for foreign key constraints. To solve this problem we add index to the
content hash column on files table.