### PR TITLE
[cmd][api] Exporter/Importer command for CodeChecker cmd

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,9 @@ subcommand (`CodeChecker cmd --help`):
 | `products` | Access subcommands related to configuring the products managed by a CodeChecker server. |
 | `components` | Access subcommands related to configuring the source components managed by a CodeChecker server. |
 | `login` | Authenticate into CodeChecker servers that require privileges. |
+| `export` | Export comments and review statuses from CodeChecker. |
+| `import` | Import comments and review statuses into CodeChecker. |
+
 
 # Usage flow
 ![Usage diagram](images/usage_flow.png)

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -37,6 +37,8 @@ Table of Contents
             * [Import suppressions between server and suppress file](#import-suppressions)
         * [`products` (Manage product configuration of a server)](#cmd-product)
         * [`login` (Authenticate to the server)](#cmd-login)
+        * [`export` (Export comments and review statuses from CodeChecker)](#cmd-export)
+        * [`import` (Import comments and review statuses into CodeChecker)](#cmd-import)
 * [Debugging CodeChecker](#debug)
 
 # CodeChecker <a name="codechecker"></a>
@@ -524,7 +526,7 @@ viewer server on its port is available in the `cmd` tool.
 
 ```
 usage: CodeChecker cmd [-h]
-                       {runs,history,results,diff,sum,token,del,update,suppress,products,components,login}
+                       {runs,history,results,diff,sum,token,del,update,suppress,products,components,login,export,import}
                        ...
 
 The command-line client is used to connect to a running 'CodeChecker server'
@@ -536,7 +538,7 @@ optional arguments:
   -h, --help            show this help message and exit
 
 available actions:
-  {runs,history,results,diff,sum,token,del,update,suppress,products,components,login}
+  {runs,history,results,diff,sum,token,del,update,suppress,products,components,login,export,import}
     runs                List the available analysis runs.
     history             Show run history of multiple runs.
     results             List analysis result (finding) summary for a given
@@ -555,6 +557,8 @@ available actions:
                         components managed by a CodeChecker server.
     login               Authenticate into CodeChecker servers that require
                         privileges.
+    export              Export comments and review statues for a given run, or
+                        if no run is provided, data from all runs is exported
 ```
 
 The operations available in `cmd` **always** require a running CodeChecker
@@ -1577,6 +1581,41 @@ not found, the user will be asked, in the command-line, to provide credentials.
 
 ```sh
 CodeChecker parse ./my_plists --suppress generated.suppress --export-source-suppress
+```
+
+### Export comments and review statuses (`export`) <a name="cmd-export"></a>
+
+```sh
+usage: CodeChecker cmd export [-h] [-n RUN_NAME [RUN_NAME ...]]
+                              [--url PRODUCT_URL]
+                              [--verbose {info,debug_analyzer,debug}]
+
+Export data (comments, review statuses) from a running CodeChecker server into
+a json format
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n RUN_NAME [RUN_NAME ...], --name RUN_NAME [RUN_NAME ...]
+                        Name of the analysis run.
+```
+ For redirecting the output to a json file, use the command:
+ ```sh
+ CodeChecker cmd export -n <run_name_1> <run_name_2> ... 2>/dev/null | python -m json.tool > <file_name>.json
+ ```
+ In the above command multiple runs can be pass as, the `...` indicate any additional runs, if needed to be provided
+
+
+### Import comments and review statuses into Codechecker (`import`) <a name="cmd-import"></a>
+```sh
+usage: CodeChecker cmd import [-h] -i JSON_FILE [--url PRODUCT_URL]
+                              [--verbose {info,debug_analyzer,debug}]
+
+Import the results into CodeChecker server
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i JSON_FILE, --import JSON_FILE
+                        Import findings from the json file into the database.
 ```
 
 # Debugging CodeChecker <a name="debug"></a>

--- a/web/api/js/codechecker-api-js/package.json
+++ b/web/api/js/codechecker-api-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api-js",
-  "version": "6.37.0",
+  "version": "6.37.0-dev5",
   "description": "Generated jQuery compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/js/codechecker-api-node/package.json
+++ b/web/api/js/codechecker-api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api",
-  "version": "6.37.0",
+  "version": "6.37.0-dev5",
   "description": "Generated node.js compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/py/codechecker_api/setup.py
+++ b/web/api/py/codechecker_api/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.37.0'
+api_version = '6.37.0-dev5'
 
 setup(
     name='codechecker_api',

--- a/web/api/py/codechecker_api_shared/setup.py
+++ b/web/api/py/codechecker_api_shared/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.37.0'
+api_version = '6.37.0-dev5'
 
 setup(
     name='codechecker_api_shared',

--- a/web/api/report_server.thrift
+++ b/web/api/report_server.thrift
@@ -362,6 +362,11 @@ struct AnalysisFailureInfo {
 }
 typedef map<string, list<AnalysisFailureInfo>> FailedFiles
 
+struct ExportData {
+  1: map<string, CommentDataList> comments,   // Map comments to report hashes.
+  2: map<string, ReviewData>      reviewData, // Map review data to report hashes.
+}
+
 service codeCheckerDBAccess {
 
   // Gives back all analyzed runs.
@@ -724,4 +729,14 @@ service codeCheckerDBAccess {
   AnalyzerStatisticsData getAnalysisStatistics(1: i64 runId,
                                                2: i64 runHistoryId)
                                                throws (1: codechecker_api_shared.RequestFailed requestError),
+  
+  // Export data from the server
+  // PERMISSION: PRODUCT_ACCESS
+  ExportData exportData(1: RunFilter runFilter)
+                        throws (1: codechecker_api_shared.RequestFailed requestError),
+
+  // Import data from the server.
+  // PERMISSION: PRODUCT_ADMIN
+  bool importData(1: ExportData exportData)
+                  throws (1: codechecker_api_shared.RequestFailed requestError),  
 }

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -1176,6 +1176,21 @@ def __register_export(parser):
                         help="Name of the analysis run.")
 
 
+def __register_importer(parser):
+    """
+    Add argparser subcommand for the "import run by run name action"
+    """
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-i', '--import',
+                       type=str,
+                       dest="input",
+                       metavar='JSON_FILE',
+                       default=argparse.SUPPRESS,
+                       help="Import findings from the json file into "
+                       "the database.")
+
+
 def __register_token(parser):
     """
     Add argparse subcommand parser for the "handle token" action.
@@ -1447,12 +1462,23 @@ full runs.""",
         'export',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="Export data (comments, review statuses) from a running "
-        "CodeChecker server into a json format",
+                    "CodeChecker server into a json format",
         help="Export data from a CodeChecker server to json format."
     )
     __register_export(export)
     export.set_defaults(func=cmd_line_client.handle_export)
     __add_common_arguments(export)
+
+    importer = subcommands.add_parser(
+        'import',
+        formatter_class=arg.RawDescriptionDefaultHelpFormatter,
+        description="Import the results into CodeChecker server",
+        help="Import the analysis from a json file exported by the "
+             "'CodeChecker cmd export' command into CodeChecker"
+    )
+    __register_importer(importer)
+    importer.set_defaults(func=cmd_line_client.handle_import)
+    __add_common_arguments(importer)
 
 
 # 'cmd' does not have a main() method in itself, as individual subcommands are

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -1163,6 +1163,19 @@ def __register_run_histories(parser):
                              "runs.")
 
 
+def __register_export(parser):
+    """
+    Add argparser subcommand for the "export run by run name action"
+    """
+    parser.add_argument('-n', '--name',
+                        type=str,
+                        nargs='+',
+                        dest="names",
+                        metavar='RUN_NAME',
+                        default=argparse.SUPPRESS,
+                        help="Name of the analysis run.")
+
+
 def __register_token(parser):
     """
     Add argparse subcommand parser for the "handle token" action.
@@ -1429,6 +1442,18 @@ full runs.""",
     __register_login(login)
     login.set_defaults(func=cmd_line_client.handle_login)
     __add_common_arguments(login, needs_product_url=False)
+
+    export = subcommands.add_parser(
+        'export',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Export data (comments, review statuses) from a running "
+        "CodeChecker server into a json format",
+        help="Export data from a CodeChecker server to json format."
+    )
+    __register_export(export)
+    export.set_defaults(func=cmd_line_client.handle_export)
+    __add_common_arguments(export)
+
 
 # 'cmd' does not have a main() method in itself, as individual subcommands are
 # handled later on separately.

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1660,3 +1660,49 @@ def handle_export(args):
 
     report = client.exportData(run_filter)
     print(CmdLineOutputEncoder().encode(report))
+
+
+def handle_import(args):
+    """
+    Argument handler for the 'CodeChecker cmd import' subcommand
+    """
+
+    init_logger(args.verbose if 'verbose' in args else None)
+
+    client = setup_client(args.product_url)
+
+    data = util.load_json_or_empty(args.input, default=None)
+    if not data:
+        LOG.error("Failed to import data!")
+        sys.exit(1)
+
+    # Convert Json comments into CommentDataList
+    comment_data_list = defaultdict(list)
+    for bug_hash, comments in data['comments'].items():
+        for comment in comments:
+            comment_data = ttypes.CommentData(
+                id=comment['id'],
+                author=comment['author'],
+                message=comment['message'],
+                createdAt=comment['createdAt'],
+                kind=comment['kind'])
+            comment_data_list[bug_hash].append(comment_data)
+
+    # Convert Json reviews into ReviewData
+    review_data_list = {}
+    for bug_hash, review in data['reviewData'].items():
+        review_data_list[bug_hash] = ttypes.ReviewData(
+            status=review['status'],
+            comment=review['comment'],
+            author=review['author'],
+            date=review['date'])
+
+    exportData = ttypes.ExportData(comments=comment_data_list,
+                                   reviewData=review_data_list)
+
+    status = client.importData(exportData)
+    if not status:
+        LOG.error("Failed to import data!")
+        sys.exit(1)
+
+    LOG.info("Import successful!")

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1469,7 +1469,7 @@ def handle_list_result_types(args):
             confirmed=checker_count(confirmed_checkers, key),
             false_positive=checker_count(false_checkers, key),
             intentional=checker_count(intentional_checkers, key)
-         ))
+        ))
         total['total_reports'] += checker_data.count
         total['total_unreviewed'] += checker_count(unrev_checkers, key)
         total['total_confirmed'] += checker_count(confirmed_checkers, key)
@@ -1643,3 +1643,20 @@ def handle_list_run_histories(args):
                          h.description if h.description else ''))
 
         print(twodim.to_str(args.output_format, header, rows))
+
+
+def handle_export(args):
+
+    stream = 'stderr'
+    init_logger(args.verbose if 'verbose' in args else None, stream)
+
+    client = setup_client(args.product_url)
+    run_filter = process_run_filter_conditions(args)
+
+    runs = get_run_data(client, run_filter)
+    if not runs:
+        LOG.warning("No runs found")
+        sys.exit(1)
+
+    report = client.exportData(run_filter)
+    print(CmdLineOutputEncoder().encode(report))

--- a/web/client/codechecker_client/helpers/results.py
+++ b/web/client/codechecker_client/helpers/results.py
@@ -134,6 +134,13 @@ class ThriftResultsHelper(BaseClientHelper):
                          offset):
         pass
 
+    @ThriftClientCall
+    def exportData(self, runId):
+        pass
+
+    @ThriftClientCall
+    def importData(self, exportData):
+        pass
     # SOURCE COMPONENT RELATED API CALLS
 
     @ThriftClientCall

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,5 +4,5 @@ alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
 
-codechecker_api==6.37.0
-codechecker_api_shared==6.37.0
+codechecker_api==6.37.0-dev5
+codechecker_api_shared==6.37.0-dev5

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -5,5 +5,5 @@ pg8000==1.15.2
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.37.0
-codechecker_api_shared==6.37.0
+codechecker_api==6.37.0-dev5
+codechecker_api_shared==6.37.0-dev5

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -5,5 +5,5 @@ psycopg2-binary==2.8.5
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.37.0
-codechecker_api_shared==6.37.0
+codechecker_api==6.37.0-dev5
+codechecker_api_shared==6.37.0-dev5

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -11,8 +11,8 @@ nose==1.3.7
 mockldap==0.3.0
 mkdocs==1.0.4
 
-codechecker_api==6.37.0
-codechecker_api_shared==6.37.0
+codechecker_api==6.37.0-dev5
+codechecker_api_shared==6.37.0-dev5
 
 # publish packages to pypi
 twine

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -4,5 +4,5 @@ portalocker==1.7.0
 psutil==5.7.0
 sqlalchemy==1.3.16
 
-codechecker_api==6.37.0
-codechecker_api_shared==6.37.0
+codechecker_api==6.37.0-dev5
+codechecker_api_shared==6.37.0-dev5

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1549,72 +1549,67 @@ class ThriftRequestHandler(object):
         with DBSession(self.__Session) as session:
             return get_report_details(session, [reportId])[reportId]
 
-    def _setReviewStatus(self, session, report_id, status, message, date=None):
+    def _setReviewStatus(self, session, report_hash, status,
+                         message, date=None):
         """
         This function sets the review status of the given report. This is the
         implementation of changeReviewStatus(), but it is also extended with
         a session parameter which represents a database transaction. This is
         needed because during storage a specific session object has to be used.
         """
-        report = session.query(Report).get(report_id)
-        if report:
-            review_status = session.query(ReviewStatus).get(report.bug_id)
-            if review_status is None:
-                review_status = ReviewStatus()
-                review_status.bug_hash = report.bug_id
+        review_status = session.query(ReviewStatus).get(report_hash)
+        if review_status is None:
+            review_status = ReviewStatus()
+            review_status.bug_hash = report_hash
 
-            old_status = review_status.status or \
-                review_status_str(ttypes.ReviewStatus.UNREVIEWED)
-            old_msg = review_status.message or None
+        old_status = review_status.status or \
+            review_status_str(ttypes.ReviewStatus.UNREVIEWED)
+        old_msg = review_status.message or None
 
-            new_status = review_status_str(status)
-            new_user = self.__get_username()
-            new_message = message.encode('utf8') if message else b''
+        new_status = review_status_str(status)
+        new_user = self.__get_username()
+        new_message = message.encode('utf8') if message else b''
 
-            # Review status is a shared table among runs. When multiple runs
-            # are stored in parallel, there may be a race condition in updating
-            # review status fields. The most common reason of deadlocks is
-            # changing only the date to current date. This condition checks if
-            # something else is also changed other than dates.
-            # We assume that report status in source code comments belong to
-            # the first user who stored the reports. If another user stores the
-            # same project with same report status then we don't change it.
-            if (old_status, old_msg) == (new_status, new_message):
-                return True
-
-            review_status.status = new_status
-            review_status.author = new_user
-            review_status.message = new_message
-            review_status.date = date or datetime.now()
-            session.add(review_status)
-
-            # Create a system comment if the review status or the message
-            # is changed.
-            old_review_status = escape_whitespaces(old_status.capitalize())
-            new_review_status = \
-                escape_whitespaces(review_status.status.capitalize())
-            if message:
-                system_comment_msg = \
-                    'rev_st_changed_msg {0} {1} {2}'.format(
-                        old_review_status, new_review_status,
-                        escape_whitespaces(message))
-            else:
-                system_comment_msg = 'rev_st_changed {0} {1}'.format(
-                    old_review_status, new_review_status)
-
-            system_comment = self.__add_comment(review_status.bug_hash,
-                                                system_comment_msg,
-                                                CommentKindValue.SYSTEM,
-                                                review_status.date)
-            session.add(system_comment)
-
-            session.flush()
-
+        # Review status is a shared table among runs. When multiple runs
+        # are stored in parallel, there may be a race condition in updating
+        # review status fields. The most common reason of deadlocks is
+        # changing only the date to current date. This condition checks if
+        # something else is also changed other than dates.
+        # We assume that report status in source code comments belong to
+        # the first user who stored the reports. If another user stores the
+        # same project with same report status then we don't change it.
+        if (old_status, old_msg) == (new_status, new_message):
             return True
+
+        review_status.status = new_status
+        review_status.author = new_user
+        review_status.message = new_message
+        review_status.date = date or datetime.now()
+        session.add(review_status)
+
+        # Create a system comment if the review status or the message
+        # is changed.
+        old_review_status = escape_whitespaces(old_status.capitalize())
+        new_review_status = \
+            escape_whitespaces(review_status.status.capitalize())
+        if message:
+            system_comment_msg = \
+                'rev_st_changed_msg {0} {1} {2}'.format(
+                    old_review_status, new_review_status,
+                    escape_whitespaces(message))
         else:
-            msg = "No report found in the database."
-            raise codechecker_api_shared.ttypes.RequestFailed(
-                codechecker_api_shared.ttypes.ErrorCode.DATABASE, msg)
+            system_comment_msg = 'rev_st_changed {0} {1}'.format(
+                old_review_status, new_review_status)
+
+        system_comment = self.__add_comment(review_status.bug_hash,
+                                            system_comment_msg,
+                                            CommentKindValue.SYSTEM,
+                                            review_status.date)
+        session.add(system_comment)
+
+        session.flush()
+
+        return True
 
     @exc_to_thrift_reqfail
     @timeit
@@ -1641,7 +1636,14 @@ class ThriftRequestHandler(object):
                 codechecker_api_shared.ttypes.ErrorCode.GENERAL, msg)
 
         with DBSession(self.__Session) as session:
-            res = self._setReviewStatus(session, report_id, status, message)
+            report = session.query(Report).get(report_id)
+            if report:
+                res = self._setReviewStatus(
+                    session, report.bug_id, status, message)
+            else:
+                raise codechecker_api_shared.ttypes.RequestFailed(
+                    codechecker_api_shared.ttypes.ErrorCode.DATABASE,
+                    "No report found in the database.")
             session.commit()
 
             LOG.info("Review status of report '%s' was changed to '%s' by %s.",
@@ -2830,7 +2832,7 @@ class ThriftRequestHandler(object):
                             rw_status = ttypes.ReviewStatus.INTENTIONAL
 
                         self._setReviewStatus(session,
-                                              report_id,
+                                              bug_id,
                                               rw_status,
                                               src_comment_data[0]['message'],
                                               run_history_time)
@@ -3338,3 +3340,57 @@ class ThriftRequestHandler(object):
 
         return ExportData(comments=comment_data_list,
                           reviewData=review_data_list)
+
+    @exc_to_thrift_reqfail
+    @timeit
+    def importData(self, exportData):
+        self.__require_admin()
+        with DBSession(self.__Session) as session:
+
+            # Logic for importing comments
+            comment_bug_ids = list(exportData.comments.keys())
+            comment_query = session.query(Comment) \
+                .filter(Comment.bug_hash.in_(comment_bug_ids)) \
+                .order_by(Comment.created_at.desc())
+            comments_in_db = defaultdict(list)
+            for comment in comment_query:
+                comments_in_db[comment.bug_hash].append(comment)
+            for bug_hash, comments in exportData.comments.items():
+                db_comments = comments_in_db[bug_hash]
+                for comment in comments:
+                    date = datetime.strptime(comment.createdAt,
+                                             '%Y-%m-%d %H:%M:%S.%f')
+                    message = comment.message.encode('utf-8') \
+                        if comment.message else b''
+                    # See if the comment is already in the database.
+                    if any(c.created_at == date and
+                           c.kind == comment.kind and
+                           c.message == message for c in db_comments):
+                        continue
+                    c = Comment(bug_hash, comment.author, message,
+                                comment.kind, date)
+                    session.add(c)
+
+            # Logic for importing review status
+            review_bug_ids = list(exportData.reviewData.keys())
+            review_query = session.query(ReviewStatus) \
+                .filter(ReviewStatus.bug_hash.in_(review_bug_ids)) \
+                .order_by(ReviewStatus.date.desc())
+            db_review_data = {}
+            for review_status in review_query:
+                db_review_data[review_status.bug_hash] = review_status
+            for bug_hash, imported_review in exportData.reviewData.items():
+                db_status = db_review_data.get(bug_hash)
+                # The status is up-to-date.
+                if db_status and str(db_status.date) == imported_review.date:
+                    continue
+                date = datetime.strptime(imported_review.date,
+                                         '%Y-%m-%d %H:%M:%S.%f')
+                self._setReviewStatus(session,
+                                      bug_hash,
+                                      imported_review.status,
+                                      imported_review.comment,
+                                      date)
+
+            session.commit()
+            return True

--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -4255,9 +4255,9 @@
       "dev": true
     },
     "codechecker-api": {
-      "version": "6.37.0",
-      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.37.0.tgz",
-      "integrity": "sha512-6/kYb8sdlCL167Zc7KlsEGmns1bAQkOYlNwST5DOQSyn8MHTa2zVb4kN206lJ7pVxREg+J2A8/VF/zrQ97Tr+Q==",
+      "version": "6.37.0-dev5",
+      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.37.0-dev5.tgz",
+      "integrity": "sha512-GagiXoQ/NsnMQtyjSRpkKfEPAxgkG9j/kfyg/xpkoM5NRnnqjFfKuOebbkD6HLkDa2hWJjUzUuVjwh2LltTcNw==",
       "requires": {
         "thrift": "0.13.0-hotfix.1"
       }

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@mdi/font": "^5.3.45",
-    "codechecker-api": "6.37.0",
+    "codechecker-api": "6.37.0-dev5",
     "chart.js": "^2.9.3",
     "chartjs-plugin-datalabels": "^0.7.0",
     "codemirror": "^5.55.0",

--- a/web/tests/functional/export_import/__init__.py
+++ b/web/tests/functional/export_import/__init__.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Setup for the test package export_import.
+"""
+
+
+import os
+import shutil
+import sys
+import uuid
+
+from libtest import codechecker
+from libtest import env
+from libtest import project
+
+
+# Test workspace should be initialized in this module.
+TEST_WORKSPACE = None
+
+
+def setup_package():
+    """Setup the environment for testing export and import."""
+
+    global TEST_WORKSPACE
+    TEST_WORKSPACE = env.get_workspace('export_import')
+
+    # Set the TEST_WORKSPACE used by the tests.
+    os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+
+    test_config = {}
+
+    test_project = 'cpp'
+
+    project_info = project.get_info(test_project)
+
+    # Copy the test project to the workspace. The tests should
+    # work only on this test project.
+    test_proj_path = os.path.join(TEST_WORKSPACE, "test_proj")
+    shutil.copytree(project.path(test_project), test_proj_path)
+
+    project_info['project_path'] = test_proj_path
+
+    # Generate a unique name for this test run.
+    test_project_name = project_info['name'] + '_' + uuid.uuid4().hex
+
+    test_config['test_project'] = project_info
+
+    # Suppress file should be set here if needed by the tests.
+    suppress_file = None
+
+    # Skip list file should be set here if needed by the tests.
+    skip_list_file = None
+
+    # Get an environment which should be used by the tests.
+    test_env = env.test_env(TEST_WORKSPACE)
+
+    # Create a basic CodeChecker config for the tests, this should
+    # be imported by the tests and they should only depend on these
+    # configuration options.
+    codechecker_cfg = {
+        'suppress_file': suppress_file,
+        'skip_list_file': skip_list_file,
+        'check_env': test_env,
+        'workspace': TEST_WORKSPACE,
+        'checkers': []
+    }
+
+    # Start or connect to the running CodeChecker server and get connection
+    # details.
+    print("This test uses a CodeChecker server... connecting...")
+    server_access = codechecker.start_or_get_server()
+    server_access['viewer_product'] = 'export_import'
+    codechecker.add_test_package_product(server_access, TEST_WORKSPACE)
+
+    # Extend the checker configuration with the server access.
+    codechecker_cfg.update(server_access)
+
+    # Clean the test project, if needed by the tests.
+    ret = project.clean(test_project)
+    if ret:
+        sys.exit(ret)
+
+    # Check the test project, if needed by the tests.
+    ret = codechecker.check_and_store(codechecker_cfg,
+                                      test_project_name,
+                                      project.path(test_project))
+    if ret:
+        sys.exit(1)
+    print("Analyzing the test project was successful.")
+
+    # Save the run names in the configuration.
+    codechecker_cfg['run_names'] = [test_project_name]
+
+    test_config['codechecker_cfg'] = codechecker_cfg
+
+    # Export the test configuration to the workspace.
+    env.export_test_cfg(TEST_WORKSPACE, test_config)
+
+
+def teardown_package():
+    """Clean up after the test."""
+
+    # TODO: If environment variable is set keep the workspace
+    # and print out the path.
+    global TEST_WORKSPACE
+
+    check_env = env.import_test_cfg(TEST_WORKSPACE)[
+        'codechecker_cfg']['check_env']
+    codechecker.remove_test_package_product(TEST_WORKSPACE, check_env)
+
+    print("Removing: " + TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/web/tests/functional/export_import/test_export_import.py
+++ b/web/tests/functional/export_import/test_export_import.py
@@ -1,0 +1,157 @@
+#
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Report exporting and importing tests
+"""
+
+
+import os
+import unittest
+import logging
+import json
+import tempfile
+
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import CommentData, \
+    ReviewStatus, CommentKind, RunFilter
+
+from libtest import env
+from libtest.thrift_client_to_db import get_all_run_results
+import subprocess
+
+
+def get_user_comments(comments):
+    """
+    Separate comments and returns a tuple of user comments and system.
+    """
+    user_comments = [c for c in comments
+                     if c.kind == CommentKind.USER]
+
+    return user_comments
+
+
+class TestExport(unittest.TestCase):
+
+    _ccClient = None
+
+    def setUp(self):
+
+        # TEST_WORKSPACE is automatically set by test package __init__.py .
+        test_workspace = os.environ['TEST_WORKSPACE']
+
+        test_class = self.__class__.__name__
+        print('Running ' + test_class + ' tests in ' + test_workspace)
+
+        codechecker_cfg = env.import_test_cfg(test_workspace)[
+            'codechecker_cfg']
+        self.server_url = env.parts_to_url(codechecker_cfg)
+
+        # Get the test project configuration from the prepared test workspace.
+        self._testproject_data = env.setup_test_proj_cfg(test_workspace)
+        self.assertIsNotNone(self._testproject_data)
+
+        # Setup a viewer client to test viewer API calls.
+        self._cc_client = env.setup_viewer_client(test_workspace)
+        self.assertIsNotNone(self._cc_client)
+
+        # Get the CodeChecker cmd if needed for the tests.
+        self._codechecker_cmd = env.codechecker_cmd()
+
+        # Get the run names which belong to this test.
+        run_names = env.get_run_names(test_workspace)
+
+        runs = self._cc_client.getRunData(None, None, 0, None)
+        self.test_runs = [run for run in runs if run.name in run_names]
+
+    def test_export_import(self):
+        """
+        Test exporting and importing feature
+        """
+        run_filter = RunFilter()
+        run_filter.names = [self.test_runs[0].name]
+        logging.debug('Get all run results from the db for runid: ' +
+                      str(self.test_runs[0].runId))
+
+        run_results = get_all_run_results(
+            self._cc_client, self.test_runs[0].runId)
+        self.assertIsNotNone(run_results)
+        self.assertNotEqual(len(run_results), 0)
+
+        bug = run_results[0]
+
+        # There are no comments available for the first bug
+        comments = self._cc_client.getComments(bug.reportId)
+        self.assertEqual(len(comments), 0)
+
+        comment1 = CommentData(author='anybody', message='First msg')
+        success = self._cc_client.addComment(bug.reportId, comment1)
+        self.assertTrue(success)
+        logging.debug('Bug commented successfully')
+
+        # Try to add another new comment for the first bug
+        comment2 = CommentData(author='anybody', message='Second msg')
+        success = self._cc_client.addComment(bug.reportId, comment2)
+        self.assertTrue(success)
+        logging.debug('Bug commented successfully')
+
+        # Change review status
+        review_comment = 'This is really a bug'
+        status = ReviewStatus.CONFIRMED
+        success = self._cc_client.changeReviewStatus(
+            bug.reportId, status, review_comment)
+
+        self.assertTrue(success)
+        logging.debug('Bug review status changed successfully')
+
+        # Export the comments and reviews
+        exported = self._cc_client.exportData(run_filter)
+        exported_comments = exported.comments[bug.bugHash]
+        exported_review = exported.reviewData[bug.bugHash]
+
+        # Check if the comments are same
+        user_comments = get_user_comments(exported_comments)
+        self.assertEqual(user_comments[0].message, comment2.message)
+        self.assertEqual(user_comments[1].message, comment1.message)
+
+        # Check for the review status
+        self.assertEqual(exported_review.status, status)
+        self.assertEqual(exported_review.comment, review_comment)
+
+        new_export_command = [self._codechecker_cmd, 'cmd', 'export',
+                              '-n', self.test_runs[0].name,
+                              '--url', str(self.server_url)]
+
+        print(new_export_command)
+        out_json = subprocess.check_output(
+            new_export_command, encoding="utf-8", errors="ignore")
+        resolved_results = json.loads(out_json)
+        print(resolved_results)
+        with tempfile.NamedTemporaryFile() as component_f:
+            component_f.write(out_json.encode('utf-8'))
+            component_f.flush()
+            component_f.seek(0)
+
+            self._cc_client.removeComment(user_comments[0].id)
+            updated_message = "The new comment for testing"
+            self._cc_client.updateComment(user_comments[1].id, updated_message)
+
+            new_import_command = [self._codechecker_cmd, 'cmd', 'import',
+                                  '-i', component_f.name,
+                                  '--url', str(self.server_url)]
+            print(new_import_command)
+            subprocess.check_output(
+                new_import_command, encoding="utf-8", errors="ignore")
+
+            exported = self._cc_client.exportData(run_filter)
+            new_comments = exported.comments[bug.bugHash]
+            print(new_comments)
+
+            # Check if the last and second last comments
+            self.assertEqual(new_comments[-1].message, comment1.message)
+            self.assertEqual(new_comments[-2].message, updated_message)


### PR DESCRIPTION
## Exporter
An exclusive command for getting the comments and review statuses for a particular run, in JSON format from CodeChecker Server.  
Multiple run names can be provided for exporting the data simultaneously.
If no run name is provided, by default, data is exported for all the runs

### Usage
```sh
CodeChecker cmd export -n <run_name-1> <run_name-2>...  2>/dev/null | python -m json.tool > <run_name>.json
```

## Importer
A command for importing comments and review statuses from a json file into codechecker server

### Usage
```sh
CodeChecker cmd import -i <path_to_json_file>.json
```

Fixes #3076 

