### PR TITLE
[gui] Show reports line number only in non unique mode

### DIFF
--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -115,7 +115,8 @@
             }}"
             class="file-name"
           >
-            {{ item.checkedFile }} @&nbsp;Line&nbsp;{{ item.line }}
+            {{ item.checkedFile }}
+            <span v-if="item.line">@&nbsp;Line&nbsp;{{ item.line }}</span>
           </router-link>
         </template>
 


### PR DESCRIPTION
In unique mode the line number is not available for reports. This patch
will handle this use case and will not show the Line label beside the
file path in unique mode.