### PR TITLE
[analyze] Fix ccache compiler detection

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -345,6 +345,11 @@ class Context(object):
 
                 self.__analyzers[name] = os.path.realpath(compiler_binary)
 
+                # If the compiler binary is a simlink to ccache, use the
+                # original compiler binary.
+                if self.__analyzers[name].endswith("/ccache"):
+                    self.__analyzers[name] = compiler_binary
+
     def __populate_replacer(self):
         """ Set clang-apply-replacements tool. """
         replacer_binary = self.pckg_layout.get('clang-apply-replacements')


### PR DESCRIPTION
> Closes #3117 and closes #2730

When we try to find compiler binaries from the `PATH` we will resolve the
symlinks by using `os.path.realpath` function. If the compiler
(`g++/gcc/clang`) is a symlink to `ccache` it will think that the compiler
is ccache. When we try to get for example the version of the detected
analyze it will return the version for the ccache binary and not for
the original compiler.
For this reason if the detected compiler binary is `ccache` we will use
the original compiler path instead of resolving the symlink.