### PR TITLE
[gui] Show review status selector even if status change is disabled

### DIFF
--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -29,7 +29,6 @@
           </v-col>
 
           <v-col
-            v-if="!isReviewStatusDisabled"
             cols="auto"
             class="review-status-wrapper pa-0"
             align-self="center"
@@ -228,8 +227,6 @@ import {
   ReviewData
 } from "@cc/report-server-types";
 
-import { mapGetters } from "vuex";
-
 import { FillHeight } from "@/directives";
 import CopyBtn from "@/components/CopyBtn";
 import { UserIcon } from "@/components/Icons";
@@ -283,10 +280,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters([
-      "currentProductConfig",
-    ]),
-
     checkerId() {
       return this.report ? this.report.checkerId : null;
     },
@@ -297,13 +290,6 @@ export default {
       return this.showComments
         ? maxCols - this.commentCols
         : maxCols;
-    },
-
-    isReviewStatusDisabled() {
-      // Disable by default.
-      if (!this.currentProductConfig) return true;
-
-      return this.currentProductConfig.isReviewStatusChangeDisabled;
     }
   },
 

--- a/web/server/vue-cli/src/components/Report/SelectReviewStatus.vue
+++ b/web/server/vue-cli/src/components/Report/SelectReviewStatus.vue
@@ -16,6 +16,7 @@
             :items="items"
             :hide-details="true"
             :menu-props="{ contentClass: 'select-review-status-menu' }"
+            :disabled="isReviewStatusDisabled"
             label="Set review status"
             item-text="label"
             item-value="id"
@@ -134,8 +135,16 @@ export default {
 
   computed: {
     ...mapGetters([
+      "currentProductConfig",
       "currentUser"
-    ])
+    ]),
+
+    isReviewStatusDisabled() {
+      // Disable by default.
+      if (!this.currentProductConfig) return true;
+
+      return this.currentProductConfig.isReviewStatusChangeDisabled;
+    }
   },
 
   created() {


### PR DESCRIPTION
> Closes #3128

Show the review status change selector in read-only mode if the
review status change is disabled on the product configuration page
instead of hiding the whole selector.