### PR TITLE
[gui] Fix undefined getRunIds function in baseline run filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -374,7 +374,7 @@ export default {
       return [].concat(...await Promise.all(
         this.selectedItems.map(async item => {
           if (!item.runIds) {
-            item.runIds = await this.getRunIds(item.title);
+            item.runIds = await ccService.getRunIds(item.title);
           }
 
           return Promise.resolve(item.runIds);


### PR DESCRIPTION
In the `BaselineRunFilter` component we called the `getRunIds` function
through the current instance but the function was moved to the `ccService`
module.

This way we were not be able to select the first item in the run list when we searched
by a regular expression.