### PR TITLE
[analyzer] Fix target attribute of the log parser

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -962,7 +962,7 @@ def parse_options(compilation_db_entry,
         'output': '',
         'lang': None,
         'arch': '',  # Target in the compile command set by -arch.
-        'target': defaultdict(dict),
+        'target': defaultdict(str),
         'source': ''}
 
     if 'arguments' in compilation_db_entry:


### PR DESCRIPTION
The target attribute should be a dictionary which contains strings instead of dictionary of dictionary.