### PR TITLE
[gui] Fix checker statistics difference

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatistics.vue
@@ -83,7 +83,7 @@ export default {
       this.statistics =
         await getCheckerStatistics(runIds, reportFilter, cmpData);
 
-      await this.fetchDifference("component");
+      await this.fetchDifference("checker");
 
       this.loading = false;
     }


### PR DESCRIPTION
Wrong field name was used in the CheckerStatistics component and
in compare mode wrong number were shown.