### PR TITLE
[ref] Use singleton when creating context objects

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 from codechecker_common import logger
+from codechecker_common.singleton import Singleton
 from codechecker_common.util import load_json_or_empty
 
 from . import env
@@ -247,7 +248,7 @@ class GuidelineMap(Mapping):
 
 
 # -----------------------------------------------------------------------------
-class Context(object):
+class Context(object, metaclass=Singleton):
     """ Generic package specific context. """
 
     def __init__(self, package_root, pckg_layout, cfg_dict):

--- a/codechecker_common/singleton.py
+++ b/codechecker_common/singleton.py
@@ -1,0 +1,11 @@
+class Singleton(type):
+    """ Helper type to create singleton classes. """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = \
+                super(Singleton, cls).__call__(*args, **kwargs)
+
+        return cls._instances[cls]

--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from codechecker_common import logger
+from codechecker_common.singleton import Singleton
 from codechecker_common.util import load_json_or_empty
 
 LOG = logger.get_logger('system')
@@ -49,7 +50,7 @@ class SeverityMap(Mapping):
 
 
 # -----------------------------------------------------------------------------
-class Context(object):
+class Context(object, metaclass=Singleton):
     """ Generic package specific context. """
 
     def __init__(self, package_root, pckg_layout, cfg_dict):


### PR DESCRIPTION
Use singleton pattern when creating context objects (analyzer/web) to improve the performance.