### PR TITLE
Makefile updated to work in windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 -include Makefile.local
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 BUILD_DIR = $(CURRENT_DIR)/build
 VENDOR_DIR = $(CURRENT_DIR)/vendor
+PYTHON_BIN ?= python3
 
 CC_BUILD_DIR = $(BUILD_DIR)/CodeChecker
 CC_BUILD_BIN_DIR = $(CC_BUILD_DIR)/bin
@@ -111,12 +112,12 @@ package: package_dir_structure set_git_commit_template package_plist_to_html pac
 	cp -r $(CC_ANALYZER)/config/* $(CC_BUILD_DIR)/config && \
 	cp -r $(CC_WEB)/config/* $(CC_BUILD_DIR)/config && \
 	cp -r $(CC_SERVER)/config/* $(CC_BUILD_DIR)/config && \
-	./scripts/build/extend_version_file.py -r $(ROOT) \
-	  $(CC_BUILD_DIR)/config/analyzer_version.json \
-	  $(CC_BUILD_DIR)/config/web_version.json
+	${PYTHON_BIN} ./scripts/build/extend_version_file.py -r $(ROOT) \
+	$(CC_BUILD_DIR)/config/analyzer_version.json \
+	$(CC_BUILD_DIR)/config/web_version.json
 
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
-	./scripts/build/create_commands.py -b $(BUILD_DIR) \
+	${PYTHON_BIN} ./scripts/build/create_commands.py -b $(BUILD_DIR) \
 	  --cmd-dir codechecker_common/cmd \
 	    $(CC_WEB)/codechecker_web/cmd \
 	    $(CC_SERVER)/codechecker_server/cmd \
@@ -137,21 +138,21 @@ standalone_package: venv package
 	# the virtual environment beforehand.
 	cd $(CC_BUILD_BIN_DIR) && \
 	mv CodeChecker _CodeChecker && \
-	$(ROOT)/scripts/build/wrap_binary_in_venv.py \
+	${PYTHON_BIN} $(ROOT)/scripts/build/wrap_binary_in_venv.py \
 		-e $(ROOT)/venv \
 		-b _CodeChecker \
 		-o CodeChecker
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && \
+	virtualenv -p ${PYTHON_BIN} venv && \
 		$(ACTIVATE_RUNTIME_VENV) && \
 		pip3 install -r $(CC_ANALYZER)/requirements.txt && \
 		pip3 install -r $(CC_WEB)/requirements.txt
 
 venv_osx:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && \
+	virtualenv -p ${PYTHON_BIN} venv && \
 		$(ACTIVATE_RUNTIME_VENV) && \
 		pip3 install -r $(CC_ANALYZER)/requirements_py/osx/requirements.txt && \
 		pip3 install -r $(CC_WEB)/requirements_py/osx/requirements.txt
@@ -169,7 +170,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && $(PIP_DEV_DEPS_CMD)
 
 clean_venv_dev:

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -1,7 +1,8 @@
 -include Makefile.local
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 BUILD_DIR ?= $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 
 CC_BUILD_DIR = $(BUILD_DIR)/CodeChecker
 CC_BUILD_LIB_DIR = $(CC_BUILD_DIR)/lib/python3
@@ -26,7 +27,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -87,12 +88,12 @@ package: package_plist_to_html package_tu_collector package_analyzer package_mer
 	# Copy config files and extend 'version.json' file with git information.
 	cp -r $(ROOT)/config $(CC_BUILD_DIR) && \
 	cp -r $(CURRENT_DIR)/config/* $(CC_BUILD_DIR)/config && \
-	$(ROOT)/scripts/build/extend_version_file.py -r $(ROOT) \
+	${PYTHON_BIN} $(ROOT)/scripts/build/extend_version_file.py -r $(ROOT) \
 	  $(CC_BUILD_DIR)/config/analyzer_version.json \
 
 	# Copy CodeChecker entry point sub-commands.
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
-	$(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
+	${PYTHON_BIN} $(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
 	  --cmd-dir codechecker_common/cmd \
 	    $(CC_ANALYZER)/codechecker_analyzer/cmd \
 	  --bin-file $(ROOT)/bin/CodeChecker \

--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -2,6 +2,7 @@
 
 # Test project configuration, tests are run on these files.
 TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
+PYTHON_BIN ?= python3
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
@@ -50,11 +51,11 @@ FUNCTIONAL_TEST_CMD = $(REPO_ROOT) $(TEST_PROJECT) \
 		nosetests $(NOSECFG) tests/functional || exit 1
 
 test_functional:
-	python3 $(ROOT)/scripts/test/check_clang.py || exit 1;
+	${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1;
 	$(FUNCTIONAL_TEST_CMD)
 
 test_functional_in_env: venv_dev
-		python3 $(ROOT)/scripts/test/check_clang.py || exit 1;
+		${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1;
 		$(ACTIVATE_DEV_VENV) && $(FUNCTIONAL_TEST_CMD)
 
 test_build_logger:

--- a/analyzer/tools/merge_clang_extdef_mappings/Makefile
+++ b/analyzer/tools/merge_clang_extdef_mappings/Makefile
@@ -6,10 +6,11 @@
 #
 # -------------------------------------------------------------------------
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 ROOT = $(CURRENT_DIR)
 
 BUILD_DIR = $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 MERGE_CLANG_EXTDEF_MAPS_DIR = $(BUILD_DIR)/merge_clang_extdef_mappings
 
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
@@ -23,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_RUNTIME_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -37,25 +38,25 @@ include tests/Makefile
 
 package:
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build:
-	python3 setup.py build --build-purelib $(MERGE_CLANG_EXTDEF_MAPS_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(MERGE_CLANG_EXTDEF_MAPS_DIR)
 
 dist:
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:

--- a/analyzer/tools/statistics_collector/Makefile
+++ b/analyzer/tools/statistics_collector/Makefile
@@ -6,10 +6,11 @@
 #
 # -------------------------------------------------------------------------
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 ROOT = $(CURRENT_DIR)
 
 BUILD_DIR = $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 STATISTICS_COLLECTOR_DIR = $(BUILD_DIR)/statistics_collector
 
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
@@ -23,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_RUNTIME_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -37,25 +38,25 @@ include tests/Makefile
 
 package:
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build:
-	python3 setup.py build --build-purelib $(STATISTICS_COLLECTOR_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(STATISTICS_COLLECTOR_DIR)
 
 dist:
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:

--- a/codechecker_common/tests/unit/Makefile
+++ b/codechecker_common/tests/unit/Makefile
@@ -1,6 +1,6 @@
 # Environment variables to run tests.
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 # Root of the repository.
 REPO_ROOT ?= REPO_ROOT=$(CURRENT_DIR)/../../../
 

--- a/tools/codechecker_report_hash/Makefile
+++ b/tools/codechecker_report_hash/Makefile
@@ -6,10 +6,11 @@
 #
 # -------------------------------------------------------------------------
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 ROOT = $(CURRENT_DIR)
 
 BUILD_DIR = $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 CC_REPORT_HASH_DIR = $(BUILD_DIR)/codechecker_report_hash
 
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
@@ -23,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_RUNTIME_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -37,25 +38,25 @@ include tests/Makefile
 
 package:
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build:
-	python3 setup.py build --build-purelib $(CC_REPORT_HASH_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(CC_REPORT_HASH_DIR)
 
 dist:
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:

--- a/tools/plist_to_html/Makefile
+++ b/tools/plist_to_html/Makefile
@@ -8,7 +8,8 @@
 
 CODEMIRROR = https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.30.0
 
-CURRENT_DIR = $(shell pwd)
+PYTHON_BIN ?= python3
+CURRENT_DIR = ${CURDIR}
 ROOT = $(CURRENT_DIR)
 
 BUILD_DIR = $(CURRENT_DIR)/build
@@ -30,14 +31,14 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_RUNTIME_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
 
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -47,25 +48,25 @@ include tests/Makefile
 
 package: dep
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build: dep
-	python3 setup.py build --build-purelib $(PLIST_TO_HTML_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(PLIST_TO_HTML_DIR)
 
 dist: dep
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 vendor_dir:

--- a/tools/report-converter/Makefile
+++ b/tools/report-converter/Makefile
@@ -5,10 +5,11 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # -------------------------------------------------------------------------
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 ROOT = $(CURRENT_DIR)
 
 BUILD_DIR = $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 REPORT_CONVERTER_DIR = $(BUILD_DIR)/report_converter
 
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
@@ -22,14 +23,14 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_RUNTIME_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
 
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -39,25 +40,25 @@ include tests/Makefile
 
 package:
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build:
-	python3 setup.py build --build-purelib $(REPORT_CONVERTER_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(REPORT_CONVERTER_DIR)
 
 dist:
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test:
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload:
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:

--- a/tools/tu_collector/Makefile
+++ b/tools/tu_collector/Makefile
@@ -9,13 +9,14 @@
 BUILD_DIR = build
 BIN_DIR = $(BUILD_DIR)/bin
 
+PYTHON_BIN ?= python3
 TU_COLLECTOR_DIR = $(BUILD_DIR)/tu_collector
 
 ACTIVATE_VENV ?= . venv/bin/activate
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p python3 venv && $(ACTIVATE_VENV)
+	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_VENV)
 
 default: all
 
@@ -23,25 +24,25 @@ all: package
 
 package:
 	# Install package in 'development mode'.
-	python3 setup.py develop
+	${PYTHON_BIN} setup.py develop
 
 build:
-	python3 setup.py build --build-purelib $(TU_COLLECTOR_DIR)
+	${PYTHON_BIN} setup.py build --build-purelib $(TU_COLLECTOR_DIR)
 
 dist:
 	# Create a source distribution.
-	python3 setup.py sdist
+	${PYTHON_BIN} setup.py sdist
 
 upload_test: dist
 	# Upload package to the TestPyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 upload: dist
 	# Upload package to the PyPI repository.
-	$(eval PKG_NAME := $(shell python3 setup.py --name))
-	$(eval PKG_VERSION := $(shell python3 setup.py --version))
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
 	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 clean:

--- a/web/Makefile
+++ b/web/Makefile
@@ -3,8 +3,9 @@
 # Set it to NO if you would not like to build the UI code.
 BUILD_UI_DIST ?= YES
 
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR = ${CURDIR}
 BUILD_DIR ?= $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
 
 CC_BUILD_DIR = $(BUILD_DIR)/CodeChecker
 CC_BUILD_WEB_DIR = $(CC_BUILD_DIR)/www
@@ -48,7 +49,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p python3 venv_dev && \
+	virtualenv -p ${PYTHON_BIN} venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:
@@ -107,12 +108,12 @@ package: package_plist_to_html package_report_hash package_web
 	cp -r $(ROOT)/config $(CC_BUILD_DIR) && \
 	cp -r $(CURRENT_DIR)/config/* $(CC_BUILD_DIR)/config && \
 	cp -r $(CC_SERVER)/config/* $(CC_BUILD_DIR)/config && \
-	$(ROOT)/scripts/build/extend_version_file.py -r $(ROOT) \
+	${PYTHON_BIN} $(ROOT)/scripts/build/extend_version_file.py -r $(ROOT) \
 	  $(CC_BUILD_DIR)/config/web_version.json
 
 	# Copy CodeChecker entry point sub-commands.
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
-	$(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
+	${PYTHON_BIN} $(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
 	  --cmd-dir codechecker_common/cmd \
 	    $(CC_WEB)/codechecker_web/cmd \
 	    $(CC_SERVER)/codechecker_server/cmd \

--- a/web/api/Makefile
+++ b/web/api/Makefile
@@ -2,8 +2,9 @@ THRIFT_OPTS = -r -o /data
 THRIFT_VERSION = "0.11.0"
 TARGET_PY = --gen py
 TARGET_JS = --gen js:jquery --gen js:node
+PYTHON_BIN ?= python3
 
-current_dir = $(shell pwd)
+current_dir = ${CURDIR}
 uid = $(shell id -u)
 guid = $(shell id -g)
 
@@ -17,10 +18,10 @@ NODE_JS_API_DIR = "$(API_DIR)/js/codechecker-api-node/lib"
 default: build
 
 install_shared_py:
-	cd codechecker_api_shared && python3 setup.py install
+	cd codechecker_api_shared && ${PYTHON_BIN} setup.py install
 
 install_api_py:
-	cd codechecker_api && python3 setup.py install
+	cd codechecker_api && ${PYTHON_BIN} setup.py install
 
 install_py: install_shared_py install_api_py
 
@@ -57,12 +58,12 @@ build: clean target_dirs
 publish: build publish_py publish_js
 
 publish_py:
-	cd py/codechecker_api && python3 setup.py sdist bdist_wheel && twine upload dist/* --verbose
-	cd py/codechecker_api_shared && python3 setup.py sdist bdist_wheel && twine upload dist/* --verbose
+	cd py/codechecker_api && ${PYTHON_BIN} setup.py sdist bdist_wheel && twine upload dist/* --verbose
+	cd py/codechecker_api_shared && ${PYTHON_BIN} setup.py sdist bdist_wheel && twine upload dist/* --verbose
 
 publish_test_py:
-	cd py/codechecker_api && python3 setup.py sdist bdist_wheel && twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
-	cd py/codechecker_api_shared && python3 setup.py sdist bdist_wheel && twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
+	cd py/codechecker_api && ${PYTHON_BIN} setup.py sdist bdist_wheel && twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
+	cd py/codechecker_api_shared && ${PYTHON_BIN} setup.py sdist bdist_wheel && twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
 
 publish_js:
 	cd js/codechecker-api-js && npm publish

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -11,6 +11,7 @@ DBUNAME ?= TEST_DBUSERNAME=postgres
 # Test project configuration, tests are run on these files.
 CLANG_VERSION ?= TEST_CLANG_VERSION=stable
 TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
+PYTHON_BIN ?= python3
 
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 CC_TEST_WORKSPACE_ROOT ?= $(BUILD_DIR)/workspace
@@ -102,18 +103,18 @@ test_functional: test_sqlite test_psql
 test_functional_in_env: test_sqlite_in_env test_psql_in_env
 
 test_sqlite:
-	python3 $(ROOT)/scripts/test/check_clang.py || exit 1;
+	${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1;
 	$(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
 
 test_sqlite_in_env: venv_dev
-	python3 $(ROOT)/scripts/test/check_clang.py || exit 1;
+	${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1;
 	$(ACTIVATE_DEV_VENV) && $(CLEAR_WORKSPACE_CMD) && $(FUNCTIONAL_TEST_CMD)
 
 test_psql: test_psql_psycopg2 test_psql_pg8000
 
 test_psql_in_env: test_psql_psycopg2_in_env test_psql_pg8000_in_env
 
-PSYCOPG2_TEST_CMD = python3 $(ROOT)/scripts/test/check_clang.py || exit 1; \
+PSYCOPG2_TEST_CMD = ${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1; \
   $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(DROP_DB_CMD) && \
   $(DBUNAME) $(DBPORT) $(PSYCOPG2) $(MAKE_DB_CMD) && \
   $(CLEAR_WORKSPACE_CMD) && \
@@ -127,7 +128,7 @@ test_psql_psycopg2:
 test_psql_psycopg2_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PSYCOPG2_TEST_CMD)
 
-PG8000_TEST_CMD = python3 $(ROOT)/scripts/test/check_clang.py || exit 1; \
+PG8000_TEST_CMD = ${PYTHON_BIN} $(ROOT)/scripts/test/check_clang.py || exit 1; \
   $(DBUNAME) $(DBPORT) $(PG8000) $(DROP_DB_CMD) && \
   $(DBUNAME) $(DBPORT) $(PG8000) $(MAKE_DB_CMD) && \
   $(CLEAR_WORKSPACE_CMD) && \


### PR DESCRIPTION
Requirements:

* make (installed with choco, GNU Make 4.3)
* windows git tools in path (for cp, ln and few other tools)

CPython in windows doesn't have 3 postfix in the binary so extra
environment/make variable "PYTHON_BIN" was introduced to tell make
the "correct" python interpreter.

Observations:

$(shell pwd) which was used to detect current directory didnt work as-is because it reports posix path if -W flag is not given, however, someone that triggered an error so defaulting to use ${CURDIR}