### PR TITLE
[cmd] Revert -MD flag skip

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -246,7 +246,7 @@ INCLUDE_OPTIONS_MERGED = \
     re.compile('(' + '|'.join(INCLUDE_OPTIONS_MERGED) + ')')
 
 
-PRECOMPILATION_OPTION = re.compile('-(E|M[G|T|Q|F|J|P|V|M|D]*)$')
+PRECOMPILATION_OPTION = re.compile('-(E|M[G|T|Q|F|J|P|V|M]*)$')
 
 # Match for all of the compiler flags.
 CLANG_OPTIONS = re.compile('.*')


### PR DESCRIPTION
We should rather consider build actions containing -MD flag as
compilation because besides emitting precompilation infos, it also
accomplishes compilation.