### PR TITLE
[gui] Always show down arrow, that will show the other bugs with the same hash

### DIFF
--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -44,7 +44,7 @@
         :footer-props="footerProps"
         :must-sort="true"
         :expanded.sync="expanded"
-        :show-expand="showExpanded"
+        show-expand
         :mobile-breakpoint="1100"
         item-key="$id"
         @item-expanded="itemExpanded"
@@ -290,10 +290,6 @@ export default {
       reportFilter: "getReportFilter",
       cmpData: "getCmpData"
     }),
-
-    showExpanded() {
-      return this.reportFilter.isUnique;
-    },
 
     tableHeaders() {
       if (!this.headers) return;


### PR DESCRIPTION
In the Reports page always show the expand button (down arrow) that will
show the other bugs with the same hash.