### PR TITLE
[analyzer] Fix skipping report from plist

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -238,12 +238,6 @@ def handle_success(rh, result_file, result_base, skip_handler,
     save_metadata(result_file, rh.analyzer_result_file,
                   rh.analyzed_source_file)
 
-    if skip_handler:
-        # We need to check the plist content because skipping
-        # reports in headers can be done only this way.
-        plist_parser.skip_report_from_plist(result_file,
-                                            skip_handler)
-
 
 def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
     """

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/output_converter.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/output_converter.py
@@ -15,6 +15,7 @@ import copy
 import json
 import os
 import plistlib
+import portalocker
 import re
 
 from codechecker_common.logger import get_logger
@@ -380,9 +381,11 @@ class PListConverter(object):
         """
         Writes out the plist XML to the given path.
         """
-
-        with open(path, 'wb') as file:
+        with portalocker.Lock(path, 'wb+') as file:
             self.write(file)
+
+            file.flush()
+            os.fsync(file.fileno())
 
     def write(self, file):
         """


### PR DESCRIPTION
Lets suppose that we are running the CodeChecker analyze command by using
multi cores and we are also using a skip file.

If the compilation database contains two translation units which
different only in the `-o` parameter, it will produce the same plist file.
It is possible that we try to modify this file from 2 threads
to skip reports from header files in a non-thread safe way. This way
the plist files may be corrupted.

In this patch we will use portalocker to lock the file before touching
it to make sure that only 1 process is writing to this file in the same time.