### PR TITLE
[client] Diff "resolved" reports of remote to local

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -917,6 +917,9 @@ def handle_diff_results(args):
                                                   diff_type,
                                                   None)
 
+        if not remote_hashes:
+            return filtered_reports, run_names
+
         if diff_type in [ttypes.DiffType.NEW, ttypes.DiffType.UNRESOLVED]:
             # Shows reports from the report dir which are not present in
             # the baseline (NEW reports) or appear in both side (UNRESOLVED

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -52,9 +52,13 @@ class LocalRemote(unittest.TestCase):
 
         self._local_test_project = \
             self._test_cfg['test_project']['project_path_local']
+        self._remote_test_project = \
+            self._test_cfg['test_project']['project_path_remote']
 
         self._local_reports = os.path.join(self._local_test_project,
                                            'reports')
+        self._remote_reports = os.path.join(self._remote_test_project,
+                                            'reports')
 
         self._url = env.parts_to_url(self._test_cfg['codechecker_cfg'])
 
@@ -599,3 +603,15 @@ class LocalRemote(unittest.TestCase):
         self.assertTrue(os.path.exists(index_html))
 
         shutil.rmtree(export_dir)
+
+    def test_diff_remote_local_resolved_same(self):
+        """ Test for resolved reports on same list remotely and locally. """
+        diff_cmd = [self._codechecker_cmd, "cmd", "diff",
+                    "--resolved",
+                    "--url", self._url,
+                    "-b", self._run_names[0],
+                    "-n", self._remote_reports,
+                    "-o", "json"]
+
+        out = self.run_cmd(diff_cmd)
+        self.assertEqual(json.loads(out), [])


### PR DESCRIPTION
1. Analyze a project to "reports" dir.
2. Store it in run named "hello"
3. CodeChecker cmd diff -b reports -n hello --resolved

This scenario shows all reports which is a bad behavior.

When server side fetches a set of reports from database, it uses a filter
object. If "reportHash" filter attribute is empty list, it means that no
report hash was selected for diffing, i.e. it takes all reports into
account.