### PR TITLE
[gui] Open filters which set during page load

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/AnalyzerNameFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/AnalyzerNameFilter.vue
@@ -7,6 +7,7 @@
     :selected-items="selectedItems"
     :search="search"
     :loading="loading"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaseFilter.mixin.js
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaseFilter.mixin.js
@@ -12,7 +12,8 @@ export default {
 
   data() {
     return {
-      defaultLimit: 10
+      defaultLimit: 10,
+      panel: false
     };
   },
 
@@ -115,7 +116,10 @@ export default {
 
     afterInit() {
       this.registerWatchers();
+      this.initPanel();
     },
+
+    initPanel() {},
 
     updateReportFilter() {},
 

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaseSelectOptionFilter.mixin.js
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaseSelectOptionFilter.mixin.js
@@ -73,6 +73,11 @@ export default {
     async afterInit() {
       this.registerWatchers();
       this.update();
+      this.initPanel();
+    },
+
+    initPanel() {
+      this.panel = this.selectedItems.length > 0;
     },
 
     async update() {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineOpenReportsDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineOpenReportsDateFilter.vue
@@ -2,6 +2,7 @@
   <filter-toolbar
     :id="id"
     title="Outstanding reports on a given date"
+    :panel="panel"
     @clear="clear(true)"
   >
     <template v-slot:append-toolbar-title>
@@ -101,6 +102,10 @@ export default {
 
         this.setDateTime(dateTime, false);
       }
+    },
+
+    initPanel() {
+      this.panel = this.date !== null;
     },
 
     clear(updateUrl) {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -8,6 +8,7 @@
     :search="search"
     :loading="loading"
     :apply="apply"
+    :panel="panel"
     @cancel="cancelRunSelection"
     @select="prevSelectedRuns = $event"
     @clear="clear(true)"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
@@ -1,6 +1,7 @@
 <template>
   <filter-toolbar
     title="Bug path length"
+    :panel="panel"
     @clear="clear(true)"
   >
     <template v-slot:append-toolbar-title>
@@ -132,6 +133,11 @@ export default {
 
         resolve();
       });
+    },
+
+    initPanel() {
+      this.panel = this.minBugPathLength !== null ||
+        this.maxBugPathLength !== null;
     },
 
     updateReportFilter() {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
@@ -8,6 +8,7 @@
     :search="search"
     :loading="loading"
     :limit="defaultLimit"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerNameFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerNameFilter.vue
@@ -8,6 +8,7 @@
     :search="search"
     :loading="loading"
     :limit="defaultLimit"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToDiffTypeFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToDiffTypeFilter.vue
@@ -7,6 +7,7 @@
     :selected-items="selectedItems"
     :loading="loading"
     :multiple="false"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionDateFilter.vue
@@ -6,6 +6,7 @@
     :selected-items="selectedItems"
     :loading="loading"
     :multiple="false"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >
@@ -171,6 +172,10 @@ export default {
 
         resolve();
       });
+    },
+
+    initPanel() {
+      this.panel = this.fromDateTime !== null || this.toDateTime !== null;
     },
 
     updateReportFilter() {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/DetectionStatusFilter.vue
@@ -6,6 +6,7 @@
     :fetch-items="fetchItems"
     :loading="loading"
     :selected-items="selectedItems"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
@@ -8,6 +8,7 @@
     :search="search"
     :loading="loading"
     :limit="defaultLimit"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
@@ -57,6 +57,12 @@ export default {
     };
   },
 
+  watch: {
+    panel() {
+      this.value = this.panel ? 0 : null;
+    }
+  },
+
   methods: {
     clear() {
       this.$emit("clear");

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReportHashFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReportHashFilter.vue
@@ -1,6 +1,7 @@
 <template>
   <filter-toolbar
     title="Report hash filter"
+    :panel="panel"
     @clear="clear(true)"
   >
     <template v-slot:append-toolbar-title>
@@ -81,6 +82,10 @@ export default {
 
         resolve();
       });
+    },
+
+    initPanel() {
+      this.panel = this.reportHash !== null;
     },
 
     clear(updateUrl) {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReviewStatusFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ReviewStatusFilter.vue
@@ -6,6 +6,7 @@
     :fetch-items="fetchItems"
     :loading="loading"
     :selected-items="selectedItems"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SeverityFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SeverityFilter.vue
@@ -6,6 +6,7 @@
     :fetch-items="fetchItems"
     :loading="loading"
     :selected-items="selectedItems"
+    :panel="panel"
     @clear="clear(true)"
     @input="setSelectedItems"
   >

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
@@ -10,6 +10,7 @@
       :selected-items="selectedItems"
       :search="search"
       :loading="loading"
+      :panel="panel"
       @clear="clear(true)"
       @input="setSelectedItems"
     >


### PR DESCRIPTION
> Part of #2898

Previously all the filter options are collapsed by default. However,
some of them is set by at page load, and these should be opened by default.