### PR TITLE
[analyzer] Clang resource dir not used in CodeChecker

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -288,13 +288,6 @@ class Context(object):
                             'plist_to_html', 'static')
 
     @property
-    def compiler_resource_dir(self):
-        resource_dir = self.pckg_layout.get('compiler_resource_dir')
-        if not resource_dir:
-            return ""
-        return os.path.join(self._package_root, resource_dir)
-
-    @property
     def path_env_extra(self):
         if env.is_analyzer_from_path():
             return []

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -17,7 +17,6 @@ import subprocess
 
 from codechecker_common.logger import get_logger
 
-from codechecker_analyzer import host_check
 from codechecker_analyzer import env
 
 from .. import analyzer_base
@@ -364,8 +363,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         handler.analyzer_plugins_dir = context.checker_plugin
         handler.analyzer_binary = context.analyzer_binaries.get(
             cls.ANALYZER_NAME)
-        handler.compiler_resource_dir = \
-            host_check.get_resource_dir(handler.analyzer_binary, context)
         handler.version_info = version.get(handler.analyzer_binary, environ)
 
         handler.report_hash = args.report_hash \

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -17,14 +17,12 @@ import subprocess
 
 from codechecker_common.logger import get_logger
 
-from codechecker_analyzer import host_check
 from codechecker_analyzer import env
 
 from .. import analyzer_base
 from ..config_handler import CheckerState
 from ..flag import has_flag
 from ..flag import prepend_all
-from ..clangsa.analyzer import ClangSA
 
 from . import config_handler
 from . import result_handler
@@ -296,11 +294,6 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         # Overwrite PATH to contain only the parent of the clang binary.
         if os.path.isabs(handler.analyzer_binary):
             check_env['PATH'] = os.path.dirname(handler.analyzer_binary)
-        clang_bin = ClangSA.resolve_missing_binary('clang',
-                                                   check_env)
-        handler.compiler_resource_dir = \
-            host_check.get_resource_dir(clang_bin, context)
-
         try:
             with open(args.tidy_args_cfg_file, 'r', encoding='utf-8',
                       errors='ignore') as tidy_cfg:

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -49,7 +49,6 @@ class AnalyzerConfigHandler(object, metaclass=ABCMeta):
 
         self.analyzer_binary = None
         self.analyzer_plugins_dir = None
-        self.compiler_resource_dir = ''
         self.analyzer_extra_arguments = []
         self.checker_config = ''
         self.report_hash = None

--- a/analyzer/codechecker_analyzer/host_check.py
+++ b/analyzer/codechecker_analyzer/host_check.py
@@ -97,36 +97,3 @@ def has_analyzer_option(clang_bin, feature, env=None):
         except OSError:
             LOG.error('Failed to run: "%s"', ' '.join(cmd))
             return False
-
-
-def get_resource_dir(clang_bin, context, env=None):
-    """
-    Returns the resource_dir of Clang or None if the switch is not supported by
-    Clang.
-    """
-    if context.compiler_resource_dir:
-        return context.compiler_resource_dir
-    # If not set then ask the binary for the resource dir.
-    cmd = [clang_bin, "-print-resource-dir"]
-    LOG.debug('run: "%s"', ' '.join(cmd))
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env,
-            universal_newlines=True,
-            encoding="utf-8",
-            errors="ignore")
-        out, err = proc.communicate()
-
-        LOG.debug("stdout:\n%s", out)
-        LOG.debug("stderr:\n%s", err)
-
-        if proc.returncode == 0:
-            return out.rstrip()
-        else:
-            return None
-    except OSError:
-        LOG.error('Failed to run: "%s"', ' '.join(cmd))
-        return False

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -24,7 +24,6 @@ class MockContextSA(object):
     ld_lib_path_extra = None
     checker_plugin = None
     analyzer_binaries = {'clangsa': 'clang'}
-    compiler_resource_dir = None
     checker_config = {'clangsa_checkers': ['a.b']}
     available_profiles = ['profile1']
     package_root = './'
@@ -100,7 +99,6 @@ class MockContextTidy(object):
     ld_lib_path_extra = None
     checker_plugin = None
     analyzer_binaries = {'clang-tidy': 'clang-tidy'}
-    compiler_resource_dir = None
     checker_config = {'clangtidy_checkers': ['d-e']}
     available_profiles = ['profile1']
     package_root = './'

--- a/config/package_layout.json
+++ b/config/package_layout.json
@@ -6,7 +6,6 @@
     },
     "clang-apply-replacements": "clang-apply-replacements"
   },
-  "compiler_resource_dir" : null,
   "ld_lib_path_extra" : [],
   "path_env_extra" : []
 }


### PR DESCRIPTION
The resource directory of Clang (lib/clang/<version>) was at a custom
location earlier inside CodeChecker package. However, it is found
relatively to "clang" binary by Clang, so it is not needed anymore to
store its location in our config file.