### PR TITLE
[web] Remove docker container after API generation is done

### DIFF
--- a/web/api/Makefile
+++ b/web/api/Makefile
@@ -33,6 +33,7 @@ target_dirs:
 
 build: clean target_dirs
 	docker run \
+	  --rm \
 	  -u "$(uid):$(guid)" \
 	  -v $(API_DIR):/data \
 	  thrift:$(THRIFT_VERSION) \


### PR DESCRIPTION
The thrift api stubs are generated by using docker. If the generation
is done we can remove the docker container automatically to not mess up
our system with exited containers.