### PR TITLE
[report-converter][fix] Coccinelle checker fix

### DIFF
--- a/tools/report-converter/README.md
+++ b/tools/report-converter/README.md
@@ -398,7 +398,7 @@ like for instance to perform some refactorings.
 The recommended way of running Coccinelle is to redirect the output to a file and
 give this file to the report converter tool.
 
-Note: the checker name will be the file name of the `.cocci` file.
+Note: the checker name will be the file name of the `.cocci` file along with `cocinelle` prefix.
 
 The following example shows you how to run Coccinelle on kernel sources 
 and store the results found by Coccinelle to the CodeChecker database.

--- a/tools/report-converter/codechecker_report_converter/coccinelle/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/coccinelle/output_parser.py
@@ -47,7 +47,8 @@ class CoccinelleParser(BaseParser):
 
         checker_match = self.checker_name_re.match(line)
         if checker_match:
-            self.checker_name = checker_match.group('checker_name')
+            self.checker_name = 'coccinelle.' + \
+                checker_match.group('checker_name')
 
         if match is None:
             return None, next(it)

--- a/tools/report-converter/tests/unit/coccinelle_output_test_files/sample.expected.plist
+++ b/tools/report-converter/tests/unit/coccinelle_output_test_files/sample.expected.plist
@@ -8,7 +8,7 @@
 			<key>category</key>
 			<string>unknown</string>
 			<key>check_name</key>
-			<string>sample</string>
+			<string>coccinelle.sample</string>
 			<key>description</key>
 			<string>WARNING comparing pointer to 0</string>
 			<key>issue_hash_content_of_line_in_context</key>


### PR DESCRIPTION
The following pull request attaches the name `coccinelle.` before the checker name for making it easy for the users to identify the tool name easily as mentioned here: https://github.com/Ericsson/codechecker/pull/2968#issuecomment-713665718