### PR TITLE
[gui] Show number of filtered items in the tooltip

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -59,6 +59,7 @@
             :items="items"
             :selected-items="prevSelectedItems"
             :search="search"
+            :limit="defaultLimit"
             @apply="apply"
             @cancel="cancel"
             @select="select"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineTagItems.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineTagItems.vue
@@ -3,6 +3,7 @@
     :items.sync="tags"
     :selected-items="selectedItems"
     :search="search"
+    :limit="defaultLimit"
     @apply="apply"
     @cancel="cancel"
     @select="select"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
@@ -7,6 +7,7 @@
     :selected-items="selectedItems"
     :search="search"
     :loading="loading"
+    :limit="defaultLimit"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerNameFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerNameFilter.vue
@@ -7,6 +7,7 @@
     :selected-items="selectedItems"
     :search="search"
     :loading="loading"
+    :limit="defaultLimit"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
@@ -7,6 +7,7 @@
     :selected-items="selectedItems"
     :search="search"
     :loading="loading"
+    :limit="defaultLimit"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/Items.vue
@@ -105,6 +105,14 @@
           No items
         </slot>
       </v-list-item>
+
+      <div
+        v-if="limit"
+        class="text-center text--secondary"
+      >
+        Showed <span v-if="limit === items.length">first</span>
+        <i>{{ items.length }}</i> items.
+      </div>
     </v-list>
 
     <v-card-actions>
@@ -144,6 +152,7 @@ export default {
   name: "SelectOptionItems",
   props: {
     items: { type: Array, required: true },
+    limit: { type: Number, default: null },
     selectedItems: { type: Array, required: true },
     multiple: { type: Boolean, default: true },
     search: { type: Object, default: null },

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
@@ -60,6 +60,7 @@
             :selected-items="prevSelectedItems"
             :search="search"
             :multiple="multiple"
+            :limit="limit"
             @apply="applyFilters"
             @cancel="cancel"
             @select="select"
@@ -122,6 +123,7 @@ export default {
     search: { type: Object, default: null },
     loading: { type: Boolean, default: false },
     panel: { type: Boolean, default: false },
+    limit: { type: Number, default: null },
     apply: {
       type: Function,
       default: function (selectedItems) {


### PR DESCRIPTION
> Closes #2862

In the report filter tooltips we show only 10 items for filters which
support searching by using * quantifiers. To identify that there can
be more results we show the number of filtered items at the bottom of
the filter items.

Screenshot:
![image](https://user-images.githubusercontent.com/6695818/93205217-ba6ad380-f757-11ea-81b7-0d99e4f122e5.png)
