### PR TITLE
[gui] Rename review status and detection status texts

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -600,13 +600,32 @@ filter arguments:
   --report-hash [REPORT_HASH [REPORT_HASH ...]]
                         Filter results by report hashes.
   --review-status [REVIEW_STATUS [REVIEW_STATUS ...]]
-                        Filter results by review statuses. This can be used
-                        only if basename or newname is a run name (on the
-                        remote server). (default: ['unreviewed', 'confirmed'])
+                        Filter results by review statuses.
+                        Reports can be assigned a review status of the
+                        following values:
+                        - Unreviewed: Nobody has seen this report.
+                        - Confirmed: This is really a bug.
+                        - False positive: This is not a bug.
+                        - Intentional: This report is a bug but we don't want
+                        to fix it. (default: ['unreviewed', 'confirmed'])
   --detection-status [DETECTION_STATUS [DETECTION_STATUS ...]]
-                        Filter results by detection statuses. This can be used
-                        only if basename or newname is a run name (on the
-                        remote server). (default: ['new', 'reopened',
+                        Filter results by detection statuses.
+                        The detection status is the latest state of a bug
+                        report in a run. When a unique report is first
+                        detected it will be marked as New. When the report is
+                        stored again with the same run name then the detection
+                        status changes to one of the following options:
+                        - Resolved: when the bug report can't be found after
+                        the subsequent storage.
+                        - Unresolved: when the bug report is still among the
+                        results after the subsequent storage.
+                        - Reopened: when a Resolved bug appears again.
+                        - Off: The bug was reported by a checker that was
+                        switched off during the last analysis which results
+                        were stored.
+                        - Unavailable: were reported by a checker that does
+                        not exists in the analyzer anymore because it was
+                        removed or renamed. (default: ['new', 'reopened',
                         'unresolved'])
   --severity [SEVERITY [SEVERITY ...]]
                         Filter results by severities.

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -57,7 +57,7 @@ def get_argparser_ctor_args():
 
     return {
         'prog': 'CodeChecker cmd',
-        'formatter_class': argparse.ArgumentDefaultsHelpFormatter,
+        'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
 
         # Description is shown when the command's help is queried directly
         'description': "The command-line client is used to connect to a "
@@ -206,16 +206,42 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                          dest="review_status",
                          metavar='REVIEW_STATUS',
                          default=init_default('review_status'),
-                         help="Filter results by review statuses." +
-                         warn_diff_mode)
+                         help="R|Filter results by review statuses.\n"
+                              "Reports can be assigned a review status of the "
+                              "following values:\n"
+                              "- Unreviewed: Nobody has seen this report.\n"
+                              "- Confirmed: This is really a bug.\n"
+                              "- False positive: This is not a bug.\n"
+                              "- Intentional: This report is a bug but we "
+                              "don't want to fix it." +
+                              warn_diff_mode)
 
     f_group.add_argument('--detection-status',
                          nargs='*',
                          dest="detection_status",
                          metavar='DETECTION_STATUS',
                          default=init_default('detection_status'),
-                         help="Filter results by detection statuses." +
-                         warn_diff_mode)
+                         help="R|Filter results by detection statuses.\n"
+                              "The detection status is the latest state of a "
+                              "bug report in a run. When a unique report is "
+                              "first detected it will be marked as New. When "
+                              "the report is stored again with the same run "
+                              "name then the detection status changes to one "
+                              "of the following options:\n"
+                              "- Resolved: when the bug report can't be found "
+                              "after the subsequent storage.\n"
+                              "- Unresolved: when the bug report is still "
+                              "among the results after the subsequent "
+                              "storage.\n"
+                              "- Reopened: when a Resolved bug appears "
+                              "again.\n"
+                              "- Off: The bug was reported by a checker that "
+                              "was switched off during the last analysis "
+                              "which results were stored.\n"
+                              "- Unavailable: were reported by a checker that "
+                              "does not exists in the analyzer anymore "
+                              "because it was removed or renamed." +
+                              warn_diff_mode)
 
     f_group.add_argument('--severity',
                          nargs='*',

--- a/web/server/vue-cli/src/assets/userguide/userguide.md
+++ b/web/server/vue-cli/src/assets/userguide/userguide.md
@@ -311,7 +311,8 @@ when the bug report is still among the results after the subsequent storage.
 - <span class="customIcon detection-status-reopened"></span> **Reopened**: when
 a resolved bug appears again.
 - <span class="customIcon detection-status-off"></span> **Off**: were reported
-by a checker that is switched off during the analysis.
+by a checker that is switched off during the last analysis which results were
+stored.
 - <span class="customIcon detection-status-unavailable"></span> **Unavailable**:
 were reported by a checker that does not exists anymore because it was removed
 or renamed.

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <select-option
     :id="id"
-    title="Detection status"
+    title="Latest Detection Status"
     :bus="bus"
     :fetch-items="fetchItems"
     :loading="loading"
@@ -14,6 +14,36 @@
     </template>
 
     <template v-slot:append-toolbar-title>
+      <tooltip-help-icon>
+        Filter reports by the <b>latest</b> detection status.<br><br>
+
+        The detection status is the latest state of a bug report in a run. When
+        a report id is first detected it will be marked as <b>New</b>. When the
+        reports stored again with the same run name then the detection status
+        can change to one of the following options:
+        <ul>
+          <li>
+            <b>Resolved:</b> when the bug report can't be found after the
+            subsequent storage.
+          </li>
+          <li>
+            <b>Unresolved:</b> when the bug report is still among the results
+            after the subsequent storage.
+          </li>
+          <li>
+            <b>Reopened:</b> when a resolved bug appears again.
+          </li>
+          <li>
+            <b>Off:</b> were reported by a checker that is switched off
+            during the last analysis which results were stored.
+          </li>
+          <li>
+            <b>Unavailable:</b> were reported by a checker that does not
+            exists anymore because it was removed or renamed.
+          </li>
+        </ul>
+      </tooltip-help-icon>
+
       <v-icon
         v-if="reportFilter.isUnique"
         color="error"
@@ -34,6 +64,7 @@
 import { ccService, handleThriftError } from "@cc-api";
 
 import { DetectionStatus, ReportFilter } from "@cc/report-server-types";
+import TooltipHelpIcon from "@/components/TooltipHelpIcon";
 import { DetectionStatusIcon } from "@/components/Icons";
 import { DetectionStatusMixin } from "@/mixins";
 
@@ -45,7 +76,8 @@ export default {
   components: {
     SelectOption,
     DetectionStatusIcon,
-    SelectedToolbarTitleItems
+    SelectedToolbarTitleItems,
+    TooltipHelpIcon
   },
   mixins: [ BaseSelectOptionFilterMixin, DetectionStatusMixin ],
 

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReviewStatusFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReviewStatusFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <select-option
     :id="id"
-    title="Review Status"
+    title="Latest Review Status"
     :bus="bus"
     :fetch-items="fetchItems"
     :loading="loading"
@@ -12,6 +12,29 @@
     <template v-slot:icon="{ item }">
       <review-status-icon :status="item.id" />
     </template>
+
+    <template v-slot:append-toolbar-title>
+      <tooltip-help-icon>
+        Filter reports by the <b>latest</b> review status.<br><br>
+
+        Reports can be assigned a review status of the following values:
+        <ul>
+          <li>
+            <b>Unreviewed</b>: Nobody has seen this report.
+          </li>
+          <li>
+            <b>Confirmed:</b> This is really a bug.
+          </li>
+          <li>
+            <b>False positive:</b> This is not a bug.
+          </li>
+          <li>
+            <b>Intentional:</b> This report is a bug but we don't want to fix
+            it.
+          </li>
+        </ul>
+      </tooltip-help-icon>
+    </template>
   </select-option>
 </template>
 
@@ -19,6 +42,7 @@
 import { ccService, handleThriftError } from "@cc-api";
 
 import { ReportFilter, ReviewStatus } from "@cc/report-server-types";
+import TooltipHelpIcon from "@/components/TooltipHelpIcon";
 import { ReviewStatusIcon } from "@/components/Icons";
 import { ReviewStatusMixin } from "@/mixins";
 
@@ -29,7 +53,8 @@ export default {
   name: "ReviewStatusFilter",
   components: {
     SelectOption,
-    ReviewStatusIcon
+    ReviewStatusIcon,
+    TooltipHelpIcon
   },
   mixins: [ BaseSelectOptionFilterMixin, ReviewStatusMixin ],
 

--- a/web/server/vue-cli/src/components/TooltipHelpIcon.vue
+++ b/web/server/vue-cli/src/components/TooltipHelpIcon.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-tooltip max-width="300" right>
+    <template v-slot:activator="{ on }">
+      <v-icon
+        color="accent"
+        class="ml-1"
+        small
+        v-on="on"
+      >
+        mdi-help-circle
+      </v-icon>
+    </template>
+    <slot />
+  </v-tooltip>
+</template>
+
+<script>
+export default {
+  name: "TooltipHelpIcon"
+};
+</script>

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -250,13 +250,13 @@ export default {
           sortable: true
         },
         {
-          text: "Review status",
+          text: "Latest review status",
           value: "reviewData",
           align: "center",
           sortable: true
         },
         {
-          text: "Detection status",
+          text: "Latest detection status",
           value: "detectionStatus",
           align: "center",
           sortable: true


### PR DESCRIPTION
> Closes #2907

Rename `Review status` to `Latest review status` and `Detection status`
to `Latest detection status` and show a tooltip icon beside the filters
which describes the filters.