### PR TITLE
[analyzer] Remove some code duplication from CodeChecker check command

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -29,29 +29,11 @@ from codechecker_common.util import load_json_or_empty
 
 LOG = logger.get_logger('system')
 
+_package_root = analyzer_context.get_context().package_root
+_severity_map_file = os.path.join(_package_root, 'config',
+                                  'checker_severity_map.json')
 
-def get_argparser_ctor_args():
-    """
-    This method returns a dict containing the kwargs for constructing an
-    argparse.ArgumentParser (either directly or as a subparser).
-    """
-
-    package_root = analyzer_context.get_context().package_root
-
-    return {
-        'prog': 'CodeChecker analyze',
-        'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
-
-        # Description is shown when the command's help is queried directly
-        'description': """
-Use the previously created JSON Compilation Database to perform an analysis on
-the project, outputting analysis results in a machine-readable format.""",
-
-        # Epilogue is shown after the arguments when the help is queried
-        # directly.
-        'epilog': """
-Environment variables
-------------------------------------------------
+epilog_env_var = f"""
   CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
                            from the `PATH` instead of the given binaries.
   CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
@@ -59,9 +41,10 @@ Environment variables
                            Clang Static Analyzer by using this environment
                            variable.
   CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
-                           Default: {}
+                           Default: {_severity_map_file}
+"""
 
-
+epilog_issue_hashes = """
 Issue hashes
 ------------------------------------------------
 - By default the issue hash calculation method for 'Clang Static Analyzer' is
@@ -103,7 +86,9 @@ checker is renamed.
 
 For more information see:
 https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/report_identification.md
+"""
 
+epilog_exit_status = """
 Exit status
 ------------------------------------------------
 0 - Successful analysis and no new reports
@@ -111,12 +96,38 @@ Exit status
 2 - At least one report emitted by an analyzer and there is no analyzer failure
 3 - Analysis of at least one translation unit failed
 128+signum - Terminating on a fatal signal whose number is signum
+"""
 
+
+def get_argparser_ctor_args():
+    """
+    This method returns a dict containing the kwargs for constructing an
+    argparse.ArgumentParser (either directly or as a subparser).
+    """
+    return {
+        'prog': 'CodeChecker analyze',
+        'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
+
+        # Description is shown when the command's help is queried directly
+        'description': """
+Use the previously created JSON Compilation Database to perform an analysis on
+the project, outputting analysis results in a machine-readable format.""",
+
+        # Epilogue is shown after the arguments when the help is queried
+        # directly.
+        'epilog': f"""
+Environment variables
+------------------------------------------------
+{epilog_env_var}
+
+{epilog_issue_hashes}
+
+{epilog_exit_status}
 
 Compilation databases can be created by instrumenting your project's build via
 'CodeChecker log'. To transform the results of the analysis to a human-friendly
 format, please see the commands 'CodeChecker parse' or 'CodeChecker store'.
-""".format(os.path.join(package_root, 'config', 'checker_severity_map.json')),
+""",
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -24,6 +24,40 @@ from codechecker_analyzer.buildlog.host_check import check_intercept
 from codechecker_common import arg, logger
 
 
+epilog_env_var = f"""
+  CC_LOGGER_ABS_PATH       If the environment variable is defined, all relative
+                           paths in the compilation commands after '-I,
+                           -idirafter, -imultilib, -iquote, -isysroot -isystem,
+                           -iwithprefix, -iwithprefixbefore, -sysroot,
+                           --sysroot' will be converted to absolute PATH when
+                           written into the compilation database.
+  CC_LOGGER_DEBUG_FILE     Output file to print log messages. By default if we
+                           run the log command in debug mode it will generate
+                           a 'codechecker.logger.debug' file beside the log
+                           file.
+  CC_LOGGER_DEF_DIRS       If the environment variable is defined, the logger
+                           will extend the compiler argument list in the
+                           compilation database with the pre-configured include
+                           paths of the logged compiler.
+  CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
+                           compilers should be logged. For example (default):
+                           export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
+                           cc:c++". The logger will match any compilers with
+                           'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
+                           their filenames.
+  CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
+                           removed from the build action. For example in case
+                           of this build command: 'gcc main.c object1.o
+                           object2.so' the 'object1.o' and 'object2.so' will be
+                           removed and only 'gcc main.c' will be captured. If
+                           only object files are provided to the compiler then
+                           the complete build action will be thrown away. This
+                           means that build actions which only perform linking
+                           will not be captured. We consider a file as object
+                           file if its extension is '.o', '.so' or '.a'.
+"""
+
+
 def get_argparser_ctor_args():
     """
     This method returns a dict containing the kwargs for constructing an
@@ -50,39 +84,11 @@ Available build logger tool that will be used is '{0}'.{1}
 """.format('intercept-build' if is_intercept else 'ld-logger',
            ldlogger_settings),
 
-        'epilog': """
+        'epilog': f"""
 Environment variables
 ------------------------------------------------
-  CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
-                           compilers should be logged. For example (default):
-                           export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
-                           cc:c++". The logger will match any compilers with
-                           'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
-                           their filenames.
-  CC_LOGGER_DEF_DIRS       If the environment variable is defined, the logger
-                           will extend the compiler argument list in the
-                           compilation database with the pre-configured include
-                           paths of the logged compiler.
-  CC_LOGGER_ABS_PATH       If the environment variable is defined, all relative
-                           paths in the compilation commands after '-I,
-                           -idirafter, -imultilib, -iquote, -isysroot -isystem,
-                           -iwithprefix, -iwithprefixbefore, -sysroot,
-                           --sysroot' will be converted to absolute PATH when
-                           written into the compilation database.
-  CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
-                           removed from the build action. For example in case
-                           of this build command: 'gcc main.c object1.o
-                           object2.so' the 'object1.o' and 'object2.so' will be
-                           removed and only 'gcc main.c' will be captured. If
-                           only object files are provided to the compiler then
-                           the complete build action will be thrown away. This
-                           means that build actions which only perform linking
-                           will not be captured. We consider a file as object
-                           file if its extension is '.o', '.so' or '.a'.
-  CC_LOGGER_DEBUG_FILE     Output file to print log messages. By default if we
-                           run the log command in debug mode it will generate
-                           a 'codechecker.logger.debug' file beside the log
-                           file.""",
+{epilog_env_var}
+""",
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -39,6 +39,22 @@ LOG = logger.get_logger('system')
 
 EXPORT_TYPES = ['html', 'json', 'codeclimate', 'gerrit']
 
+_package_root = analyzer_context.get_context().package_root
+_severity_map_file = os.path.join(_package_root, 'config',
+                                  'checker_severity_map.json')
+
+epilog_env_var = f"""
+  CC_CHANGED_FILES       Path of changed files json from Gerrit. Use it when
+                         generating gerrit output.
+  CC_REPO_DIR            Root directory of the sources, i.e. the directory
+                         where the repository was cloned. Use it when
+                         generating gerrit output.
+  CC_REPORT_URL          URL where the report can be found. Use it when
+                         generating gerrit output.
+  CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
+                         Default: {_severity_map_file}
+"""
+
 
 class PlistToPlaintextFormatter(object):
     """
@@ -361,9 +377,6 @@ def get_argparser_ctor_args():
     This method returns a dict containing the kwargs for constructing an
     argparse.ArgumentParser (either directly or as a subparser).
     """
-
-    package_root = analyzer_context.get_context().package_root
-
     return {
         'prog': 'CodeChecker parse',
         'formatter_class': arg.RawDescriptionDefaultHelpFormatter,
@@ -375,20 +388,11 @@ Parse and pretty-print the summary and results from one or more
 "false_positive", "suppress" and "intentional" source code comments will not be
 printed by the `parse` command.""",
 
-        'epilog': """
+        'epilog': f"""
 Environment variables
 ------------------------------------------------
-  CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
-  CC_REPO_DIR         Root directory of the sources, i.e. the directory where
-                      the repository was cloned. Use it when generating gerrit
-                      output.
-  CC_REPORT_URL       URL where the report can be found. Use it when generating
-                      gerrit output.
-  CC_CHANGED_FILES    Path of changed files json from Gerrit. Use it when
-                      generating gerrit output.
-                         Default: {}
-
-""".format(os.path.join(package_root, 'config', 'checker_severity_map.json')),
+{epilog_env_var}
+""",
 
         # Help is shown when the "parent" CodeChecker command lists the
         # individual subcommands.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -398,6 +398,41 @@ output arguments:
 
 Environment variables
 ------------------------------------------------
+Environment variables for 'CodeChecker log' command:
+
+  CC_LOGGER_ABS_PATH       If the environment variable is defined, all relative
+                           paths in the compilation commands after '-I,
+                           -idirafter, -imultilib, -iquote, -isysroot -isystem,
+                           -iwithprefix, -iwithprefixbefore, -sysroot,
+                           --sysroot' will be converted to absolute PATH when
+                           written into the compilation database.
+  CC_LOGGER_DEBUG_FILE     Output file to print log messages. By default if we
+                           run the log command in debug mode it will generate
+                           a 'codechecker.logger.debug' file beside the log
+                           file.
+  CC_LOGGER_DEF_DIRS       If the environment variable is defined, the logger
+                           will extend the compiler argument list in the
+                           compilation database with the pre-configured include
+                           paths of the logged compiler.
+  CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
+                           compilers should be logged. For example (default):
+                           export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
+                           cc:c++". The logger will match any compilers with
+                           'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
+                           their filenames.
+  CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
+                           removed from the build action. For example in case
+                           of this build command: 'gcc main.c object1.o
+                           object2.so' the 'object1.o' and 'object2.so' will be
+                           removed and only 'gcc main.c' will be captured. If
+                           only object files are provided to the compiler then
+                           the complete build action will be thrown away. This
+                           means that build actions which only perform linking
+                           will not be captured. We consider a file as object
+                           file if its extension is '.o', '.so' or '.a'.
+
+Environment variables for 'CodeChecker analyze' command:
+
   CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
                            from the `PATH` instead of the given binaries.
   CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
@@ -406,12 +441,18 @@ Environment variables
                            variable.
   CC_SEVERITY_MAP_FILE     Path of the checker-severity mapping config file.
                            Default: <package>/config/checker_severity_map.json
-  CC_LOGGER_DEBUG_FILE     If -b and -o flags are used with debug logs, the
-                           logging phase emits its debug logs in
-                           'codechecker.logger.debug' under the output
-                           directory by default. This environment variable
-                           can be given a file path which overrides this
-                           default location.
+
+Environment variables for 'CodeChecker parse' command:
+
+  CC_CHANGED_FILES       Path of changed files json from Gerrit. Use it when
+                         generating gerrit output.
+  CC_REPO_DIR            Root directory of the sources, i.e. the directory
+                         where the repository was cloned. Use it when
+                         generating gerrit output.
+  CC_REPORT_URL          URL where the report can be found. Use it when
+                         generating gerrit output.
+  CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
+                         Default: <package>/config/checker_severity_map.json
 
 Issue hashes
 ------------------------------------------------
@@ -517,22 +558,27 @@ optional arguments:
 
 Environment variables
 ------------------------------------------------
-  CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
-                           compilers should be logged. For example (default):
-                           export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
-                           cc:c++". The logger will match any compilers with
-                           'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
-                           their filenames.
-  CC_LOGGER_DEF_DIRS       If the environment variable is defined, the logger
-                           will extend the compiler argument list in the
-                           compilation database with the pre-configured include
-                           paths of the logged compiler.
+
   CC_LOGGER_ABS_PATH       If the environment variable is defined, all relative
                            paths in the compilation commands after '-I,
                            -idirafter, -imultilib, -iquote, -isysroot -isystem,
                            -iwithprefix, -iwithprefixbefore, -sysroot,
                            --sysroot' will be converted to absolute PATH when
                            written into the compilation database.
+  CC_LOGGER_DEBUG_FILE     Output file to print log messages. By default if we
+                           run the log command in debug mode it will generate
+                           a 'codechecker.logger.debug' file beside the log
+                           file.
+  CC_LOGGER_DEF_DIRS       If the environment variable is defined, the logger
+                           will extend the compiler argument list in the
+                           compilation database with the pre-configured include
+                           paths of the logged compiler.
+  CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
+                           compilers should be logged. For example (default):
+                           export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
+                           cc:c++". The logger will match any compilers with
+                           'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
+                           their filenames.
   CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
                            removed from the build action. For example in case
                            of this build command: 'gcc main.c object1.o
@@ -543,10 +589,6 @@ Environment variables
                            means that build actions which only perform linking
                            will not be captured. We consider a file as object
                            file if its extension is '.o', '.so' or '.a'.
-  CC_LOGGER_DEBUG_FILE     Output file to print log messages. By default if we
-                           run the log command in debug mode it will generate
-                           a 'codechecker.logger.debug' file beside the log
-                           file.
 ```
 </details>
 
@@ -870,6 +912,7 @@ optional arguments:
 
 Environment variables
 ------------------------------------------------
+
   CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
                            from the `PATH` instead of the given binaries.
   CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
@@ -1589,14 +1632,15 @@ export arguments:
 
 Environment variables
 ------------------------------------------------
+
+  CC_CHANGED_FILES       Path of changed files json from Gerrit. Use it when
+                         generating gerrit output.
+  CC_REPO_DIR            Root directory of the sources, i.e. the directory
+                         where the repository was cloned. Use it when
+                         generating gerrit output.
+  CC_REPORT_URL          URL where the report can be found. Use it when
+                         generating gerrit output.
   CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
-  CC_REPO_DIR         Root directory of the sources, i.e. the directory where
-                      the repository was cloned. Use it when generating gerrit
-                      output.
-  CC_REPORT_URL       URL where the report can be found. Use it when generating
-                      gerrit output.
-  CC_CHANGED_FILES    Path of changed files json from Gerrit. Use it when
-                      generating gerrit output.
                          Default: <package>/config/checker_severity_map.json
 ```
 </details>


### PR DESCRIPTION
Remove code duplication which is related to epilog from the `CodeChecker check` command.