### PR TITLE
[clang-tidy][doc] Show config for all checks

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -82,7 +82,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
     @classmethod
     def get_analyzer_checkers(cls, cfg_handler, environ):
         """
-        Return the list of the supported checkers.
+        Return the list of the all of the supported checkers.
         """
         try:
             result = subprocess.check_output(
@@ -97,9 +97,12 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def get_checker_config(cls, cfg_handler, environ):
+        """
+        Return the checker configuration of the all of the supported checkers.
+        """
         try:
             result = subprocess.check_output(
-                [cfg_handler.analyzer_binary, "-dump-config"],
+                [cfg_handler.analyzer_binary, "-dump-config", "-checks=*"],
                 env=environ,
                 universal_newlines=True,
                 encoding="utf-8",
@@ -110,9 +113,12 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def get_analyzer_config(cls, cfg_handler, environ):
+        """
+        Return the analyzer configuration with all checkers enabled.
+        """
         try:
             result = subprocess.check_output(
-                [cfg_handler.analyzer_binary, "-dump-config"],
+                [cfg_handler.analyzer_binary, "-dump-config", "-checks=*"],
                 env=environ,
                 universal_newlines=True,
                 encoding="utf-8",

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -172,8 +172,9 @@ def add_arguments_to_parser(parser):
                         default=argparse.SUPPRESS,
                         action='store_true',
                         required=False,
-                        help="Show checker configuration options. These can "
-                             "be given to 'CodeChecker analyze "
+                        help="Show checker configuration options for all "
+                             "existing checkers supported by the analyzer. "
+                             "These can be given to 'CodeChecker analyze "
                              "--checker-config'.")
 
     filters = parser.add_mutually_exclusive_group(required=False)

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1098,6 +1098,8 @@ the available checkers and find the one which checks functions' size:
 ```
 CodeChecker checkers --details
 ```
+Every supported checker is reported by the `checkers` command and all of its
+subcommands.
 
 After finding `google-readability-function-size` checker, you can list the
 config options with the following command:
@@ -1633,8 +1635,10 @@ optional arguments:
                         a rule. Without additional parameter, the available
                         guidelines and their corresponding rules will be
                         listed.
-  --checker-config      Show checker configuration options. These can be
-                        given to 'CodeChecker analyze --checker-config'.
+  --checker-config      Show checker configuration options for all
+                        existing checkers supported by the analyzer.
+                        These can be given to 'CodeChecker analyze
+                        --checker-config'.
   --only-enabled        Show only the enabled checkers.
   --only-disabled       Show only the disabled checkers.
   -o {rows,table,csv,json}, --output {rows,table,csv,json}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -327,6 +327,9 @@ CodeChecker checkers --details
 ```
 those marked with (+) are enabled by default.
 
+Every supported checker is reported by the `checkers` command and all of its
+subcommands.
+
 You may want to enable more checkers or disable some of them using the -e, -d
 switches of the analyze command.
 


### PR DESCRIPTION
CodeChecker checkers now shows configuration options for all available
checks instead of only default-enabled ones.