### PR TITLE
[server] Add more info log to the store API function

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -3037,7 +3037,10 @@ class ThriftRequestHandler(object):
         wrong_src_code_comments = []
         try:
             with TemporaryDirectory() as zip_dir:
+                LOG.info("[%s] Unzip storage file...", name)
                 zip_size = unzip(b64zip, zip_dir)
+                LOG.info("[%s] Unzip storage file done.", name)
+
                 if zip_size == 0:
                     raise codechecker_api_shared.ttypes.RequestFailed(
                         codechecker_api_shared.ttypes.
@@ -3072,9 +3075,11 @@ class ThriftRequestHandler(object):
                 filename_to_hash = util.load_json_or_empty(content_hash_file,
                                                            {})
 
+                LOG.info("[%s] Store source files...", name)
                 file_path_to_id = self.__store_source_files(source_root,
                                                             filename_to_hash,
                                                             trim_path_prefixes)
+                LOG.info("[%s] Store source files done.", name)
 
                 run_history_time = datetime.now()
 
@@ -3146,6 +3151,7 @@ class ThriftRequestHandler(object):
                                                             statistics,
                                                             description)
 
+                            LOG.info("[%s] Store reports...", name)
                             self.__store_reports(session,
                                                  report_dir,
                                                  source_root,
@@ -3157,6 +3163,7 @@ class ThriftRequestHandler(object):
                                                  skip_handler,
                                                  checkers,
                                                  trim_path_prefixes)
+                            LOG.info("[%s] Store reports done.", name)
 
                             store_handler.setRunDuration(session,
                                                          run_id,


### PR DESCRIPTION
The storage API request (`massStoreRun`) is a very heavy operation and most
of the cases when the user stores huge amount of reports to the database it
takes too much time (10-20 minutes) to perform this operation. For this reason
in this patch we will insert some info log to see where the store operation
is.