### PR TITLE
[server] ignore encoding errors for source file content

### DIFF
--- a/web/codechecker_web/shared/convert.py
+++ b/web/codechecker_web/shared/convert.py
@@ -12,9 +12,13 @@ import base64
 
 def to_b64(string):
     """ encode a string to a base64 encoded string """
-    return base64.b64encode(string.encode('utf-8')).decode('utf-8')
+    return base64.b64encode(string.encode("utf-8")).decode(
+        "utf-8", errors="ignore"
+    )
 
 
 def from_b64(string_b64):
     """ decode a b46 encoded string to a string """
-    return base64.b64decode(string_b64.encode('utf-8')).decode('utf-8')
+    return base64.b64decode(string_b64.encode("utf-8")).decode(
+        "utf-8", errors="ignore"
+    )

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1741,9 +1741,10 @@ class ThriftRequestHandler(object):
                 if encoding == Encoding.BASE64:
                     source = base64.b64encode(source)
 
+                source = source.decode('utf-8', errors='ignore')
                 return SourceFileData(fileId=sourcefile.id,
                                       filePath=sourcefile.filepath,
-                                      fileContent=source.decode('utf-8'))
+                                      fileContent=source)
             else:
                 return SourceFileData(fileId=sourcefile.id,
                                       filePath=sourcefile.filepath)

--- a/web/tests/projects/cpp/call_and_message.cpp
+++ b/web/tests/projects/cpp/call_and_message.cpp
@@ -43,5 +43,5 @@ void test4() {
 
 void test5() {
   C *pc = 0;
-  pc->f(); // warn: object pointer is null
+  pc->f(); // warn: object pointer is null <- non breaking space here save the file in latin1 (ISO-8895-1)
 }


### PR DESCRIPTION
If for some reason a file content was stored with a content
which can not be decoded to utf-8 ignore those characters.

New tests were added where a source file was saved with latin1
encoding to see if the file content can be loaded back
without any execeptions.

The characters which can not be encoded are ignored.