### PR TITLE
[report-converter][cmd] Add smatch parser

### DIFF
--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -54,6 +54,8 @@ from codechecker_report_converter.markdownlint.analyzer_result import \
     MarkdownlintAnalyzerResult  # noqa
 from codechecker_report_converter.coccinelle.analyzer_result import \
     CoccinelleAnalyzerResult  # noqa
+from codechecker_report_converter.smatch.analyzer_result import \
+    SmatchAnalyzerResult  # noqa
 
 
 LOG = logging.getLogger('ReportConverter')
@@ -89,7 +91,8 @@ supported_converters = {
     UBSANAnalyzerResult.TOOL_NAME: UBSANAnalyzerResult,
     SpotBugsAnalyzerResult.TOOL_NAME: SpotBugsAnalyzerResult,
     MarkdownlintAnalyzerResult.TOOL_NAME: MarkdownlintAnalyzerResult,
-    CoccinelleAnalyzerResult.TOOL_NAME: CoccinelleAnalyzerResult
+    CoccinelleAnalyzerResult.TOOL_NAME: CoccinelleAnalyzerResult,
+    SmatchAnalyzerResult.TOOL_NAME: SmatchAnalyzerResult
 }
 
 supported_metadata_keys = ["analyzer_command", "analyzer_version"]

--- a/tools/report-converter/codechecker_report_converter/smatch/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/smatch/__init__.py
@@ -1,0 +1,7 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------

--- a/tools/report-converter/codechecker_report_converter/smatch/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/smatch/analyzer_result.py
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+from codechecker_report_converter.analyzer_result import AnalyzerResult
+
+from .output_parser import SmatchParser
+from ..plist_converter import PlistConverter
+
+
+class SmatchAnalyzerResult(AnalyzerResult):
+    """ Transform analyzer result of Smatch. """
+
+    TOOL_NAME = 'smatch'
+    NAME = 'Smatch'
+    URL = 'https://repo.or.cz/w/smatch.git'
+
+    def parse(self, analyzer_result):
+        """ Creates plist files from the given analyzer result to the given
+        output directory.
+        """
+        parser = SmatchParser(analyzer_result)
+
+        content = self._get_analyzer_result_file_content(analyzer_result)
+        if not content:
+            return
+
+        messages = parser.parse_messages(content)
+
+        plist_converter = PlistConverter(self.TOOL_NAME)
+        plist_converter.add_messages(messages)
+        return plist_converter.get_plist_results()

--- a/tools/report-converter/codechecker_report_converter/smatch/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/smatch/output_parser.py
@@ -1,0 +1,60 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+import logging
+import os
+import re
+
+from ..output_parser import BaseParser, Message
+LOG = logging.getLogger('ReportConverter')
+
+
+class SmatchParser(BaseParser):
+    """
+    Parser for Smatch Output
+    """
+
+    def __init__(self, analyzer_result):
+        super(SmatchParser, self).__init__()
+
+        self.analyzer_result = analyzer_result
+
+        self.message_line_re = re.compile(
+            # File path followed by a ':'.
+            r'^(?P<path>[\S ]+?):'
+            # Line number followed by a ' '.
+            r'(?P<line>\d+?) '
+            # Message.
+            r'(?P<message>[\S \t]+)\s*')
+
+    def parse_message(self, it, line):
+        """
+        Actual Parsing function for the given line
+        """
+        match = self.message_line_re.match(line)
+        if match is None:
+            return None, next(it)
+
+        file_path = os.path.normpath(
+            os.path.join(os.path.dirname(self.analyzer_result),
+                         match.group('path')))
+
+        checker_name = None
+        column_num = -1
+
+        message = Message(
+            file_path,
+            int(match.group('line')),
+            column_num,
+            match.group('message').strip(),
+            checker_name)
+
+        try:
+            return message, next(it)
+        except StopIteration:
+            return message, ''


### PR DESCRIPTION
Add support to parse output from smatch and use in report converter tool.
Smatch is a static analysis tool mostly used for the kernel source.