### PR TITLE
[gui] Remove regex icon from the report filters

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
@@ -42,10 +42,6 @@
               />
             </v-list-item-action>
 
-            <v-list-item-icon class="ma-1 mr-2">
-              <v-icon>mdi-regex</v-icon>
-            </v-list-item-icon>
-
             <v-list-item-content>
               <v-list-item-title>
                 {{ search.regexLabel }}: {{ searchTxt }}


### PR DESCRIPTION
Some of the report filters support custom search with * quantifiers.
If the user types something to the input box then a custom filter item
is appeared with a regex icon at the top of the filter items which allows the user
to filter by wildcard pattern. This is actually not a regex expression so
the regex icon is a little bit misleading. To solve this problem this patch
will remove this icon.