### PR TITLE
[web] Rename open reports date filter

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -644,7 +644,7 @@ filter arguments:
                         Valid values are: "4:10", "4:", ":10"
   --tag [TAG [TAG ...]]
                         Filter results by version tag names.
-  --open-reports-date TIMESTAMP
+  --outstanding-reports-date TIMESTAMP, --open-reports-date TIMESTAMP
                         Get results which were detected BEFORE the given date
                         and NOT FIXED BEFORE the given date. The detection
                         date of a report is the storage date when the report
@@ -944,7 +944,7 @@ usage: CodeChecker cmd results [-h] [--details] [--uniqueing {on,off}]
                                [--severity [SEVERITY [SEVERITY ...]]]
                                [--bug-path-length BUG_PATH_LENGTH]
                                [--tag [TAG [TAG ...]]]
-                               [--open-reports-date TIMESTAMP]
+                               [--outstanding-reports-date TIMESTAMP]
                                [--file [FILE_PATH [FILE_PATH ...]]]
                                [--checker-name [CHECKER_NAME [CHECKER_NAME ...]]]
                                [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]
@@ -1013,7 +1013,7 @@ usage: CodeChecker cmd diff [-h] [-b BASE_RUNS [BASE_RUNS ...]]
                             [--severity [SEVERITY [SEVERITY ...]]]
                             [--bug-path-length BUG_PATH_LENGTH]
                             [--tag [TAG [TAG ...]]]
-                            [--open-reports-date TIMESTAMP]
+                            [--outstanding-reports-date TIMESTAMP]
                             [--file [FILE_PATH [FILE_PATH ...]]]
                             [--checker-name [CHECKER_NAME [CHECKER_NAME ...]]]
                             [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]
@@ -1199,7 +1199,7 @@ usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a)
                            [--severity [SEVERITY [SEVERITY ...]]]
                            [--bug-path-length BUG_PATH_LENGTH]
                            [--tag [TAG [TAG ...]]]
-                           [--open-reports-date TIMESTAMP]
+                           [--outstanding-reports-date TIMESTAMP]
                            [--file [FILE_PATH [FILE_PATH ...]]]
                            [--checker-name [CHECKER_NAME [CHECKER_NAME ...]]]
                            [--checker-msg [CHECKER_MSG [CHECKER_MSG ...]]]

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -267,7 +267,7 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                          help="Filter results by version tag names." +
                          warn_diff_mode)
 
-    f_group.add_argument('--open-reports-date',
+    f_group.add_argument('--outstanding-reports-date', '--open-reports-date',
                          type=valid_time,
                          dest="open_reports_date",
                          metavar='TIMESTAMP',

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineOpenReportsDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineOpenReportsDateFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <filter-toolbar
     :id="id"
-    title="Open Reports Date"
+    title="Outstanding reports on a given date"
     @clear="clear(true)"
   >
     <template v-slot:append-toolbar-title>


### PR DESCRIPTION
- Rename open reports date filter to "Outstanding reports on a given date"
on the GUI.
- Add another name (--outstanding-reports-date) for the --open-reports-date
option in the CLI.