### PR TITLE
[analyzer] parse the compilation tag separately

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -223,6 +223,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                 analyzer_cmd.append("--target=" +
                                     self.buildaction.target.get(compile_lang))
 
+            if not has_flag('-arch', analyzer_cmd) and \
+                    self.buildaction.arch != "":
+                analyzer_cmd.extend(["-arch ", self.buildaction.arch])
+
             if not has_flag('-std', analyzer_cmd) and \
                     self.buildaction.compiler_standard.get(compile_lang, "") \
                     != "":

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -200,6 +200,10 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                     "--target=" + self.buildaction.target.get(compile_lang,
                                                               ""))
 
+            if not has_flag('-arch', analyzer_cmd) and \
+                    self.buildaction.arch != "":
+                analyzer_cmd.extend(["-arch ", self.buildaction.arch])
+
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 
             analyzer_cmd.extend(prepend_all(

--- a/analyzer/codechecker_analyzer/buildlog/build_action.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_action.py
@@ -24,6 +24,7 @@ class BuildAction(object):
                  'lang',
                  'target',
                  'source',
+                 'arch',
                  'action_type']
 
     LINK = 0

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -825,6 +825,23 @@ def __get_arch(flag_iterator, details):
     return False
 
 
+def __get_target(flag_iterator, details):
+    """
+    This function consumes --target or -target flag which is followed by the
+    compilation target architecture.
+    This target might be different from the default compilation target
+    collected from the compiler if cross compilation is done for
+    another target.
+    This is then collected to the buildaction object.
+    """
+    if flag_iterator.item in ['--target', '-target']:
+        next(flag_iterator)
+        details['compilation_target'] = flag_iterator.item
+        return True
+
+    return False
+
+
 def __get_language(flag_iterator, details):
     """
     This function consumes -x flag which is followed by the language. This
@@ -936,6 +953,7 @@ def parse_options(compilation_db_entry,
         'analyzer_options': [],
         'compiler_includes': defaultdict(dict),  # For each language c/cpp.
         'compiler_standard': defaultdict(dict),  # For each language c/cpp.
+        'compilation_target': '',  # Compilation target in the compilation cmd.
         'analyzer_type': -1,
         'original_command': '',
         'directory': '',
@@ -972,6 +990,7 @@ def parse_options(compilation_db_entry,
         __get_output,
         __determine_action_type,
         __get_arch,
+        __get_target,
         __get_language,
         __collect_transform_include_opts,
         __collect_clang_compile_opts
@@ -985,6 +1004,7 @@ def parse_options(compilation_db_entry,
         __determine_action_type,
         __skip_sources,
         __get_arch,
+        __get_target,
         __get_language,
         __get_output]
 
@@ -1050,7 +1070,7 @@ def parse_options(compilation_db_entry,
     # Option parser detects target architecture but does not know about the
     # language during parsing. Set the collected compilation target for the
     # language detected language.
-    details['target'][lang] = details['arch']
+    details['target'][lang] = details['compilation_target']
 
     # With gcc-toolchain a non default compiler toolchain can be set. Clang
     # will search for include paths and libraries based on the gcc-toolchain

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -132,7 +132,7 @@ class OptionParserTest(unittest.TestCase):
         print(res)
 
         self.assertTrue('main.c' == res.source)
-        self.assertEqual(arch['c'], res.target['c'])
+        self.assertEqual(arch['c'], res.arch)
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
     def test_compile_optimized(self):
@@ -310,6 +310,19 @@ class OptionParserTest(unittest.TestCase):
         res = log_parser.parse_options(warning_action_clang)
 
         self.assertEqual(["-std=gnu++14"], res.analyzer_options)
+
+    def test_target_parsing_clang(self):
+        """Parse compilation target."""
+
+        warning_action_clang = {
+            "directory": "/tmp",
+            "command":
+            "clang++ -target compilation-target -B/tmp/dir -c /tmp/a.cpp",
+            "file": "/tmp/a.cpp"}
+
+        res = log_parser.parse_options(warning_action_clang)
+        self.assertEqual(["-B/tmp/dir"], res.analyzer_options)
+        self.assertEqual("compilation-target", res.target['c++'])
 
     def test_ignore_xclang_flags_clang(self):
         """Skip some specific xclang constructs"""


### PR DESCRIPTION
The compilation target which could be different from the default
compiler target was not correctly parsed from the compilation command.
This could cause problems in case the project was cross compiled
to a different target.
The default compilation target is collected but that might be
different from the target used in the compile command.

resolves #2916