### PR TITLE
[travis] Remove thrift-compiler dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ addons:
             - gcc-multilib
             - libc6-dev-i386
             - libpq-dev
-            - thrift-compiler
             - clang-11
             - clang-tidy-11
     postgresql: "9.6"


### PR DESCRIPTION
`thrift-compiler` is not required to build CodeChecker anymore so we can
remove it from the travis dependency list.