### PR TITLE
[fix] Fix concurrency error by sharing config dict

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -743,6 +743,11 @@ def start_workers(actions_map, actions, context, analyzer_config_map,
             # while map or map_async function is running.
             # It is a python bug, this does not happen if a timeout is
             # specified, then receive the interrupt immediately.
+
+            # FIXME: Ensure all shared data structures are wrapped in manager
+            #        proxy objects before passing them to other processes via
+            #        map_async.
+            #        Note that even deep-copying is known to be insufficient.
             pool.map_async(check,
                            analyzed_actions,
                            1,

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -294,6 +294,7 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
     manager = SyncManager()
     manager.start(__mgr_init)
 
+    config_map = manager.dict(config_map)
     actions_map = create_actions_map(actions, manager)
 
     # Setting to not None value will enable statistical analysis features.

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -200,7 +200,10 @@ def run_pre_analysis(actions, context, clangsa_config,
                             ctu_data,
                             statistics_data)
                            for build_action in actions]
-
+        # FIXME: Ensure all shared data structures are wrapped in manager
+        #        proxy objects before passing them to other processes via
+        #        map_async.
+        #        Note that even deep-copying is known to be insufficient.
         pool.map_async(pre_analyze, collect_actions)
         pool.close()
     except Exception:


### PR DESCRIPTION
Wrap analyzer options dictionary in multiprocessing manager proxy object to
ensure safe sharing.