### PR TITLE
[gui] Use textarea at source component description

### DIFF
--- a/web/server/vue-cli/e2e/pages/report.js
+++ b/web/server/vue-cli/e2e/pages/report.js
@@ -201,7 +201,7 @@ module.exports = {
       elements: {
         name: ".component-name input[type='text']",
         value: ".component-value textarea",
-        description: ".component-description input[type='text']",
+        description: ".component-description textarea",
         saveBtn: ".save-btn",
         cancelBtn: ".cancel-btn",
       }

--- a/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
+++ b/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
@@ -56,7 +56,7 @@
               :rules="rules.value"
             />
 
-            <v-text-field
+            <v-textarea
               v-model.trim="component.description"
               class="component-description "
               label="Description"


### PR DESCRIPTION
> Closes #3164

The `Description` field on the Web GUI when editing source components
is a single-line textbox, which makes writing anything longer than six
words needing scroll. For this reason we turn the UI element into a
textarea.