### PR TITLE
[gui] Keepalive component states

### DIFF
--- a/web/server/vue-cli/src/App.vue
+++ b/web/server/vue-cli/src/App.vue
@@ -3,8 +3,9 @@
     <the-header />
 
     <v-main>
-      <router-view />
-
+      <keep-alive include="Products">
+        <router-view />
+      </keep-alive>
       <errors />
     </v-main>
   </v-app>

--- a/web/server/vue-cli/src/views/ProductDetail.vue
+++ b/web/server/vue-cli/src/views/ProductDetail.vue
@@ -1,6 +1,8 @@
 <template>
   <v-container id="product" fluid>
-    <router-view />
+    <keep-alive>
+      <router-view />
+    </keep-alive>
   </v-container>
 </template>
 


### PR DESCRIPTION
Use vue `keep-alive` built-in component to cache component states.

So for example when navigating from the Runs page to the Reports page
the state of the Runs page component is saved. So once we go back to the
Runs page component the user will see the previous state.

This will also help us to reduce API requests to the server.