### PR TITLE
[refactor] output formatters, type hints, report types

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyzer_version.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzer_version.py
@@ -16,7 +16,7 @@ import json
 from codechecker_analyzer import analyzer_context
 
 from codechecker_common import logger
-from codechecker_common import output_formatters
+from codechecker_common.output import USER_FORMATS, twodim
 
 
 def get_argparser_ctor_args():
@@ -49,7 +49,7 @@ def add_arguments_to_parser(parser):
                         dest='output_format',
                         required=False,
                         default='table',
-                        choices=output_formatters.USER_FORMATS,
+                        choices=USER_FORMATS,
                         help="The format to use when printing the version.")
 
     logger.add_verbose_arguments(parser)
@@ -69,16 +69,14 @@ def print_version(output_format=None):
         ("Git tag information", context.package_git_tag)
     ]
 
-    if output_format != "json":
-        print(output_formatters.twodim_to_str(output_format,
-                                              ["Kind", "Version"],
-                                              rows))
-    elif output_format == "json":
+    if output_format == "json":
         # Use a special JSON format here, instead of
         # [ {"kind": "something", "version": "0.0.0"}, {"kind": "foo", ... } ]
         # do
         # { "something": "0.0.0", "foo": ... }
         print(json.dumps(dict(rows)))
+    else:
+        print(twodim.to_str(output_format, ["Kind", "Version"], rows))
 
 
 def main(args):

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -19,7 +19,7 @@ from codechecker_analyzer import env
 from codechecker_analyzer.analyzers import analyzer_types
 
 from codechecker_common import logger
-from codechecker_common import output_formatters
+from codechecker_common.output import twodim, USER_FORMATS
 
 LOG = logger.get_logger('system')
 
@@ -98,7 +98,7 @@ def add_arguments_to_parser(parser):
                         dest='output_format',
                         required=False,
                         default='rows',
-                        choices=output_formatters.USER_FORMATS,
+                        choices=USER_FORMATS,
                         help="Specify the format of the output list.")
 
     logger.add_verbose_arguments(parser)
@@ -176,8 +176,7 @@ def main(args):
         rows = [(':'.join((analyzer, c[0])), c[1]) if 'details' in args
                 else (':'.join((analyzer, c[0])),) for c in configs]
 
-        print(output_formatters.twodim_to_str(args.output_format,
-                                              header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
 
         return
 
@@ -215,5 +214,4 @@ def main(args):
                              err_reason])
 
     if rows:
-        print(output_formatters.twodim_to_str(args.output_format,
-                                              header, rows))
+        print(twodim.to_str(args.output_format, header, rows))

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -20,9 +20,8 @@ from codechecker_analyzer import analyzer_context
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.analyzers.clangsa.analyzer import ClangSA
 
-from codechecker_common import arg
-from codechecker_common import logger
-from codechecker_common import output_formatters
+from codechecker_common import arg, logger
+from codechecker_common.output import USER_FORMATS, twodim
 from codechecker_analyzer import env
 from codechecker_analyzer.analyzers.config_handler import CheckerState
 
@@ -195,7 +194,7 @@ def add_arguments_to_parser(parser):
                         dest='output_format',
                         required=False,
                         default='rows',
-                        choices=output_formatters.USER_FORMATS,
+                        choices=USER_FORMATS,
                         help="The format to list the applicable checkers as.")
 
     logger.add_verbose_arguments(parser)
@@ -267,8 +266,7 @@ def main(args):
         if args.output_format in ['csv', 'json']:
             header = list(map(uglify, header))
 
-        print(output_formatters.twodim_to_str(args.output_format,
-                                              header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
         return
 
     # List checker config options.
@@ -291,8 +289,7 @@ def main(args):
             rows.extend((':'.join((analyzer, c[0])), c[1]) if 'details' in args
                         else (':'.join((analyzer, c[0])),) for c in configs)
 
-        print(output_formatters.twodim_to_str(args.output_format,
-                                              header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
         return
 
     if args.guideline is not None and len(args.guideline) == 0:
@@ -316,8 +313,7 @@ def main(args):
                 print('Guideline: {}'.format(row[0]))
                 print('Rules: {}'.format(row[1]))
         else:
-            print(output_formatters.twodim_to_str(args.output_format,
-                                                  header, rows))
+            print(twodim.to_str(args.output_format, header, rows))
         return
 
     # List available checkers.
@@ -401,8 +397,7 @@ def main(args):
                 rows.append([warning])
 
     if rows:
-        print(output_formatters.twodim_to_str(args.output_format,
-                                              header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
 
     for analyzer_binary, reason in errored:
         LOG.error("Failed to get checkers for '%s'!"

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -890,6 +890,7 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
+        print(out)
         # First it's printed as the member of enabled checkers at the beginning
         # of the output. Second it is printed as a found report.
         self.assertEqual(out.count('hicpp-use-nullptr'), 2)
@@ -930,7 +931,7 @@ class TestAnalyze(unittest.TestCase):
             encoding="utf-8",
             errors="ignore")
         out, _ = process.communicate()
-
+        print(out)
         # First it's printed as the member of enabled checkers at the beginning
         # of the output. Second it is printed as a found report.
         self.assertEqual(out.count('UninitializedObject'), 2)
@@ -953,6 +954,7 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
+        print(out)
         # It is printed as the member of enabled checkers, but it gives no
         # report.
         self.assertEqual(out.count('UninitializedObject'), 1)

--- a/analyzer/tests/functional/fixit/test_fixit.py
+++ b/analyzer/tests/functional/fixit/test_fixit.py
@@ -315,7 +315,8 @@ int main()
             cwd=self.test_workspace,
             encoding="utf-8",
             errors="ignore")
-        out, _ = process.communicate()
+        out, err = process.communicate()
+        print('\n' + out + '\n')
 
         process = subprocess.Popen(
             fixit_cmd,
@@ -324,6 +325,6 @@ int main()
             stdin=subprocess.PIPE,
             encoding="utf-8",
             errors="ignore")
-        out, _ = process.communicate(input=out)
-
+        out, err = process.communicate(input=out)
+        print('\n' + out + '\n')
         self.assertEqual(out.count("DiagnosticMessage"), 1)

--- a/codechecker_common/cmd/version.py
+++ b/codechecker_common/cmd/version.py
@@ -13,7 +13,7 @@ Defines a subcommand for CodeChecker which prints version information.
 import argparse
 
 from codechecker_common import logger
-from codechecker_common import output_formatters
+from codechecker_common.output import USER_FORMATS
 
 
 def get_argparser_ctor_args():
@@ -45,7 +45,7 @@ def add_arguments_to_parser(parser):
                         dest='output_format',
                         required=False,
                         default='table',
-                        choices=output_formatters.USER_FORMATS,
+                        choices=USER_FORMATS,
                         help="The format to use when printing the version.")
 
     logger.add_verbose_arguments(parser)

--- a/codechecker_common/output/__init__.py
+++ b/codechecker_common/output/__init__.py
@@ -1,0 +1,11 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+# The supported formats the users should specify. (This is not an exhaustive
+# list of ALL formats available.)
+USER_FORMATS = ['rows', 'table', 'csv', 'json']

--- a/codechecker_common/output/codeclimate.py
+++ b/codechecker_common/output/codeclimate.py
@@ -1,0 +1,52 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Codeclimate output helpers."""
+
+import os
+from typing import Dict, List
+
+from codechecker_common.report import Report
+
+
+def convert(reports: List[Report], repo_dirs: List[str]) -> Dict:
+    """Convert the given reports to codeclimate format.
+
+    This function will convert the given report to Code Climate format.
+    reports - list of reports type Report
+    repo_dir - Root directory of the sources, i.e. the directory where the
+               repository was cloned, which will be trimmed if set.
+
+    returns a list of reports converted to codeclimate format
+    """
+    codeclimate_reports = []
+    for report in reports:
+        if repo_dirs:
+            report.trim_path_prefixes(repo_dirs)
+
+        codeclimate_reports.append(__to_codeclimate(report))
+    return codeclimate_reports
+
+
+def __to_codeclimate(report: Report) -> Dict:
+    """Convert a Report to Code Climate format."""
+    location = report.main['location']
+    _, file_name = os.path.split(location['file'])
+
+    return {
+        "type": "issue",
+        "check_name": report.check_name,
+        "description": report.description,
+        "categories": ["Bug Risk"],
+        "fingerprint": report.report_hash,
+        "location": {
+            "path": file_name,
+            "lines": {
+                "begin": location['line']
+            }
+        }
+    }

--- a/codechecker_common/output/gerrit.py
+++ b/codechecker_common/output/gerrit.py
@@ -1,0 +1,136 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Helper and converter functions for the gerrit review json format."""
+
+from typing import Dict, List, Union
+from codechecker_common.report import Report
+
+import os
+import re
+import json
+
+
+def convert(reports: List[Report], severity_map: Dict[str, str]) -> Dict:
+    """Convert reports to gerrit review format.
+
+    Process the required environment variables and convert the reports
+    to the required gerrit json format.
+    """
+    repo_dir = os.environ.get('CC_REPO_DIR')
+    report_url = os.environ.get('CC_REPORT_URL')
+    changed_file_path = os.environ.get('CC_CHANGED_FILES')
+    changed_files = __get_changed_files(changed_file_path)
+
+    gerrit_reports = __convert_reports(reports, repo_dir, report_url,
+                                       changed_files, changed_file_path,
+                                       severity_map)
+    return gerrit_reports
+
+
+def __convert_reports(reports: List[Report],
+                      repo_dir: str,
+                      report_url: str,
+                      changed_files: List[str],
+                      changed_file_path: str,
+                      severity_map: Dict[str, str]) -> Dict:
+    """Convert the given reports to gerrit json format.
+
+    This function will convert the given report to Gerrit json format.
+    reports - list of reports comming from a plist file or
+              from the CodeChecker server (both types can be processed)
+    repo_dir - Root directory of the sources, i.e. the directory where the
+               repository was cloned.
+    report_url - URL where the report can be found something like this:
+      "http://jenkins_address/userContent/$JOB_NAME/$BUILD_NUM/index.html"
+    changed_files - list of the changed files
+    severity_map
+    """
+    review_comments = {}
+
+    report_count = 0
+    for report in reports:
+        bug_line = report.line
+        bug_col = report.col
+
+        check_name = report.check_name
+        severity = severity_map.get(check_name, "UNSPECIFIED")
+        file_name = report.file_path
+        checked_file = file_name \
+            + ':' + str(bug_line) + ":" + str(bug_col)
+        check_msg = report.description
+        source_line = report.line
+        # Skip the report if it is not in the changed files.
+        if changed_file_path and not \
+                any([file_name.endswith(c) for c in changed_files]):
+            continue
+
+        report_count += 1
+        rel_file_path = os.path.relpath(file_name, repo_dir) \
+            if repo_dir else file_name
+
+        if rel_file_path not in review_comments:
+            review_comments[rel_file_path] = []
+
+        review_comment_msg = "[{0}] {1}: {2} [{3}]\n{4}".format(
+            severity, checked_file, check_msg, check_name, source_line)
+
+        review_comments[rel_file_path].append({
+            "range": {
+                "start_line": bug_line,
+                "start_character": bug_col,
+                "end_line": bug_line,
+                "end_character": bug_col},
+            "message": review_comment_msg})
+
+    message = "CodeChecker found {0} issue(s) in the code.".format(
+        report_count)
+
+    if report_url:
+        message += " See: '{0}'".format(report_url)
+
+    review = {"tag": "jenkins",
+              "message": message,
+              "labels": {
+                  "Code-Review": -1 if report_count else 1,
+                  "Verified": -1 if report_count else 1},
+              "comments": review_comments}
+    return review
+
+
+def __get_changed_files(changed_file_path: Union[None, str]) -> List[str]:
+    """Return a list of changed files.
+
+    Process the given gerrit changed file object and return a list of
+    file paths which changed.
+
+    The file can contain some garbage values at start, so we use regex
+    to find a json object.
+    """
+    changed_files = []
+
+    if not changed_file_path or not os.path.exists(changed_file_path):
+        return changed_files
+
+    with open(changed_file_path,
+              encoding='utf-8',
+              errors='ignore') as changed_file:
+        content = changed_file.read()
+
+        # The file can contain some garbage values at start, so we use
+        # regex search to find a json object.
+        match = re.search(r'\{[\s\S]*\}', content)
+        if not match:
+            return changed_files
+
+        for filename in json.loads(match.group(0)):
+            if "/COMMIT_MSG" in filename:
+                continue
+
+            changed_files.append(filename)
+
+    return changed_files

--- a/codechecker_common/output/json.py
+++ b/codechecker_common/output/json.py
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Helper and converter functions for json output format."""
+
+from typing import Dict
+from codechecker_common.report import Report
+
+
+def convert_to_parse(report: Report) -> Dict:
+    """Converts to a special json format for the parse command.
+
+    This format is used by the parse command when the reports are printed
+    to the stdout in json format.
+    """
+    ret = report.main
+    ret["path"] = report.bug_path
+    ret["files"] = [v for k, v in report.files.items()]
+
+    return ret

--- a/codechecker_common/output/twodim.py
+++ b/codechecker_common/output/twodim.py
@@ -13,14 +13,10 @@ Contains functions to format and pretty-print data from two-dimensional arrays.
 import json
 from operator import itemgetter
 
-# The supported formats the users should specify. (This is not an exhaustive
-# list of ALL formats available.)
-USER_FORMATS = ['rows', 'table', 'csv', 'json']
 
-
-def twodim_to_str(format_name, keys, rows,
-                  sort_by_column_number=None, rev=False,
-                  separate_footer=False):
+def to_str(format_name, keys, rows,
+           sort_by_column_number=None, rev=False,
+           separate_footer=False):
     """
     Converts the given two-dimensional array (with the specified keys)
     to the given format.
@@ -33,21 +29,21 @@ def twodim_to_str(format_name, keys, rows,
         all_rows = [keys] + list(rows)
 
     if format_name == 'rows':
-        return twodim_to_rows(rows)
+        return __to_rows(rows)
     elif format_name == 'table' or format_name == 'plaintext':
         # TODO: 'plaintext' for now to support the 'CodeChecker cmd' interface.
-        return twodim_to_table(all_rows, True, separate_footer)
+        return __to_table(all_rows, True, separate_footer)
     elif format_name == 'csv':
-        return twodim_to_csv(all_rows)
+        return __to_csv(all_rows)
     elif format_name == 'dictlist':
-        return twodim_to_dictlist(keys, rows)
+        return __to_dictlist(keys, rows)
     elif format_name == 'json':
-        return json.dumps(twodim_to_dictlist(keys, rows))
+        return json.dumps(__to_dictlist(keys, rows))
     else:
         raise ValueError("Unsupported format")
 
 
-def twodim_to_rows(lines):
+def __to_rows(lines):
     """
     Prints the given rows with minimal formatting.
     """
@@ -85,7 +81,7 @@ def twodim_to_rows(lines):
     return '\n'.join(str_parts)
 
 
-def twodim_to_table(lines, separate_head=True, separate_footer=False):
+def __to_table(lines, separate_head=True, separate_footer=False):
     """
     Pretty-prints the given two-dimensional array's lines.
     """
@@ -127,7 +123,7 @@ def twodim_to_table(lines, separate_head=True, separate_footer=False):
     return '\n'.join(str_parts)
 
 
-def twodim_to_csv(lines):
+def __to_csv(lines):
     """
     Pretty-print the given two-dimensional array's lines in CSV format.
     """
@@ -159,7 +155,7 @@ def twodim_to_csv(lines):
     return '\n'.join(str_parts)
 
 
-def twodim_to_dictlist(key_list, lines):
+def __to_dictlist(key_list, lines):
     """
     Pretty-print the given two-dimensional array's lines into a JSON
     object list. The key_list acts as the "header" of the table, specifying the
@@ -175,23 +171,3 @@ def twodim_to_dictlist(key_list, lines):
         res.append({key: value for (key, value) in zip(key_list, line)})
 
     return res
-
-
-def dictlist_to_twodim(key_list, dictlist, key_convert=None):
-    """
-    Converts the given list of dict objects to a two-dimensional array.
-
-    If key_convert is specified, the resulting array will have the converted
-    strings in its "header" row. key_list and key_convert must correspond with
-    each other in order.
-    """
-
-    if not key_convert:
-        lines = [key_list]
-    else:
-        lines = [key_convert]
-
-    for d in dictlist:
-        lines.append([d[key] for key in key_list])
-
-    return lines

--- a/tools/codechecker_report_hash/codechecker_report_hash/hash.py
+++ b/tools/codechecker_report_hash/codechecker_report_hash/hash.py
@@ -276,12 +276,14 @@ def get_report_path_hash(report):
     """ Returns path hash for the given bug path.
 
     This can be used to filter deduplications of multiple reports.
+
+    report type should be codechecker_common.Report
     """
     report_path_hash = ''
     events = [i for i in report.bug_path if i.get('kind') == 'event']
-
     for event in events:
-        file_name = os.path.basename(report.files[event['location']['file']])
+        file_name = \
+            os.path.basename(report.files.get(event['location']['file']))
         line = str(event['location']['line']) if 'location' in event else 0
         col = str(event['location']['col']) if 'location' in event else 0
 

--- a/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
+++ b/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/codechecker_report_hash_test.py
@@ -101,7 +101,8 @@ class CodeCheckerReportHashTest(unittest.TestCase):
 
         for diag in plist['diagnostics']:
             diag['bug_path'] = diag['path']
-            diag['files'] = plist['files']
+            diag['files'] = \
+                {i: filepath for i, filepath in enumerate(plist['files'])}
             path_hash = get_report_path_hash(
                     namedtuple('Report', diag.keys())(*diag.values()))
             actual_report_hash = diag['issue_hash_content_of_line_in_context']

--- a/web/Makefile
+++ b/web/Makefile
@@ -27,6 +27,7 @@ VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 
 include tests/Makefile
 include server/tests/Makefile
+include client/tests/Makefile
 
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)

--- a/web/client/codechecker_client/client.py
+++ b/web/client/codechecker_client/client.py
@@ -218,7 +218,7 @@ def get_new_token(protocol, host, port, cred_manager):
     return perform_auth_for_handler(auth_client, host, port, cred_manager)
 
 
-def setup_client(product_url):
+def setup_client(product_url) -> thrift_helper.ThriftClientHelper:
     """Setup the Thrift Product or Service client and
     check API version and authentication needs.
     """

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -22,8 +22,8 @@ from codechecker_client import cmd_line_client
 from codechecker_client import product_client
 from codechecker_client import source_component_client, token_client
 
-from codechecker_common import arg, logger, output_formatters, util
-
+from codechecker_common import arg, logger, util
+from codechecker_common.output import USER_FORMATS
 
 DEFAULT_FILTER_VALUES = {
     'review_status': ['unreviewed', 'confirmed'],
@@ -31,7 +31,7 @@ DEFAULT_FILTER_VALUES = {
     'uniqueing': 'off'
 }
 
-DEFAULT_OUTPUT_FORMATS = ["plaintext"] + output_formatters.USER_FORMATS
+DEFAULT_OUTPUT_FORMATS = ["plaintext"] + USER_FORMATS
 
 
 def valid_time(t):

--- a/web/client/codechecker_client/product_client.py
+++ b/web/client/codechecker_client/product_client.py
@@ -16,7 +16,7 @@ from codechecker_api.ProductManagement_v6.ttypes import DatabaseConnection, \
     ProductConfiguration
 
 from codechecker_common import logger
-from codechecker_common.output_formatters import twodim_to_str
+from codechecker_common.output import twodim
 
 from codechecker_web.shared import database_status, convert
 
@@ -72,7 +72,7 @@ def handle_list_products(args):
             rows.append((db_status_msg,
                          product.endpoint, name, description))
 
-        print(twodim_to_str(args.output_format, header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
 
 
 def handle_add_product(args):

--- a/web/client/codechecker_client/report_type_converter.py
+++ b/web/client/codechecker_client/report_type_converter.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""Convert between the codechecker_common.Report type and
+the thrift ReportData type."""
+
+from typing import Dict
+from codechecker_common.report import Report
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportData, Severity
+
+
+def reportData_to_report(report_data: ReportData) -> Report:
+    """Create a report object from the given thrift report data."""
+    main = {
+        "check_name": report_data.checkerId,
+        "description": report_data.checkerMsg,
+        "issue_hash_content_of_line_in_context": report_data.bugHash,
+        "location": {
+            "line": report_data.line,
+            "col": report_data.column,
+            "file": report_data.checkedFile,
+        },
+    }
+    bug_path = None
+    files = {0: report_data.checkedFile}
+    # TODO Can not reconstruct because only the analyzer name was stored
+    # it should be a analyzer_name analyzer_version
+    return Report(main, bug_path, files, metadata=None)
+
+
+def report_to_reportData(report: Report,
+                         severity_map: Dict[str, str]) -> ReportData:
+    """Convert a Report object to a Thrift ReportData type."""
+    events = [i for i in report.bug_path if i.get("kind") == "event"]
+
+    report_hash = report.main["issue_hash_content_of_line_in_context"]
+    checker_name = report.main["check_name"]
+
+    severity = None
+    if severity_map:
+        severity_name = severity_map.get(checker_name)
+        severity = Severity._NAMES_TO_VALUES[severity_name]
+
+    return ReportData(
+        checkerId=checker_name,
+        bugHash=report_hash,
+        checkedFile=report.main["location"]["file"],
+        checkerMsg=report.main["description"],
+        line=report.main["location"]["line"],
+        column=report.main["location"]["col"],
+        severity=severity,
+        bugPathLength=len(events),
+    )

--- a/web/client/codechecker_client/source_component_client.py
+++ b/web/client/codechecker_client/source_component_client.py
@@ -13,7 +13,7 @@ Argument handlers for the 'CodeChecker cmd components' subcommands.
 import sys
 
 from codechecker_common import logger
-from codechecker_common.output_formatters import twodim_to_str
+from codechecker_common.output import twodim
 from codechecker_web.shared.env import get_user_input
 
 from .client import setup_client
@@ -83,7 +83,7 @@ def handle_list_components(args):
                     if idx == 0 and res.description else ''
                 rows.append((name, value, description))
 
-        print(twodim_to_str(args.output_format, header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
 
 
 def handle_del_component(args):

--- a/web/client/codechecker_client/token_client.py
+++ b/web/client/codechecker_client/token_client.py
@@ -11,7 +11,7 @@ Argument handlers for the 'CodeChecker cmd token' subcommands.
 
 
 from codechecker_common import logger
-from codechecker_common.output_formatters import twodim_to_str
+from codechecker_common.output import twodim
 
 from .client import setup_auth_client, perform_auth_for_handler
 from .cmd_line import CmdLineOutputEncoder
@@ -87,7 +87,7 @@ def handle_list_tokens(args):
                          res.description if res.description else '',
                          res.lastAccess))
 
-        print(twodim_to_str(args.output_format, header, rows))
+        print(twodim.to_str(args.output_format, header, rows))
 
 
 def handle_del_token(args):

--- a/web/client/tests/Makefile
+++ b/web/client/tests/Makefile
@@ -1,0 +1,7 @@
+UNIT_TEST_CMD = $(REPO_ROOT) BUILD_DIR=$(BUILD_DIR) nosetests $(NOSECFG) -w client tests/unit
+
+test_unit_client:
+	$(UNIT_TEST_CMD)
+
+test_unit_client_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)

--- a/web/client/tests/unit/__init__.py
+++ b/web/client/tests/unit/__init__.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Setup python modules for the unit tests.
+"""
+
+import json
+import os
+import sys
+
+# Add the generated thrift files for the unit tests.
+BUILD_DIR = os.path.abspath(os.environ['BUILD_DIR'])
+
+REPO_ROOT = os.path.abspath(os.environ['REPO_ROOT'])
+PKG_ROOT = os.path.join(REPO_ROOT, 'build', 'CodeChecker')
+
+sys.path.append(REPO_ROOT)
+sys.path.append(os.path.join(REPO_ROOT, 'web'))

--- a/web/client/tests/unit/test_report_converter.py
+++ b/web/client/tests/unit/test_report_converter.py
@@ -1,0 +1,76 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Test the report converter between the common Report type and the
+thrift ReportData type
+"""
+
+import unittest
+
+from codechecker_common import report
+from codechecker_client import report_type_converter
+from codechecker_api.codeCheckerDBAccess_v6 import ttypes
+
+
+class ReportTypeConverterTest(unittest.TestCase):
+    """Type conversion tests."""
+
+    def test_Report_to_ReportData(self):
+        """Report to reportData conversion."""
+        check_name = "checker.name"
+        report_hash = "2343we23"
+        source_file = "main.cpp"
+        description = "some checker message"
+        line = 10
+        column = 8
+
+        main = {
+            "description": description,
+            "check_name": check_name,
+            "issue_hash_content_of_line_in_context": report_hash,
+            "location": {"line": line, "col": column, "file": source_file},
+        }
+
+        rep = report.Report(main=main, bugpath=[], files={}, metadata=None)
+        severity_map = {check_name: "LOW"}
+        rep_data = report_type_converter.report_to_reportData(rep, severity_map)
+
+        self.assertEqual(rep_data.checkerId, rep.check_name)
+        self.assertEqual(rep_data.bugHash, rep.report_hash)
+        self.assertEqual(rep_data.checkedFile, rep.file_path)
+        self.assertEqual(rep_data.line, rep.line)
+        self.assertEqual(rep_data.column, rep.col)
+        self.assertEqual(rep_data.severity, ttypes.Severity.LOW)
+
+    def test_ReportData_to_Report(self):
+        """ReportData to Report conversion."""
+        check_name = "checker.name"
+        report_hash = "2343we23"
+        source_file = "main.cpp"
+        description = "some checker message"
+        line = 10
+        column = 8
+
+        rep_data = ttypes.ReportData(
+            checkerId=check_name,
+            bugHash=report_hash,
+            checkedFile=source_file,
+            checkerMsg=description,
+            line=line,
+            column=column,
+            severity="LOW",
+            bugPathLength=5,
+        )
+
+        rep = report_type_converter.reportData_to_report(rep_data)
+        self.assertEqual(rep.check_name, rep_data.checkerId)
+        self.assertEqual(rep.report_hash, rep_data.bugHash)
+        self.assertEqual(rep.file_path, rep_data.checkedFile)
+        self.assertEqual(rep.description, rep_data.checkerMsg)
+        self.assertEqual(rep.line, rep_data.line)
+        self.assertEqual(rep.col, rep_data.column)

--- a/web/codechecker_web/cmd/web_version.py
+++ b/web/codechecker_web/cmd/web_version.py
@@ -14,7 +14,7 @@ import argparse
 import json
 
 from codechecker_common import logger
-from codechecker_common import output_formatters
+from codechecker_common.output import USER_FORMATS, twodim
 
 from codechecker_web.shared import webserver_context, version
 
@@ -49,7 +49,7 @@ def add_arguments_to_parser(parser):
                         dest='output_format',
                         required=False,
                         default='table',
-                        choices=output_formatters.USER_FORMATS,
+                        choices=USER_FORMATS,
                         help="The format to use when printing the version.")
 
     logger.add_verbose_arguments(parser)
@@ -79,9 +79,9 @@ def print_version(output_format=None):
     ]
 
     if output_format != "json":
-        print(output_formatters.twodim_to_str(output_format,
-                                              ["Kind", "Version"],
-                                              rows))
+        print(twodim.to_str(output_format,
+                            ["Kind", "Version"],
+                            rows))
     elif output_format == "json":
         # Use a special JSON format here, instead of
         # [ {"kind": "something", "version": "0.0.0"}, {"kind": "foo", ... } ]

--- a/web/server/codechecker_server/cmd/server.py
+++ b/web/server/codechecker_server/cmd/server.py
@@ -26,7 +26,8 @@ from sqlalchemy.orm import sessionmaker
 
 from codechecker_api_shared.ttypes import DBStatus
 
-from codechecker_common import arg, logger, output_formatters, util, cmd_config
+from codechecker_common import arg, logger, util, cmd_config
+from codechecker_common.output import twodim
 
 from codechecker_server import instance_manager, server
 from codechecker_server.database import database
@@ -456,10 +457,10 @@ def print_prod_status(prod_status):
         rows.append([k, db_status_msg, db_location, str(schema_ver),
                      package_ver])
 
-    prod_status = output_formatters.twodim_to_str('table',
-                                                  header,
-                                                  rows,
-                                                  sort_by_column_number=0)
+    prod_status = twodim.to_str('table',
+                                header,
+                                rows,
+                                sort_by_column_number=0)
     LOG.info('Status of products:\n%s', prod_status)
 
 
@@ -695,7 +696,7 @@ def __instance_management(args):
                              str(instance['port'])))
 
         print("Your running CodeChecker servers:")
-        print(output_formatters.twodim_to_str('table', head, rows))
+        print(twodim.to_str('table', head, rows))
     elif 'stop' in args or 'stop_all' in args:
         for i in instance_manager.get_instances():
             if i['hostname'] != socket.gethostname():

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -93,9 +93,9 @@ run_test:
 run_test_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(RUN_TEST_CMD)
 
-test_unit: test_unit_server
+test_unit: test_unit_server test_unit_client
 
-test_unit_in_env: test_unit_server_in_env
+test_unit_in_env: test_unit_server_in_env test_unit_client_in_env
 
 test_functional: test_sqlite test_psql
 

--- a/web/tests/functional/cli_config/test_store_config.py
+++ b/web/tests/functional/cli_config/test_store_config.py
@@ -60,8 +60,12 @@ class TestStoreConfig(unittest.TestCase):
         store_cmd = [env.codechecker_cmd(), 'store', '--config',
                      self.config_file]
 
-        subprocess.check_output(
-            store_cmd, env=cc_env, encoding="utf-8", errors="ignore")
+        try:
+            subprocess.check_output(
+                store_cmd, env=cc_env, encoding="utf-8", errors="ignore")
+        except subprocess.CalledProcessError as cerr:
+            print(cerr.output)
+            raise
 
     def test_invalid_config(self):
         """ Store with an invalid configuration file. """
@@ -92,5 +96,9 @@ class TestStoreConfig(unittest.TestCase):
                      '--url', env.parts_to_url(self.codechecker_cfg),
                      self.codechecker_cfg['reportdir']]
 
-        subprocess.check_output(
-            store_cmd, encoding="utf-8", errors="ignore")
+        try:
+            subprocess.check_output(
+                store_cmd, encoding="utf-8", errors="ignore")
+        except subprocess.CalledProcessError as cerr:
+            print(cerr.output)
+            raise

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -116,9 +116,11 @@ class DiffLocal(unittest.TestCase):
                              '--severity', 'high',
                              '--new', '-o', 'json']
         print(high_severity_cmd)
-        out_json = subprocess.check_output(
-            high_severity_cmd, encoding="utf-8", errors="ignore")
-        print(out_json)
+        try:
+            out_json = subprocess.check_output(
+                high_severity_cmd, encoding="utf-8", errors="ignore")
+        except subprocess.CalledProcessError as cerr:
+            print(cerr.output)
         high_severity_res = json.loads(out_json)
         self.assertEqual((len(high_severity_res)), 4)
 
@@ -150,11 +152,14 @@ class DiffLocal(unittest.TestCase):
                              '--severity', 'high', 'low',
                              '--unresolved']
         print(high_severity_cmd)
-        out = subprocess.check_output(
-            high_severity_cmd,
-            encoding="utf-8",
-            errors="ignore")
-        print(out)
+        try:
+            out = subprocess.check_output(
+                high_severity_cmd,
+                encoding="utf-8",
+                errors="ignore")
+        except subprocess.CalledProcessError as cerr:
+            print(cerr.stdout)
+            print(cerr.stderr)
         self.assertEqual(len(re.findall(r'\[HIGH\]', out)), 15)
         self.assertEqual(len(re.findall(r'\[LOW\]', out)), 6)
 


### PR DESCRIPTION
A new common output module was created for the output formats.
The output formatters should depend on the common Report type
and not use the thrift ReportData type so they can be shared
between multiple parts of the source code.

There is one case in the server command line client
where the json format uses the ReportData and that is
converted to json. For backward compatibility that is
kept for now.

The common module can be extended with additional output formats
later so they can be shared between the analyzer and the web parts.

The twodim format functions were moved that module too together
with the codeclimate and gerrit formatters.

Additionaly the cmd_line_client file was refactored.
Multiple smaller functions were factored out not
to depend on function internal variables where
they were. It is easier to test them like that.

A new report type converter was added for the
type conversion betwen the Report and ReportData
types. Should be needed only at the web part.
The common and analyzer parts use only the Report type.

Type hints were added to multiple functions for
better understanding what type is expected where.

The plist parser module was changed because the
comments and the actual source code assumed different types.
Instead of the list of files a dict of files is used there.
The order is important! The key is the index of the source
file where it was in the list of files in the plist report.

The main section in the Report type does not reference the
source file as an index anymore to simplify the usage.
The source file path is stored there.
For the bug path sections this replacement was not done.