### PR TITLE
[server] Set analyzer name for clang-diagnostic checkers

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2511,6 +2511,9 @@ class ThriftRequestHandler(object):
             if report.metadata:
                 return report.metadata.get("analyzer", {}).get("name")
 
+            if report.check_name.startswith('clang-diagnostic-'):
+                return 'clang-tidy'
+
         # Processing PList files.
         _, _, report_files = next(os.walk(report_dir), ([], [], []))
         all_report_checkers = set()

--- a/web/tests/functional/report_viewer_api/__init__.py
+++ b/web/tests/functional/report_viewer_api/__init__.py
@@ -57,7 +57,7 @@ def setup_package():
         'skip_list_file': skip_list_file,
         'check_env': test_env,
         'workspace': TEST_WORKSPACE,
-        'checkers': [],
+        'checkers': ['-e', 'clang-diagnostic-return-type'],
         'tag': tag
     }
 

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -62,7 +62,8 @@ class TestReportFilter(unittest.TestCase):
         self._runids = [r.runId for r in self._test_runs]
 
         self.run1_checkers = \
-            {'core.CallAndMessage': 5,
+            {'clang-diagnostic-division-by-zero': 3,
+             'core.CallAndMessage': 5,
              'core.DivideZero': 10,
              'core.NullDereference': 4,
              'core.StackAddrEscapeBase': 3,
@@ -72,7 +73,8 @@ class TestReportFilter(unittest.TestCase):
              'unix.Malloc': 1}
 
         self.run2_checkers = \
-            {'core.CallAndMessage': 5,
+            {'clang-diagnostic-division-by-zero': 3,
+             'core.CallAndMessage': 5,
              'core.DivideZero': 10,
              'core.NullDereference': 4,
              'cplusplus.NewDelete': 5,
@@ -81,19 +83,19 @@ class TestReportFilter(unittest.TestCase):
              'unix.MismatchedDeallocator': 1}
 
         self.run1_sev_counts = {Severity.UNSPECIFIED: 3,
-                                Severity.MEDIUM: 3,
+                                Severity.MEDIUM: 6,
                                 Severity.LOW: 6,
                                 Severity.HIGH: 24}
 
-        self.run2_sev_counts = {Severity.MEDIUM: 3,
+        self.run2_sev_counts = {Severity.MEDIUM: 6,
                                 Severity.LOW: 6,
                                 Severity.HIGH: 24}
 
         self.run1_detection_counts = \
-            {DetectionStatus.NEW: 36}
+            {DetectionStatus.NEW: 39}
 
         self.run2_detection_counts = \
-            {DetectionStatus.NEW: 33}
+            {DetectionStatus.NEW: 36}
 
         self.run1_files = \
             {'file_to_be_skipped.cpp': 2,
@@ -101,11 +103,11 @@ class TestReportFilter(unittest.TestCase):
              'new_delete.cpp': 6,
              'stack_address_escape.cpp': 3,
              'call_and_message.cpp': 5,
-             'divide_zero.cpp': 4,
+             'divide_zero.cpp': 5,
              'divide_zero_duplicate.cpp': 2,
              'has a space.cpp': 1,
-             'skip_header.cpp': 1,
-             'skip.h': 2,
+             'skip_header.cpp': 2,
+             'skip.h': 3,
              'path_begin.cpp': 2,
              'path_end.h': 3
              }
@@ -113,13 +115,13 @@ class TestReportFilter(unittest.TestCase):
         self.run2_files = \
             {'call_and_message.cpp': 5,
              'new_delete.cpp': 6,
-             'divide_zero.cpp': 4,
+             'divide_zero.cpp': 5,
              'divide_zero_duplicate.cpp': 2,
              'null_dereference.cpp': 5,
              'file_to_be_skipped.cpp': 2,
              'has a space.cpp': 1,
-             'skip_header.cpp': 1,
-             'skip.h': 2,
+             'skip_header.cpp': 2,
+             'skip.h': 3,
              'path_begin.cpp': 2,
              'path_end.h': 3
              }
@@ -523,7 +525,8 @@ class TestReportFilter(unittest.TestCase):
                                                        0)
         checkers_dict = dict((res.name, res.count) for res in new_reports)
 
-        new = {'core.CallAndMessage': 5,
+        new = {'clang-diagnostic-division-by-zero': 3,
+               'core.CallAndMessage': 5,
                'core.StackAddrEscapeBase': 3,
                'cplusplus.NewDelete': 5,
                'core.NullDereference': 4,

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -216,7 +216,7 @@ class TestReportFilter(unittest.TestCase):
                                                              None,
                                                              None)
 
-        self.assertEqual(run_result_count, 69)
+        self.assertEqual(run_result_count, 75)
 
         run_results = self._cc_client.getRunResults(self._runids,
                                                     run_result_count,
@@ -375,7 +375,7 @@ class TestReportFilter(unittest.TestCase):
         run_results = self._cc_client.getRunResults(self._runids, None, 0,
                                                     None, report_filter, None,
                                                     False)
-        self.assertEqual(len(run_results), 36)
+        self.assertEqual(len(run_results), 39)
 
     def test_fix_date_filters(self):
         """ Filter by fix dates. """
@@ -421,7 +421,6 @@ class TestReportFilter(unittest.TestCase):
                                                             an_f,
                                                             None,
                                                             False)
-                for r in run_results:
-                    print(r)
+
                 self.assertIsNotNone(run_results)
                 self.assertEqual(test_result_count, len(run_results))

--- a/web/tests/projects/cpp/Makefile
+++ b/web/tests/projects/cpp/Makefile
@@ -1,6 +1,6 @@
 OBJS = $(SRCS:.cpp=.o)
 
-CXXFLAGS = -Wno-all -Wno-extra -Wno-division-by-zero
+CXXFLAGS = -Wno-all -Wno-extra
 
 SRCS = call_and_message.cpp \
 	   divide_zero.cpp \

--- a/web/tests/projects/cpp/project_info.json
+++ b/web/tests/projects/cpp/project_info.json
@@ -12,6 +12,7 @@
             { "file": "divide_zero.cpp", "line": 12, "checker": "core.DivideZero", "hash": "0db7fdfc2bc9d487ca571fbbb68029cc" },
             { "file": "divide_zero.cpp", "line": 17, "checker": "core.DivideZero", "hash": "5c5190f9153be2ea5e0b523a1af5faa1" },
             { "file": "divide_zero.cpp", "line": 12, "checker": "deadcode.DeadStores", "hash": "2bd08e713b88b6ae4da2671b87870a62" },
+            { "file": "divide_zero.cpp", "line": 17, "checker": "clang-diagnostic-division-by-zero", "hash": "0ac7dc80f8597ab3663bd9b87d016672" },
             { "file": "divide_zero.cpp", "line": 17, "checker": "deadcode.DeadStores", "hash": "c71054be96fe0483cebf5bdda7ae07d5" },
             { "file": "divide_zero_duplicate.cpp", "line": 12, "checker": "core.DivideZero", "hash": "0db7fdfc2bc9d487ca571fbbb68029cc" },
             { "file": "divide_zero_duplicate.cpp", "line": 12, "checker": "deadcode.DeadStores", "hash": "2bd08e713b88b6ae4da2671b87870a62" },
@@ -36,17 +37,19 @@
             { "file": "stack_address_escape.cpp", "line": 18, "checker": "core.StackAddrEscapeBase", "hash": "afb5b4e0f6ed01dff585689bcf458a7e" },
             { "file": "stack_address_escape.cpp", "line": 25, "checker": "core.StackAddrEscapeBase", "hash": "ab4781a0c24cd271c0da36b8b8ed0dc0" },
             { "file": "skip_header.cpp", "line": 15, "checker": "core.DivideZero", "hash": "6323bb2b22ffeff5c265eb14ae402d29" },
+            { "file": "skip_header.cpp", "line": 15, "checker": "clang-diagnostic-division-by-zero", "hash": "480caff35245121deb7d14f7fcf6787c" },
             { "file": "skip.h", "line": 8, "checker": "core.DivideZero", "hash": "269d82a20d38f23bbf730a2cf1d1668b" },
             { "file": "skip.h", "line": 7, "checker": "misc-definitions-in-headers", "hash": "3fa3c4f09e3bb769a68e377bd5ab3222" },
+            { "file": "skip.h", "line": 8, "checker": "clang-diagnostic-division-by-zero", "hash": "4608dd0c3faa82830a43f529a6c76a7f" },
             { "file": "path_begin.cpp", "line": 12, "checker": "core.DivideZero", "hash": "73e6a2e1091295da065a6527f8540366" },
             { "file": "path_begin.cpp", "line": 18, "checker": "core.DivideZero", "hash": "73e6a2e1091295da065a6527f8540366" }
         ],
-        "filter_severity_levels": [{"MEDIUM": 3}, {"LOW": 6}, {"HIGH": 24}, {"STYLE": 0}, {"UNSPECIFIED": 3}, {"CRITICAL": 0}],
+        "filter_severity_levels": [{"MEDIUM": 6}, {"LOW": 6}, {"HIGH": 24}, {"STYLE": 0}, {"UNSPECIFIED": 3}, {"CRITICAL": 0}],
         "filter_checker_id": [{"*unix*": 1}, {"core*": 22}, {"*DeadStores": 6}],
-        "filter_analyzer_name": [{"clang-tidy": 2}, {"clangsa": 34}],
+        "filter_analyzer_name": [{"clang-tidy": 5}, {"clangsa": 34}],
         "filter_filepath": [{"*null*": 5}],
         "filter_filepath_case_insensitive": [{"*null*": 5}, {"*nULl*": 5}, {"*NULL*": 5}, {"*Null*": 5}],
-        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 36}, {"FALSE_POSITIVE": 0}, {"INTENTIONAL": 0}],
+        "filter_review_status": [{"UNREVIEWED": 0}, {"CONFIRMED": 39}, {"FALSE_POSITIVE": 0}, {"INTENTIONAL": 0}],
         "diff_res_types_filter": [{"deadcode.DeadStores": 6},  {"cplusplus.NewDelete": 5}, {"unix.Malloc": 1}]
     }
 }


### PR DESCRIPTION
Checkers that start with `clang-diagnostic-` are compiler warnings and these
are not in the metadata.json file when storing results. We didn't handle this
use case so we were not able to set analyzer names for these checkers previously.
This commits solves this problem and set the analyzer name field for these
checkers too.