### PR TITLE
[test] Use -std=c++98 standard in fixit tests

### DIFF
--- a/analyzer/tests/functional/fixit/test_fixit.py
+++ b/analyzer/tests/functional/fixit/test_fixit.py
@@ -61,7 +61,7 @@ class TestFixit(unittest.TestCase):
 
         # Create a compilation database.
         build_log = [{"directory": self.test_workspace,
-                      "command": "clang++ -c " + source_file_cpp,
+                      "command": "g++ -c -std=c++98 " + source_file_cpp,
                       "file": source_file_cpp
                       }]
 
@@ -153,7 +153,7 @@ int main()
 
         # Create a compilation database.
         build_log = [{"directory": self.test_workspace,
-                      "command": "clang++ -c " + source_file_cpp,
+                      "command": "g++ -c -std=c++98 " + source_file_cpp,
                       "file": source_file_cpp
                       }]
 


### PR DESCRIPTION
In some environments there may be a too old gcc standard library which
results compiler error in the compilation of the most basic source
files. So we use g++ with -std=c++98 flag in order to meet the least
requirements.