### PR TITLE
feat(credential_manager): allow users to overwrite location of session file

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -372,6 +372,11 @@ The location of the password file can be configured by the `CC_PASS_FILE`
 environment variable. This environment variable can also be used to setup
 different credential files to login to the same server with a different user.
 
+Furthermore, the location of the session file can be configured by the
+`CC_SESSION_FILE` environment variable. This can be useful if CodeChecker does
+not have the permission to create a session file under the user's home
+directory (e.g. in some CI environments).
+
 ### Automatic login <a name="automatic-login"></a>
 
 If authentication is required by the server and the user hasn't logged in but

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -235,6 +235,14 @@ environment variables:
                    It can also be used to setup different credential files to
                    login to the same server with a different user.
 
+  CC_SESSION_FILE  The location of the session file where valid sessions are
+                   stored. This file will be automatically created by
+                   CodeChecker. By default CodeChecker will use
+                   '~/.codechecker.session.json'. This can be used if
+                   restrictive permissions forbid CodeChecker from creating
+                   files in the users home directory (e.g. in a CI
+                   environment).
+
 The results can be viewed by connecting to such a server in a Web browser or
 via 'CodeChecker cmd'.
 ```

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -129,6 +129,14 @@ environment variables:
                    It can also be used to setup different credential files to
                    login to the same server with a different user.
 
+  CC_SESSION_FILE  The location of the session file where valid sessions are
+                   stored. This file will be automatically created by
+                   CodeChecker. By default CodeChecker will use
+                   '~/.codechecker.session.json'. This can be used if
+                   restrictive permissions forbid CodeChecker from creating
+                   files in the users home directory (e.g. in a CI
+                   environment).
+
 
 The results can be viewed by connecting to such a server in a Web browser or
 via 'CodeChecker cmd'.""",

--- a/web/client/codechecker_client/credential_manager.py
+++ b/web/client/codechecker_client/credential_manager.py
@@ -10,7 +10,6 @@ Handles the management of stored user credentials and currently known session
 tokens.
 """
 
-
 import json
 import os
 import re
@@ -21,7 +20,8 @@ import portalocker
 from codechecker_common.logger import get_logger
 from codechecker_common.util import load_json_or_empty
 
-from codechecker_web.shared.env import check_file_owner_rw, get_password_file
+from codechecker_web.shared.env import check_file_owner_rw, get_password_file,\
+    get_session_file
 from codechecker_web.shared.version import SESSION_COOKIE_NAME as _SCN
 
 LOG = get_logger('system')
@@ -95,7 +95,7 @@ class UserCredentials(object):
         self.__save = scfg_dict
         self.__autologin = scfg_dict.get('client_autologin', True)
         # Check and load token storage for user.
-        self.token_file = os.path.join(user_home, ".codechecker.session.json")
+        self.token_file = get_session_file()
         LOG.info("Checking for local valid sessions.")
 
         if os.path.exists(self.token_file):

--- a/web/codechecker_web/shared/env.py
+++ b/web/codechecker_web/shared/env.py
@@ -33,6 +33,13 @@ def get_password_file():
                                        ".codechecker.passwords.json"))
 
 
+def get_session_file():
+    """ Return the location of the CodeChecker session file. """
+    return os.environ.get("CC_SESSION_FILE",
+                          os.path.join(os.path.expanduser("~"),
+                                       ".codechecker.session.json"))
+
+
 def get_user_input(msg):
     """
     Get the user input.

--- a/web/server/vue-cli/e2e/init.db.js
+++ b/web/server/vue-cli/e2e/init.db.js
@@ -9,6 +9,7 @@ const url = `http://${host}:${port}`;
 const CC_DIR = path.join(__dirname, "__codechecker");
 const REPORTS_DIR = path.join(CC_DIR, "reports");
 const PASSWORD_FILE = path.join(CC_DIR, "codechecker.passwords.json");
+const SESSION_FILE = path.join(CC_DIR, "codechecker.session.json");
 
 // List of products which will be added to the server.
 const PRODUCTS = [
@@ -73,7 +74,8 @@ async function login (username) {
     stdio: "inherit",
     env: {
       ...process.env,
-      "CC_PASS_FILE": PASSWORD_FILE
+      "CC_PASS_FILE": PASSWORD_FILE,
+      "CC_SESSION_FILE": SESSION_FILE
     }
   });
 }


### PR DESCRIPTION
Some CI environments are not allowed to create files outside of their
designated workspace. This might include the home directory.
This commit allows users to overwrite the hardcoded path and name of
the session file by setting the CC_SESSION_FILE environment variable.

I didn't know where - if any - to put tests. If required, please tell me what kind of tests you'd like to see and where I should put them. I only tested locally and in our CI environment and it works as expected.