### PR TITLE
[server] Configure keepalive

### DIFF
--- a/docs/web/server_config.md
+++ b/docs/web/server_config.md
@@ -65,6 +65,53 @@ size of uploadable compilation database file in *bytes*.
 
 *Default value*: 104857600 bytes = 100 MB
 
+### Keepalive
+Linux has built-in support for keepalive. When using a CodeChecker server
+with `Docker Swarm` it is recommended to use the following settings:
+```json
+{
+  "keepalive": {
+    "enabled": true,
+    "idle": 600,
+    "interval": 30,
+    "max_probe": 10
+  }
+}
+```
+
+Otherwise you may get a `[Errno 104] Connection reset by peer` exception on the
+server side and the client may hang forever.
+
+For more detailed information about these configuration option see:
+https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+
+For more information about this problem can be found here:
+https://github.com/moby/moby/issues/31208#issuecomment-303905737
+
+#### Idle time
+The interval between the last data packet sent (simple ACKs are not considered
+data) and the first keepalive probe.
+
+By default the server will use the value from your host configured by the
+`net.ipv4.tcp_keepalive_time` parameter. This value can be overriden by the
+`idle` key in the server configuration file.
+
+#### Interval time
+The interval between subsequential keepalive probes, regardless of what the
+connection has exchanged in the meantime.
+
+By default the server will use the value from your host configured by the
+`net.ipv4.tcp_keepalive_intvl` parameter. This value can be overriden by the
+`interval` key in the server configuration file.
+
+#### Probes
+The number of unacknowledged probes to send before considering the connection
+dead and notifying the application layer.
+
+By default the server will use the value from your host configured by the
+`net.ipv4.tcp_keepalive_probes` parameter. This value can be overriden by the
+`max_probe` key in the server configuration file.
+
 ## Authentication
 For authentication configuration options and which options can be reloaded see
 the [Authentication](authentication.md) documentation.

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -180,6 +180,7 @@ class SessionManager(object):
         self.__worker_processes = get_worker_processes(scfg_dict)
         self.__max_run_count = scfg_dict.get('max_run_count', None)
         self.__store_config = scfg_dict.get('store', {})
+        self.__keepalive_config = scfg_dict.get('keepalive', {})
         self.__auth_config = scfg_dict['authentication']
 
         if force_auth:
@@ -656,6 +657,25 @@ class SessionManager(object):
         """
         limit = self.__store_config.get('limit', {})
         return limit.get('compilation_database_size')
+
+    def is_keepalive_enabled(self):
+        """
+        True if the keepalive functionality is explicitly enabled, otherwise it
+        will return False.
+        """
+        return self.__keepalive_config.get('enabled')
+
+    def get_keepalive_idle(self):
+        """ Get keepalive idle time. """
+        return self.__keepalive_config.get('idle')
+
+    def get_keepalive_interval(self):
+        """ Get keepalive interval time. """
+        return self.__keepalive_config.get('interval')
+
+    def get_keepalive_max_probe(self):
+        """ Get keepalive max probe count. """
+        return self.__keepalive_config.get('max_probe')
 
     def __get_local_session_from_db(self, token):
         """

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -8,6 +8,12 @@
       "compilation_database_size": 104857600
     }
   },
+  "keepalive": {
+    "enabled": false,
+    "idle": 600,
+    "interval": 30,
+    "max_probe": 10
+  },
   "authentication": {
     "enabled" : false,
     "realm_name" : "CodeChecker Privileged server",


### PR DESCRIPTION
When using a CodeChecker server with `Docker Swarm` on the server side
we may get a `[Errno 104] Connection reset by peer` exception when for
example the storage takes more than 15 minutes. With the keepalive
parameters we can solve this problem by not destroying the connection
when an operation takes too much time.