### PR TITLE
[analyzer] Handle clang binary without installed dir

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -48,7 +48,10 @@ def parse_clang_help_page(command, start_label, environ):
     except (subprocess.CalledProcessError, OSError):
         return []
 
-    help_page = help_page[help_page.index(start_label) + len(start_label):]
+    try:
+        help_page = help_page[help_page.index(start_label) + len(start_label):]
+    except ValueError:
+        return []
 
     # This regex will match lines which contain only a flag or a flag and a
     # description: '  <flag>', '  <flag> <description>'.

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/clang_options.py
@@ -36,13 +36,14 @@ def get_analyzer_checkers_cmd(cfg_handler, alpha=True, debug=True):
     # The new checker help printig flags are not available there yet.
     # If the OSX clang will be updated to based on clang v8
     # this early return can be removed.
-    if cfg_handler.version_info.vendor != "clang":
+    version_info = cfg_handler.version_info
+    if not version_info or version_info.vendor != "clang":
         return command
 
-    if alpha and cfg_handler.version_info.major_version > 8:
+    if alpha and version_info.major_version > 8:
         command.append("-analyzer-checker-help-alpha")
 
-    if debug and cfg_handler.version_info.major_version > 8:
+    if debug and version_info.major_version > 8:
         command.append("-analyzer-checker-help-developer")
 
     return command

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
@@ -75,7 +75,7 @@ class CTUAutodetection(object):
             LOG.debug('Failed to invoke command to get Clang version!')
             return None
 
-        version_parser = version.ClangVersionInfoParser()
+        version_parser = version.ClangVersionInfoParser(self.__analyzer_binary)
         version_info = version_parser.parse(analyzer_version)
 
         if not version_info:

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -49,14 +49,15 @@ class ClangVersionInfoParser(object):
         """Try to parse the version string using the predefined patterns."""
         version_match = re.search(self.clang_version_pattern, version_string)
         if not version_match:
-            return False
+            return
 
         installed_dir_match = re.search(
             self.clang_installed_dir_pattern, version_string)
 
-        installed_dir = os.path.dirname(shutil.which(self.analyzer_binary))
         if installed_dir_match:
             installed_dir = installed_dir_match.group('installed_dir')
+        else:
+            installed_dir = os.path.dirname(shutil.which(self.analyzer_binary))
 
         return ClangVersionInfo(
             version_match.group('major_version'),

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -108,10 +108,11 @@ class TestAnalyze(unittest.TestCase):
                 os.remove(f)
         self.assertEqual(failed_file_count, failed_count)
 
-    @unittest.skipIf(version.get("gcc") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        version.get("gcc"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_compiler_info_files(self):
         '''
         Test that the compiler info files are generated

--- a/analyzer/tests/unit/test_clang_version_parsing.py
+++ b/analyzer/tests/unit/test_clang_version_parsing.py
@@ -47,7 +47,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse('')
 
-        self.assertFalse(version_info, False)
+        self.assertFalse(version_info)
 
     def test_built_from_source_clang_7(self):
         """
@@ -62,7 +62,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
-        self.assertIsNot(version_info, False)
+        self.assertIsNot(version_info, None)
         self.assertEqual(version_info.major_version, 7)
         self.assertEqual(version_info.minor_version, 1)
         self.assertEqual(version_info.patch_version, 0)
@@ -81,7 +81,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
-        self.assertIsNot(version_info, False)
+        self.assertIsNot(version_info, None)
         self.assertEqual(version_info.major_version, 8)
         self.assertEqual(version_info.minor_version, 0)
         self.assertEqual(version_info.patch_version, 1)
@@ -100,7 +100,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
-        self.assertIsNot(version_info, False)
+        self.assertIsNot(version_info, None)
         self.assertEqual(version_info.major_version, 7)
         self.assertEqual(version_info.minor_version, 0)
         self.assertEqual(version_info.patch_version, 0)
@@ -119,7 +119,7 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
 
-        self.assertIsNot(version_info, False)
+        self.assertIsNot(version_info, None)
         self.assertEqual(version_info.major_version, 9)
         self.assertEqual(version_info.minor_version, 0)
         self.assertEqual(version_info.patch_version, 0)
@@ -134,4 +134,4 @@ class CTUAutodetectionVersionParsingTest(unittest.TestCase):
 
         parser = version.ClangVersionInfoParser()
         version_info = parser.parse(version_string)
-        self.assertIs(version_info, False)
+        self.assertIs(version_info, None)

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -25,10 +25,11 @@ class OptionParserTest(unittest.TestCase):
     parsing of the g++/gcc compiler options.
     """
 
-    @unittest.skipIf(clangsa.version.get("gcc") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("gcc"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_build_onefile(self):
         """
         Test the build command of a simple file.
@@ -45,10 +46,11 @@ class OptionParserTest(unittest.TestCase):
         self.assertTrue(BuildAction.COMPILE, res.action_type)
         self.assertEqual(0, len(res.analyzer_options))
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_build_multiplefiles(self):
         """
         Test the build command of multiple files.
@@ -155,10 +157,11 @@ class OptionParserTest(unittest.TestCase):
         self.assertTrue(set(compiler_options) == set(res.analyzer_options))
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_compile_with_include_paths(self):
         """
         sysroot should be detected as compiler option because it is needed
@@ -206,10 +209,11 @@ class OptionParserTest(unittest.TestCase):
         print(res)
         self.assertEqual(BuildAction.LINK, res.action_type)
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_link_with_include_paths(self):
         """
         Should be link if only object files are in the command.
@@ -267,17 +271,18 @@ class OptionParserTest(unittest.TestCase):
         self.assertEqual(res.source, 'main.cpp')
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_ignore_flags_gcc(self):
         """
         Test if special compiler options are ignored properly.
         """
         ignore = ["-Werror", "-fsyntax-only",
                   "-mfloat-gprs=double", "-mfloat-gprs=yes",
-                  "-mabi=spe", "-mabi=eabi", "-fext-numeric-literal"]
+                  "-mabi=spe", "-mabi=eabi", "-fext-numeric-literals"]
         action = {
             'file': 'main.cpp',
             'command': "g++ {} main.cpp".format(' '.join(ignore)),
@@ -478,10 +483,11 @@ class OptionParserTest(unittest.TestCase):
         self.assertEqual(res,
                          '/usr/lib/ccache/g++')
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_compiler_gcc_implicit_includes(self):
         action = {
             'file': 'main.cpp',
@@ -524,10 +530,11 @@ class OptionParserTest(unittest.TestCase):
             res = log_parser.parse_options(action, keep_gcc_intrin=True)
             self.assertEqual(include_dirs, res.analyzer_options)
 
-    @unittest.skipIf(clangsa.version.get("g++") is not None,
-                     "If gcc or g++ is a symlink to clang this test should be "
-                     "skipped. Option filtering is different for the two "
-                     "compilers. This test is gcc/g++ specific.")
+    @unittest.skipUnless(
+        clangsa.version.get("g++"),
+        "If gcc or g++ is a symlink to clang this test should be "
+        "skipped. Option filtering is different for the two "
+        "compilers. This test is gcc/g++ specific.")
     def test_compiler_gcc_intrin_headers(self):
         def contains_intrinsic_headers(dirname):
             for f in os.listdir(dirname):


### PR DESCRIPTION
> Closes #3113

Handle use cases when the `clang --version` command doesn't have an `InstalledDir` field.