### PR TITLE
[cmd] Handle duplication warning at store

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -648,7 +648,12 @@ def assemble_zip(inputs, zip_file, client):
             if h in necessary_hashes or h in file_hash_with_review_status:
                 LOG.debug("File contents for '%s' needed by the server", f)
 
-                zipf.write(f, os.path.join('root', f.lstrip('/')))
+                file_path = os.path.join('root', f.lstrip('/'))
+
+                try:
+                    zipf.getinfo(file_path)
+                except KeyError:
+                    zipf.write(f, file_path)
 
         zipf.writestr('content_hashes.json', json.dumps(file_to_hash))
 


### PR DESCRIPTION
> Closes #2510

Somehow it is possible that the store command tries to write the same
source file to the zip multiple times. This patch will handle that use
case and add a file to the zip if the file is not in there.