### PR TITLE
[analyzer] Add ctu related files if the analyzer crashes

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -309,6 +309,20 @@ def handle_failure(source_analyzer, rh, zip_file, result_base, actions_map):
         archive.writestr("analyzer-command", ' '.join(rh.analyzer_cmd))
         archive.writestr("return-code", str(rh.analyzer_returncode))
 
+        if isinstance(source_analyzer, ClangSA) and \
+           source_analyzer.is_ctu_enabled:
+            LOG.debug("[ZIP] Writing externalDefMap...")
+            ctu_dir = source_analyzer.get_ctu_dir()
+            abspath_extdefmap = os.path.join(ctu_dir, "externalDefMap.txt")
+            archive.write(abspath_extdefmap, "externalDefMap.txt")
+
+            # Also copy invocation-list.yml if exists.
+            abspath_invocationlist = os.path.join(
+                ctu_dir, "invocation-list.yml")
+            if os.path.isfile(abspath_invocationlist):
+                LOG.debug("[ZIP] Writing invocation-list...")
+                archive.write(abspath_invocationlist, "invocation-list.yml")
+
         toolchain = gcc_toolchain.toolchain_in_args(
             shlex.split(action.original_command))
         if toolchain:

--- a/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
@@ -152,6 +152,8 @@ class TestCtuFailure(unittest.TestCase):
             files = archive.namelist()
             self.assertIn("build-action", files)
             self.assertIn("analyzer-command", files)
+            self.assertIn("externalDefMap.txt", files)
+            self.assertNotIn("invocation-list.yml", files)
 
             def check_source_in_archive(source_in_archive):
                 source_file = os.path.join(self.test_dir, source_in_archive)
@@ -203,6 +205,8 @@ class TestCtuFailure(unittest.TestCase):
             files = archive.namelist()
             self.assertIn("build-action", files)
             self.assertIn("analyzer-command", files)
+            self.assertIn("externalDefMap.txt", files)
+            self.assertIn("invocation-list.yml", files)
 
             def check_source_in_archive(source_in_archive):
                 source_file = os.path.join(self.test_dir, source_in_archive)
@@ -254,6 +258,8 @@ class TestCtuFailure(unittest.TestCase):
 
             self.assertIn("build-action", files)
             self.assertIn("analyzer-command", files)
+            self.assertIn("externalDefMap.txt", files)
+            self.assertNotIn("invocation-list.yml", files)
 
             def check_source_in_archive(source_in_archive):
                 source_file = os.path.join(self.test_dir, source_in_archive)
@@ -307,6 +313,8 @@ class TestCtuFailure(unittest.TestCase):
 
             self.assertIn("build-action", files)
             self.assertIn("analyzer-command", files)
+            self.assertIn("externalDefMap.txt", files)
+            self.assertIn("invocation-list.yml", files)
 
             def check_source_in_archive(source_in_archive):
                 source_file = os.path.join(self.test_dir, source_in_archive)


### PR DESCRIPTION
In CTU mode, the `externalDefMap.txt` file is required to debug the bug
effectively.

If the the ClangSA uses on-demand parsing, `invocation-list.yml` could
be also useful reproducing the crash.

This commit saves these two files to the failedzip, if they are available.