### PR TITLE
[fix] Wait while filters are initalized and cleared properly

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -271,7 +271,8 @@ export default {
       if (runs.length || tags.length) {
         const selectedRuns = await this.getSelectedRunItems(runs);
         const selectedTags = await this.getSelectedTagItems(tags);
-        this.setSelectedItems(selectedRuns, selectedTags, false);
+
+        await this.setSelectedItems(selectedRuns, selectedTags, false);
       }
     },
 
@@ -281,8 +282,8 @@ export default {
       this.setSelectedItems(selectedRunItems, this.prevSelectedTagItems);
     },
 
-    clear(updateUrl) {
-      this.setSelectedItems([], [], updateUrl);
+    async clear(updateUrl) {
+      await this.setSelectedItems([], [], updateUrl);
     },
 
     selectRunTags(selectedItems) {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -464,7 +464,7 @@ export default {
       }
     },
 
-    clearAllFilters() {
+    async clearAllFilters() {
       const filters = this.$refs.filters;
 
       // Unregister watchers.
@@ -472,7 +472,7 @@ export default {
       filters.forEach(filter => filter.unregisterWatchers());
 
       // Clear all filters and update the url.
-      filters.forEach(filter => filter.clear(false) );
+      await Promise.all(filters.map(filter => filter.clear(false)));
       this.updateUrl();
 
       // Update filters after clear.


### PR DESCRIPTION
- `initByUrl` is an async function which returns a Promise. Unfortunatelly
in the Run Filter it is called an async function (setSelectedItems) but we
forgot to wait for it. This way the filters are not initalized properly.
For example when we opened a product and clicked on a run name the reports
are not filtered by run name.
- `clear` functions can be async functions so we need to wait for them
before we update the report filters when clearing all reports filter.