### PR TITLE
[cmd] Catch and print every exceptions in the main script

### DIFF
--- a/bin/CodeChecker.py
+++ b/bin/CodeChecker.py
@@ -137,10 +137,14 @@ output.
 
                 args = parser.parse_args()
 
-        try:
+        if 'func' in args:
             args.func(args)
-        except AttributeError:
-            parser.print_help()
+        else:
+            # Print the help message of the current command if no subcommand
+            # is given.
+            sys.argv.append("--help")
+            args = parser.parse_args()
+            args.func(args)
 
     except KeyboardInterrupt as kb_err:
         print(str(kb_err))


### PR DESCRIPTION
Previously we handled the use case when no subcommand is given by catching
an Attribute exception (#2600). We cought this exception in our main script and
we print the help message of the CodeChecker command.
This is bad because the CodeChecker code can thrown this type of exception
a couple of ways. For example if we call a function on a NoneType variable.

For this reason we will print the help message of the given command only
if no subcommand is given.