### PR TITLE
[gui] Clear detection date selected filter items on change

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
@@ -96,6 +96,7 @@ export default {
       this.updateReportFilter();
 
       if (updateUrl) {
+        this.selectedItems = [];
         this.$emit("update:url");
       }
     },
@@ -105,6 +106,7 @@ export default {
       this.updateReportFilter();
 
       if (updateUrl) {
+        this.selectedItems = [];
         this.$emit("update:url");
       }
     },
@@ -192,6 +194,7 @@ export default {
     clear(updateUrl) {
       this.setFromDateTime(null, false);
       this.setToDateTime(null, false);
+      this.selectedItems = [];
 
       if (updateUrl) {
         this.$emit("update:url");


### PR DESCRIPTION
There are multiple scenarios when the selected filter items list of the detection
date filter need to be cleard:
 - When the user clears the filter with the thrash icon.
 - When the user clears the filters with the Clear all filters button.
 - When the user changes the input one of the detection date filter input.

This way for example if the user selects the Today date and clear or change the
date filter he will be able to select the Today date again.