### PR TITLE
[cmd] Expand environment variables in config file

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -329,9 +329,13 @@ def add_arguments_to_parser(parser):
                                     "    \"--enable=core.CallAndMessage\",\n"
                                     "    \"--report-hash=context-free-v2\",\n"
                                     "    \"--verbose=debug\",\n"
+                                    "    \"--skip=$HOME/project/skip.txt\",\n"
                                     "    \"--clean\"\n"
                                     "  ]\n"
-                                    "}")
+                                    "}.\n"
+                                    "You can use any environment variable "
+                                    "inside this file and it will be "
+                                    "expaneded.")
 
     analyzer_opts.add_argument('--saargs',
                                dest="clangsa_args_cfg_file",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -328,9 +328,13 @@ used to generate a log file on the fly.""")
                                     "    \"--enable=core.CallAndMessage\",\n"
                                     "    \"--report-hash=context-free-v2\",\n"
                                     "    \"--verbose=debug\",\n"
+                                    "    \"--skip=$HOME/project/skip.txt\",\n"
                                     "    \"--clean\"\n"
                                     "  ]\n"
-                                    "}")
+                                    "}.\n"
+                                    "You can use any environment variable "
+                                    "inside this file and it will be "
+                                    "expaneded.")
 
     # TODO: One day, get rid of these. See Issue #36, #427.
     analyzer_opts.add_argument('--saargs',

--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -123,6 +123,9 @@ output.
         if 'func_process_config_file' in args:
             cfg_args = args.func_process_config_file(args)
             if cfg_args:
+                # Expand environment variables in the arguments.
+                cfg_args = map(lambda cfg: os.path.expandvars(cfg), cfg_args)
+
                 sys.argv.extend(cfg_args)
                 args = parser.parse_args()
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -225,9 +225,12 @@ analyzer arguments:
                             "--enable=core.CallAndMessage",
                             "--report-hash=context-free-v2",
                             "--verbose=debug",
+                            "--skip=$HOME/project/skip.txt",
                             "--clean"
                           ]
-                        } (default: None)
+                        }.
+                        You can use any environment variable inside this file
+                        and it will be expaneded. (default: None)
   --saargs CLANGSA_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang Static analyzer.
@@ -881,9 +884,12 @@ analyzer arguments:
                             "--enable=core.CallAndMessage",
                             "--report-hash=context-free-v2",
                             "--verbose=debug",
+                            "--skip=$HOME/project/skip.txt",
                             "--clean"
                           ]
-                        } (default: None)
+                        }.
+                        You can use any environment variable inside this file
+                        and it will be expaneded. (default: None)
   --saargs CLANGSA_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang Static Analyzer.
@@ -977,6 +983,9 @@ formats:
   `{ "analyzer": [ "--verbose=debug" ] }`
 - Use separated values for option and parameter:
   `{ "analyzer": [ "--verbose", "debug" ] }`
+
+Note: environment variables inside this config file will be expanded:
+`{ "analyzer": [ "--skip=$HOME/project/skip.txt" ] }`
 
 #### Analyzer and checker config options <a name="analyzer-checker-config-option"></a>
 

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -202,12 +202,13 @@ optional arguments:
                         config file will overwrite the values set in the
                         command line. The format of configuration file is:
                         {
-                          "store": [
-                            "--name=run_name",
-                            "--tag=my_tag",
-                            "--url=http://codechecker.my/MyProduct"
+                          "server": [
+                            "--workspace=$HOME/workspace",
+                            "--port=9090"
                           ]
-                        }. (default: None)
+                        }.
+                        You can use any environment variable inside this file
+                        and it will be expaneded. (default: None)
   -f, --force           Delete analysis results stored in the database for the
                         current analysis run's name and store only the results
                         reported in the 'input' files. (By default,

--- a/web/server/codechecker_server/cmd/server.py
+++ b/web/server/codechecker_server/cmd/server.py
@@ -145,11 +145,12 @@ def add_arguments_to_parser(parser):
                              "configuration file is: \n"
                              "{\n"
                              "  \"server\": [\n"
-                             "    \"--workspace=/home/<username>/workspace\","
-                             "\n"
+                             "    \"--workspace=$HOME/workspace\",\n"
                              "    \"--port=9090\"\n"
                              "  ]\n"
-                             "}.")
+                             "}.\n"
+                             "You can use any environment variable inside "
+                             "this file and it will be expaneded.")
 
     dbmodes = parser.add_argument_group("configuration database arguments")
 

--- a/web/tests/functional/cli_config/test_store_config.py
+++ b/web/tests/functional/cli_config/test_store_config.py
@@ -45,19 +45,23 @@ class TestStoreConfig(unittest.TestCase):
 
     def test_valid_config(self):
         """ Store with a valid configuration file. """
+        cc_env = env.codechecker_env()
+        cc_env["CC_REPORT_DIR"] = self.codechecker_cfg['reportdir']
+
         with open(self.config_file, 'w+',
                   encoding="utf-8", errors="ignore") as config_f:
             json.dump({
                 'store': [
                     '--name=' + 'store_config',
+                    '--trim-path-prefix=$HOME',
                     '--url=' + env.parts_to_url(self.codechecker_cfg),
-                    self.codechecker_cfg['reportdir']]}, config_f)
+                    '$CC_REPORT_DIR']}, config_f)
 
         store_cmd = [env.codechecker_cmd(), 'store', '--config',
                      self.config_file]
 
         subprocess.check_output(
-            store_cmd, encoding="utf-8", errors="ignore")
+            store_cmd, env=cc_env, encoding="utf-8", errors="ignore")
 
     def test_invalid_config(self):
         """ Store with an invalid configuration file. """


### PR DESCRIPTION
Expand environment variables in the config file given by the
--config option.