### PR TITLE
[client] Fix source content change error when diffing remote runs

### DIFF
--- a/web/tests/functional/diff_remote/__init__.py
+++ b/web/tests/functional/diff_remote/__init__.py
@@ -189,6 +189,10 @@ def setup_package():
     # Export the test configuration to the workspace.
     env.export_test_cfg(TEST_WORKSPACE, test_config)
 
+    # Remove report directories which are not used anymore.
+    shutil.rmtree(test_proj_path_base)
+    shutil.rmtree(test_proj_path_new)
+
 
 def teardown_package():
     """Clean up after the test."""


### PR DESCRIPTION
> Closes #3182

When diffing two runs from a command-line client, a
`The following source file contents changed since the latest analysis:`
error is shown instead of the diff.

To reproduce the problem we just have to remove the project folder after
storage or use the --trim-path-prefix option during storage and then
just run the diff command with two remote runs.