### PR TITLE
create venv with interpreter instead of the virtualenv command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,14 +145,14 @@ standalone_package: venv package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && \
+	python3 -m venv venv && \
 		$(ACTIVATE_RUNTIME_VENV) && \
 		pip3 install -r $(CC_ANALYZER)/requirements.txt && \
 		pip3 install -r $(CC_WEB)/requirements.txt
 
 venv_osx:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && \
+	python3 -m venv venv && \
 		$(ACTIVATE_RUNTIME_VENV) && \
 		pip3 install -r $(CC_ANALYZER)/requirements_py/osx/requirements.txt && \
 		pip3 install -r $(CC_WEB)/requirements_py/osx/requirements.txt
@@ -170,7 +170,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && $(PIP_DEV_DEPS_CMD)
 
 clean_venv_dev:

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -27,7 +27,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/analyzer/tools/merge_clang_extdef_mappings/Makefile
+++ b/analyzer/tools/merge_clang_extdef_mappings/Makefile
@@ -24,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/analyzer/tools/statistics_collector/Makefile
+++ b/analyzer/tools/statistics_collector/Makefile
@@ -24,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,7 +169,7 @@ The following commands are used to bootstrap CodeChecker on Ubuntu 20.04 LTS:
 # NOTE: clang or clang-tidy can be any sufficiently fresh version, and need not
 #       come from package manager!
 sudo apt-get install clang clang-tidy build-essential curl doxygen gcc-multilib \
-      git python3-virtualenv python3-dev
+      git python3-dev python3-venv
 
 # Install nodejs dependency for web. In case of Debian/Ubuntu you can use the
 # following commands. For more information see the official docs:
@@ -215,7 +215,7 @@ out-of-the-box. To fix this issue, run the following command to upgrade your
 
 ```sh
 cd ~/codechecker/venv
-virtualenv -p /usr/bin/python3 .
+python3 -m venv .
 ```
 
 ## Mac OS X

--- a/tools/codechecker_report_hash/Makefile
+++ b/tools/codechecker_report_hash/Makefile
@@ -24,11 +24,11 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/tools/plist_to_html/Makefile
+++ b/tools/plist_to_html/Makefile
@@ -31,14 +31,14 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
 
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/tools/report-converter/Makefile
+++ b/tools/report-converter/Makefile
@@ -23,14 +23,14 @@ all: package
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_RUNTIME_VENV)
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
 
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:

--- a/tools/tu_collector/Makefile
+++ b/tools/tu_collector/Makefile
@@ -16,7 +16,7 @@ ACTIVATE_VENV ?= . venv/bin/activate
 
 venv:
 	# Create a virtual environment which can be used to run the build package.
-	virtualenv -p ${PYTHON_BIN} venv && $(ACTIVATE_VENV)
+	python3 -m venv venv && $(ACTIVATE_VENV)
 
 default: all
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -49,7 +49,7 @@ pip_dev_deps:
 
 venv_dev:
 	# Create a virtual environment for development.
-	virtualenv -p ${PYTHON_BIN} venv_dev && \
+	python3 -m venv venv_dev && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
 
 clean_venv_dev:


### PR DESCRIPTION
Installing some dependencies (psutil) might fail if the virtual environment
was created with the virtualenv command.
See: https://stackoverflow.com/questions/60423668/psutil-fails-to-pip-install-inside-python3-virtualenv-fatal-error-python-h-no