### PR TITLE
[fix] Handle None when print a table

### DIFF
--- a/codechecker_common/output/twodim.py
+++ b/codechecker_common/output/twodim.py
@@ -50,6 +50,8 @@ def __to_rows(lines):
 
     str_parts = []
 
+    lines = [['' if e is None else e for e in line] for line in lines]
+
     # Count the column width.
     widths = []
     for line in lines:
@@ -87,6 +89,11 @@ def __to_table(lines, separate_head=True, separate_footer=False):
     """
 
     str_parts = []
+
+    # It is possible that one of the item in the line is None which will
+    # raise an exception when passed to the format function below. So this is
+    # the reason why we need to convert None values to valid strings here.
+    lines = [['' if e is None else e for e in line] for line in lines]
 
     # Count the column width.
     widths = []
@@ -129,6 +136,8 @@ def __to_csv(lines):
     """
 
     str_parts = []
+
+    lines = [['' if e is None else e for e in line] for line in lines]
 
     # Count the columns.
     columns = 0


### PR DESCRIPTION
When printing a table (e.g.: `CodeChecker version`) it is possible
that a value is None (e.g.: a package is built from a release zip file
which will not contain git information). In this case when printing the
table the following exception will be raised:
```
unsupported format string passed to NoneType.__format__
```
In this patch we will convert None values to empty string to handle this
use case too.