### PR TITLE
[server] Don't remove reports with the same report hash

### DIFF
--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -211,12 +211,13 @@ int f(int x) { return 1 / x; }
         self._cc_client = env.setup_viewer_client(self.test_workspace)
         self.assertIsNotNone(self._cc_client)
 
-        self.assertEqual(len(files_in_report_before & files_in_report_after),
-                         0)
+        self.assertNotEqual(
+            len(files_in_report_before & files_in_report_after),
+            0)
 
         for file_id in files_in_report_before:
             f = self._cc_client.getSourceFileData(file_id, False, None)
-            self.assertIsNone(f.fileId)
+            self.assertIsNotNone(f.fileId)
 
         # Checker severity levels.
         self.__check_serverity_of_reports()

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -186,7 +186,10 @@ int main()
                 self.assertIn(report.bugHash,
                               ['cbd629ba2ee25c41cdbf5e2e336b1b1c'])
             else:
-                self.assertTrue(False)
+                self.assertIn(report.bugHash,
+                              ['3cfc9ec31117e138b052abfb064517e5',
+                               '209be2f6905590d99853ce01d52a78e0',
+                               'e8f47588c8095f02a53e338984ce52ba'])
 
         # Check the third file version
         self._create_source_file(2)
@@ -201,17 +204,18 @@ int main()
         for report in reports:
             if report.detectionStatus == DetectionStatus.RESOLVED:
                 self.assertIn(report.bugHash,
-                              ['209be2f6905590d99853ce01d52a78e0',
-                               'e8f47588c8095f02a53e338984ce52ba'])
+                              ['3cfc9ec31117e138b052abfb064517e5',
+                               '209be2f6905590d99853ce01d52a78e0',
+                               'e8f47588c8095f02a53e338984ce52ba',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
 
                 file_content = self._cc_client.getSourceFileData(
                     report.fileId,
                     True,
                     Encoding.DEFAULT).fileContent
 
-                self.assertEqual(
-                    file_content,
-                    self.sources[1],
+                self.assertTrue(
+                    file_content in [self.sources[0], self.sources[1]],
                     "Resolved bugs should be shown with the old file content.")
 
             elif report.detectionStatus == DetectionStatus.NEW:
@@ -233,6 +237,9 @@ int main()
                     "Unresolved bug should be shown with the new file "
                     "content.")
 
+            elif report.detectionStatus == DetectionStatus.REOPENED:
+                self.assertIn(report.bugHash,
+                              ['3cfc9ec31117e138b052abfb064517e5'])
             else:
                 self.assertTrue(False)
 
@@ -254,10 +261,16 @@ int main()
             elif report.detectionStatus == DetectionStatus.REOPENED:
                 self.assertIn(report.bugHash,
                               ['209be2f6905590d99853ce01d52a78e0',
-                               'e8f47588c8095f02a53e338984ce52ba'])
+                               'e8f47588c8095f02a53e338984ce52ba',
+                               '3cfc9ec31117e138b052abfb064517e5',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
             elif report.detectionStatus == DetectionStatus.RESOLVED:
                 self.assertIn(report.bugHash,
-                              ['ac147b31a745d91be093bd70bbc5567c'])
+                              ['ac147b31a745d91be093bd70bbc5567c',
+                               '209be2f6905590d99853ce01d52a78e0',
+                               '3cfc9ec31117e138b052abfb064517e5',
+                               'e8f47588c8095f02a53e338984ce52ba',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c'])
 
         # Check the fourth file version
         self._create_source_file(3)
@@ -289,7 +302,11 @@ int main()
 
             elif report.detectionStatus == DetectionStatus.RESOLVED:
                 self.assertIn(report.bugHash,
-                              ['ac147b31a745d91be093bd70bbc5567c'])
+                              ['ac147b31a745d91be093bd70bbc5567c',
+                               '209be2f6905590d99853ce01d52a78e0',
+                               '3cfc9ec31117e138b052abfb064517e5',
+                               'cbd629ba2ee25c41cdbf5e2e336b1b1c',
+                               'e8f47588c8095f02a53e338984ce52ba'])
 
     def test_check_without_metadata(self):
         """

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -566,7 +566,7 @@ class DiffRemote(unittest.TestCase):
                                                  False)
 
         # 5 new core.CallAndMessage issues.
-        self.assertEqual(len(diff_res), 5)
+        self.assertEqual(len(diff_res), 10)
 
         cmp_data.diffType = DiffType.RESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
@@ -586,7 +586,7 @@ class DiffRemote(unittest.TestCase):
                                                  tag_filter,
                                                  cmp_data,
                                                  False)
-        self.assertEqual(len(diff_res), 26)
+        self.assertEqual(len(diff_res), 78)
 
     def test_diff_open_reports_date(self):
         """Test for diff results by open reports date."""
@@ -624,7 +624,7 @@ class DiffRemote(unittest.TestCase):
                                                  False)
 
         # 5 new core.CallAndMessage issues.
-        self.assertEqual(len(diff_res), 5)
+        self.assertEqual(len(diff_res), 10)
 
         cmp_data.diffType = DiffType.RESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
@@ -644,7 +644,7 @@ class DiffRemote(unittest.TestCase):
                                                  tag_filter,
                                                  cmp_data,
                                                  False)
-        self.assertEqual(len(diff_res), 26)
+        self.assertEqual(len(diff_res), 78)
 
     def test_multiple_runs(self):
         """ Count the unresolved results in multiple runs without filter. """

--- a/web/tests/functional/run_tag/test_run_tag.py
+++ b/web/tests/functional/run_tag/test_run_tag.py
@@ -172,13 +172,16 @@ int main()
         # Check the second file version.
         self._create_source_file(1, 'test_run_tag_update')
 
+        test_run_tags = self.__get_run_tag_counts(run_id, 100, 0)
+        run_tags_v0 = [t for t in test_run_tags if t.name == self.tags[0]]
+        self.assertEqual(len(run_tags_v0), 1)
+        run_tags_v0 = run_tags_v0[0]
+
         # We do not show future bugs for later tags.
         reports = self.__reports_by_tag([run_tags_v0.id])
         self.assertEqual(run_tags_v0.count, len(reports))
 
-        test_run_tags = self.__get_run_tag_counts(run_id)
         run_tags_v1 = [t for t in test_run_tags if t.name == self.tags[1]]
-
         self.assertEqual(len(run_tags_v1), 1)
         run_tags_v1 = run_tags_v1[0]
         self.__check_reports(run_tags_v1)


### PR DESCRIPTION
Previously the server removed reports from the database which have the same
report hash on run update. With this patch we will not remove these reports
but we will set the detection status to Resolved.