### PR TITLE
[server][auth] user dn postfix preference

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -219,6 +219,17 @@ servers as it can elongate the authentication process.
 
    Example configuration: `(&(objectClass=person)(sAMAccountName=$USN$))`
 
+ * `user_dn_postfix_preference`
+
+    User DN postfix preference value can be used to select out one prefered
+    user DN if multiple DN entries are found by the LDAP search.
+    The configured value will be matched and the first matching will be used.
+    If only one DN was found this postfix matching will not be used.
+    If not set and multiple values are found the first value
+    in the search result list will be used.
+
+   Example configuration: `OU=people,DC=example,DC=com`
+
  * `groupBase`
 
    Root tree containing all the groups.
@@ -250,6 +261,7 @@ servers as it can elongate the authentication process.
       "accountBase" : null,
       "accountScope" : "subtree",
       "accountPattern" : "(&(objectClass=person)(sAMAccountName=$USN$))",
+      "user_dn_postfix_preference": null,
       "groupBase" : null,
       "groupScope" : "subtree",
       "groupPattern" : "(&(objectClass=group)(member=$USERDN$))",

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -32,6 +32,7 @@
           "accountBase" : null,
           "accountScope" : "subtree",
           "accountPattern" : "(&(objectClass=person)(sAMAccountName=$USN$))",
+          "user_dn_postfix_preference": null,
           "groupBase" : null,
           "groupScope" : "subtree",
           "groupPattern" : "(&(objectClass=group)(member=$USERDN$))",


### PR DESCRIPTION
When searching for a user in the LDAP directory it is possible that
multiple DNs are found for a user. To select a prefered DN the
`user_dn_postfix_preference` value can be set at the server config and
it will return the first DN where the end of the DN matches
the user_dn_postfix_preference value.