### PR TITLE
[fix] Opt-in fix escape in logger in case of backslash, CR, LF

### DIFF
--- a/analyzer/tools/build-logger/README.md
+++ b/analyzer/tools/build-logger/README.md
@@ -88,3 +88,12 @@ are provided to the compiler then the complete build action will be thrown
 away. This means that build actions which only perform linking will not be
 captured. We consider a file as object file if its extension is `.o`, `.so` or
 `.a`.
+
+### `CC_LOGGER_NEW_ESCAPING`
+If the environment variable is defined, we will use the *new* shell-escape mechanism
+when we generate the `compile_commands.json`.
+Use this option **if** without it the `CodeChecker log` command fails to produce
+a valid json output.
+The *old* mechanism had a bug when the invocation contained backslashes.
+If everything goes well, the new escaping will be enabled by default.
+

--- a/analyzer/tools/build-logger/src/ldlogger-util.c
+++ b/analyzer/tools/build-logger/src/ldlogger-util.c
@@ -82,6 +82,7 @@ static void getCurrentTime(char* buff_)
   return buff_;
 }
 
+// FIXME: Deprecated. Use the predictEscapedSizeFixed instead.
 int predictEscapedSize(const char* str_)
 {
   int size = 0;
@@ -105,6 +106,31 @@ int predictEscapedSize(const char* str_)
   return size;
 }
 
+int predictEscapedSizeFixed(const char* str_)
+{
+  int size = 0;
+
+  while (*str_)
+  {
+    if (strchr("\t\b\f\r\v\n ", *str_))
+      size += 2;
+    else if (*str_ == '"' || *str_ == '\\')
+      /* The quote (") and backslash (\) needs an extra escaped escape
+         character because the JSON string literals are surrounded by quote
+         by default. */
+      size += 3;
+
+    ++size;
+    ++str_;
+  }
+
+  /* For closing \0 character. */
+  ++size;
+
+  return size;
+}
+
+// FIXME: Deprecated. Use the shellEscapeStrFixed instead.
 char* shellEscapeStr(const char* str_, char* buff_)
 {
   char* out = buff_;
@@ -124,6 +150,44 @@ char* shellEscapeStr(const char* str_, char* buff_)
         *out++ = *str_++;
         break;
 
+      case '\"':
+        *out++ = '\\';
+        *out++ = '\\';
+        *out++ = '\\';
+        *out++ = *str_++;
+        break;
+
+      default:
+        *out++ = *str_++;
+        break;
+        }
+    }
+
+    *out = '\0';
+    return buff_;
+}
+
+char* shellEscapeStrFixed(const char* str_, char* buff_)
+{
+  char* out = buff_;
+
+  while (*str_)
+  {
+    switch (*str_)
+    {
+      case '\t':
+      case '\b':
+      case '\f':
+      case '\r':
+      case '\v':
+      case '\n':
+      case ' ':
+        *out++ = '\\';
+        *out++ = '\\';
+        *out++ = *str_++;
+        break;
+
+      case '\\':
       case '\"':
         *out++ = '\\';
         *out++ = '\\';

--- a/analyzer/tools/build-logger/src/ldlogger-util.h
+++ b/analyzer/tools/build-logger/src/ldlogger-util.h
@@ -25,8 +25,21 @@
  * hello world -> hello\\ world (length = 14)
  * "hello" -> \\\"hello\\\" (length = 14)
  * "hello world" -> \\\"hello\\ world\\\" (length = 22)
+ *
+ * BUGS:
+ * The '\\', '\r' and '\v' characters are not escaped correctly.
+ *
+ * When we generate the json, we will automatically select this or the fixed
+ * version whether the CC_LOGGER_NEW_ESCAPING environment variable is defined
+ * or not. By default the buggy version will be selected.
  */
 int predictEscapedSize(const char* str_);
+
+/**
+ * Does the same as predictEscapedSize, but fixes the escape bug.
+ * The '\\', '\r' and '\v' characters are escaped correctly.
+ */
+int predictEscapedSizeFixed(const char* str_);
 
 /**
  * Generates a shell-escaped version of the given string. The output buffer
@@ -34,12 +47,25 @@ int predictEscapedSize(const char* str_);
  * This escaped version is safe to place in a JSON string. After reading this
  * serialized form from the JSON, the original string will be returned. See
  * the documentation of predictEscapedSize() for some examples.
+ *
+ * BUGS:
+ * The '\\', '\r' and '\v' characters are not escaped correctly.
+ *
+ * When we generate the json, we will automatically select this or the fixed
+ * version whether the CC_LOGGER_NEW_ESCAPING environment variable is defined
+ * or not. By default the buggy version will be selected.
  * 
  * @param str_ a string to escape (non null).
  * @param buff_ an output buffer (non null).
  * @return anways returns buff_.
  */
 char* shellEscapeStr(const char* str_, char* buff_);
+
+/**
+ * Does the same as shellEscapeStr, but fixes the escape bug.
+ * The '\\', '\r' and '\v' characters are escaped correctly.
+ */
+char* shellEscapeStrFixed(const char* str_, char* buff_);
 
 /**
  * Resolves a given path to an absolute path. The given buffer (resolved) may


### PR DESCRIPTION
The build logger did not escape '\\', '\r' and '\n' correctly.
This patch fixes this issue, while preserving the old version.

By default the old version will be used, unless the
`CC_LOGGER_NEW_ESCAPING` environment variable is defined.

It is mentioned in the README.md.

I test both versions in the test files.
Also adds a few tips how to debug such cases with confidence.