### PR TITLE
[cmd] Set verified label properly for gerrit output

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1181,7 +1181,7 @@ def handle_diff_results(args):
                   "message": message,
                   "labels": {
                       "Code-Review": -1 if report_count else 1,
-                      "Verified": 1},
+                      "Verified": -1 if report_count else 1},
                   "comments": review_comments}
 
         gerrit_review_json = os.path.join(output_dir,

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -387,7 +387,7 @@ class LocalRemote(unittest.TestCase):
             review_data = json.load(rw_file)
 
         lbls = review_data["labels"]
-        self.assertEqual(lbls["Verified"], 1)
+        self.assertEqual(lbls["Verified"], -1)
         self.assertEqual(lbls["Code-Review"], -1)
         self.assertEqual(review_data["message"],
                          "CodeChecker found 4 issue(s) in the code.")
@@ -454,7 +454,7 @@ class LocalRemote(unittest.TestCase):
             review_data = json.load(rw_file)
 
         lbls = review_data["labels"]
-        self.assertEqual(lbls["Verified"], 1)
+        self.assertEqual(lbls["Verified"], -1)
         self.assertEqual(lbls["Code-Review"], -1)
         self.assertEqual(review_data["message"],
                          "CodeChecker found 4 issue(s) in the code. "


### PR DESCRIPTION
Previously the `Verified` label in the generated gerrit review file
was always be set to `1` which enables submission.
This commit changes this behaviour and if the report count is not
zero it will set this label to `-1` (similar to `Code-Review` label)
so it will block the submission.