### PR TITLE
[WIP] handle clang-tidy v12 aliases in the plist files

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -208,7 +208,9 @@ class PlistToPlaintextFormatter(object):
                     report.files[last_report_event['location']['file']]
 
                 file_stats[f_path] += 1
-                severity = self.__severity_map.get(checker_name)
+                # tidy checker name aliases are separated by a comma.
+                checker_names = checker_name.split(',')
+                severity = self.__severity_map.get(checker_names[0])
                 severity_stats[severity] += 1
                 report_count["report_count"] += 1
 

--- a/codechecker_common/report.py
+++ b/codechecker_common/report.py
@@ -71,8 +71,13 @@ class Report(object):
         return self.__main['issue_hash_content_of_line_in_context']
 
     @property
+    def check_aliases(self) -> List[str]:
+        # tidy checker name aliases are separated by a comma.
+        return self.__main['check_name'].split(',')
+
+    @property
     def check_name(self) -> str:
-        return self.__main['check_name']
+        return self.check_aliases[0]
 
     @property
     def bug_path(self) -> Dict:

--- a/tools/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/tools/plist_to_html/plist_to_html/PlistToHtml.py
@@ -348,7 +348,10 @@ def get_report_data_from_plist(plist, skip_report_handler=None,
         source_file = files[diag['location']['file']]
         report_line = diag['location']['line']
         report_hash = diag['issue_hash_content_of_line_in_context']
-        checker_name = diag['check_name']
+        # tidy checker name aliases are separated by a comma.
+        checker_names = diag['check_name']
+        checker_name = checker_names[0]
+
         source_code_comments = []
 
         if skip_report_handler:

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -158,14 +158,14 @@ def reports_to_html_report_data(reports: List[Report]) -> Dict:
             notes.append({'location': note['location'],
                           'message': note['message']})
 
-        report_hash = report.main['issue_hash_content_of_line_in_context']
+        report_hash = report.report_hash
         report_data.append({
             'events': events,
             'macros': macros,
             'notes': notes,
             'path': report.main['location']['file'],
             'reportHash': report_hash,
-            'checkerName': report.main['check_name']})
+            'checkerName': report.check_name})
 
     return {'files': file_sources,
             'reports': report_data}

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1775,6 +1775,12 @@ class ThriftRequestHandler(object):
          - checkerId
         """
 
+        LOG.error(checkerId)
+        # tidy checker name aliases are separated by a comma.
+        checker_names = checkerId.split(',')
+        LOG.error(checker_names)
+        checkerId = checker_names[0]
+
         missing_doc = "No documentation found for checker: " + checkerId + \
                       "\n\nPlease refer to the documentation at the "
 
@@ -2706,7 +2712,9 @@ class ThriftRequestHandler(object):
             # Store report.
             for report in reports:
                 checker_name = report.main['check_name']
-                all_report_checkers.add(checker_name)
+                # tidy checker name aliases are separated by a comma.
+                checker_names = checker_name.split(',')
+                all_report_checkers.add(checker_names[0])
 
                 report.trim_path_prefixes(trim_path_prefixes)
                 source_file = report.file_path

--- a/web/server/codechecker_server/api/store_handler.py
+++ b/web/server/codechecker_server/api/store_handler.py
@@ -436,7 +436,9 @@ def addReport(session,
     """
     try:
 
-        checker_name = main_section['check_name']
+        checker_names = main_section['check_name'].split(',')
+        # tidy checker name aliases are separated by a comma.
+        checker_name = checker_names[0]
         severity_name = severity_map.get(checker_name)
         severity = ttypes.Severity._NAMES_TO_VALUES[severity_name]
 


### PR DESCRIPTION
If there are multiple checker names (aliases) in a plist report
created by parsing the clang-tidy output use the first checker
name from the list, to store the report for filtering, checker
documentation detection, severity detection, source
code review comment handling.

clang-tidy v12 is not released yet, so the output format might change
See the discussion here: https://reviews.llvm.org/D72566

resolves #2886