### PR TITLE
[client] Handle invalid proxy settings

### DIFF
--- a/web/client/codechecker_client/helpers/base.py
+++ b/web/client/codechecker_client/helpers/base.py
@@ -40,11 +40,11 @@ class BaseClientHelper(object):
             # Initalizing THttpClient may raise an exception if proxy settings
             # are used but the port number is not a valid integer.
             pass
-        finally:
-            # Thrift do not handle the use case when invalid proxy format is
-            # used (e.g.: no schema is specified). For this reason we need to
-            # verify the proxy format in our side.
-            self._validate_proxy_format()
+
+        # Thrift do not handle the use case when invalid proxy format is
+        # used (e.g.: no schema is specified). For this reason we need to
+        # verify the proxy format in our side.
+        self._validate_proxy_format()
 
         self.protocol = TJSONProtocol.TJSONProtocol(self.transport)
         self.client = None

--- a/web/client/codechecker_client/thrift_call.py
+++ b/web/client/codechecker_client/thrift_call.py
@@ -21,37 +21,6 @@ from codechecker_common.logger import get_logger
 
 LOG = get_logger('system')
 
-PROXY_VALIDATION_NEEDED = True
-
-
-def proxy_settings_are_valid(transport):
-    """
-    Return True if no proxy settings are used or the proxy format it valid.
-    """
-    if not transport.using_proxy():
-        return True
-
-    return transport.host and isinstance(transport.port, int)
-
-
-def validate_proxy_format(transport):
-    """
-    It will check the proxy settings once and validate the proxy settings.
-    If the proxy settings are invalid, it will print an error message and
-    stop the program.
-    """
-    global PROXY_VALIDATION_NEEDED
-
-    if PROXY_VALIDATION_NEEDED:
-        if not proxy_settings_are_valid(transport):
-            LOG.error("Invalid proxy format! Check your "
-                      "HTTP_PROXY/HTTPS_PROXY environment variables if "
-                      "these are in the right format:"
-                      "'http[s]://host:port'.")
-            sys.exit(1)
-
-        PROXY_VALIDATION_NEEDED = False
-
 
 def truncate_arg(arg, max_len=100):
     """ Truncate the given argument if the length is too large. """
@@ -69,11 +38,6 @@ def ThriftClientCall(function):
     funcName = function.__name__
 
     def wrapper(self, *args, **kwargs):
-        # Thrift do not handle the use case when invalid proxy format is used
-        # (e.g.: no schema is specified). For this reason we need to verify
-        # the proxy format in our side.
-        validate_proxy_format(self.transport)
-
         self.transport.open()
         func = getattr(self.client, funcName)
         try:

--- a/web/client/codechecker_client/thrift_call.py
+++ b/web/client/codechecker_client/thrift_call.py
@@ -21,6 +21,37 @@ from codechecker_common.logger import get_logger
 
 LOG = get_logger('system')
 
+PROXY_VALIDATION_NEEDED = True
+
+
+def proxy_settings_are_valid(transport):
+    """
+    Return True if no proxy settings are used or the proxy format it valid.
+    """
+    if not transport.using_proxy():
+        return True
+
+    return transport.host and isinstance(transport.port, int)
+
+
+def validate_proxy_format(transport):
+    """
+    It will check the proxy settings once and validate the proxy settings.
+    If the proxy settings are invalid, it will print an error message and
+    stop the program.
+    """
+    global PROXY_VALIDATION_NEEDED
+
+    if PROXY_VALIDATION_NEEDED:
+        if not proxy_settings_are_valid(transport):
+            LOG.error("Invalid proxy format! Check your "
+                      "HTTP_PROXY/HTTPS_PROXY environment variables if "
+                      "these are in the right format:"
+                      "'http[s]://host:port'.")
+            sys.exit(1)
+
+        PROXY_VALIDATION_NEEDED = False
+
 
 def truncate_arg(arg, max_len=100):
     """ Truncate the given argument if the length is too large. """
@@ -38,6 +69,11 @@ def ThriftClientCall(function):
     funcName = function.__name__
 
     def wrapper(self, *args, **kwargs):
+        # Thrift do not handle the use case when invalid proxy format is used
+        # (e.g.: no schema is specified). For this reason we need to verify
+        # the proxy format in our side.
+        validate_proxy_format(self.transport)
+
         self.transport.open()
         func = getattr(self.client, funcName)
         try:


### PR DESCRIPTION
If `HTTP_PROXY` / `HTTPS_PROXY` environment variables are set and the
URL is invalid (e.g.: it doesn't contains a schema like localhost:8001)
the client will throw the following exception:
```
'NoneType' object has no attribute 'rfind'
  File "/codechecker/build/CodeChecker/cc_bin/CodeChecker.py", line 174, in <module>
    main(commands)
  File "/codechecker/build/CodeChecker/cc_bin/CodeChecker.py", line 141, in main
    sys.exit(args.func(args))
  File "//codechecker/build/CodeChecker/lib/python3/codechecker_client/cmd/store.py", line 856, in main
    traceback.print_stack()
```
From this error message it is hard to understand the real problem.

Unfortunately Thrift does not handle the use case when invalid proxy format
is used (e.g.: no schema is specified). For this reason we need to verify
the proxy format in our side.