### PR TITLE
[gui] Fix setting detection date filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
@@ -105,7 +105,15 @@ export default {
 
         const toDateTime = this.$route.query[this.toDateTimeId];
         if (toDateTime) {
-          this.setToDateTime(new Date(toDateTime), false);
+          const dateTime = new Date(toDateTime);
+
+          // We need to round the date upward because we will send the dates
+          // to the server without milliseconds.
+          if (dateTime.getMilliseconds()) {
+            dateTime.setMilliseconds(1000);
+          }
+
+          this.setToDateTime(dateTime, false);
         }
 
         resolve();

--- a/web/server/vue-cli/src/views/RunHistoryList.vue
+++ b/web/server/vue-cli/src/views/RunHistoryList.vue
@@ -324,27 +324,24 @@ export default {
 
       urlState["run"] = bRuns;
       urlState["run-tag"] = bTags.length ? bTags : undefined;
-      if (firstDetectionDates.length) {
-        const minDate = min(firstDetectionDates.map(d =>
-          parse(d, "yyyy-MM-dd HH:mm:ss.SSSSSS", new Date())));
-        urlState["first-detection-date"] =
-          format(minDate, "yyyy-MM-dd HH:mm:ss");
-      }
 
       const { runs: nRuns, tags: nTags, times: fixDates } =
         this.getSelectedTagData(this.selectedNewcheckTags);
 
       urlState["newcheck"] = nRuns;
       urlState["run-tag-newcheck"] = nTags.length ? nTags : undefined;
-      if (fixDates.length) {
-        const maxDate = max(fixDates.map(d =>
+
+      if (firstDetectionDates.length || fixDates.length) {
+        const dates = [ ...firstDetectionDates, ...fixDates ];
+
+        const minDate = min(dates.map(d =>
+          parse(d, "yyyy-MM-dd HH:mm:ss.SSSSSS", new Date())));
+        const maxDate = max(dates.map(d =>
           parse(d, "yyyy-MM-dd HH:mm:ss.SSSSSS", new Date())));
 
-        // We need to round the date upward because in the url we will save
-        // the dates without milliseconds.
-        maxDate.setMilliseconds(1000);
-
-        urlState["fix-date"] = format(maxDate, "yyyy-MM-dd HH:mm:ss");
+        urlState["first-detection-date"] =
+            format(minDate, "yyyy-MM-dd HH:mm:ss.SSSSS");
+        urlState["fix-date"] = format(maxDate, "yyyy-MM-dd HH:mm:ss.SSSSS");
       }
 
       return {


### PR DESCRIPTION
- We need to round the fix date upward because we will send the dates to the
server without milliseconds.
- Set detection date to the minimum date and the fix date to the maximum date
from the selected run history items during diff.