### PR TITLE
[github] Fix context of the docker github action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: .
+          context: ./web/docker/
           file: ./web/docker/Dockerfile
           tags: |
             codechecker/codechecker-web:latest


### PR DESCRIPTION
Unfortunately previously the github action which generates docker images
failed because it couldn't find the `entrypoint.sh` file. To solve
this problem we need to set the context parameter to the directory where
the docker file and the entrypoint file can be found.