### PR TITLE
Add the checker security.insecureAPI.DeprecatedOrUnsafeBufferHandling

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -384,6 +384,7 @@
   "security.insecureAPI.bcmp":                                  "LOW",
   "security.insecureAPI.bcopy":                                 "LOW",
   "security.insecureAPI.bzero":                                 "LOW",
+  "security.insecureAPI.DeprecatedOrUnsafeBufferHandling":      "MEDIUM",
   "security.insecureAPI.getpw":                                 "MEDIUM",
   "security.insecureAPI.gets":                                  "MEDIUM",
   "security.insecureAPI.mkstemp":                               "MEDIUM",


### PR DESCRIPTION
Medium as it matches the severity of security.insecureAPI.strcpy