### PR TITLE
[gui] Refactor unique reports helper icon

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/UniqueFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/UniqueFilter.vue
@@ -7,34 +7,25 @@
   >
     <template v-slot:label>
       Unique reports
-      <v-tooltip max-width="200" right>
-        <template v-slot:activator="{ on }">
-          <v-icon
-            color="accent"
-            class="ml-1"
-            v-on="on"
-          >
-            mdi-help-circle
-          </v-icon>
-        </template>
-        <span>
-          This narrows the report list to unique bug. The same bug may appear
-          several times if it is found on different control paths, i.e. through
-          different function calls. By checking <b>Unique reports</b> a report
-          appears only once even if it is found on several paths.
-        </span>
-      </v-tooltip>
+      <tooltip-help-icon>
+        This narrows the report list to unique bug. The same bug may appear
+        several times if it is found on different control paths, i.e. through
+        different function calls or in different runs. By checking
+        <b>Unique reports</b>, a report appears only once even if it is found
+        on several paths or in different runs.
+      </tooltip-help-icon>
     </template>
   </v-checkbox>
 </template>
 
 <script>
+import TooltipHelpIcon from "@/components/TooltipHelpIcon";
 import BaseFilterMixin from "./BaseFilter.mixin";
 
 export default {
   name: "UniqueFilter",
+  components: { TooltipHelpIcon },
   mixins: [ BaseFilterMixin ],
-
   data() {
     return {
       id: "is-unique",


### PR DESCRIPTION
- Use the TooltipHelpIcon to show the help icon beside the unique report filter.
- Mention that the same bug may appear in different runs too.