### PR TITLE
[fix] Fix file path in codeclimate output

### DIFF
--- a/codechecker_common/output/codeclimate.py
+++ b/codechecker_common/output/codeclimate.py
@@ -7,7 +7,6 @@
 # -------------------------------------------------------------------------
 """Codeclimate output helpers."""
 
-import os
 from typing import Dict, List
 
 from codechecker_common.report import Report
@@ -29,8 +28,6 @@ def convert(reports: List[Report]) -> Dict:
 
 def __to_codeclimate(report: Report) -> Dict:
     """Convert a Report to Code Climate format."""
-    _, file_name = os.path.split(report.file_path)
-
     return {
         "type": "issue",
         "check_name": report.check_name,
@@ -38,7 +35,7 @@ def __to_codeclimate(report: Report) -> Dict:
         "categories": ["Bug Risk"],
         "fingerprint": report.report_hash,
         "location": {
-            "path": file_name,
+            "path": report.file_path,
             "lines": {
                 "begin": report.main['location']['line']
             }


### PR DESCRIPTION
> Closes #3199

Previously if there was a report for a `a/b/c/file.cpp`, then exporting in
codeclimate format always presented only `file.cpp` as file path. This
prevents correct navigation when viewing the report in GitLab. Using
`--trim-path-prefix` made no effect in `CodeChecker parse` output.