### PR TITLE
[web] Introduce new detection date filter options

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -637,11 +637,50 @@ filter arguments:
                         only if basename or newname is a run name (on the
                         remote server).
   --detected-at TIMESTAMP
-                        Filter results by detection date. The format of
+                        DEPRECATED. Use the '--detected-after/--detected-
+                        before' options to filter results by detection date.
+                        Filter results by fix date (fixed after the given
+                        date) if the --detection-status filter option is set
+                        only to Resolved otherwise it filters the results by
+                        detection date (detected after the given date). The
+                        format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
+  --fixed-at TIMESTAMP  DEPRECATED. Use the '--fixed-after/--fixed-before'
+                        options to filter results by fix date. Filter results
+                        by fix date (fixed before the given date) if the
+                        --detection-status filter option is set only to
+                        Resolved otherwise it filters the results by detection
+                        date (detected before the given date). The format of
                         TIMESTAMP is 'year:month:day:hour:minute:second' (the
                         "time" part can be omitted, in which case midnight
                         (00:00:00) is used).
-  --fixed-at TIMESTAMP  Filter results by fix date. The format of TIMESTAMP is
+  --detected-before TIMESTAMP
+                        Get results which were detected before the given date.
+                        The detection date of a report is the storage date
+                        when the report was stored to the server for the first
+                        time. The format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
+  --detected-after TIMESTAMP
+                        Get results which were detected after the given date.
+                        The detection date of a report is the storage date
+                        when the report was stored to the server for the first
+                        time. The format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
+  --fixed-before TIMESTAMP
+                        Get results which were fixed before the given date.
+                        The format of TIMESTAMP is
+                        'year:month:day:hour:minute:second' (the "time" part
+                        can be omitted, in which case midnight (00:00:00) is
+                        used).
+  --fixed-after TIMESTAMP
+                        Get results which were fixed after the given date. The
+                        format of TIMESTAMP is
                         'year:month:day:hour:minute:second' (the "time" part
                         can be omitted, in which case midnight (00:00:00) is
                         used).
@@ -870,8 +909,12 @@ usage: CodeChecker cmd results [-h] [--details] [--uniqueing {on,off}]
                                [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]
                                [--component [COMPONENT [COMPONENT ...]]]
                                [--detected-at TIMESTAMP]
-                               [--fixed-at TIMESTAMP] [-s] [--filter FILTER]
-                               [--url PRODUCT_URL]
+                               [--fixed-at TIMESTAMP]
+                               [--detected-before TIMESTAMP]
+                               [--detected-after TIMESTAMP]
+                               [--fixed-before TIMESTAMP]
+                               [--fixed-after TIMESTAMP] [-s]
+                               [--filter FILTER] [--url PRODUCT_URL]
                                [-o {plaintext,rows,table,csv,json}]
                                [--verbose {info,debug,debug_analyzer}]
                                RUN_NAMES [RUN_NAMES ...]
@@ -933,7 +976,10 @@ usage: CodeChecker cmd diff [-h] [-b BASE_RUNS [BASE_RUNS ...]]
                             [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]
                             [--component [COMPONENT [COMPONENT ...]]]
                             [--detected-at TIMESTAMP] [--fixed-at TIMESTAMP]
-                            [-s] [--filter FILTER]
+                            [--detected-before TIMESTAMP]
+                            [--detected-after TIMESTAMP]
+                            [--fixed-before TIMESTAMP]
+                            [--fixed-after TIMESTAMP] [-s] [--filter FILTER]
                             (--new | --resolved | --unresolved)
                             [--url PRODUCT_URL]
                             [-o {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...]]
@@ -1114,7 +1160,11 @@ usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a)
                            [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]
                            [--component [COMPONENT [COMPONENT ...]]]
                            [--detected-at TIMESTAMP] [--fixed-at TIMESTAMP]
-                           [-s] [--filter FILTER] [--url PRODUCT_URL]
+                           [--detected-before TIMESTAMP]
+                           [--detected-after TIMESTAMP]
+                           [--fixed-before TIMESTAMP]
+                           [--fixed-after TIMESTAMP] [-s] [--filter FILTER]
+                           [--url PRODUCT_URL]
                            [-o {plaintext,rows,table,csv,json}]
                            [--verbose {info,debug,debug_analyzer}]
 

--- a/web/api/js/codechecker-api-js/package.json
+++ b/web/api/js/codechecker-api-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api-js",
-  "version": "6.28.0",
+  "version": "6.28.0-dev3",
   "description": "Generated jQuery compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/js/codechecker-api-node/package.json
+++ b/web/api/js/codechecker-api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api",
-  "version": "6.28.0",
+  "version": "6.28.0-dev3",
   "description": "Generated node.js compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/py/codechecker_api/setup.py
+++ b/web/api/py/codechecker_api/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.28.0'
+api_version = '6.28.0-dev3'
 
 setup(
     name='codechecker_api',

--- a/web/api/py/codechecker_api_shared/setup.py
+++ b/web/api/py/codechecker_api_shared/setup.py
@@ -10,7 +10,7 @@ with open('README.md', encoding='utf-8', errors="ignore") as f:
 
 setup(
     name='codechecker_api_shared',
-    version='6.28.0',
+    version='6.28.0-dev3',
     description='Shared API stub types package for the CodeChecker API.',
     long_description_content_type='text/markdown',
     long_description=long_description,

--- a/web/api/report_server.thrift
+++ b/web/api/report_server.thrift
@@ -247,6 +247,16 @@ struct BugPathLengthRange {
   2: i64  max, // Maximum value of bug path length.
 }
 
+struct DateInterval {
+  1: i64  before, // Unix (epoch) time.
+  2: i64  after,  // Unix (epoch) time.
+}
+
+struct ReportDate {
+  1: DateInterval detected,  // Date interval when the report was detected at.
+  2: DateInterval fixed,     // Date interval when the report was fixed at.
+}
+
 /**
  * Members of this struct are interpreted in "OR" relation with each other.
  * Between the elements of the list there is "AND" relation.
@@ -260,13 +270,14 @@ struct ReportFilter {
   6: list<ReviewStatus>    reviewStatus,
   7: list<DetectionStatus> detectionStatus,
   8: list<string>          runHistoryTag,      // Date of the run tag. !Deprecated!
-  9: optional i64          firstDetectionDate,
-  10: optional i64         fixDate,
+  9: optional i64          firstDetectionDate, // !Deprecated! Use reportDate instead of this.
+  10: optional i64         fixDate,            // !Deprecated! Use reportDate instead of this.
   11: optional bool        isUnique,
   12: list<string>         runName,
   13: list<i64>            runTag,             // Ids of the run history tags.
   14: list<string>         componentNames,     // Names of the source components.
   15: optional BugPathLengthRange bugPathLength, // Minimum and maximum values of bug path length.
+  16: optional ReportDate         date,          // Dates of the report.
 }
 
 struct RunReportCount {

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -288,8 +288,14 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                          dest="detected_at",
                          metavar='TIMESTAMP',
                          default=argparse.SUPPRESS,
-                         help="Filter results by detection date. The format "
-                              " of TIMESTAMP is "
+                         help="DEPRECATED. Use the '--detected-after/"
+                              "--detected-before' options to filter results "
+                              "by detection date. Filter results by fix date "
+                              "(fixed after the given date) if the "
+                              "--detection-status filter option is set only "
+                              "to Resolved otherwise it filters the results "
+                              "by detection date (detected after the given "
+                              "date). The format of TIMESTAMP is "
                               "'year:month:day:hour:minute:second' (the "
                               "\"time\" part can be omitted, in which case "
                               "midnight (00:00:00) is used).")
@@ -299,8 +305,64 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                          dest="fixed_at",
                          metavar='TIMESTAMP',
                          default=argparse.SUPPRESS,
-                         help="Filter results by fix date. The format "
-                              " of TIMESTAMP is "
+                         help="DEPRECATED. Use the '--fixed-after/"
+                              "--fixed-before' options to filter results "
+                              "by fix date. Filter results by fix date (fixed "
+                              "before the given date) if the "
+                              "--detection-status filter option is set only "
+                              "to Resolved otherwise it filters the results "
+                              "by detection date (detected before the given "
+                              "date). The format of TIMESTAMP is "
+                              "'year:month:day:hour:minute:second' (the "
+                              "\"time\" part can be omitted, in which case "
+                              "midnight (00:00:00) is used).")
+
+    f_group.add_argument('--detected-before',
+                         type=valid_time,
+                         dest="detected_before",
+                         metavar='TIMESTAMP',
+                         default=argparse.SUPPRESS,
+                         help="Get results which were detected before the "
+                              "given date. The detection date of a report is "
+                              "the storage date when the report was stored to "
+                              "the server for the first time. The format of "
+                              "TIMESTAMP is "
+                              "'year:month:day:hour:minute:second' (the "
+                              "\"time\" part can be omitted, in which case "
+                              "midnight (00:00:00) is used).")
+
+    f_group.add_argument('--detected-after',
+                         type=valid_time,
+                         dest="detected_after",
+                         metavar='TIMESTAMP',
+                         default=argparse.SUPPRESS,
+                         help="Get results which were detected after the "
+                              "given date. The detection date of a report is "
+                              "the storage date when the report was stored to "
+                              "the server for the first time. The format of "
+                              "TIMESTAMP is "
+                              "'year:month:day:hour:minute:second' (the "
+                              "\"time\" part can be omitted, in which case "
+                              "midnight (00:00:00) is used).")
+
+    f_group.add_argument('--fixed-before',
+                         type=valid_time,
+                         dest="fixed_before",
+                         metavar='TIMESTAMP',
+                         default=argparse.SUPPRESS,
+                         help="Get results which were fixed before the "
+                              "given date. The format of TIMESTAMP is "
+                              "'year:month:day:hour:minute:second' (the "
+                              "\"time\" part can be omitted, in which case "
+                              "midnight (00:00:00) is used).")
+
+    f_group.add_argument('--fixed-after',
+                         type=valid_time,
+                         dest="fixed_after",
+                         metavar='TIMESTAMP',
+                         default=argparse.SUPPRESS,
+                         help="Get results which were fixed after the "
+                              "given date. The format of TIMESTAMP is "
                               "'year:month:day:hour:minute:second' (the "
                               "\"time\" part can be omitted, in which case "
                               "midnight (00:00:00) is used).")

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -154,6 +154,18 @@ def check_deprecated_arg_usage(args):
                     'separate filter options of this command to filter the '
                     'results. For more information see the help.')
 
+    if 'detected_at' in args:
+        LOG.warning('"--detected-at" option has been deprecated. Use '
+                    '--detected-before/--detected-after options to filter the '
+                    'results by detection date. For more information see the '
+                    'help.')
+
+    if 'fixed_at' in args:
+        LOG.warning('"--fixed-at" option has been deprecated. Use '
+                    '--fixed-before/--fixed-after options to filter the '
+                    'results by fix date. For more information see the '
+                    'help.')
+
 
 def get_run_data(client, run_filter, sort_mode=None,
                  limit=constants.MAX_QUERY_SIZE):
@@ -319,6 +331,31 @@ def add_filter_conditions(client, report_filter, args):
 
     if 'fixed_at' in args:
         report_filter.fixDate = int(str_to_timestamp(args.fixed_at))
+
+    detected_at = None
+    fixed_at = None
+
+    if 'detected_before' in args or 'detected_after' in args:
+        detected_at = ttypes.DateInterval()
+
+        if 'detected_before' in args:
+            detected_at.before = int(str_to_timestamp(args.detected_before))
+
+        if 'detected_after' in args:
+            detected_at.after = int(str_to_timestamp(args.detected_after))
+
+    if 'fixed_before' in args or 'fixed_after' in args:
+        fixed_at = ttypes.DateInterval()
+
+        if 'fixed_before' in args:
+            fixed_at.before = int(str_to_timestamp(args.fixed_before))
+
+        if 'fixed_after' in args:
+            fixed_at.after = int(str_to_timestamp(args.fixed_after))
+
+    if detected_at or fixed_at:
+        report_filter.date = ttypes.ReportDate(detected=detected_at,
+                                               fixed=fixed_at)
 
 
 def process_run_filter_conditions(args):

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,5 +4,5 @@ alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
 
-codechecker_api==6.28.0
-codechecker_api_shared==6.28.0
+codechecker_api==6.28.0-dev3
+codechecker_api_shared==6.28.0-dev3

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -5,5 +5,5 @@ pg8000==1.15.2
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.28.0
-codechecker_api_shared==6.28.0
+codechecker_api==6.28.0-dev3
+codechecker_api_shared==6.28.0-dev3

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -5,5 +5,5 @@ psycopg2-binary==2.8.5
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.28.0
-codechecker_api_shared==6.28.0
+codechecker_api==6.28.0-dev3
+codechecker_api_shared==6.28.0-dev3

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -11,8 +11,8 @@ nose==1.3.7
 mockldap==0.3.0
 mkdocs==1.0.4
 
-codechecker_api==6.28.0
-codechecker_api_shared==6.28.0
+codechecker_api==6.28.0-dev3
+codechecker_api_shared==6.28.0-dev3
 
 # publish packages to pypi
 twine

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -4,5 +4,5 @@ portalocker==1.7.0
 psutil==5.7.0
 sqlalchemy==1.3.16
 
-codechecker_api==6.28.0
-codechecker_api_shared==6.28.0
+codechecker_api==6.28.0-dev3
+codechecker_api_shared==6.28.0-dev3

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -265,28 +265,34 @@ def process_report_filter(session, report_filter):
 
         AND.append(or_(*OR))
 
-    detection_status = report_filter.detectionStatus
     if report_filter.firstDetectionDate is not None:
         date = datetime.fromtimestamp(report_filter.firstDetectionDate)
-
-        OR = []
-        if detection_status is not None and len(detection_status) == 1 and \
-           ttypes.DetectionStatus.RESOLVED in detection_status:
-            OR.append(Report.fixed_at >= date)
-        else:
-            OR.append(Report.detected_at >= date)
-        AND.append(or_(*OR))
+        AND.append(Report.detected_at >= date)
 
     if report_filter.fixDate is not None:
         date = datetime.fromtimestamp(report_filter.fixDate)
+        AND.append(Report.detected_at < date)
 
-        OR = []
-        if detection_status is not None and len(detection_status) == 1 and \
-           ttypes.DetectionStatus.RESOLVED in detection_status:
-            OR.append(Report.fixed_at < date)
-        else:
-            OR.append(Report.detected_at < date)
-        AND.append(or_(*OR))
+    if report_filter.date:
+        detected_at = report_filter.date.detected
+        if detected_at:
+            if detected_at.before:
+                detected_before = datetime.fromtimestamp(detected_at.before)
+                AND.append(Report.detected_at <= detected_before)
+
+            if detected_at.after:
+                detected_after = datetime.fromtimestamp(detected_at.after)
+                AND.append(Report.detected_at >= detected_after)
+
+        fixed_at = report_filter.date.fixed
+        if fixed_at:
+            if fixed_at.before:
+                fixed_before = datetime.fromtimestamp(fixed_at.before)
+                AND.append(Report.fixed_at <= fixed_before)
+
+            if fixed_at.after:
+                fixed_after = datetime.fromtimestamp(fixed_at.after)
+                AND.append(Report.fixed_at >= fixed_after)
 
     if report_filter.runHistoryTag:
         OR = []

--- a/web/server/vue-cli/e2e/pages/report.js
+++ b/web/server/vue-cli/e2e/pages/report.js
@@ -70,6 +70,20 @@ const createOptionFilterSection = (selector) => {
   };
 };
 
+const createDateFilterSection = (selector) => {
+  return {
+    selector,
+    elements: {
+      expansionBtn: ".expansion-btn",
+      settings: ".settings-btn",
+      clearBtn: ".clear-btn",
+      selectedItems: ".selected-item",
+      from: ".row > div:first-child .v-input",
+      to: ".row > div:last-child .v-input"
+    }
+  };
+};
+
 module.exports = {
   url: function() {
     return this.api.launchUrl + "/e2e/reports?review-status=Unreviewed&"
@@ -162,26 +176,26 @@ module.exports = {
         cancelBtn: ".cancel-btn",
       }
     },
-    detectionDateFilter: {
-      selector: "#detection-date-filter",
+    dateFilters: {
+      selector: "#date-filters",
       elements: {
-        expansionBtn: ".expansion-btn",
-        from: ".first-detection-date",
-        to: ".fix-date",
-        settings: ".settings-btn",
-        clearBtn: ".clear-btn"
+        expansionBtn: ".v-expansion-panel-header__icon",
+        active: ".v-expansion-panel--active"
       },
-      commands: [ filterCommands ]
+      sections: {
+        detectionDateFilter: createDateFilterSection("#detection-date-filter"),
+        fixDateFilter: createDateFilterSection("#fix-date-filter")
+      }
     },
-    fromDetectionDateDialog: {
-      selector: ".first-detection-date.v-dialog--active",
+    fromDateDialog: {
+      selector: ".v-dialog--active",
       elements: {
         date: ".v-date-picker-table td button",
         ok: ".ok-btn"
       }
     },
-    toDetectionDateDialog: {
-      selector: ".fix-date.v-dialog--active",
+    toDateDialog: {
+      selector: ".v-dialog--active",
       elements: {
         date: ".v-date-picker-table td button",
         ok: ".ok-btn"

--- a/web/server/vue-cli/e2e/specs/history.js
+++ b/web/server/vue-cli/e2e/specs/history.js
@@ -45,8 +45,8 @@ module.exports = {
           .diffFirstTwoRunHistoryItems()
           .assert.urlContains("/reports")
           .assert.urlContains(`run-tag=${tag}`)
-          .assert.urlContains("first-detection-date=")
-          .assert.urlContains("fix-date=")
+          .assert.urlContains("detected-after=")
+          .assert.urlContains("detected-before=")
           .back();
 
         await runHistoryPage.waitForProgressBarNotPresent();

--- a/web/server/vue-cli/e2e/specs/reports.js
+++ b/web/server/vue-cli/e2e/specs/reports.js
@@ -27,7 +27,6 @@ module.exports = {
       reportPage.section.sourceComponentFilter,
       reportPage.section.checkerMessageFilter,
       reportPage.section.checkerMessageFilter,
-      reportPage.section.detectionDateFilter,
       reportPage.section.reportHashFilter,
       reportPage.section.bugPathLengthFilter
     ].forEach(section => {
@@ -453,11 +452,57 @@ module.exports = {
     });
   },
 
+  "open date expansion panel" (browser) {
+    const reportPage = browser.page.report();
+    const dateSection = reportPage.section.dateFilters;
+    const detectionDateFilterSection = dateSection.section.detectionDateFilter;
+
+    reportPage.click(dateSection);
+    dateSection.expect.section(detectionDateFilterSection)
+      .to.be.visible.before(5000);
+
+    [
+      dateSection.section.detectionDateFilter,
+      dateSection.section.fixDateFilter
+    ].forEach(section => {
+      section.click("@expansionBtn");
+    });
+  },
+
   "set detection date filters" (browser) {
     const reportPage = browser.page.report();
-    const section = reportPage.section.detectionDateFilter;
-    const fromDateDialog = reportPage.section.fromDetectionDateDialog;
-    const toDateDialog = reportPage.section.toDetectionDateDialog;
+    const dateSection = reportPage.section.dateFilters;
+    const section = dateSection.section.detectionDateFilter;
+    const fromDateDialog = reportPage.section.fromDateDialog;
+    const toDateDialog = reportPage.section.toDateDialog;
+
+    section.click("@from");
+    reportPage.expect.section(fromDateDialog).to.be.visible.before(5000);
+
+    fromDateDialog
+      .click("@date")
+      .click("@ok");
+
+    section.click("@to");
+    reportPage.expect.section(toDateDialog).to.be.visible.before(5000);
+
+    toDateDialog
+      .click("@date")
+      .click("@ok");
+
+    section.click("@clearBtn");
+
+    reportPage
+      .pause(500)
+      .waitForElementNotPresent("@progressBar");
+  },
+
+  "set fix date filters" (browser) {
+    const reportPage = browser.page.report();
+    const dateSection = reportPage.section.dateFilters;
+    const section = dateSection.section.fixDateFilter;
+    const fromDateDialog = reportPage.section.fromDateDialog;
+    const toDateDialog = reportPage.section.toDateDialog;
 
     section.click("@from");
     reportPage.expect.section(fromDateDialog).to.be.visible.before(5000);

--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -4154,9 +4154,9 @@
       "dev": true
     },
     "codechecker-api": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.28.0.tgz",
-      "integrity": "sha512-pmaKQ3x9KZ9+bG5olHlaiMSZzGWm0gPHRjQpN6Mr0eiwUM+62bPz6RNuzjF9L2sAfSy2f9mlJ+y+SCzg8l5ZTg==",
+      "version": "6.28.0-dev3",
+      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.28.0-dev3.tgz",
+      "integrity": "sha512-i0OygETzrQ5D+bi5CEC0muUCzmtcanEHsCN9qz+7iDOQp1boj+Nkqt/TZqV0yPwEl65MVJoAol+berPUMnp2Dw==",
       "requires": {
         "thrift": "0.11.0"
       }

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@mdi/font": "^5.3.45",
-    "codechecker-api": "6.28.0",
+    "codechecker-api": "6.28.0-dev3",
     "codemirror": "^5.55.0",
     "date-fns": "^2.14.0",
     "highlight.js": "^10.1.1",

--- a/web/server/vue-cli/src/components/DateTimePicker.vue
+++ b/web/server/vue-cli/src/components/DateTimePicker.vue
@@ -8,7 +8,8 @@
       <v-text-field
         :label="label"
         :value="formattedDatetime"
-        :class="inputClass"
+        :class="[ inputClass, 'pa-0', 'ma-0' ]"
+        hide-details
         readonly
         v-on="on"
       />

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FixDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FixDateFilter.vue
@@ -1,0 +1,18 @@
+<script>
+import DetectionDateFilter from "./DetectionDateFilter";
+
+export default {
+  name: "FixDateFilter",
+  mixins: [ DetectionDateFilter ],
+  data() {
+    return {
+      title: "Fix date",
+      fromDateTimeId: "fixed-after",
+      toDateTimeId: "fixed-before",
+      fromDateTimeLabel: "Fixed after...",
+      toDateTimeLabel: "Fixed before...",
+      filterFieldName: "fixed"
+    };
+  }
+};
+</script>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/index.js
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/index.js
@@ -7,6 +7,7 @@ import ComparedToRunFilter from "./ComparedToRunFilter";
 import ComparedToTagFilter from "./ComparedToTagFilter";
 import ReviewStatusFilter from "./ReviewStatusFilter";
 import DetectionStatusFilter from "./DetectionStatusFilter";
+import FixDateFilter from "./FixDateFilter";
 import SeverityFilter from "./SeverityFilter";
 import DetectionDateFilter from "./DetectionDateFilter";
 import FilePathFilter from "./FilePathFilter";
@@ -26,6 +27,7 @@ export {
   ComparedToTagFilter,
   ReviewStatusFilter,
   DetectionStatusFilter,
+  FixDateFilter,
   SeverityFilter,
   DetectionDateFilter,
   FilePathFilter,

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -201,20 +201,38 @@
         </v-list-item-content>
       </v-list-item>
 
-      <v-divider />
-
-      <v-list-item class="pl-1">
+      <v-list-item id="date-filters" class="pl-0">
         <v-list-item-content class="pa-0">
-          <detection-date-filter
-            id="detection-date-filter"
-            ref="filters"
-            :namespace="namespace"
-            @update:url="updateUrl"
-          />
+          <v-expansion-panels v-model="activeDatePanelId" hover>
+            <v-expansion-panel>
+              <v-expansion-panel-header
+                class="pa-0 px-1"
+              >
+                <header>
+                  <b>Dates</b>
+                </header>
+              </v-expansion-panel-header>
+              <v-expansion-panel-content class="pa-1">
+                <detection-date-filter
+                  id="detection-date-filter"
+                  ref="filters"
+                  :namespace="namespace"
+                  @update:url="updateUrl"
+                />
+
+                <v-divider />
+
+                <fix-date-filter
+                  id="fix-date-filter"
+                  ref="filters"
+                  :namespace="namespace"
+                  @update:url="updateUrl"
+                />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+          </v-expansion-panels>
         </v-list-item-content>
       </v-list-item>
-
-      <v-divider />
 
       <v-list-item class="pl-1">
         <v-list-item-content class="pa-0">
@@ -273,6 +291,7 @@ import {
   DetectionDateFilter,
   DetectionStatusFilter,
   FilePathFilter,
+  FixDateFilter,
   ReportHashFilter,
   ReviewStatusFilter,
   SeverityFilter,
@@ -301,6 +320,7 @@ export default {
     SeverityFilter,
     DetectionDateFilter,
     FilePathFilter,
+    FixDateFilter,
     SourceComponentFilter,
     CheckerNameFilter,
     CheckerMessageFilter,
@@ -318,12 +338,16 @@ export default {
   data() {
     return {
       activeBaselinePanelId: 0,
-      activeCompareToPanelId: 0
+      activeCompareToPanelId: 0,
+      activeDatePanelId: 0
     };
   },
 
   computed: {
     ...mapState({
+      reportFilter(state) {
+        return state[this.namespace].reportFilter;
+      },
       cmpData(state) {
         return state[this.namespace].cmpData;
       }
@@ -405,7 +429,21 @@ export default {
         if (!this.cmpData?.runIds && !this.cmpData?.runTag) {
           this.activeCompareToPanelId = -1;
         }
+
+        this.closePanelsOnInit();
       });
+    },
+
+    closePanelsOnInit() {
+      // Close NEWCHECK expansion panel if no compare data is set.
+      if (!this.cmpData?.runIds && !this.cmpData?.runTag) {
+        this.activeNewcheckPanelId = -1;
+      }
+
+      // Close Dates expansion panel if no dates are set.
+      if (!this.reportFilter.date) {
+        this.activeDatePanelId = -1;
+      }
     },
 
     clearAllFilters() {
@@ -448,7 +486,8 @@ export default {
 }
 
 #baseline-filters,
-#compare-to-filters {
+#compare-to-filters,
+#date-filters {
   border: 1px solid rgba(0, 0, 0, 0.12);
 }
 

--- a/web/server/vue-cli/src/views/RunHistoryList.vue
+++ b/web/server/vue-cli/src/views/RunHistoryList.vue
@@ -338,10 +338,8 @@ export default {
           parse(d, "yyyy-MM-dd HH:mm:ss.SSSSSS", new Date())));
         const maxDate = max(dates.map(d =>
           parse(d, "yyyy-MM-dd HH:mm:ss.SSSSSS", new Date())));
-
-        urlState["first-detection-date"] =
-            format(minDate, "yyyy-MM-dd HH:mm:ss.SSSSS");
-        urlState["fix-date"] = format(maxDate, "yyyy-MM-dd HH:mm:ss.SSSSS");
+        urlState["detected-after"] = format(minDate, "yyyy-MM-dd HH:mm:ss");
+        urlState["detected-before"] = format(maxDate, "yyyy-MM-dd HH:mm:ss");
       }
 
       return {
@@ -519,7 +517,7 @@ export default {
       return {
         run: history.runName,
         "run-tag": history.versionTag || undefined,
-        "fix-date": history.versionTag ? undefined : history.time,
+        "detected-before": history.versionTag ? undefined : history.time,
         ...defaultReportFilterValues
 
       };

--- a/web/tests/functional/report_viewer_api/__init__.py
+++ b/web/tests/functional/report_viewer_api/__init__.py
@@ -112,6 +112,16 @@ def setup_package():
         sys.exit(1)
     print("Third analysis of the test project was successful.")
 
+    # Let's run the second analysis and updat the same run.
+    codechecker_cfg['checkers'] = ['-d', 'core.StackAddressEscape']
+    ret = codechecker.check_and_store(codechecker_cfg,
+                                      test_project_name_third,
+                                      project.path(test_project))
+
+    if ret:
+        sys.exit(1)
+    print("4th analysis of the test project was successful.")
+
     codechecker_cfg['run_names'] = [test_project_name,
                                     test_project_name_new]
 


### PR DESCRIPTION
The old detection date filter options were not only filtered the detection/fix
dates but it is also depend on the detection status filter.

- With this patch new filter options will be introduced in the UI and in the
command line (--detected-before/--detected-after).
- The API and the server are able to filter by fix dates. These filters are not
shown in the UI and in the command line.
- The detection status dependency from the detection date filter is removed.
- New test cases are introduced.