### PR TITLE
[gui] Add button to copy file path

### DIFF
--- a/web/server/vue-cli/src/components/CopyBtn.vue
+++ b/web/server/vue-cli/src/components/CopyBtn.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-tooltip
+    v-model="copyInProgress"
+    color="black"
+    right
+  >
+    <template v-slot:activator="{}">
+      <v-btn icon x-small @click="copy">
+        <v-icon v-if="copyInProgress" color="green">
+          mdi-check
+        </v-icon>
+
+        <v-icon v-else>
+          mdi-content-paste
+        </v-icon>    
+      </v-btn>
+    </template>
+    Copied!
+  </v-tooltip>
+</template>
+
+<script>
+function writeToClipboard(str) {
+  const el = document.createElement("textarea");
+  el.value = str;
+
+  document.body.appendChild(el);
+  el.select();
+
+  document.execCommand("copy");
+
+  document.body.removeChild(el);
+}
+
+export default {
+  name: "CopyBtn",
+  props: {
+    value: { type: String, required: true }
+  },
+  data() {
+    return {
+      copyInProgress: false
+    };
+  },
+  methods: {
+    copy() {
+      this.copyInProgress = true;
+
+      writeToClipboard(this.value);
+
+      setTimeout(() => this.copyInProgress = false, 1000);
+    }
+  }
+};
+</script>

--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -144,6 +144,8 @@
                 class="file-path py-0"
                 align-self="center"
               >
+                <copy-btn v-if="sourceFile" :value="sourceFile.filePath" />
+
                 <span
                   v-if="sourceFile"
                   class="file-path"
@@ -229,6 +231,7 @@ import {
 import { mapGetters } from "vuex";
 
 import { FillHeight } from "@/directives";
+import CopyBtn from "@/components/CopyBtn";
 import { UserIcon } from "@/components/Icons";
 
 import ReportTreeKind from "@/components/Report/ReportTree/ReportTreeKind";
@@ -246,6 +249,7 @@ const ReportStepMessageClass = Vue.extend(ReportStepMessage);
 export default {
   name: "Report",
   components: {
+    CopyBtn,
     ReportComments,
     ReportInfoButton,
     SelectReviewStatus,


### PR DESCRIPTION
Add a button to the report detail view beside the file name which can be
used to copy the full file path easily.

Screenshots:
- Before clicking on the copy button:
![image](https://user-images.githubusercontent.com/6695818/106742929-f8d93000-661d-11eb-95a0-9ffcea1c96d9.png)
- After clicking on the copy button:
![image](https://user-images.githubusercontent.com/6695818/106743056-29b96500-661e-11eb-97bb-00633b258c10.png)
