### PR TITLE
[tools] Add type hints to codechecker report hash tool

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -2,3 +2,4 @@ lxml==4.6.2
 portalocker==1.7.0
 psutil==5.7.0
 PyYAML==5.3.1
+mypy_extensions==0.4.3

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -6,3 +6,4 @@ portalocker==1.7.0
 pylint==2.4.4
 mkdocs==1.0.4
 PyYAML==5.3.1
+mypy_extensions==0.4.3

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -3,3 +3,4 @@ portalocker==1.7.0
 psutil==5.7.0
 scan-build==2.0.19
 PyYAML==5.3.1
+mypy_extensions==0.4.3

--- a/tools/codechecker_report_hash/requirements_py/dev/requirements.txt
+++ b/tools/codechecker_report_hash/requirements_py/dev/requirements.txt
@@ -1,3 +1,5 @@
 nose==1.3.7
 pycodestyle==2.5.0
 pylint==2.4.4
+mypy==0.812
+mypy_extensions==0.4.3

--- a/tools/codechecker_report_hash/tests/Makefile
+++ b/tools/codechecker_report_hash/tests/Makefile
@@ -8,9 +8,17 @@ REPO_ROOT ?= REPO_ROOT=$(ROOT)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: pycodestyle pylint test_unit
+test: mypy pycodestyle pylint test_unit
 
 test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env
+
+MYPY_TEST_CMD = mypy --ignore-missing-imports codechecker_report_hash tests
+
+mypy:
+	$(MYPY_TEST_CMD)
+
+mypy_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(MYPY_TEST_CMD)
 
 PYCODESTYLE_TEST_CMD = pycodestyle codechecker_report_hash tests
 

--- a/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/__init__.py
+++ b/tools/codechecker_report_hash/tests/unit/codechecker_report_hash/__init__.py
@@ -56,4 +56,4 @@ def teardown_package():
     global TEST_WORKSPACE
 
     print("Removing: " + TEST_WORKSPACE)
-    # shutil.rmtree(TEST_WORKSPACE)
+    shutil.rmtree(TEST_WORKSPACE)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,6 +3,7 @@ sqlalchemy==1.3.16
 alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
+mypy_extensions==0.4.3
 
 codechecker_api==6.39.0
 codechecker_api_shared==6.39.0

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -10,6 +10,7 @@ pylint==2.4.4
 nose==1.3.7
 mockldap==0.3.0
 mkdocs==1.0.4
+mypy_extensions==0.4.3
 
 codechecker_api==6.39.0
 codechecker_api_shared==6.39.0

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -3,6 +3,7 @@ alembic==1.4.2
 portalocker==1.7.0
 psutil==5.7.0
 sqlalchemy==1.3.16
+mypy_extensions==0.4.3
 
 codechecker_api==6.39.0
 codechecker_api_shared==6.39.0


### PR DESCRIPTION
- Add type hints to `codechecker_report_hash` tool.
- Add `mypy` static type checker to the requirements
- Create new targets to check the code with mypy.