### PR TITLE
[report-converter][fix] Smatch checker fix

### DIFF
--- a/tools/report-converter/codechecker_report_converter/smatch/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/smatch/output_parser.py
@@ -32,7 +32,7 @@ class SmatchParser(BaseParser):
             # Function name followed by a whitespace.
             r'(?P<function_name>\S+)\s'
             # Checker name followed by a whitespace
-            r'\[smatch\.(?P<checker_name>\S+)\]\s'
+            r'\[(?P<checker_name>smatch\.\S+)\]\s'
             # Message.
             r'(?P<message>[\S \t]+)\s*')
 

--- a/tools/report-converter/tests/unit/smatch_output_test_files/sample.expected.plist
+++ b/tools/report-converter/tests/unit/smatch_output_test_files/sample.expected.plist
@@ -8,7 +8,7 @@
 			<key>category</key>
 			<string>unknown</string>
 			<key>check_name</key>
-			<string>check_zero_to_err_ptr</string>
+			<string>smatch.check_zero_to_err_ptr</string>
 			<key>description</key>
 			<string>warn: passing zero to 'ERR_PTR'</string>
 			<key>issue_hash_content_of_line_in_context</key>


### PR DESCRIPTION
The following pull request does not truncate the `smatch.` in front of the checker name, thus making it easy to identify the tool name as mentioned here: https://github.com/Ericsson/codechecker/pull/2968#issuecomment-713665718