### PR TITLE
[server] Add regex_groups authentication method

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -15,6 +15,7 @@ Table of Contents
         * [<i>PAM</i> authentication](#pam-authentication)
         * [<i>LDAP</i> authentication](#ldap-authentication)
             * [Configuration options](#configuration-options)
+    * Membership in custom groups with [<i>regex_groups</i>](#regex_groups-authentication)
 * [Client-side configuration](#client-side-configuration)
     * [Web-browser client](#web-browser-client)
     * [Command-line client](#command-line-client)
@@ -284,6 +285,32 @@ servers as it can elongate the authentication process.
   ]
 }
 ~~~
+
+## Membership in custom groups with <a name="regex_groups-authentication">regex_groups</a>
+
+Many regular expressions can be listed to define a group. Please note that the
+regular expressions are searched in the whole username string, so they should
+be properly anchored if you want to match only in the beginning or in the
+end. Regular expression matching follows the rules of Python's
+[re.search()](https://docs.python.org/3/library/re.html).
+
+The following example will create a group named `everybody` that contains
+every user regardless of the authentication method, and a group named `admins`
+that contains the user `root`, all usernames containing the string "whatever",
+and all usernames starting with `admin_` or ending with `_admin`.
+
+~~~{.json}
+"regex_groups": {
+  "enabled" : true,
+  "groups" : {
+      "everybody" : [ ".*" ],
+      "admins"    : [ "whatever", "^root$", "^admin_", "_admin$" ]
+  }
+}
+~~~
+
+When we manage permissions on the GUI we can give permission to these
+groups. For more information [see](permissions.md#managing-permissions).
 
 ----
 

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -296,15 +296,15 @@ end. Regular expression matching follows the rules of Python's
 
 The following example will create a group named `everybody` that contains
 every user regardless of the authentication method, and a group named `admins`
-that contains the user `root`, all usernames containing the string "whatever",
-and all usernames starting with `admin_` or ending with `_admin`.
+that contains the user `admin` and all usernames starting with `admin_` or
+ending with `_admin`.
 
 ~~~{.json}
 "regex_groups": {
   "enabled" : true,
   "groups" : {
       "everybody" : [ ".*" ],
-      "admins"    : [ "whatever", "^root$", "^admin_", "_admin$" ]
+      "admins"    : [ "^admin$", "^admin_", "_admin$" ]
   }
 }
 ~~~

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -196,14 +196,13 @@ class SessionManager(object):
         # Save the root SHA into the configuration (but only in memory!)
         self.__auth_config['method_root'] = root_sha
 
-        try:
-            self.__regex_groups_enabled = \
-                self.__auth_config['regex_groups'].get('enabled')
-        except KeyError:
-            self.__regex_groups_enabled = False
+        self.__regex_groups_enabled = False
 
         # Pre-compile the regular expressions of 'regex_groups'
         if 'regex_groups' in self.__auth_config:
+            self.__regex_groups_enabled = self.__auth_config['regex_groups'] \
+                                              .get('enabled', False)
+
             regex_groups = self.__auth_config['regex_groups'] \
                                .get('groups', [])
             d = dict()
@@ -501,13 +500,15 @@ class SessionManager(object):
         the username matches the regular expression of the group.
 
         """
+        if not self.__regex_groups_enabled:
+            return set()
+
         matching_groups = set()
-        if self.__regex_groups_enabled:
-            for group_name, regex_list \
-                    in self.__group_regexes_compiled.items():
-                for r in regex_list:
-                    if re.search(r, username):
-                        matching_groups.add(group_name)
+        for group_name, regex_list in self.__group_regexes_compiled.items():
+            for r in regex_list:
+                if re.search(r, username):
+                    matching_groups.add(group_name)
+
         return matching_groups
 
     @staticmethod

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import hashlib
 import json
 import os
+import re
 import uuid
 
 from codechecker_common.logger import get_logger
@@ -195,6 +196,21 @@ class SessionManager(object):
         # Save the root SHA into the configuration (but only in memory!)
         self.__auth_config['method_root'] = root_sha
 
+        try:
+            self.__regex_groups_enabled = \
+                self.__auth_config['regex_groups'].get('enabled')
+        except KeyError:
+            self.__regex_groups_enabled = False
+
+        # Pre-compile the regular expressions of 'regex_groups'
+        if 'regex_groups' in self.__auth_config:
+            regex_groups = self.__auth_config['regex_groups'] \
+                               .get('groups', [])
+            d = dict()
+            for group_name, regex_list in regex_groups.items():
+                d[group_name] = [re.compile(r) for r in regex_list]
+            self.__group_regexes_compiled = d
+
         # If no methods are configured as enabled, disable authentication.
         if scfg_dict['authentication'].get('enabled'):
             found_auth_method = False
@@ -333,23 +349,22 @@ class SessionManager(object):
 
         This validation object contains two keys: username and groups.
         """
-        validation = self.__try_auth_root(auth_string)
-        if validation:
-            return validation
+        validation = self.__try_auth_root(auth_string) \
+            or self.__try_auth_dictionary(auth_string) \
+            or self.__try_auth_pam(auth_string) \
+            or self.__try_auth_ldap(auth_string)
+        if not validation:
+            return False
 
-        validation = self.__try_auth_dictionary(auth_string)
-        if validation:
-            return validation
+        # If a validation method is enabled and regex_groups is enabled too,
+        # we will extend the 'groups'.
+        extra_groups = self.__try_regex_groups(validation['username'])
+        if extra_groups:
+            already_groups = set(validation['groups'])
+            validation['groups'] = list(already_groups | extra_groups)
 
-        validation = self.__try_auth_pam(auth_string)
-        if validation:
-            return validation
-
-        validation = self.__try_auth_ldap(auth_string)
-        if validation:
-            return validation
-
-        return False
+        LOG.debug('User validation details: %s', str(validation))
+        return validation
 
     def __is_method_enabled(self, method):
         return method not in UNSUPPORTED_METHODS and \
@@ -479,6 +494,21 @@ class SessionManager(object):
                 transaction.close()
 
         return False
+
+    def __try_regex_groups(self, username):
+        """
+        Return a set of groups that the user belongs to, depending on whether
+        the username matches the regular expression of the group.
+
+        """
+        matching_groups = set()
+        if self.__regex_groups_enabled:
+            for group_name, regex_list \
+                    in self.__group_regexes_compiled.items():
+                for r in regex_list:
+                    if re.search(r, username):
+                        matching_groups.add(group_name)
+        return matching_groups
 
     @staticmethod
     def get_user_name(auth_string):

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -48,6 +48,12 @@
       "groups": [
         "adm", "cc-users"
       ]
+    },
+    "regex_groups": {
+      "enabled" : false,
+      "groups" : {
+        "admins_custom_group" : [ "whatever", "^root$", "^admin_", "_admin$" ]
+      }
     }
   }
 }

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -52,7 +52,7 @@
     "regex_groups": {
       "enabled" : false,
       "groups" : {
-        "admins_custom_group" : [ "whatever", "^root$", "^admin_", "_admin$" ]
+        "admins_custom_group" : [ "^admin$", "^admin_", "_admin$" ]
       }
     }
   }

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -353,9 +353,10 @@ def enable_auth(workspace):
     scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
     scfg_dict["authentication"]["method_dictionary"]["auths"] = \
         ["cc:test", "john:doe", "admin:admin123", "colon:my:password",
-         "admin_group_user:admin123"]
+         "admin_group_user:admin123", "regex_admin:blah"]
     scfg_dict["authentication"]["method_dictionary"]["groups"] = \
         {"admin_group_user": ["admin_GROUP"]}
+    scfg_dict["authentication"]["regex_groups"]["enabled"] = True
 
     with open(server_cfg_file, 'w',
               encoding="utf-8", errors="ignore") as scfg:


### PR DESCRIPTION
This creates new groups that users can belong to if their username
matches some regular expression.

Makes it possible to have all users belonging to a group in order to set
default permissions for products.

Closes #3072.