### PR TITLE
[client] Using tags names in diff commands

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -314,7 +314,7 @@ optional arguments:
   -f CONFIG_DIRECTORY, --config-directory CONFIG_DIRECTORY
                         Directory where CodeChecker server should read server-
                         specific configuration (such as authentication
-                        settings, and SSL certificates) from. 
+                        settings, and SSL certificates) from.
                         (default: /home/<username>/.codechecker)
   --host LISTEN_ADDRESS
                         The IP address or hostname of the server on which it
@@ -443,10 +443,10 @@ access your server using the `https://host:port` URL format.
 
 To enable SSL simply place an SSL certificate to `<CONFIG_DIRECTORY>/cert.pem`
 and the corresponding private key to `<CONFIG_DIRECTORY>/key.pem`.
-You can generate these certificates for example 
+You can generate these certificates for example
 using the [openssl tool](https://www.openssl.org/).
-When the server finds these files upon start-up, 
-SSL will be automatically enabled. 
+When the server finds these files upon start-up,
+SSL will be automatically enabled.
 
 ### Managing running servers <a name="managing-running-servers"></a>
 
@@ -1047,7 +1047,9 @@ optional arguments:
                         of run name the the basename can contain * quantifiers
                         which matches any number of characters (zero or more).
                         So if you have run-a-1, run-a-2 and run-b-1 then
-                        "run-a*" selects the first two.
+                        "run-a*" selects the first two. In case of run names
+                        tag labels can also be used separated by a colon (:)
+                        character: "run_name:tag_name".
   -n NEW_RUNS [NEW_RUNS ...], --newname NEW_RUNS [NEW_RUNS ...]
                         The 'new' (right) side of the difference: these
                         analysis runs are compared to the -b/--basename runs.
@@ -1057,7 +1059,9 @@ optional arguments:
                         newname can contain * quantifiers which matches any
                         number of characters (zero or more). So if you have
                         run-a-1, run-a-2 and run-b-1 then "run-a*" selects the
-                        first two.
+                        first two. In case of run names tag labels can also be
+                        used separated by a colon (:) character:
+                        "run_name:tag_name".
   -o {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...], --output {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...]
                         The output format(s) to use in showing the data.
                         - html: multiple html files will be generated in the

--- a/web/api/js/codechecker-api-js/package.json
+++ b/web/api/js/codechecker-api-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api-js",
-  "version": "6.38.0",
+  "version": "6.38.0-dev1",
   "description": "Generated jQuery compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/js/codechecker-api-node/package.json
+++ b/web/api/js/codechecker-api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechecker-api",
-  "version": "6.38.0",
+  "version": "6.38.0-dev1",
   "description": "Generated node.js compatible API stubs for CodeChecker server.",
   "main": "lib",
   "homepage": "https://github.com/Ericsson/codechecker",

--- a/web/api/py/codechecker_api/setup.py
+++ b/web/api/py/codechecker_api/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.38.0'
+api_version = '6.38.0-dev1'
 
 setup(
     name='codechecker_api',

--- a/web/api/py/codechecker_api_shared/setup.py
+++ b/web/api/py/codechecker_api_shared/setup.py
@@ -8,7 +8,7 @@ from io import open
 with open('README.md', encoding='utf-8', errors="ignore") as f:
     long_description = f.read()
 
-api_version = '6.38.0'
+api_version = '6.38.0-dev1'
 
 setup(
     name='codechecker_api_shared',

--- a/web/api/report_server.thrift
+++ b/web/api/report_server.thrift
@@ -412,7 +412,8 @@ service codeCheckerDBAccess {
   list<string> getDiffResultsHash(1: list<i64>    runIds,
                                   2: list<string> reportHashes,
                                   3: DiffType     diffType,
-                                  4: optional list<DetectionStatus> skipDetectionStatuses)
+                                  4: optional list<DetectionStatus> skipDetectionStatuses,
+                                  5: optional list<i64> tagIds)
                                   throws (1: codechecker_api_shared.RequestFailed requestError)
 
   // PERMISSION: PRODUCT_ACCESS

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -496,7 +496,10 @@ def __register_diff(parser):
                              "can contain * quantifiers which matches any "
                              "number of characters (zero or more). So if you "
                              "have run-a-1, run-a-2 and run-b-1 then "
-                             "\"run-a*\" selects the first two.")
+                             "\"run-a*\" selects the first two. In case of "
+                             "run names tag labels can also be used separated "
+                             "by a colon (:) character: "
+                             "\"run_name:tag_name\".")
 
     parser.add_argument('-n', '--newname',
                         type=str,
@@ -513,7 +516,10 @@ def __register_diff(parser):
                              "contain * quantifiers which matches any number "
                              "of characters (zero or more). So if you have "
                              "run-a-1, run-a-2 and run-b-1 then "
-                             "\"run-a*\" selects the first two.")
+                             "\"run-a*\" selects the first two. In case of "
+                             "run names tag labels can also be used separated "
+                             "by a colon (:) character: "
+                             "\"run_name:tag_name\".")
 
     __add_filtering_arguments(parser, DEFAULT_FILTER_VALUES, True)
 

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -857,7 +857,8 @@ def handle_diff_results(args):
         suppressed_in_code = get_suppressed_reports(report_dir_results)
 
         diff_type = get_diff_type(args)
-        run_ids, run_names, _ = process_run_args(client, remote_run_names)
+        run_ids, run_names, tag_ids = \
+            process_run_args(client, remote_run_names)
         local_report_hashes = set([r.report_hash for r in report_dir_results])
 
         if diff_type == ttypes.DiffType.NEW:
@@ -866,7 +867,8 @@ def handle_diff_results(args):
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
                                           ttypes.DiffType.RESOLVED,
-                                          None)
+                                          None,
+                                          tag_ids)
 
             results = get_diff_base_results(client, args, run_ids,
                                             remote_hashes,
@@ -880,7 +882,8 @@ def handle_diff_results(args):
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
                                           ttypes.DiffType.UNRESOLVED,
-                                          None)
+                                          None,
+                                          tag_ids)
             for result in report_dir_results:
                 rep_h = result.report_hash
                 if rep_h in remote_hashes and rep_h not in suppressed_in_code:
@@ -892,7 +895,8 @@ def handle_diff_results(args):
                 client.getDiffResultsHash(run_ids,
                                           local_report_hashes,
                                           ttypes.DiffType.UNRESOLVED,
-                                          None)
+                                          None,
+                                          tag_ids)
             for result in report_dir_results:
                 if result.report_hash not in remote_hashes:
                     filtered_reports.append(result)
@@ -909,13 +913,15 @@ def handle_diff_results(args):
         suppressed_in_code = get_suppressed_reports(report_dir_results)
 
         diff_type = get_diff_type(args)
-        run_ids, run_names, _ = process_run_args(client, remote_run_names)
+        run_ids, run_names, tag_ids = \
+            process_run_args(client, remote_run_names)
         local_report_hashes = set([r.report_hash for r in report_dir_results])
 
         remote_hashes = client.getDiffResultsHash(run_ids,
                                                   local_report_hashes,
                                                   diff_type,
-                                                  None)
+                                                  None,
+                                                  tag_ids)
 
         if not remote_hashes:
             return filtered_reports, run_names

--- a/web/client/codechecker_client/helpers/results.py
+++ b/web/client/codechecker_client/helpers/results.py
@@ -49,7 +49,7 @@ class ThriftResultsHelper(BaseClientHelper):
 
     @ThriftClientCall
     def getDiffResultsHash(self, run_ids, report_hashes, diff_type,
-                           skip_detection_statuses):
+                           skip_detection_statuses, tag_ids):
         pass
 
     @ThriftClientCall

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,5 +4,5 @@ alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
 
-codechecker_api==6.38.0
-codechecker_api_shared==6.38.0
+codechecker_api==6.38.0-dev1
+codechecker_api_shared==6.38.0-dev1

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -5,5 +5,5 @@ pg8000==1.15.2
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.38.0
-codechecker_api_shared==6.38.0
+codechecker_api==6.38.0-dev1
+codechecker_api_shared==6.38.0-dev1

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -5,5 +5,5 @@ psycopg2-binary==2.8.5
 psutil==5.7.0
 portalocker==1.7.0
 
-codechecker_api==6.38.0
-codechecker_api_shared==6.38.0
+codechecker_api==6.38.0-dev1
+codechecker_api_shared==6.38.0-dev1

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -11,8 +11,8 @@ nose==1.3.7
 mockldap==0.3.0
 mkdocs==1.0.4
 
-codechecker_api==6.38.0
-codechecker_api_shared==6.38.0
+codechecker_api==6.38.0-dev1
+codechecker_api_shared==6.38.0-dev1
 
 # publish packages to pypi
 twine

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -4,5 +4,5 @@ portalocker==1.7.0
 psutil==5.7.0
 sqlalchemy==1.3.16
 
-codechecker_api==6.38.0
-codechecker_api_shared==6.38.0
+codechecker_api==6.38.0-dev1
+codechecker_api_shared==6.38.0-dev1

--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -4255,9 +4255,9 @@
       "dev": true
     },
     "codechecker-api": {
-      "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.38.0.tgz",
-      "integrity": "sha512-vcHksR/Ws0r6FOtkATHgzTQhOe74eu3e7KchCOr9EeofCf/clHqhm3hbKAP/dJJlh7MhtUDqIDewaiQkSfwCEw==",
+      "version": "6.38.0-dev1",
+      "resolved": "https://registry.npmjs.org/codechecker-api/-/codechecker-api-6.38.0-dev1.tgz",
+      "integrity": "sha512-TrCGdDaIuDFoZwF+KP+si648HvJlIYFLn69Yo6NJJMpLyFxMx9Rg1gH0SP1jI57wbYR3AYac7419+NHEdq9m7g==",
       "requires": {
         "thrift": "0.13.0-hotfix.1"
       }

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@mdi/font": "^5.3.45",
-    "codechecker-api": "6.38.0",
+    "codechecker-api": "6.38.0-dev1",
     "chart.js": "^2.9.3",
     "chartjs-plugin-datalabels": "^0.7.0",
     "codemirror": "^5.55.0",


### PR DESCRIPTION
Some run tags can be provided by : character when querying for diff
involving reports on the server.