### PR TITLE
[server] Verify TLS certificate in LDAPS connections

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -182,6 +182,11 @@ servers as it can elongate the authentication process.
    URL of the LDAP server which will be queried for user information and group
    membership.
 
+ * `tls_require_cert`
+
+   If set to `never`, skip verification of certificate in LDAPS connections
+   (!!! INSECURE !!!).
+
  * `username`
 
    Optional username for LDAP bind, if not set bind with the login credentials
@@ -268,7 +273,8 @@ servers as it can elongate the authentication process.
       "groupNameAttr" : "sAMAccountName"
     },
     {
-      "connection_url" : "ldaps://secure.internal.example.org:636",
+      "connection_url"   : "ldaps://secure.internal.example.org:636",
+      "tls_require_cert" : null,
       "username" : null,
       "password" : null,
       "referrals" : false,

--- a/web/server/codechecker_server/auth/cc_ldap.py
+++ b/web/server/codechecker_server/auth/cc_ldap.py
@@ -230,8 +230,8 @@ class LDAPConnection(object):
             self.connection = None
             return
 
-        referals = ldap_config.get('referals', False)
-        ldap.set_option(ldap.OPT_REFERRALS, 1 if referals else 0)
+        referrals = ldap_config.get('referrals', False)
+        ldap.set_option(ldap.OPT_REFERRALS, 1 if referrals else 0)
 
         deref = ldap_config.get('deref', ldap.DEREF_ALWAYS)
         if deref == 'never':

--- a/web/server/codechecker_server/auth/cc_ldap.py
+++ b/web/server/codechecker_server/auth/cc_ldap.py
@@ -132,6 +132,10 @@ def ldap_error_handler():
     except ldap.FILTER_ERROR as ex:
         LOG.error("Filter error: %s", str(ex))
 
+    except ldap.SERVER_DOWN:
+        LOG.error("Can't connect to LDAP server,"
+                  " or LDAPS certificate verification failed")
+
     except ldap.LDAPError as err:
         LOG.error("Exception ldap.%s (%s)",
                   type(err).__name__, str(err))

--- a/web/server/codechecker_server/auth/cc_ldap.py
+++ b/web/server/codechecker_server/auth/cc_ldap.py
@@ -18,6 +18,7 @@ In the configuration `null` means it is not configured.
   "authorities": [
     {
       "connection_url" : null,
+      "tls_require_cert" : null,
       "username" : null,
       "password" : null,
       "referrals" : false,
@@ -242,8 +243,12 @@ class LDAPConnection(object):
 
         ldap.protocol_version = ldap.VERSION3
 
-        # Check cert if available but do not fail if not.
-        ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+        # Verify certificate in LDAPS connections
+        tls_require_cert = ldap_config.get('tls_require_cert', '')
+        if tls_require_cert.lower() == 'never':
+            LOG.debug("Insecure LDAPS connection because of "
+                      "tls_require_cert=='never'")
+            ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
         self.connection = ldap.initialize(ldap_server, bytes_mode=False)
 

--- a/web/server/codechecker_server/auth/cc_ldap.py
+++ b/web/server/codechecker_server/auth/cc_ldap.py
@@ -133,7 +133,8 @@ def ldap_error_handler():
         LOG.error("Filter error: %s", str(ex))
 
     except ldap.LDAPError as err:
-        LOG.error("LDAP Error: %s", str(err))
+        LOG.error("Exception ldap.%s (%s)",
+                  type(err).__name__, str(err))
 
 
 def get_user_dn(con,


### PR DESCRIPTION
If LDAP authentication is used in the server and the LDAP server
connection is using LDAPS, then reject the connection if the certificate
is not trusted by the system.

This can be overriden by setting the environment variable
LDAPTLS_REQCERT=never just like in the ldapsearch command.

NOTE: The option used before to skip the SSL certificate verification
was OPT_X_TLS_ALLOW, which is documented in python-ldap as "used
internally by slapd server". Thus the one used now is OPT_X_TLS_NEVER.

Resolves #3082