### PR TITLE
[cmd] Close and join process pool

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -760,6 +760,8 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
         finally:
             pool.join()
     else:
+        pool.close()
+        pool.join()
         LOG.info("----==== Summary ====----")
 
     for skp in skipped_actions:


### PR DESCRIPTION
The process pool needs to be closed and joined otherwise the main wait()
function will wait for infinity in case there is no files to analyze in
a CTU analysis.