### PR TITLE
[fix] Fix bugs in debug_tools scripts

### DIFF
--- a/scripts/debug_tools/prepare_all_cmd_for_ctu.py
+++ b/scripts/debug_tools/prepare_all_cmd_for_ctu.py
@@ -30,8 +30,8 @@ def execute(cmd):
             errors="ignore")
         out, err = proc.communicate()
 
-        print("stdout:\n\n" + out.decode("utf-8"))
-        print("stderr:\n\n" + err.decode("utf-8"))
+        print("stdout:\n\n" + out)
+        print("stderr:\n\n" + err)
 
         if proc.returncode != 0:
             print('Unsuccessful run: "' + ' '.join(cmd) + '"')

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -26,8 +26,17 @@ class AnalyzerCommandPathModifier(object):
 
     def __call__(self, path):
 
-        if re.search('clang$', path):
+        if re.search('clang(-(\d)+)?$', path):
             return self.opts.clang
+
+        if re.search('\.plist$', path):
+            # put a plist (seemingly analyzer output) file into the report_debug directory
+            # that is 2 levels above ctu-dir
+            return os.path.join(
+                os.path.dirname(
+                    os.path.dirname(
+                        self.opts.ctu_dir.rstrip(os.path.sep))),
+                os.path.basename(path))
 
         if self.opts.clang_plugin_name is not None and\
                 re.search(self.opts.clang_plugin_name, path):

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -26,12 +26,15 @@ class AnalyzerCommandPathModifier(object):
 
     def __call__(self, path):
 
+        # Find a clang executable that can be "clang" or "clang-<version>".
+        # The version here is only a simple number (no point inside),
+        # clang should generate only version with whole release number.
         if re.search('clang(-(\d)+)?$', path):
             return self.opts.clang
 
         if re.search('\.plist$', path):
-            # put a plist (seemingly analyzer output) file into the report_debug directory
-            # that is 2 levels above ctu-dir
+            # Put a plist (seemingly analyzer output) file into the report_debug directory,
+            # that is 2 levels above ctu_dir ("report_debug/ctu-dir/<target>").
             return os.path.join(
                 os.path.dirname(
                     os.path.dirname(

--- a/scripts/debug_tools/prepare_compiler_info.py
+++ b/scripts/debug_tools/prepare_compiler_info.py
@@ -20,17 +20,19 @@ def prepare(compiler_info_file, sources_root):
     sources_root_abs = os.path.abspath(sources_root)
     new_json_data = dict()
     for compiler in json_data:
-        lines = json_data[compiler]['includes']
-        changed_lines = []
-        for line in lines:
-            changed_lines.append(
-                lib.change_paths(line,
-                                 lib.IncludePathModifier(sources_root_abs)))
-        new_json_data[compiler] = {
-            'includes': changed_lines,
-            'target': json_data[compiler]['target'],
-            'default_standard': json_data[compiler]['default_standard']
-        }
+        new_json_data[compiler] = dict()
+        for language in json_data[compiler]:
+            lines = json_data[compiler][language]['compiler_includes']
+            changed_lines = []
+            for line in lines:
+                changed_lines.append(
+                    lib.change_paths(line,
+                                     lib.IncludePathModifier(sources_root_abs)))
+            new_json_data[compiler][language] = {
+                'compiler_includes': changed_lines,
+                'target': json_data[compiler][language]['target'],
+                'compiler_standard': json_data[compiler][language]['compiler_standard']
+            }
     return new_json_data
 
 


### PR DESCRIPTION
The debug_tools did not work with current version of files got from
clang and tu_collector. At least part of the problems is fixed.
The problems are related to file format changes and name of clang executable.