### PR TITLE
[analyzer] config file option for the parse subcommand

### DIFF
--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -121,7 +121,10 @@ output.
         # extend the system argument list with these options and try to parse
         # the argument list again to validate it.
         if 'func_process_config_file' in args:
-            cfg_args = args.func_process_config_file(args)
+            if len(sys.argv) > 1:
+                called_sub_command = sys.argv[1]
+
+            cfg_args = args.func_process_config_file(args, called_sub_command)
             if cfg_args:
                 # Expand environment variables in the arguments.
                 cfg_args = [os.path.expandvars(cfg) for cfg in cfg_args]

--- a/codechecker_common/cmd_config.py
+++ b/codechecker_common/cmd_config.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+import os
+
+from codechecker_common.util import load_json_or_empty
+from codechecker_common import logger
+
+LOG = logger.get_logger('system')
+
+
+def process_config_file(args, subcommand_name):
+    """
+    Handler to get config file options.
+    """
+    if 'config_file' not in args:
+        return {}
+    if args.config_file and os.path.exists(args.config_file):
+        cfg = load_json_or_empty(args.config_file, default={})
+
+        # The subcommand name is analyze but the
+        # configuration section name is analyzer.
+        if subcommand_name == 'analyze':
+            # The config value can be 'analyze' or 'analyzer'
+            # for backward compatibility.
+            analyze_cfg = cfg.get("analyze", [])
+            analyzer_cfg = cfg.get("analyzer", [])
+            if analyze_cfg:
+                if analyzer_cfg:
+                    LOG.warning("There is an 'analyze' and an 'analyzer' "
+                                "config configuration option in the config "
+                                "file. Please use the 'analyze' value to be "
+                                "in sync with the subcommands.\n"
+                                "Using the 'analyze' configuration.")
+                return analyze_cfg
+            if analyzer_cfg:
+                return analyzer_cfg
+
+        return cfg.get(subcommand_name, [])
+
+
+def check_config_file(args):
+    """Check if a config file is set in the arguments and if the file exists.
+
+    returns - None if not set or the file exists or
+              FileNotFoundError exception if the set config file is missing.
+    """
+    if 'config_file' not in args:
+        return
+
+    if 'config_file' in args and args.config_file \
+            and not os.path.exists(args.config_file):
+        raise FileNotFoundError(
+            f"Configuration file '{args.config_file}' does not exist.")

--- a/config/codechecker.json
+++ b/config/codechecker.json
@@ -1,9 +1,24 @@
 {
-    "analyzer": [
-        "--enable", "core.DivideZero",
-        "--enable", "core.CallAndMessage",
-        "--disable", "alpha",
-        "--analyzers", "clangsa", "clang-tidy",
-        "--clean"
-    ]
+  "analyze": [
+    "--enable=core.DivideZero",
+    "--enable=core.CallAndMessage",
+    "--analyzer-config",
+    "clangsa:unroll-loops=true",
+    "--checker-config",
+    "clang-tidy:google-readability-function-size.StatementThreshold=100"
+    "--report-hash", "context-free-v2"
+    "--verbose=debug",
+    "--clean"
+  ],
+  "parse": [
+    "--trim-path-prefix",
+    "/$HOME/workspace"
+  ],
+  "server": [
+    "--workspace=$HOME/workspace",
+    "--port=9090"
+  ],
+  "store": [
+    "--url", "localhost:9090/Default"
+  ]
 }

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -220,7 +220,7 @@ analyzer arguments:
                         the config file will be emplaced as command line
                         arguments. The format of configuration file is:
                         {
-                          "analyzer": [
+                          "analyze": [
                             "--enable=core.DivideZero",
                             "--enable=core.CallAndMessage",
                             "--report-hash=context-free-v2",
@@ -886,7 +886,7 @@ analyzer arguments:
                         the config file will be emplaced as command line
                         arguments. The format of configuration file is:
                         {
-                          "analyzer": [
+                          "analyze": [
                             "--enable=core.DivideZero",
                             "--enable=core.CallAndMessage",
                             "--report-hash=context-free-v2",
@@ -956,10 +956,10 @@ The parameters in the config file will be emplaced as command line arguments.
 
 **Example**:
 Lets assume you have a configuration file
-[`codechecker.json`](#config/codechecker.json) with the following content:
+[`codechecker.json`](../../config/codechecker.json) with the following content:
 ```json
 {
-  "analyzer": [
+  "analyze": [
     "--enable=core.DivideZero",
     "--enable=core.CallAndMessage",
     "--analyzer-config",
@@ -969,9 +969,26 @@ Lets assume you have a configuration file
     "--report-hash", "context-free-v2"
     "--verbose=debug",
     "--clean"
+  ],
+  "parse": [
+    "--trim-path-prefix",
+    "/$HOME/workspace"
+  ],
+  "server": [
+    "--workspace=$HOME/workspace",
+    "--port=9090"
+  ],
+  "store": [
+    "--name=run_name",
+    "--tag=my_tag",
+    "--url=http://codechecker.my:9090/MyProduct"
   ]
 }
 ```
+This configuration file example contains configuration options for multiple
+codechecker subcommands (analyze, parse, server, store) so not just the
+`analyze` subcommand can be configured like this.  
+The focus is on the `analyze` subcommand configuration in the next examples.
 
 If you run the following command:
 ```sh
@@ -987,12 +1004,12 @@ Note: Options which require parameters have to be in either of the following
 formats:
 
 - Use equal to separate option and parameter in quotes:
-  `{ "analyzer": [ "--verbose=debug" ] }`
+  `{ "analyze": [ "--verbose=debug" ] }`
 - Use separated values for option and parameter:
-  `{ "analyzer": [ "--verbose", "debug" ] }`
+  `{ "analyze": [ "--verbose", "debug" ] }`
 
 Note: environment variables inside this config file will be expanded:
-`{ "analyzer": [ "--skip=$HOME/project/skip.txt" ] }`
+`{ "analyze": [ "--skip=$HOME/project/skip.txt" ] }`
 
 #### Analyzer and checker config options <a name="analyzer-checker-config-option"></a>
 
@@ -1409,6 +1426,16 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config CONFIG_FILE  Allow the configuration from an explicit JSON based
+                        configuration file. The value of the 'parse' key in
+                        the config file will be emplaced as command line
+                        arguments. The format of configuration file is:
+                        {
+                          "parse": [
+                            "--trim-path-prefix",
+                            "$HOME/workspace"
+                          ]
+                        } (default: None)
   -t {plist}, --type {plist}, --input-format {plist}
                         Specify the format the analysis results were created
                         as. (default: plist)

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -202,11 +202,12 @@ optional arguments:
                         config file will overwrite the values set in the
                         command line. The format of configuration file is:
                         {
-                          "server": [
-                            "--workspace=$HOME/workspace",
-                            "--port=9090"
+                          "store": [
+                            "--name=run_name",
+                            "--tag=my_tag",
+                            "--url=http://codechecker.my:9090/MyProduct"
                           ]
-                        }.
+                        }. (default: None)
                         You can use any environment variable inside this file
                         and it will be expaneded. (default: None)
   -f, --force           Delete analysis results stored in the database for the


### PR DESCRIPTION
Add support to use a config file by the parse subcommand.
The subcommand arguments can be saved and used from the
CodeChecker config file.

Common config file checking and parsing parts were
moved to the codechecker_common module because
the analyzer and the server parts use the same code.