### PR TITLE
[analyze] Handle no analyzer use cases

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -176,8 +176,9 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
 
     analyzers = args.analyzers if 'analyzers' in args \
         else analyzer_types.supported_analyzers
-    analyzers, _ = analyzer_types.check_supported_analyzers(
+    analyzers, errored = analyzer_types.check_supported_analyzers(
         analyzers, context)
+    analyzer_types.check_available_analyzers(analyzers, errored)
 
     ctu_collect = False
     ctu_analyze = False
@@ -365,6 +366,8 @@ def perform_analysis(args, skip_handler, context, actions, metadata_tool,
 
     end_time = time.time()
     LOG.info("Analysis length: %s sec.", end_time - start_time)
+
+    analyzer_types.print_unsupported_analyzers(errored)
 
     metadata_tool['timestamps'] = {'begin': start_time,
                                    'end': end_time}

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -339,8 +339,8 @@ class Context(object):
                 env_path = analyzer_env['PATH'] if analyzer_env else None
                 compiler_binary = find_executable(value, env_path)
                 if not compiler_binary:
-                    LOG.warning("'%s' binary can not be found in your PATH!",
-                                value)
+                    LOG.debug("'%s' binary can not be found in your PATH!",
+                              value)
                     continue
 
                 self.__analyzers[name] = os.path.realpath(compiler_binary)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -943,8 +943,11 @@ def main(args):
     analyzer_clang_binary = \
         context.analyzer_binaries.get(
             clangsa.analyzer.ClangSA.ANALYZER_NAME)
-    analyzer_clang_version = clangsa.version.get(analyzer_clang_binary,
-                                                 analyzer_env)
+
+    analyzer_clang_version = None
+    if analyzer_clang_binary:
+        analyzer_clang_version = clangsa.version.get(analyzer_clang_binary,
+                                                     analyzer_env)
 
     actions, skipped_cmp_cmd_count = log_parser.parse_unique_log(
         compile_commands,

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -217,6 +217,7 @@ def main(args):
     working_analyzers, errored = analyzer_types.check_supported_analyzers(
         args.analyzers,
         context)
+    analyzer_types.check_available_analyzers(working_analyzers, errored)
 
     analyzer_environment = env.extend(context.path_env_extra,
                                       context.ld_lib_path_extra)
@@ -400,8 +401,4 @@ def main(args):
     if rows:
         print(twodim.to_str(args.output_format, header, rows))
 
-    for analyzer_binary, reason in errored:
-        LOG.error("Failed to get checkers for '%s'!"
-                  "The error reason was: '%s'", analyzer_binary, reason)
-        LOG.error("Please check your installation and the "
-                  "'config/package_layout.json' file!")
+    analyzer_types.print_unsupported_analyzers(errored)


### PR DESCRIPTION
> Closes #3141

Handle use cases when no analyzer can be found (clang, clang-tidy) on the user's host machine at all or one of the enabled analyzer is missing.