### PR TITLE
[api][server] Fix comments for CodeChecker cmd results

### DIFF
--- a/web/api/js/codechecker-api-js/package.json
+++ b/web/api/js/codechecker-api-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api-js",
-  "version": "6.36.0",
+  "version": "6.36.0-dev1",
   "description": "Generated jQuery compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/js/codechecker-api-node/package.json
+++ b/web/api/js/codechecker-api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api",
-  "version": "6.36.0",
+  "version": "6.36.0-dev1",
   "description": "Generated node.js compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/py/codechecker_api/setup.py
+++ b/web/api/py/codechecker_api/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.36.0'
+api_version = '6.36.0-dev1'
 
 setup(
     name='codechecker_api',

--- a/web/api/py/codechecker_api_shared/setup.py
+++ b/web/api/py/codechecker_api_shared/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.36.0'
+api_version = '6.36.0-dev1'
 
 setup(
     name='codechecker_api_shared',

--- a/web/api/report_server.thrift
+++ b/web/api/report_server.thrift
@@ -151,6 +151,7 @@ struct ReportDetails {
   1: BugPathEvents pathEvents,
   2: BugPath       executionPath,
   3: optional ExtendedReportDataList extendedData,
+  4: optional CommentDataList comments,
 }
 
 typedef string AnalyzerType

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,5 +4,5 @@ alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
 
-codechecker_api==6.36.0
-codechecker_api_shared==6.36.0
+codechecker_api==6.36.0-dev1
+codechecker_api_shared==6.36.0-dev1

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -5,5 +5,5 @@ pg8000==1.15.2
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.36.0
-codechecker_api_shared==6.36.0
+codechecker_api==6.36.0-dev1
+codechecker_api_shared==6.36.0-dev1

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -5,5 +5,5 @@ psycopg2-binary==2.8.5
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.36.0
-codechecker_api_shared==6.36.0
+codechecker_api==6.36.0-dev1
+codechecker_api_shared==6.36.0-dev1

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -11,8 +11,8 @@ nose==1.3.7
 mockldap==0.3.0
 mkdocs==1.0.4
 
-codechecker_api==6.36.0
-codechecker_api_shared==6.36.0
+codechecker_api==6.36.0-dev1
+codechecker_api_shared==6.36.0-dev1
 
 # publish packages to pypi
 twine

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -4,5 +4,5 @@ portalocker==1.7.0
 psutil==5.7.0
 sqlalchemy==1.3.16
 
-codechecker_api==6.36.0
-codechecker_api_shared==6.36.0
+codechecker_api==6.36.0-dev1
+codechecker_api_shared==6.36.0-dev1

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -412,8 +412,8 @@ def get_diff_bug_id_query(session, run_ids, tag_ids, open_reports_date):
     if tag_ids:
         q = q.outerjoin(RunHistory,
                         RunHistory.run_id == Report.run_id) \
-             .filter(RunHistory.id.in_(tag_ids)) \
-             .filter(get_open_reports_date_filter_query())
+            .filter(RunHistory.id.in_(tag_ids)) \
+            .filter(get_open_reports_date_filter_query())
 
     if open_reports_date:
         date = datetime.fromtimestamp(open_reports_date)
@@ -433,7 +433,7 @@ def get_diff_run_id_query(session, run_ids, tag_ids):
     if tag_ids:
         q = q.outerjoin(RunHistory,
                         RunHistory.run_id == Run.id) \
-             .filter(RunHistory.id.in_(tag_ids))
+            .filter(RunHistory.id.in_(tag_ids))
 
     return q
 
@@ -623,11 +623,23 @@ def get_report_details(session, report_ids):
         extended_data.filePath = file_path
         extended_data_list[report_id].append(extended_data)
 
+    # Get Comments for report data
+    comment_data_list = defaultdict(list)
+    comment_query = session.query(Comment, Report.id)\
+        .filter(Report.id.in_(report_ids)) \
+        .outerjoin(Report, Report.bug_id == Comment.bug_hash)
+
+    for data, report_id in comment_query:
+        report_id = report_id
+        comment_data = comment_data_db_to_api(data)
+        comment_data_list[report_id].append(comment_data)
+
     for report_id in report_ids:
         details[report_id] = \
             ReportDetails(pathEvents=bug_events_list[report_id],
                           executionPath=bug_point_list[report_id],
-                          extendedData=extended_data_list[report_id])
+                          extendedData=extended_data_list[report_id],
+                          comments=comment_data_list[report_id])
 
     return details
 
@@ -660,6 +672,41 @@ def extended_data_db_to_api(erd):
         endCol=erd.col_end,
         message=erd.message,
         fileId=erd.file_id)
+
+
+def comment_data_db_to_api(comm):
+    """
+    Returns a CommentData Object with all the relevant fields
+    """
+    return ttypes.CommentData(
+        id=comm.id,
+        author=comm.author,
+        message=get_comment_msg(comm),
+        createdAt=str(comm.created_at),
+        kind=comm.kind
+    )
+
+
+def get_comment_msg(comment):
+    """
+    Checks for the comment kind. If the comment is
+    identified as a system comment, it is formatted accordindly.
+    """
+    context = webserver_context.get_context()
+    message = comment.message.decode('utf-8')
+    sys_comment = comment_kind_from_thrift_type(
+        ttypes.CommentKind.SYSTEM)
+    if comment.kind == sys_comment:
+        elements = shlex.split(message)
+        system_comment = context.system_comment_map.get(
+            elements[0])
+        if system_comment:
+            for idx, value in enumerate(elements[1:]):
+                system_comment = system_comment.replace(
+                    '{' + str(idx) + '}', value)
+            message = system_comment
+
+    return message
 
 
 def unzip(b64zip, output_dir):
@@ -916,8 +963,8 @@ class ThriftRequestHandler(object):
             args['config_db_session'] = session
 
             if not any([permissions.require_permission(
-                            perm, args, self.__auth_session)
-                        for perm in required]):
+                    perm, args, self.__auth_session)
+                    for perm in required]):
                 raise codechecker_api_shared.ttypes.RequestFailed(
                     codechecker_api_shared.ttypes.ErrorCode.UNAUTHORIZED,
                     "You are not authorized to execute this action.")
@@ -1607,21 +1654,8 @@ class ThriftRequestHandler(object):
                     .order_by(Comment.created_at.desc()) \
                     .all()
 
-                context = webserver_context.get_context()
                 for comment in comments:
-                    message = comment.message.decode('utf-8')
-                    sys_comment = comment_kind_from_thrift_type(
-                        ttypes.CommentKind.SYSTEM)
-                    if comment.kind == sys_comment:
-                        elements = shlex.split(message)
-                        system_comment = context.system_comment_map.get(
-                            elements[0])
-                        if system_comment:
-                            for idx, value in enumerate(elements[1:]):
-                                system_comment = system_comment.replace(
-                                    '{' + str(idx) + '}', value)
-                            message = system_comment
-
+                    message = get_comment_msg(comment)
                     result.append(CommentData(
                         comment.id,
                         comment.author,
@@ -1783,7 +1817,7 @@ class ThriftRequestHandler(object):
             missing_doc += "[ClangSA](" + sa_link + ")"
         elif "-" in checkerId:
             tidy_link = "http://clang.llvm.org/extra/clang-tidy/checks/" + \
-                      checkerId + ".html"
+                checkerId + ".html"
             missing_doc += "[ClangTidy](" + tidy_link + ")"
         missing_doc += " homepage."
 
@@ -1881,10 +1915,10 @@ class ThriftRequestHandler(object):
             is_unique = report_filter is not None and report_filter.isUnique
             if is_unique:
                 q = session.query(func.max(Report.checker_id).label(
-                                      'checker_id'),
-                                  func.max(Report.severity).label(
-                                      'severity'),
-                                  Report.bug_id)
+                    'checker_id'),
+                    func.max(Report.severity).label(
+                    'severity'),
+                    Report.bug_id)
             else:
                 q = session.query(Report.checker_id,
                                   Report.severity,
@@ -1935,8 +1969,8 @@ class ThriftRequestHandler(object):
             is_unique = report_filter is not None and report_filter.isUnique
             if is_unique:
                 q = session.query(func.max(Report.analyzer_name).label(
-                                      'analyzer_name'),
-                                  Report.bug_id)
+                    'analyzer_name'),
+                    Report.bug_id)
             else:
                 q = session.query(Report.analyzer_name,
                                   func.count(Report.id))
@@ -2017,8 +2051,8 @@ class ThriftRequestHandler(object):
             is_unique = report_filter is not None and report_filter.isUnique
             if is_unique:
                 q = session.query(func.max(Report.checker_message).label(
-                                      'checker_message'),
-                                  Report.bug_id)
+                    'checker_message'),
+                    Report.bug_id)
             else:
                 q = session.query(Report.checker_message,
                                   func.count(Report.id))
@@ -2419,8 +2453,8 @@ class ThriftRequestHandler(object):
 
         with DBSession(self.__Session) as session:
             check_new_run_name = session.query(Run) \
-                    .filter(Run.name == new_run_name) \
-                    .all()
+                .filter(Run.name == new_run_name) \
+                .all()
             if check_new_run_name:
                 msg = "New run name '" + new_run_name + "' already exists."
                 LOG.error(msg)

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -627,7 +627,8 @@ def get_report_details(session, report_ids):
     comment_data_list = defaultdict(list)
     comment_query = session.query(Comment, Report.id)\
         .filter(Report.id.in_(report_ids)) \
-        .outerjoin(Report, Report.bug_id == Comment.bug_hash)
+        .outerjoin(Report, Report.bug_id == Comment.bug_hash) \
+        .order_by(Comment.created_at.desc())
 
     for data, report_id in comment_query:
         report_id = report_id

--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -4228,9 +4228,9 @@
       "dev": true
     },
     "codechecker-api": {
-      "version": "6.36.0",
-      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.36.0.tgz",
-      "integrity": "sha512-ajSdUVFAsXkOpxxLfyo6q3nxvl48POs9NHlLC+9Z/NuzwCapwXKy97DxdsJVy0N3Z2KPPxiWdQSEx+5Rsgf6iA==",
+      "version": "6.36.0-dev1",
+      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.36.0-dev1.tgz",
+      "integrity": "sha512-CFT6XIJ9lWRyIvCFgDScXIzWEEa2md1XO6j6QvP6DyuJ6p4x8idr6t8APGc2TMnK7zhI5yFujNYA2kmwpkEgSw==",
       "requires": {
         "thrift": "0.13.0-hotfix.1"
       }

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@mdi/font": "^5.3.45",
-    "codechecker-api": "6.36.0",
+    "codechecker-api": "6.36.0-dev1",
     "chart.js": "^2.9.3",
     "chartjs-plugin-datalabels": "^0.7.0",
     "codemirror": "^5.55.0",

--- a/web/tests/functional/comment/test_comment.py
+++ b/web/tests/functional/comment/test_comment.py
@@ -182,6 +182,16 @@ class TestComment(unittest.TestCase):
         self.assertEqual(user_comments[0].message, new_msg)
         self.assertEqual(len(system_comments), 1)
 
+        # Test user and system comments fetched
+        details = self._cc_client.getReportDetails(bug.reportId)
+        user_c, system_c = separate_comments(details.comments)
+
+        self.assertEqual(len(user_c), len(user_comments))
+        self.assertEqual(user_c[0].message, user_comments[0].message)
+
+        self.assertEqual(len(system_c), len(system_comments))
+        self.assertEqual(system_c[0].message, system_comments[0].message)
+
         # Remove the last comment for the first bug
         success = self._cc_client.removeComment(user_comments[0].id)
         self.assertTrue(success)


### PR DESCRIPTION
## Drawback with the Previous System
The command `CodeChecker cmd results` was not able to fetch all the comments appropriately from the `CodeChecker server`. In many runs, the comments were displayed as `""`, thus making it impossible to use Codechecker as an exporter.

## Functionality Added
Comments are fetched and formatted appropriately. The comments are fetched with the command
```sh
CodeChecker cmd results <run_name> -o json --details
```
- [x] Implementation 
- [x] Tests

Fixes #3005 
