### PR TITLE
[analyze] Fix duplication warning when creating failed zip

### DIFF
--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -323,6 +323,8 @@ class TestAnalyze(unittest.TestCase):
         errcode = process.returncode
         self.assertEqual(errcode, 3)
 
+        self.assertNotIn("UserWarning: Duplicate name", err)
+
         # We expect a failure archive to be in the failed directory.
         failed_files = os.listdir(failed_dir)
         self.assertEqual(len(failed_files), 1)

--- a/analyzer/tests/functional/analyze/test_files/failure.c
+++ b/analyzer/tests/functional/analyze/test_files/failure.c
@@ -1,3 +1,6 @@
+#include "includes/simple.h"
+#include "includes/../includes/simple.h"
+
 int main(void){
 	return 0;
 	xxx //will cause a compilation error

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -330,7 +330,8 @@ def add_sources_to_zip(zip_file, files):
 
     with zipfile.ZipFile(zip_file, 'a') as archive:
         for f in files:
-            archive_path = os.path.join('sources-root', f.lstrip(os.sep))
+            archive_path = os.path.normpath(
+                os.path.join('sources-root', f.lstrip(os.sep)))
 
             try:
                 archive.getinfo(archive_path)


### PR DESCRIPTION
> Closes #3001

When there is a compilation failure, we will try to create a failed zip file
with source files. It is possible that we will try to add the same file
multiple times but on different path: `a/b/c` and `/a/b/../b/c`. In this
case CodeChecker will print out the following warning message:
`UserWarning: Duplicate name:...`
To avoid this problem we normalize the path before inserting it to the
zip file.