### PR TITLE
[gui] Allow diff and review status filters in statistics page

### DIFF
--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -4,8 +4,6 @@
       <report-filter
         v-fill-height
         :namespace="namespace"
-        :show-newcheck="false"
-        :show-review-status="false"
         :show-remove-filtered-reports="false"
         :report-count="reportCount"
         @refresh="refresh"


### PR DESCRIPTION
Allow the same filters in the statistics page as in the reports page