### PR TITLE
[fix] getTags function is called in a wrong way in the run filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -249,7 +249,7 @@ export default {
       const tags2 = tagWithRunNames.length
         ? (await Promise.all(tagWithRunNames.map(async s => {
           const { runName, tagName } = this.extractTagWithRunName(s);
-          const tags = await this.getTags(s);
+          const tags = await this.getTags(null, s);
           return {
             id: tags[0].id,
             runName: runName ? runName : tags[0].runName,


### PR DESCRIPTION
The `getTags` function in the run filter component expects two parameters:
tag ids and tag names. In one place this function was called in a wrong way:
only one parameter was given and it was a string (run name). This commit
solves this problem.