### PR TITLE
[test] Fix detection date filter test

### DIFF
--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -359,8 +359,8 @@ class TestReportFilter(unittest.TestCase):
 
     def test_detection_date_filters(self):
         """ Filter by detection dates. """
-        run_results = self._cc_client.getRunResults(self._runids, 1, 0, None,
-                                                    None, None, False)
+        run_results = self._cc_client.getRunResults([self._runids[0]], 1, 0,
+                                                    None, None, None, False)
         self.assertEqual(len(run_results), 1)
 
         detected_after = datetime.strptime(run_results[0].detectedAt,


### PR DESCRIPTION
At the begining of the detection date filter tests we get one report from
the database based on the first two runs. The order of the result was
unspecified on the API call so the default order was by severity.
It was possible that on the first test run the report related to the
first run was queried from the database but on the second test run the
report related to the second run was queried. So this cause a
non-deteministic test run.