### PR TITLE
[analyzer][fix] Unique lines when collecting statistics

### DIFF
--- a/analyzer/tools/statistics_collector/codechecker_statistics_collector/post_process_stats.py
+++ b/analyzer/tools/statistics_collector/codechecker_statistics_collector/post_process_stats.py
@@ -63,14 +63,14 @@ def process(input_dir, output_dir,
         SpecialReturnValueCollector(stats_min_sample_count,
                                     stats_relevance_threshold)
 
+    lines = set()
     for clang_output in clang_outs:
         with open(clang_output, 'r',
                   encoding='utf-8', errors='ignore') as out:
-            clang_output = ""
-            for line in out:
-                clang_output += line + "\n"
-                ret_collector.process_line(line)
-                special_ret_collector.process_line(line)
+            lines |= set(out.readlines())
+    for line in lines:
+        ret_collector.process_line(line)
+        special_ret_collector.process_line(line)
     LOG.debug("Collecting statistics finished.")
 
     # Write out statistics.


### PR DESCRIPTION
If a header file is included into multiple source files in a C code,
its lines are counted multiple times when processing the statistics.
This leads to false positives if e.g. the return value of a function
is used in a header but not in the source files. This patch fixes it
by collecting all lines to a set first and then processing the set.