### PR TITLE
[refactor] reorder how the log levels are printed

### DIFF
--- a/codechecker_common/logger.py
+++ b/codechecker_common/logger.py
@@ -25,7 +25,7 @@ ERROR = logging.ERROR
 CRITICAL = logging.CRITICAL
 NOTSET = logging.NOTSET
 
-CMDLINE_LOG_LEVELS = ['info', 'debug', 'debug_analyzer']
+CMDLINE_LOG_LEVELS = ['info', 'debug_analyzer', 'debug']
 
 DEBUG_ANALYZER = logging.DEBUG_ANALYZER = 15
 logging.addLevelName(DEBUG_ANALYZER, 'DEBUG_ANALYZER')


### PR DESCRIPTION
The log level verbosity goes from:
info -> debug_analyzer -> debug

The printed order should reflect that.

resolves #2922