### PR TITLE
[gui] Set title attribute of filter items

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
@@ -83,7 +83,7 @@
 
             <v-list-item-content>
               <slot name="title" :item="item">
-                <v-list-item-title>
+                <v-list-item-title :title="item.title">
                   {{ item.title }}
                 </v-list-item-title>
               </slot>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/ItemsSelected.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/ItemsSelected.vue
@@ -24,7 +24,7 @@
 
         <v-list-item-content class="pa-0">
           <slot name="title" :item="item">
-            <v-list-item-title>
+            <v-list-item-title :title="item.title">
               {{ item.title }}
             </v-list-item-title>
           </slot>


### PR DESCRIPTION
Set title attribute of the filter items so on hover it will show the full
title in a tooltip even if title of the filter item is truncated.