### PR TITLE
[gui] Show filters in expansion panels

### DIFF
--- a/web/server/vue-cli/e2e/pages/report.js
+++ b/web/server/vue-cli/e2e/pages/report.js
@@ -61,6 +61,7 @@ const createOptionFilterSection = (selector) => {
   return {
     selector,
     elements: {
+      expansionBtn: ".expansion-btn",
       settings: ".settings-btn",
       clearBtn: ".clear-btn",
       selectedItems: ".selected-item"
@@ -90,6 +91,7 @@ module.exports = {
     newcheckFilters: {
       selector: "#newcheck-filters",
       elements: {
+        expansionBtn: ".v-expansion-panel-header__icon",
         active: ".v-expansion-panel--active"
       },
       sections: {
@@ -107,6 +109,7 @@ module.exports = {
     bugPathLengthFilter: {
       selector: "#bug-path-length-filter",
       elements: {
+        expansionBtn: ".expansion-btn",
         min: "#min-bug-path-length",
         max: "#max-bug-path-length",
         clearBtn: ".clear-btn",
@@ -115,21 +118,15 @@ module.exports = {
     reportHashFilter: {
       selector: "#report-hash-filter",
       elements: {
+        expansionBtn: ".expansion-btn",
         reportHash: "#report-hash",
-        clearBtn: ".clear-btn"
-      }
-    },
-    detectionDateFilter: {
-      selector: "#detection-date-filter",
-      elements: {
-        from: "#first-detection-date",
-        to: "#fix-date",
         clearBtn: ".clear-btn"
       }
     },
     sourceComponentFilter: {
       selector: "#source-component",
       elements: {
+        expansionBtn: ".expansion-btn",
         manageBtn: ".manage-components-btn",
         settings: ".settings-btn",
         clearBtn: ".clear-btn",
@@ -168,6 +165,7 @@ module.exports = {
     detectionDateFilter: {
       selector: "#detection-date-filter",
       elements: {
+        expansionBtn: ".expansion-btn",
         from: ".first-detection-date",
         to: ".fix-date",
         settings: ".settings-btn",

--- a/web/server/vue-cli/e2e/specs/reports.js
+++ b/web/server/vue-cli/e2e/specs/reports.js
@@ -15,6 +15,24 @@ module.exports = {
     reportPage
       .waitForElementVisible("@page", 10000)
       .waitForProgressBarNotPresent();
+
+    [
+      reportPage.section.baselineRunFilter,
+      reportPage.section.baselineTagFilter,
+      reportPage.section.filePathFilter,
+      reportPage.section.checkerNameFilter,
+      reportPage.section.severityFilter,
+      reportPage.section.reviewStatusFilter,
+      reportPage.section.detectionStatusFilter,
+      reportPage.section.sourceComponentFilter,
+      reportPage.section.checkerMessageFilter,
+      reportPage.section.checkerMessageFilter,
+      reportPage.section.detectionDateFilter,
+      reportPage.section.reportHashFilter,
+      reportPage.section.bugPathLengthFilter
+    ].forEach(section => {
+      section.click("@expansionBtn");
+    });
   },
 
   after(browser) {
@@ -25,7 +43,6 @@ module.exports = {
 
   "clear all filters" (browser) {
     const reportPage = browser.page.report();
-    const newcheckSection = reportPage.section.newcheckFilters;
 
     reportPage.click("@clearAllFilterBtn");
     reportPage
@@ -35,8 +52,6 @@ module.exports = {
     [
       reportPage.section.baselineRunFilter,
       reportPage.section.baselineTagFilter,
-      newcheckSection.section.newcheckRunFilter,
-      newcheckSection.section.newcheckTagFilter,
       reportPage.section.filePathFilter,
       reportPage.section.checkerNameFilter,
       reportPage.section.severityFilter,
@@ -155,6 +170,14 @@ module.exports = {
     reportPage.click(newcheckSection);
     newcheckSection.expect.section("@newcheckRunFilter")
       .to.be.visible.before(5000);
+
+    [
+      newcheckSection.section.newcheckRunFilter,
+      newcheckSection.section.newcheckTagFilter,
+      newcheckSection.section.newcheckDiffTypeFilter,
+    ].forEach(section => {
+      section.click("@expansionBtn");
+    });
   },
 
   async "set newcheck run filter" (browser) {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
@@ -3,6 +3,16 @@
     title="Bug path length"
     @clear="clear(true)"
   >
+    <template v-slot:append-toolbar-title>
+      <span
+        v-if="selectedBugPathLengthTitle"
+        class="selected-items"
+        :title="selectedBugPathLengthTitle"
+      >
+        ({{ selectedBugPathLengthTitle }})
+      </span>
+    </template>
+
     <v-form ref="form">
       <v-container
         class="py-0"
@@ -69,9 +79,18 @@ export default {
     };
   },
 
+  computed: {
+    selectedBugPathLengthTitle() {
+      return [
+        ...(this.minBugPathLength ? [ `min: ${this.minBugPathLength}` ]: []),
+        ...(this.maxBugPathLength ? [ `max: ${this.maxBugPathLength}` ]: [])
+      ].join(", ");
+    }
+  },
+
   methods: {
     setMinBugPathLength(bugPathLength, updateUrl=true) {
-      if (!this.$refs.form.validate()) return;
+      if (this.$refs.form && !this.$refs.form.validate()) return;
 
       this.minBugPathLength = bugPathLength;
       this.updateReportFilter();
@@ -82,7 +101,7 @@ export default {
     },
 
     setMaxBugPathLength(bugPathLength, updateUrl=true) {
-      if (!this.$refs.form.validate()) return;
+      if (this.$refs.form && !this.$refs.form.validate()) return;
 
       this.maxBugPathLength = bugPathLength;
       this.updateReportFilter();

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
@@ -13,6 +13,16 @@
       <detection-date-filter-icon :value="item.id" />
     </template>
 
+    <template v-slot:append-toolbar-title>
+      <span
+        v-if="selectedDetectionDateTitle"
+        class="selected-items"
+        :title="selectedDetectionDateTitle"
+      >
+        ({{ selectedDetectionDateTitle }})
+      </span>
+    </template>
+
     <v-container
       class="py-0"
     >
@@ -78,6 +88,17 @@ export default {
       fromDateTime: null,
       toDateTime: null
     };
+  },
+
+  computed: {
+    selectedDetectionDateTitle() {
+      return [
+        ...(this.fromDateTime
+          ? [ `after: ${this.dateTimeToStr(this.fromDateTime)}` ]: []),
+        ...(this.toDateTime
+          ? [ `before: ${this.dateTimeToStr(this.toDateTime)}` ]: [])
+      ].join(", ");
+    }
   },
 
   methods: {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
@@ -13,7 +13,7 @@
       <detection-status-icon :status="item.id" />
     </template>
 
-    <template v-slot:prepend-toolbar-title>
+    <template v-slot:append-toolbar-title>
       <v-icon
         v-if="reportFilter.isUnique"
         color="error"
@@ -21,6 +21,11 @@
       >
         mdi-alert
       </v-icon>
+
+      <selected-toolbar-title-items
+        v-if="selectedItems"
+        :value="selectedItems"
+      />
     </template>
   </select-option>
 </template>
@@ -32,14 +37,15 @@ import { DetectionStatus, ReportFilter } from "@cc/report-server-types";
 import { DetectionStatusIcon } from "@/components/Icons";
 import { DetectionStatusMixin } from "@/mixins";
 
-import SelectOption from "./SelectOption/SelectOption";
+import { SelectOption, SelectedToolbarTitleItems } from "./SelectOption";
 import BaseSelectOptionFilterMixin from "./BaseSelectOptionFilter.mixin";
 
 export default {
   name: "DetectionStatusFilter",
   components: {
     SelectOption,
-    DetectionStatusIcon
+    DetectionStatusIcon,
+    SelectedToolbarTitleItems
   },
   mixins: [ BaseSelectOptionFilterMixin, DetectionStatusMixin ],
 

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
@@ -1,39 +1,60 @@
 <template>
-  <v-card flat>
-    <v-toolbar flat dense>
-      <v-toolbar-title class="font-weight-bold body-2">
-        {{ title }}
-      </v-toolbar-title>
+  <v-expansion-panels
+    v-model="value"
+    flat
+  >
+    <v-expansion-panel>
+      <v-expansion-panel-header class="pa-0" hide-actions>
+        <v-toolbar flat dense>
+          <v-toolbar-title class="font-weight-bold body-2">
+            <v-icon class="expansion-btn">
+              {{ value == 0 ? "mdi-chevron-up" : "mdi-chevron-down" }}
+            </v-icon>
+            {{ title }}
 
-      <slot name="prepend-toolbar-title" />
+            <slot name="append-toolbar-title" />
+          </v-toolbar-title>
 
-      <v-spacer />
+          <slot name="prepend-toolbar-title" />
 
-      <v-toolbar-items>
-        <slot name="prepend-toolbar-items" />
+          <v-spacer />
 
-        <v-btn
-          icon
-          small
-          class="clear-btn"
-          @click="clear(true)"
-        >
-          <v-icon>mdi-delete</v-icon>
-        </v-btn>
+          <v-toolbar-items>
+            <slot name="prepend-toolbar-items" />
 
-        <slot name="append-toolbar-items" />
-      </v-toolbar-items>
-    </v-toolbar>
+            <v-btn
+              icon
+              small
+              class="clear-btn"
+              @click.stop="clear"
+            >
+              <v-icon>mdi-delete</v-icon>
+            </v-btn>
 
-    <slot />
-  </v-card>
+            <slot name="append-toolbar-items" />
+          </v-toolbar-items>
+        </v-toolbar>
+      </v-expansion-panel-header>
+
+      <v-expansion-panel-content>
+        <slot />
+      </v-expansion-panel-content>
+    </v-expansion-panel>
+  </v-expansion-panels>
 </template>
 
 <script>
 export default {
   name: "FilterToolbar",
   props: {
-    title: { type: String, required: true }
+    title: { type: String, required: true },
+    panel: { type: Boolean, default: false }
+  },
+
+  data() {
+    return {
+      value: this.panel ? 0 : null
+    };
   },
 
   methods: {
@@ -47,5 +68,9 @@ export default {
 <style lang="scss" scoped>
 ::v-deep .v-toolbar > .v-toolbar__content {
   padding: 0;
+}
+
+::v-deep .selected-items {
+  color: grey;
 }
 </style>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReportHashFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReportHashFilter.vue
@@ -3,6 +3,16 @@
     title="Report hash filter"
     @clear="clear(true)"
   >
+    <template v-slot:append-toolbar-title>
+      <span
+        v-if="reportHash"
+        class="selected-items"
+        :title="reportHash"
+      >
+        ({{ reportHash }})
+      </span>
+    </template>
+
     <v-card-actions class="">
       <v-text-field
         :id="id"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
@@ -1,8 +1,18 @@
 <template>
   <filter-toolbar
     :title="title"
+    :panel="panel"
     @clear="clear"
   >
+    <template v-slot:append-toolbar-title>
+      <slot name="append-toolbar-title">
+        <selected-toolbar-title-items
+          v-if="selectedItems"
+          :value="selectedItems"
+        />
+      </slot>
+    </template>
+
     <template v-slot:prepend-toolbar-title>
       <slot name="prepend-toolbar-title" />
     </template>
@@ -81,13 +91,15 @@
 import FilterToolbar from "../Layout/FilterToolbar";
 import Items from "./Items";
 import ItemsSelected from "./ItemsSelected";
+import SelectedToolbarTitleItems from "./SelectedToolbarTitleItems";
 
 export default {
   name: "SelectOption",
   components: {
     FilterToolbar,
     Items,
-    ItemsSelected
+    ItemsSelected,
+    SelectedToolbarTitleItems
   },
   props: {
     title: { type: String, required: true },
@@ -96,7 +108,8 @@ export default {
     selectedItems: { type: Array, default: () => [] },
     multiple: { type: Boolean, default: true },
     search: { type: Object, default: null },
-    loading: { type: Boolean, default: false }
+    loading: { type: Boolean, default: false },
+    panel: { type: Boolean, default: false }
   },
   data() {
     return {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectedToolbarTitleItems.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectedToolbarTitleItems.vue
@@ -1,0 +1,33 @@
+<template>
+  <span
+    class="selected-items"
+    :title="title"
+  >
+    <v-chip class="px-1" color="grey" label small outlined>
+      {{ value.length }}
+    </v-chip>
+    <span v-if="selectedItems">- {{ selectedItems }}</span>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "SelectedToolbarTitleItems",
+  props: {
+    value: { type: Array, default: () => [] },
+  },
+  computed: {
+    selectedItems() {
+      return this.value
+        ? this.value.map(i => i.title).join(", ")
+        : "";
+    },
+
+    title() {
+      return this.selectedItems
+        ? `Selected: ${this.selectedItems}.`
+        : "No filter items are selected.";
+    }
+  },
+};
+</script>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/index.js
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/index.js
@@ -1,0 +1,11 @@
+import Items from "./Items";
+import ItemsSelected from "./ItemsSelected";
+import SelectedToolbarTitleItems from "./SelectedToolbarTitleItems";
+import SelectOption from "./SelectOption";
+
+export {
+  Items,
+  ItemsSelected,
+  SelectedToolbarTitleItems,
+  SelectOption
+};

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
@@ -18,7 +18,7 @@
           class="manage-components-btn"
           icon
           small
-          @click="dialog = true"
+          @click.stop="dialog = true"
         >
           <v-icon>mdi-pencil</v-icon>
         </v-btn>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -36,9 +36,7 @@
         </v-list-item-content>
       </v-list-item>
 
-      <v-divider />
-
-      <v-list-item id="baseline-filters" class="pl-1">
+      <v-list-item id="baseline-filters" class="pl-0">
         <v-list-item-content class="pa-0">
           <v-expansion-panels
             v-model="activeBaselinePanelId"
@@ -48,7 +46,9 @@
               <v-expansion-panel-header
                 class="pa-0 px-1 primary--text"
               >
-                <b>BASELINE</b>
+                <header>
+                  <b>BASELINE</b>
+                </header>
               </v-expansion-panel-header>
               <v-expansion-panel-content class="pa-1">
                 <baseline-run-filter
@@ -70,12 +70,10 @@
         </v-list-item-content>
       </v-list-item>
 
-      <v-divider v-if="showNewcheck" />
-
       <v-list-item
         v-if="showNewcheck"
         id="newcheck-filters"
-        class="pl-1"
+        class="pl-0"
       >
         <v-list-item-content class="pa-0">
           <v-expansion-panels
@@ -86,7 +84,9 @@
               <v-expansion-panel-header
                 class="pa-0 px-1 primary--text"
               >
-                <b>NEWCHECK</b>
+                <header>
+                  <b>NEWCHECK</b>
+                </header>
               </v-expansion-panel-header>
               <v-expansion-panel-content class="pa-1">
                 <newcheck-run-filter
@@ -115,8 +115,6 @@
           </v-expansion-panels>
         </v-list-item-content>
       </v-list-item>
-
-      <v-divider />
 
       <v-list-item class="pl-1">
         <v-list-item-content class="pa-0">
@@ -439,12 +437,29 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+.v-expansion-panel--active > .v-expansion-panel-header,
 .v-expansion-panel-header {
   min-height: 40px;
 }
 
-.v-expansion-panel-content > ::v-deep .v-expansion-panel-content__wrap {
+.v-expansion-panel-content > .v-expansion-panel-content__wrap {
   padding: 0 4px 0 6px;
+}
+
+#baseline-filters,
+#newcheck-filters {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+#newcheck-filters {
+  border-top: 0;
+}
+
+.v-expansion-panel-header__icon {
+  order: 1;
+}
+.v-expansion-panel-header header {
+  order: 2;
 }
 </style>


### PR DESCRIPTION
We already have many report filters on the UI and it is hard to see
through where is the filter what the user actually want to set. For
this reason with this patch we will show each filter in an expansion
panel and every filter will be closed by default. We will also show
the selected filter items in the filter header bar which will be trimmed
when too many filter items are selected.

Screenshot:
![image](https://user-images.githubusercontent.com/6695818/89635721-b7064180-d8a7-11ea-8f84-cf21cb1fb125.png)



