### PR TITLE
[cmd] Fix HTML generation of the CodeChecker parse command

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -707,23 +707,29 @@ def main(args):
             LOG.error(f"Unknown export format: {export}")
             return
 
-        try:
-            res = parse_convert_reports(args.input,
-                                        export,
-                                        context.severity_map,
-                                        trim_path_prefixes)
-            if 'output_path' in args:
-                output_path = os.path.abspath(args.output_path)
-                reports_json = os.path.join(output_path, 'reports.json')
-                with open(reports_json,
-                          mode='w',
-                          encoding='utf-8', errors="ignore") as output_f:
-                    output_f.write(json.dumps(res))
+        # The HTML part will be handled separately below.
+        if export != 'html':
+            try:
+                res = parse_convert_reports(args.input,
+                                            export,
+                                            context.severity_map,
+                                            trim_path_prefixes)
+                if 'output_path' in args:
+                    output_path = os.path.abspath(args.output_path)
 
-            return print(json.dumps(res))
-        except Exception as ex:
-            LOG.error(ex)
-            return
+                    if not os.path.exists(output_path):
+                        os.mkdir(output_path)
+
+                    reports_json = os.path.join(output_path, 'reports.json')
+                    with open(reports_json,
+                              mode='w',
+                              encoding='utf-8', errors="ignore") as output_f:
+                        output_f.write(json.dumps(res))
+
+                return print(json.dumps(res))
+            except Exception as ex:
+                LOG.error(ex)
+                sys.exit(1)
 
     def trim_path_prefixes_handler(source_file):
         """

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -346,3 +346,21 @@ class AnalyzeParseTestCase(
         out, _ = call_command(extract_cmd, cwd=self.test_dir, env=self.env)
 
         self.assertTrue("Invalid plist file" in out)
+
+    def test_html_output_for_macros(self):
+        """ Test parse HTML output for macros. """
+        test_project_macros = os.path.join(self.test_workspaces['NORMAL'],
+                                           "test_files", "macros")
+
+        output_path = os.path.join(test_project_macros, 'html')
+        extract_cmd = ['CodeChecker', 'parse',
+                       '-e', 'html',
+                       '-o', output_path,
+                       test_project_macros]
+
+        out, err = call_command(extract_cmd, cwd=self.test_dir, env=self.env)
+        self.assertFalse(err)
+
+        self.assertTrue('Html file was generated' in out)
+        self.assertTrue('Summary' in out)
+        self.assertTrue('Statistics' in out)


### PR DESCRIPTION
> Closes #3019

- Create the output directory if it doesn't exist.
- Do not write empty reports.json file in case of HTML generation.
- Add new test case for HTML generation.