### PR TITLE
[cmd] Do not allow ctu-ast-mode in non-CTU mode

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -513,9 +513,10 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                   action='store',
                                   dest='ctu_ast_mode',
                                   choices=['load-from-pch', 'parse-on-demand'],
-                                  default='parse-on-demand',
+                                  default=argparse.SUPPRESS,
                                   help="Choose the way ASTs are loaded during "
-                                       "CTU analysis. Mode 'load-from-pch' "
+                                       "CTU analysis. Only available if CTU "
+                                       "mode is enabled. Mode 'load-from-pch' "
                                        "generates PCH format serialized ASTs "
                                        "during the 'collect' phase. Mode "
                                        "'parse-on-demand' only generates the "
@@ -525,7 +526,8 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                        "serialized ASTs, while mode "
                                        "'parse-on-demand' can incur some "
                                        "runtime CPU overhead in the second "
-                                       "phase of the analysis.")
+                                       "phase of the analysis. (default: "
+                                       "parse-on-demand)")
 
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(
@@ -854,6 +856,11 @@ def main(args):
 
     # Process the skip list if present.
     skip_handler = __get_skip_handler(args)
+
+    # CTU loading mode is only meaningful if CTU itself is enabled.
+    if 'ctu_ast_mode' in args and 'ctu_phases' not in args:
+        LOG.error("Analyzer option 'ctu-ast-mode' requires CTU mode enabled")
+        sys.exit(1)
 
     # Enable alpha uniqueing by default if ctu analysis is used.
     if 'none' in args.compile_uniqueing and 'ctu_phases' in args:

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -817,6 +817,11 @@ def main(args):
     """
     logger.setup_logger(args.verbose if 'verbose' in args else None)
 
+    # CTU loading mode is only meaningful if CTU itself is enabled.
+    if 'ctu_ast_mode' in args and 'ctu_phases' not in args:
+        LOG.error("Analyzer option 'ctu-ast-mode' requires CTU mode enabled")
+        sys.exit(1)
+
     try:
         cmd_config.check_config_file(args)
     except FileNotFoundError as fnerr:
@@ -856,11 +861,6 @@ def main(args):
 
     # Process the skip list if present.
     skip_handler = __get_skip_handler(args)
-
-    # CTU loading mode is only meaningful if CTU itself is enabled.
-    if 'ctu_ast_mode' in args and 'ctu_phases' not in args:
-        LOG.error("Analyzer option 'ctu-ast-mode' requires CTU mode enabled")
-        sys.exit(1)
 
     # Enable alpha uniqueing by default if ctu analysis is used.
     if 'none' in args.compile_uniqueing and 'ctu_phases' in args:

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -515,9 +515,10 @@ is called.""")
                                   action='store',
                                   dest='ctu_ast_mode',
                                   choices=['load-from-pch', 'parse-on-demand'],
-                                  default='parse-on-demand',
+                                  default=argparse.SUPPRESS,
                                   help="Choose the way ASTs are loaded during "
-                                       "CTU analysis. Mode 'load-from-pch' "
+                                       "CTU analysis. Only available if CTU "
+                                       "mode is enabled. Mode 'load-from-pch' "
                                        "generates PCH format serialized ASTs "
                                        "during the 'collect' phase. Mode "
                                        "'parse-on-demand' only generates the "
@@ -527,7 +528,8 @@ is called.""")
                                        "serialized ASTs, while mode "
                                        "'parse-on-demand' can incur some "
                                        "runtime CPU overhead in the second "
-                                       "phase of the analysis.")
+                                       "phase of the analysis. (default: "
+                                       "parse-on-demand)")
 
     if analyzer_types.is_statistics_capable(context):
         stat_opts = parser.add_argument_group(

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -14,6 +14,7 @@ stdout.
 import argparse
 import os
 import shutil
+import sys
 import tempfile
 
 from codechecker_analyzer import analyzer_context
@@ -730,6 +731,10 @@ def main(args):
     """
 
     logger.setup_logger(args.verbose if 'verbose' in args else None)
+
+    if 'ctu_ast_mode' in args and 'ctu_phases' not in args:
+        LOG.error("Analyzer option 'ctu-ast-mode' requires CTU mode enabled")
+        sys.exit(1)
 
     def __update_if_key_exists(source, target, key):
         """Append the source Namespace's element with 'key' to target with

--- a/analyzer/tests/functional/ctu/test_ctu.py
+++ b/analyzer/tests/functional/ctu/test_ctu.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import unittest
 
+from subprocess import run
 from typing import IO
 
 from libtest import env
@@ -77,6 +78,16 @@ class TestCtu(unittest.TestCase):
 
         shutil.rmtree(self.report_dir, ignore_errors=True)
         os.chdir(self.__old_pwd)
+
+    @skipUnlessCTUCapable
+    def test_ctu_loading_mode_requires_ctu_mode(self):
+        """ Test ctu-ast-mode option requires ctu mode enabled. """
+        cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
+               '--analyzers', 'clangsa', '--ctu-ast-mode=load-from-pch',
+               self.buildlog]
+
+        self.assertEqual(1,
+                         run(cmd, cwd=self.test_dir, env=self.env).returncode)
 
     @skipUnlessCTUCapable
     def test_ctu_all_ast_dump_based(self):

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -302,16 +302,16 @@ cross translation unit analysis arguments:
                         If Cross-TU analysis is enabled and fails for some
                         reason, try to re analyze the same translation unit
                         without Cross-TU enabled.
-                         [--ctu-ast-mode {load-from-pch,parse-on-demand}]
   --ctu-ast-mode {load-from-pch,parse-on-demand}
-                        Choose the way ASTs are loaded during CTU analysis.
-                        Mode 'load-from-pch' generates PCH format serialized
-                        ASTs during the 'collect' phase. Mode 'parse-on-
-                        demand' only generates the invocations needed to parse
-                        the ASTs. Mode 'load-from-pch' can use significant
-                        disk-space for the serialized ASTs, while mode 'parse-
-                        on-demand' can incur some runtime CPU overhead in the
-                        second phase of the analysis. (default: parse-on-demand)
+                        Choose the way ASTs are loaded during CTU analysis. Only
+                        available if CTU mode is enabled. Mode 'load-from-pch'
+                        generates PCH format serialized ASTs during the
+                        'collect' phase. Mode 'parse-on-demand' only generates
+                        the invocations needed to parse the ASTs. Mode
+                        'load-from-pch' can use significant disk-space for the
+                        serialized ASTs, while mode 'parse-on-demand' can incur
+                        some runtime CPU overhead in the second phase of the
+                        analysis. (default: parse-on-demand)
 
 checker configuration:
 
@@ -1441,16 +1441,16 @@ cross translation unit analysis arguments:
                         analysis, using already available extra files in
                         '<OUTPUT_DIR>/ctu-dir'. (These files will not be
                         cleaned up in this mode.)
-
   --ctu-ast-mode {load-from-pch,parse-on-demand}
-                        Choose the way ASTs are loaded during CTU analysis.
-                        Mode 'load-from-pch' generates PCH format serialized
-                        ASTs during the 'collect' phase. Mode 'parse-on-
-                        demand' only generates the invocations needed to parse
-                        the ASTs. Mode 'load-from-pch' can use significant
-                        disk-space for the serialized ASTs, while mode 'parse-
-                        on-demand' can incur some runtime CPU overhead in the
-                        second phase of the analysis. (default: parse-on-demand)
+                        Choose the way ASTs are loaded during CTU analysis. Only
+                        available if CTU mode is enabled. Mode 'load-from-pch'
+                        generates PCH format serialized ASTs during the
+                        'collect' phase. Mode 'parse-on-demand' only generates
+                        the invocations needed to parse the ASTs. Mode
+                        'load-from-pch' can use significant disk-space for the
+                        serialized ASTs, while mode 'parse-on-demand' can incur
+                        some runtime CPU overhead in the second phase of the
+                        analysis. (default: parse-on-demand)
 ```
 
 ### Statistical analysis mode <a name="statistical"></a>


### PR DESCRIPTION
Option ctu-ast-mode is only meaningful if ctu mode is active.
Exit early if ctu-ast-mode is specified but ctu mode is not enabled.
