### PR TITLE
[github] Create docker images automatically

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: codechecker-docker
+
+# Triggers the workflow when a new release is published.
+on:
+  release:
+    types: [published]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: ./web/docker/Dockerfile
+          tags: |
+            codechecker/codechecker-web:latest
+            codechecker/codechecker-web:${{ steps.get_version.outputs.VERSION }}
+          build-args: |
+            CC_VERSION=v${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Create docker images automatically with github actions when a new release
is published. It will create a docker image from the published version and
also update the latest tag.