### PR TITLE
[gui] Wrap bugstep messages

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportStepMessage.vue
+++ b/web/server/vue-cli/src/components/Report/ReportStepMessage.vue
@@ -7,11 +7,12 @@
     :step-id="id"
     :type="type"
     :style="{ 'margin-left': marginLeft }"
+    :title="value"
   >
     <report-step-enum-icon
       :type="type"
       :index="index"
-      class="mr-1"
+      class="report-step-enum mr-1"
     />
 
     <v-btn
@@ -108,10 +109,21 @@ export default {
 };
 </script>
 
-<style type="scss">
+<style lang="scss">
 .report-step-msg {
   padding-top: 2px;
   padding-bottom: 2px;
   margin-bottom: 2px;
+  max-width: 640px;
+  white-space: inherit;
+
+  &.v-size--small {
+    min-height: 24px;
+    height: auto;
+
+    .v-chip.report-step-enum {
+      overflow: inherit;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
It is possible (for example in case of macro expansion) that the message of a bug step is very long. Previously we put the whole message into one line but it was very hard to read. For this reason with this patch we will break long messages.

Screenshot:
- **Before**
![image](https://user-images.githubusercontent.com/6695818/106749423-c6800080-6626-11eb-95d3-e8c54ce7b01b.png)

- **After**
![image](https://user-images.githubusercontent.com/6695818/106749343-b23c0380-6626-11eb-943e-fddc5344767b.png)
