### PR TITLE
[server] Fix filtering number of outstanding reports on the statistics page

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Overview/Reports.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/Reports.vue
@@ -120,7 +120,10 @@ export default {
   mixins: [ DateMixin ],
   props: {
     bus: { type: Object, required: true },
-    runIds: { type: Array, required: true },
+    runIds: {
+      required: true,
+      validator: v => typeof v === "object" || v === null
+    },
     reportFilter: { type: Object, required: true },
   },
   data() {
@@ -186,6 +189,7 @@ export default {
       rFilter.openReportsDate = this.getUnixTime(date[0]);
 
       const cmpData = new CompareData({
+        runIds: this.runIds,
         openReportsDate: this.getUnixTime(date[1]),
         diffType: DiffType.NEW
       });


### PR DESCRIPTION
The number of outstanding reports are not filtered by the BASELINE run filters
because the run ids in the compare data for the API function is not set.