### PR TITLE
[log] ld_logger debug logs go to report dir

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -99,8 +99,11 @@ def perform_build_command(logfile, command, context, keep_link, silent=False,
 
             is_debug = verbose and verbose in ['debug', 'debug_analyzer']
             if is_debug and 'CC_LOGGER_DEBUG_FILE' not in log_env:
-                log_file = os.path.join(os.path.dirname(logfile),
-                                        'codechecker.logger.debug')
+                if 'CC_LOGGER_DEBUG_FILE' in os.environ:
+                    log_file = os.environ['CC_LOGGER_DEBUG_FILE']
+                else:
+                    log_file = os.path.join(os.path.dirname(logfile),
+                                            'codechecker.logger.debug')
 
                 if os.path.exists(log_file):
                     os.remove(log_file)

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -57,6 +57,12 @@ Environment variables
                            variable.
   CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
                            Default: {}
+  CC_LOGGER_DEBUG_FILE     If -b and -o flags are used with debug logs, the
+                           logging phase emits its debug logs in
+                           'codechecker.logger.debug' under the output
+                           directory by default. This environment variable
+                           can be given a file path which overrides this
+                           default location.
 
 
 Issue hashes
@@ -766,6 +772,14 @@ def main(args):
             import codechecker_analyzer.cmd.log as log_module
             LOG.debug("Calling LOG with args:")
             LOG.debug(log_args)
+
+            # If not explicitly given the debug log file of ld_logger is placed
+            # in report directory if any. Otherwise parallel "CodeChecker
+            # check" commands would overwrite each other's log files under /tmp
+            # which is the default location for "CodeChecker check".
+            if 'CC_LOGGER_DEBUG_FILE' not in os.environ:
+                os.environ['CC_LOGGER_DEBUG_FILE'] = \
+                    os.path.join(output_dir, 'codechecker.logger.debug')
 
             log_module.main(log_args)
         elif 'logfile' in args:

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -401,6 +401,12 @@ Environment variables
                            variable.
   CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
                            Default: <package>/config/checker_severity_map.json
+  CC_LOGGER_DEBUG_FILE     If -b and -o flags are used with debug logs, the
+                           logging phase emits its debug logs in
+                           'codechecker.logger.debug' under the output
+                           directory by default. This environment variable
+                           can be given a file path which overrides this
+                           default location.
 
 Issue hashes
 ------------------------------------------------


### PR DESCRIPTION
If not explicitly given the debug log file of ld_logger is placed in
report directory if any. Otherwise parallel "CodeChecker check"
commands would overwrite each other's log files under /tmp which is the
default location for "CodeChecker check".