### PR TITLE
Less checkers in enable all

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -257,7 +257,8 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
             state, _ = data
             metadata_info['checkers'].update({
                 check: state == CheckerState.enabled})
-            enabled_checkers[analyzer].append(check)
+            if state == CheckerState.enabled:
+                enabled_checkers[analyzer].append(check)
 
         version = config_map[analyzer].get_version(check_env)
         metadata_info['analyzer_statistics']['version'] = version

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -189,11 +189,15 @@ class AnalyzerConfigHandler(object, metaclass=ABCMeta):
                 self.set_checker_enabled(checker)
 
         # If enable_all is given, almost all checkers should be enabled.
+        disabled_groups = ["alpha.", "debug.", "osx.", "abseil-", "android-",
+                           "darwin-", "objc-", "cppcoreguidelines-",
+                           "fuchsia.", "fuchsia-", "hicpp-", "llvm-",
+                           "llvmlibc-", "google-", "zircon-"]
         if enable_all:
-            for checker_name, enabled in checkers:
-                if not checker_name.startswith("alpha.") and \
-                        not checker_name.startswith("debug.") and \
-                        not checker_name.startswith("osx."):
+            for checker_name, _ in checkers:
+                if not any(checker_name.startswith(d_grp) for d_grp in
+                           disabled_groups):
+
                     # There are a few exceptions, though, which still need to
                     # be manually enabled by the user: alpha and debug.
                     self.set_checker_enabled(checker_name)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -667,7 +667,12 @@ output of "CodeChecker checkers --guideline" command.""")
                                default=argparse.SUPPRESS,
                                help="Force the running analyzers to use "
                                     "almost every checker available. The "
-                                    "checker groups 'alpha.', 'debug.' and "
+                                    "checker groups 'alpha.', 'debug.',"
+                                    "'osx.', 'abseil-', 'android-', "
+                                    "'darwin-', 'objc-', "
+                                    "'cppcoreguidelines-', 'fuchsia.', "
+                                    "'fuchsia-', 'hicpp-', 'llvm-', "
+                                    "'llvmlibc-', 'google-', 'zircon-', "
                                     "'osx.' (on Linux) are NOT enabled "
                                     "automatically and must be EXPLICITLY "
                                     "specified. WARNING! Enabling all "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -667,7 +667,12 @@ output of "CodeChecker checkers --guideline" command.""")
                                default=argparse.SUPPRESS,
                                help="Force the running analyzers to use "
                                     "almost every checker available. The "
-                                    "checker groups 'alpha.', 'debug.' and "
+                                    "checker groups 'alpha.', 'debug.',"
+                                    "'osx.', 'abseil-', 'android-', "
+                                    "'darwin-', 'objc-', "
+                                    "'cppcoreguidelines-', 'fuchsia.', "
+                                    "'fuchsia-', 'hicpp-', 'llvm-', "
+                                    "'llvmlibc-', 'google-', 'zircon-', "
                                     "'osx.' (on Linux) are NOT enabled "
                                     "automatically and must be EXPLICITLY "
                                     "specified. WARNING! Enabling all "

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -893,7 +893,7 @@ class TestAnalyze(unittest.TestCase):
         print(out)
         # First it's printed as the member of enabled checkers at the beginning
         # of the output. Second it is printed as a found report.
-        self.assertEqual(out.count('hicpp-use-nullptr'), 2)
+        self.assertEqual(out.count('hicpp-use-nullptr'), 1)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clang-tidy", "-o", self.report_dir,
@@ -914,7 +914,7 @@ class TestAnalyze(unittest.TestCase):
 
         # First it's printed as the member of enabled checkers at the beginning
         # of the output. Second and third it is printed as a found report.
-        self.assertEqual(out.count('hicpp-use-nullptr'), 3)
+        self.assertEqual(out.count('hicpp-use-nullptr'), 2)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clangsa", "-o", self.report_dir,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -375,12 +375,15 @@ checker configuration:
                         labeled: 'profile:security' or 'guideline:sei-cert'.
   --enable-all          Force the running analyzers to use almost every
                         checker available. The checker groups 'alpha.',
-                        'debug.' and 'osx.' (on Linux) are NOT enabled
-                        automatically and must be EXPLICITLY specified.
-                        WARNING! Enabling all checkers might result in the
-                        analysis losing precision and stability, and could
-                        even result in a total failure of the analysis. USE
-                        WISELY AND AT YOUR OWN RISK!
+                        'debug.','osx.', 'abseil-', 'android-', 'darwin-',
+                        'objc-', 'cppcoreguidelines-', 'fuchsia.', 'fuchsia-',
+                        'hicpp-', 'llvm-', 'llvmlibc-', 'google-', 'zircon-',
+                        'osx.' (on Linux) are NOT enabled automatically and
+                        must be EXPLICITLY specified. WARNING! Enabling all
+                        checkers might result in the analysis losing precision
+                        and stability, and could even result in a total
+                        failure of the analysis. USE WISELY AND AT YOUR OWN
+                        RISK!
 
 output arguments:
   --print-steps         Print the steps the analyzers took in finding the
@@ -1258,12 +1261,15 @@ checker configuration:
                         labeled: 'profile:security' or 'guideline:sei-cert'.
   --enable-all          Force the running analyzers to use almost every
                         checker available. The checker groups 'alpha.',
-                        'debug.' and 'osx.' (on Linux) are NOT enabled
-                        automatically and must be EXPLICITLY specified.
-                        WARNING! Enabling all checkers might result in the
-                        analysis losing precision and stability, and could
-                        even result in a total failure of the analysis. USE
-                        WISELY AND AT YOUR OWN RISK!
+                        'debug.','osx.', 'abseil-', 'android-', 'darwin-',
+                        'objc-', 'cppcoreguidelines-', 'fuchsia.', 'fuchsia-',
+                        'hicpp-', 'llvm-', 'llvmlibc-', 'google-', 'zircon-',
+                        'osx.' (on Linux) are NOT enabled automatically and
+                        must be EXPLICITLY specified. WARNING! Enabling all
+                        checkers might result in the analysis losing precision
+                        and stability, and could even result in a total
+                        failure of the analysis. USE WISELY AND AT YOUR OWN
+                        RISK!
 ```
 
 Both `--enable` and `--disable` take individual checkers, checker groups or


### PR DESCRIPTION
There is a bugfix and a change in the two commits.
The bugfix is for printing the enabled checkers and the change is to remove more groups from the enable-all configuration.