### PR TITLE
[client] Handle no mandatory env var when using gerrit output

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -652,6 +652,9 @@ def main(args):
                   "when exporting to HTML.")
         sys.exit(1)
 
+    if export == 'gerrit' and gerrit.no_mandatory_env_var_is_set():
+        sys.exit(1)
+
     context = analyzer_context.get_context()
 
     # To ensure the help message prints the default folder properly,

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -628,7 +628,7 @@ def parse_convert_reports(input_dirs: List[str],
     if out_format == "json":
         return [out_json.convert_to_parse(r) for r in all_reports]
 
-    LOG.error(f"Unknown export format: {out_format}")
+    LOG.error("Unknown export format: %s", out_format)
     return {}
 
 
@@ -652,7 +652,7 @@ def main(args):
                   "when exporting to HTML.")
         sys.exit(1)
 
-    if export == 'gerrit' and gerrit.no_mandatory_env_var_is_set():
+    if export == 'gerrit' and not gerrit.mandatory_env_var_is_set():
         sys.exit(1)
 
     context = analyzer_context.get_context()

--- a/codechecker_common/output/gerrit.py
+++ b/codechecker_common/output/gerrit.py
@@ -34,27 +34,27 @@ def convert(reports: List[Report], severity_map: Dict[str, str]) -> Dict:
                              severity_map)
 
 
-def no_mandatory_env_var_is_set():
+def mandatory_env_var_is_set():
     """
-    True and print error messages if no mandatory environment variables are set
-    when using gerrit output.
+    True if mandatory environment variables are set otherwise False and print
+    error messages.
     """
-    has_error = False
+    no_missing_env_var = True
 
     if os.environ.get('CC_REPO_DIR') is None:
         LOG.error("When using gerrit output the 'CC_REPO_DIR' environment "
                   "variable needs to be set to the root directory of the "
                   "sources, i.e. the directory where the repository was "
                   "cloned!")
-        has_error = True
+        no_missing_env_var = False
 
     if os.environ.get('CC_CHANGED_FILES') is None:
         LOG.error("When using gerrit output the 'CC_CHANGED_FILES' "
                   "environment variable needs to be set to the path of "
                   "changed files json from Gerrit!")
-        has_error = True
+        no_missing_env_var = False
 
-    return has_error
+    return no_missing_env_var
 
 
 def __convert_reports(reports: List[Report],

--- a/codechecker_common/output/gerrit.py
+++ b/codechecker_common/output/gerrit.py
@@ -8,11 +8,14 @@
 """Helper and converter functions for the gerrit review json format."""
 
 from typing import Dict, List, Union
-from codechecker_common.report import Report
-
+import json
 import os
 import re
-import json
+
+from codechecker_common import logger
+from codechecker_common.report import Report
+
+LOG = logger.get_logger('system')
 
 
 def convert(reports: List[Report], severity_map: Dict[str, str]) -> Dict:
@@ -29,6 +32,29 @@ def convert(reports: List[Report], severity_map: Dict[str, str]) -> Dict:
     return __convert_reports(reports, repo_dir, report_url,
                              changed_files, changed_file_path,
                              severity_map)
+
+
+def no_mandatory_env_var_is_set():
+    """
+    True and print error messages if no mandatory environment variables are set
+    when using gerrit output.
+    """
+    has_error = False
+
+    if os.environ.get('CC_REPO_DIR') is None:
+        LOG.error("When using gerrit output the 'CC_REPO_DIR' environment "
+                  "variable needs to be set to the root directory of the "
+                  "sources, i.e. the directory where the repository was "
+                  "cloned!")
+        has_error = True
+
+    if os.environ.get('CC_CHANGED_FILES') is None:
+        LOG.error("When using gerrit output the 'CC_CHANGED_FILES' "
+                  "environment variable needs to be set to the path of "
+                  "changed files json from Gerrit!")
+        has_error = True
+
+    return has_error
 
 
 def __convert_reports(reports: List[Report],

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -844,7 +844,8 @@ def handle_diff_results(args):
                   "are selected!")
         sys.exit(1)
 
-    if 'gerrit' in args.output_format and gerrit.no_mandatory_env_var_is_set():
+    if 'gerrit' in args.output_format and \
+            not gerrit.mandatory_env_var_is_set():
         sys.exit(1)
 
     check_deprecated_arg_usage(args)

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -844,6 +844,9 @@ def handle_diff_results(args):
                   "are selected!")
         sys.exit(1)
 
+    if 'gerrit' in args.output_format and gerrit.no_mandatory_env_var_is_set():
+        sys.exit(1)
+
     check_deprecated_arg_usage(args)
     context = webserver_context.get_context()
     source_line_contents = {}

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -376,6 +376,10 @@ class LocalRemote(unittest.TestCase):
 
         export_dir = os.path.join(self._local_reports, "export_dir1")
 
+        env = self._env.copy()
+        env["CC_REPO_DIR"] = ''
+        env["CC_CHANGED_FILES"] = ''
+
         diff_cmd = [self._codechecker_cmd, "cmd", "diff",
                     "--new",
                     "--url", self._url,
@@ -384,7 +388,7 @@ class LocalRemote(unittest.TestCase):
                     "-o", "gerrit",
                     "-e", export_dir]
 
-        self.run_cmd(diff_cmd)
+        self.run_cmd(diff_cmd, env)
         gerrit_review_file = os.path.join(export_dir, 'gerrit_review.json')
         self.assertTrue(os.path.exists(gerrit_review_file))
 
@@ -425,6 +429,10 @@ class LocalRemote(unittest.TestCase):
         """
         base_run_name = self._run_names[0]
 
+        env = self._env.copy()
+        env["CC_REPO_DIR"] = ''
+        env["CC_CHANGED_FILES"] = ''
+
         diff_cmd = [self._codechecker_cmd, "cmd", "diff",
                     "--new",
                     "--url", self._url,
@@ -432,7 +440,7 @@ class LocalRemote(unittest.TestCase):
                     "-n", self._local_reports,
                     "-o", "gerrit"]
 
-        review_data = self.run_cmd(diff_cmd)
+        review_data = self.run_cmd(diff_cmd, env)
         print(review_data)
         review_data = json.loads(review_data)
         lbls = review_data["labels"]
@@ -495,6 +503,13 @@ class LocalRemote(unittest.TestCase):
             changed_file.write(json.dumps(changed_files))
 
         env["CC_CHANGED_FILES"] = changed_file_path
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            out = self.run_cmd(diff_cmd)
+            self.assertIn("'CC_REPO_DIR'", out)
+            self.assertIn("'CC_CHANGED_FILES'", out)
+            self.assertIn("needs to be set", out)
+
         self.run_cmd(diff_cmd, env)
         gerrit_review_file = os.path.join(export_dir, 'gerrit_review.json')
         self.assertTrue(os.path.exists(gerrit_review_file))
@@ -612,6 +627,10 @@ class LocalRemote(unittest.TestCase):
 
         export_dir = os.path.join(self._local_reports, "export_dir3")
 
+        env = self._env.copy()
+        env["CC_REPO_DIR"] = ''
+        env["CC_CHANGED_FILES"] = ''
+
         diff_cmd = [self._codechecker_cmd, "cmd", "diff",
                     "--resolved",
                     "--url", self._url,
@@ -620,7 +639,7 @@ class LocalRemote(unittest.TestCase):
                     "-o", "html", "gerrit", "plaintext",
                     "-e", export_dir]
 
-        out = self.run_cmd(diff_cmd)
+        out = self.run_cmd(diff_cmd, env)
 
         # Check the plaintext output.
         count = len(re.findall(r'\[core\.NullDereference\]', out))


### PR DESCRIPTION
> Closes #3122

Print error messages and stop the command when no mandatory environment variables (`CC_REPO_DIR`, `CC_CHANGED_FILES`) are set when using gerrit output.