### PR TITLE
Set severity for cppcoreguidelines-prefer-member-initializer

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -165,6 +165,7 @@
   "cppcoreguidelines-no-malloc":                                "LOW",
   "cppcoreguidelines-non-private-member-variables-in-classes":  "LOW",
   "cppcoreguidelines-owning-memory":                            "STYLE",
+  "cppcoreguidelines-prefer-member-initializer":                "STYLE",
   "cppcoreguidelines-pro-bounds-array-to-pointer-decay":        "LOW",
   "cppcoreguidelines-pro-bounds-constant-array-index":          "LOW",
   "cppcoreguidelines-pro-bounds-pointer-arithmetic":            "LOW",


### PR DESCRIPTION
Reusing "modernize-use-default-member-init" severity but we could move it to LOW
as it has an impact on performance