### PR TITLE
[analyzer] Make on-demand AST loading mode default

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -497,7 +497,7 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                   action='store',
                                   dest='ctu_ast_mode',
                                   choices=['load-from-pch', 'parse-on-demand'],
-                                  default='load-from-pch',
+                                  default='parse-on-demand',
                                   help="Choose the way ASTs are loaded during "
                                        "CTU analysis. Mode 'load-from-pch' "
                                        "generates PCH format serialized ASTs "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -499,7 +499,7 @@ is called.""")
                                   action='store',
                                   dest='ctu_ast_mode',
                                   choices=['load-from-pch', 'parse-on-demand'],
-                                  default='load-from-pch',
+                                  default='parse-on-demand',
                                   help="Choose the way ASTs are loaded during "
                                        "CTU analysis. Mode 'load-from-pch' "
                                        "generates PCH format serialized ASTs "

--- a/analyzer/tests/functional/ctu/test_ctu.py
+++ b/analyzer/tests/functional/ctu/test_ctu.py
@@ -157,8 +157,8 @@ class TestCtu(unittest.TestCase):
 
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
                '--analyzers', 'clangsa', '--ctu-all']
-        if on_demand:
-            cmd.append('--ctu-ast-mode=parse-on-demand')
+        cmd.extend(['--ctu-ast-mode',
+                    'parse-on-demand' if on_demand else 'load-from-pch'])
         cmd.append(self.buildlog)
         out, _ = call_command(cmd, cwd=self.test_dir, env=self.env)
         return out
@@ -168,8 +168,8 @@ class TestCtu(unittest.TestCase):
 
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
                '--analyzers', 'clangsa', '--ctu-collect']
-        if on_demand:
-            cmd.append('--ctu-ast-mode=parse-on-demand')
+        cmd.extend(['--ctu-ast-mode',
+                    'parse-on-demand' if on_demand else 'load-from-pch'])
         cmd.append(self.buildlog)
         call_command(cmd, cwd=self.test_dir, env=self.env)
 
@@ -192,8 +192,8 @@ class TestCtu(unittest.TestCase):
 
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
                '--analyzers', 'clangsa', '--ctu-analyze']
-        if on_demand:
-            cmd.append('--ctu-ast-mode=parse-on-demand')
+        cmd.extend(['--ctu-ast-mode',
+                    'parse-on-demand' if on_demand else 'load-from-pch'])
         cmd.append(self.buildlog)
         out, _ = call_command(cmd, cwd=self.test_dir, env=self.env)
         return out

--- a/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
@@ -399,8 +399,8 @@ class TestCtuFailure(unittest.TestCase):
 
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
                '--analyzers', 'clangsa', '--ctu-all']
-        if on_demand:
-            cmd.append('--ctu-ast-mode=parse-on-demand')
+        cmd.extend(['--ctu-ast-mode',
+                    'parse-on-demand' if on_demand else 'load-from-pch'])
         if extra_args is not None:
             cmd.extend(extra_args)
         cmd.append(self.buildlog)

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -304,7 +304,7 @@ cross translation unit analysis arguments:
                         the ASTs. Mode 'load-from-pch' can use significant
                         disk-space for the serialized ASTs, while mode 'parse-
                         on-demand' can incur some runtime CPU overhead in the
-                        second phase of the analysis. (default: load-from-pch)
+                        second phase of the analysis. (default: parse-on-demand)
 
 checker configuration:
   
@@ -1355,7 +1355,7 @@ cross translation unit analysis arguments:
                         the ASTs. Mode 'load-from-pch' can use significant
                         disk-space for the serialized ASTs, while mode 'parse-
                         on-demand' can incur some runtime CPU overhead in the
-                        second phase of the analysis. (default: load-from-pch)
+                        second phase of the analysis. (default: parse-on-demand)
 ```
 
 ### Statistical analysis mode <a name="statistical"></a>


### PR DESCRIPTION
Make the default mode of loading AST-s during CTU analysis
'parse-on-demand' in case the Clang SA used supports it.

Note that if there is no support for the `parse-on-demand` feature then the default `load-from-pch` mode is used instead. This could be the case if upstream Clang 10 or lower is used.