### PR TITLE
[gui] Handle missing report

### DIFF
--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -111,7 +111,9 @@
             :to="{ name: 'report-detail', query: {
               ...$router.currentRoute.query,
               'report-id': item.reportId ? item.reportId : undefined,
-              'report-hash': item.reportId ? undefined : item.bugHash
+              'report-hash': item.bugHash,
+              'report-filepath': reportFilter.isUnique
+                ? `*${item.checkedFile}` : item.checkedFile
             }}"
             class="file-name"
           >


### PR DESCRIPTION
The server will remove reports from the database which have the same
report hash on run update. This can cause problem, when the user saves
the URL which contains a report id which is actually removed from
the database.

For this reason we will save the report hash and the file path in the
URL and if no report is found with the report id in the database we will
falback and search the report by report hash and file path.

If the report hash is not in the url or the report can not be found
by the report id or report hash we will display this information to
the user.