### PR TITLE
[analyze] Fix cleanup metadata

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -761,10 +761,21 @@ def __cleanup_metadata(metadata_prev, metadata):
                 LOG.info("Remove plist file '%s' because it refers to a "
                          "source file ('%s') which was removed.",
                          plist_file, source_file)
-                del metadata['result_source_files'][plist_file]
+                __del_result_source_file(metadata, plist_file)
                 os.remove(plist_file)
             except OSError:
                 LOG.warning("Failed to remove plist file: %s", plist_file)
+
+
+def __del_result_source_file(metadata, file_path):
+    """ Remove file path from metadata result source files. """
+    if 'result_source_files' in metadata:
+        # Kept for backward-compatibility reason.
+        del metadata['result_source_files'][file_path]
+    else:
+        for tool in metadata.get('tools', {}):
+            result_source_files = tool.get('result_source_files', {})
+            del result_source_files[file_path]
 
 
 def __get_result_source_files(metadata):


### PR DESCRIPTION
> Closes #3180

At the end of the analysis we try to cleanup the metadata file when we
do an incremental analysis. If the source file for a plist doesn't exist,
we try to remove the plist file from the system and from the metadata.

Previously we created a new metadata format but we forgot to modify this
code part where we remove the plist file from this metadata file.

This commit will handle the use case when old and new metadata format
already can be found in report directory during analysis and the
plist file need to be removed.