### PR TITLE
[tools] Add compilation database generator for Bazel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install common dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install gcc-multilib
+          sudo apt-get install gcc-multilib bazel
 
       - name: Run build-logger tests
         working-directory: analyzer/tools/build-logger
@@ -74,6 +74,12 @@ jobs:
 
       - name: Run tu-collector tests
         working-directory: tools/tu_collector
+        run: |
+          pip install -r requirements_py/dev/requirements.txt
+          make test
+
+      - name: Run bazel-compile-commands tests
+        working-directory: tools/bazel
         run: |
           pip install -r requirements_py/dev/requirements.txt
           make test

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -102,10 +102,20 @@ package_statistics_collector: build_statistics_collector package_dir_structure
 	cd $(CC_BUILD_BIN_DIR) && \
 	ln -sf ../lib/python3/codechecker_statistics_collector/cli.py post-process-stats
 
+build_bazel_compile_commands:
+	$(MAKE) -C $(ROOT)/tools/bazel build
+
+package_bazel_compile_commands: build_bazel_compile_commands package_dir_structure
+	# Copy bazel_compile_commands files.
+	cp -rp $(CC_TOOLS)/bazel/build/bazel/bazel_compile_commands $(CC_BUILD_LIB_DIR) && \
+	chmod u+x $(CC_BUILD_LIB_DIR)/bazel_compile_commands/bazel_compile_commands.py && \
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../lib/python3/bazel_compile_commands/bazel_compile_commands.py bazel-compile-commands
+
 # This target should be used from the top level Makefile to build the package
 # together with the web part. This way we will not build plist-to-html
 # multiple times.
-package_analyzer: package_dir_structure package_plist_to_html package_tu_collector package_report_hash package_merge_clang_extdef_mappings package_report_converter package_statistics_collector
+package_analyzer: package_dir_structure package_plist_to_html package_tu_collector package_report_hash package_merge_clang_extdef_mappings package_report_converter package_statistics_collector package_bazel_compile_commands
 
 package: package_analyzer
 	# Copy libraries.
@@ -174,7 +184,7 @@ else
   endif
 endif
 
-clean_package: clean_plist_to_html clean_tu_collector
+clean_package: clean_plist_to_html clean_tu_collector clean_bazel_compile_commands
 	rm -rf $(BUILD_DIR)
 	find . -name "*.pyc" -delete
 
@@ -183,3 +193,6 @@ clean_plist_to_html:
 
 clean_tu_collector:
 	rm -rf $(ROOT)/tools/tu_collector/build
+
+clean_bazel_compile_commands:
+	rm -rf $(ROOT)/tools/bazel/build

--- a/tools/bazel/.gitignore
+++ b/tools/bazel/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.egg-info

--- a/tools/bazel/.noserc
+++ b/tools/bazel/.noserc
@@ -1,0 +1,13 @@
+[nosetests]
+
+# increase verbosity level
+verbosity=3
+
+# more detailed error messages on failed asserts
+detailed-errors=1
+
+# stop running tests on first error
+stop=1
+
+# do not capture stdout
+#nocapture=1

--- a/tools/bazel/.pypirc
+++ b/tools/bazel/.pypirc
@@ -1,0 +1,10 @@
+[distutils]
+index-servers =
+  pypi
+  testpypi
+
+[pypi]
+repository: https://upload.pypi.org/legacy/
+
+[testpypi]
+repository: https://test.pypi.org/legacy/

--- a/tools/bazel/LICENSE.txt
+++ b/tools/bazel/LICENSE.txt
@@ -1,0 +1,218 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/tools/bazel/MANIFEST.in
+++ b/tools/bazel/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include *.txt

--- a/tools/bazel/Makefile
+++ b/tools/bazel/Makefile
@@ -1,0 +1,66 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+CURRENT_DIR = ${CURDIR}
+ROOT = $(CURRENT_DIR)
+
+BUILD_DIR = $(CURRENT_DIR)/build
+PYTHON_BIN ?= python3
+COMPILE_COMMANDS_DIR = $(BUILD_DIR)/bazel
+
+ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
+ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
+
+VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
+
+default: all
+
+all: package
+
+venv:
+	# Create a virtual environment which can be used to run the build package.
+	python3 -m venv venv && $(ACTIVATE_RUNTIME_VENV)
+
+pip_dev_deps:
+	pip3 install -r $(VENV_DEV_REQ_FILE)
+
+venv_dev:
+	# Create a virtual environment for development.
+	python3 -m venv venv_dev && \
+		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
+
+clean_venv_dev:
+	rm -rf venv_dev
+
+include tests/Makefile
+
+package:
+	# Install package in 'development mode'.
+	${PYTHON_BIN} setup.py develop
+
+build:
+	${PYTHON_BIN} setup.py build --build-purelib $(COMPILE_COMMANDS_DIR)
+
+dist:
+	# Create a source distribution.
+	${PYTHON_BIN} setup.py sdist
+
+upload_test:
+	# Upload package to the TestPyPI repository.
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
+	twine upload -r testpypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
+
+upload:
+	# Upload package to the PyPI repository.
+	$(eval PKG_NAME := $(shell ${PYTHON_BIN} setup.py --name))
+	$(eval PKG_VERSION := $(shell ${PYTHON_BIN} setup.py --version))
+	twine upload -r pypi dist/$(PKG_NAME)-$(PKG_VERSION).tar.gz
+
+clean:
+	rm -rf $(BUILD_DIR)
+	rm -rf bazel_compile_commands.egg-info

--- a/tools/bazel/README.md
+++ b/tools/bazel/README.md
@@ -1,0 +1,43 @@
+# Bazel compilation database generator
+`bazel-compile-commands` is a python tool which generates compilation database
+(`compile_commands.json` file) from Bazel build command.
+
+The tool uses `bazel aquery` command output to produce compile commands
+without executing build itself.
+
+## Install guide
+```sh
+# Create a Python virtualenv and set it as your environment.
+make venv
+source $PWD/venv/bin/activate
+
+# Build and install bazel-compile-commands package.
+make package
+```
+
+## Usage
+<details>
+  <summary>
+    <i>$ <b>bazel-compile-commands --help</b> (click to expand)</i>
+  </summary>
+
+```
+usage: bazel-compile-commands [-h] [-o OUTPUT] [-b BUILD] [-v]
+
+Run bazel aquery to produce compilation database (compile_commands.json)
+for particular bazel build command
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        output compile_commands.json file
+  -b BUILD, --build BUILD
+                        bazel build command arguments
+  -v, --verbosity       increase output verbosity (e.g., -v or -vv)
+```
+</details>
+
+## License
+
+The project is licensed under Apache License v2.0 with LLVM Exceptions.
+See LICENSE.TXT for details.

--- a/tools/bazel/bazel_compile_commands/__init__.py
+++ b/tools/bazel/bazel_compile_commands/__init__.py
@@ -1,0 +1,7 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------

--- a/tools/bazel/bazel_compile_commands/bazel_compile_commands.py
+++ b/tools/bazel/bazel_compile_commands/bazel_compile_commands.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Run bazel aquery to produce compilation database (compile_commands.json)
+for particular bazel build command
+"""
+
+from __future__ import print_function
+import argparse
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+
+
+def parse_args():
+    """
+    Parse command line arguments or show help.
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=__doc__)
+    parser.add_argument("-o", "--output",
+                        default="compile_commands.json",
+                        help="output compile_commands.json file")
+    parser.add_argument("-b", "--build",
+                        help="bazel build command arguments")
+    parser.add_argument("-v", "--verbosity",
+                        default=1,
+                        action="count",
+                        help="enable verbose logging")
+    parser.add_argument("--log-format",
+                        default="[bazel] %(levelname)5s: %(message)s",
+                        help=argparse.SUPPRESS)
+
+    options = parser.parse_args()
+
+    if options.verbosity >= 2:
+        log_level = logging.DEBUG
+    elif options.verbosity >= 1:
+        log_level = logging.INFO
+    else:
+        log_level = logging.WARN
+    logging.basicConfig(level=log_level, format=options.log_format)
+
+    return options
+
+
+def split_to_list(arguments):
+    """
+    Split argument string to list
+    """
+    if type(arguments) is list:
+        return arguments
+    else:
+        return shlex.split(arguments)
+
+
+def run_command(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
+    """
+    Run shell command
+    """
+    cmd = split_to_list(command)
+    process = subprocess.Popen(cmd, stdout=stdout, stderr=stderr)
+    out, err = process.communicate()
+    if process.returncode:
+        logging.error("Command: %s...\nError: %s", command, err)
+    return out.decode("utf-8")
+
+
+def bazel_aquery(build_arguments):
+    """
+    Run bazel query and return list of source files, e.g.:
+    bazel cquery 'kind("source file", deps("@workspace//target"))'
+        --config=something --noimplicit_deps --notool_deps
+    """
+    arguments = split_to_list(build_arguments)
+    targets = []
+    configs = []
+    bazel = arguments[0]
+    logging.debug("Bazel: %s", bazel)
+    logging.debug("Bazel build arguments:")
+    for argument in arguments:
+        logging.debug("   %s", argument)
+        if re.search(r"^(@|:|\/\/)\S*", argument) or argument == "...":
+            targets.append(argument)
+        elif re.search(r"^--\S*", argument):
+            configs.append(argument)
+    logging.debug("Targets: %s", targets)
+    logging.debug("Configs: %s", configs)
+    if len(targets) < 1:
+        logging.error(
+            "No targets found for bazel query in: %s",
+            build_arguments)
+        return
+
+    deps = " + ".join([
+        "deps(\"{target}\")".format(target=target) for target in targets
+    ])
+    logging.debug("Deps: %s", deps)
+
+    options = [
+        "--output=jsonproto",
+        "--include_artifacts=false",
+    ]
+    function = "mnemonic(\"CppCompile\", {deps})".format(deps=deps)
+    command = "{bazel} aquery {options} '{function}' {configs}".format(
+        bazel=bazel,
+        options=" ".join(options),
+        function=function,
+        configs=" ".join(configs))
+    logging.debug("Command: %s", command)
+
+    out = run_command(command)
+    if out:
+        data = json.loads(out)
+        return data
+
+
+def get_compile_commands(data,
+                         directories=["."],
+                         base_dir=None,
+                         output_base=None):
+    """
+    Produce compile commands from action graph JSON data
+    """
+    compile_commands = []
+    not_found = 0
+    skipped = 0
+    for action in data["actions"]:
+        if "mnemonic" in action and action["mnemonic"] in ["CppCompile"]:
+            arguments = action["arguments"]
+            try:
+                index = arguments.index("-c")
+                file = arguments[index + 1]
+                if not file.endswith(".asm"):
+                    (full_path, directory) = find_file(file, directories)
+                    if full_path and directory:
+                        if base_dir:
+                            directory = base_dir
+                        compile_command = {
+                            "file": full_path,
+                            "directory": directory,
+                            "command": " ".join(arguments),
+                        }
+                        filter_compile_command(compile_command, output_base)
+                        compile_commands.append(compile_command)
+                        logging.info("Add file: %s", file)
+                    else:
+                        logging.warning("Cannot find: %s", file)
+                        not_found += 1
+                else:
+                    logging.info("Skipping: %s", file)
+                    skipped += 1
+            except ValueError:
+                logging.warning("Wrong compile command: %s", str(arguments))
+    logging.info("%d files added, %d skipped (asm), %d not found",
+                 len(compile_commands), skipped, not_found)
+    return compile_commands
+
+
+def find_file(file, directories):
+    """
+    Find file in the list of directories.
+    Return full path and corresponding directory.
+    """
+    for directory in directories:
+        full_path = os.path.join(directory, file)
+        if os.path.isfile(full_path):
+            return (full_path, directory)
+    return (False, False)
+
+
+def filter_compile_command(compile_command, output_base):
+    """
+    Remove irrelevant options and change paths
+    """
+    command = compile_command["command"]
+    if output_base:
+        # bazel-out/k8-fastbuild/bin/external/ -> /abs/path/external/
+        command = re.sub(r"( |=)bazel-out\/\S*\/bin\/external\/",
+                         r"\1" + output_base + "/external/",
+                         command)
+    else:
+        # bazel-out/k8-fastbuild/bin/external/ -> ../../external/
+        command = re.sub(r"( |=)bazel-out\/\S*\/bin\/external\/",
+                         r"\1../../external/",
+                         command)
+    # Remove unsupported options (clang)
+    command = re.sub(r" -MD ", " ", command)
+    command = re.sub(r" -MF \S* ", " ", command)
+    command = re.sub(r" -MT \S* ", " ", command)
+    compile_command["command"] = command
+
+
+def run(build_command, output_file_name):
+    """
+    Run bazel aquaery and generate compile_commands.json:
+    - get bazel info params
+    - run bazel aquery and parse output as JSON data
+    - create compile commands from JSON data:
+      * take only arguments
+      * add: file, directory, command
+      * change to full paths
+      * filter compiler options
+    - save to output file (compile_commands.json)
+    """
+    if not build_command:
+        logging.error("No bazel build command specified")
+        return False
+
+    if not output_file_name:
+        logging.error("No output file is specified")
+        return False
+
+    bazel_info = split_to_list(build_command)[0] + " info "
+    bazel_workspace = run_command(bazel_info + "workspace").rstrip()
+    bazel_output_base = run_command(bazel_info + "output_base").rstrip()
+    bazel_execution_root = run_command(bazel_info + "execution_root").rstrip()
+
+    bazel_work_dir = bazel_execution_root.replace("/execroot/", "/external/")
+    if not os.path.exists(bazel_work_dir):
+        bazel_work_dir = bazel_workspace
+
+    logging.info("Bazel workspace:     %s", bazel_workspace)
+    logging.info("Bazel output base:   %s", bazel_output_base)
+    logging.info("Bazel work dir:      %s", bazel_work_dir)
+
+    logging.info("Bazel build options: %s", build_command)
+    data = bazel_aquery(build_command)
+    if not data:
+        logging.error("Command '%s'", build_command)
+        logging.error("Produces no output")
+        return False
+
+    directories = [
+        bazel_output_base,
+        bazel_work_dir,
+    ]
+    compile_commands = get_compile_commands(
+        data, directories, output_base=bazel_output_base)
+
+    logging.info("Saving to: %s", output_file_name)
+    with open(output_file_name, "w") as compile_commands_file:
+        json.dump(compile_commands, compile_commands_file, indent=4)
+    return True
+
+
+def main():
+    """
+    Main function
+    """
+    options = parse_args()
+    logging.debug("Options: %s", options)
+    if not run(options.build, options.output):
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bazel/requirements_py/dev/requirements.txt
+++ b/tools/bazel/requirements_py/dev/requirements.txt
@@ -1,0 +1,3 @@
+nose==1.3.7
+pycodestyle==2.5.0
+pylint==2.4.4

--- a/tools/bazel/setup.py
+++ b/tools/bazel/setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import setuptools
+
+with open("README.md", "r", encoding="utf-8", errors="ignore") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="bazel-compile-commands",
+    version="0.1.0",
+    author='CodeChecker Team (Ericsson)',
+    description="Generate compilation database (compile_commands.json)"
+                " from bazel build.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Ericsson/CodeChecker",
+    keywords=['bazel', 'compile_commands.json', 'compilation database'],
+    license='LICENSE.txt',
+    packages=setuptools.find_packages(),
+    include_package_data=True,
+    classifiers=[
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Operating System :: MacOS",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3",
+    ],
+    python_requires='>=3.6',
+    entry_points={
+        'console_scripts': [
+            'bazel-compile-commands = bazel_compile_commands.bazel_compile_commands:main'
+        ]
+    },
+)

--- a/tools/bazel/tests/Makefile
+++ b/tools/bazel/tests/Makefile
@@ -1,0 +1,40 @@
+# Environment variables to run tests.
+
+# Test project configuration, tests are run on these files.
+TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
+
+REPO_ROOT ?= REPO_ROOT=$(ROOT)
+
+# Nose test runner configuration options.
+NOSECFG = --config .noserc
+
+test: pycodestyle pylint test_unit
+
+test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env
+
+PYCODESTYLE_TEST_CMD = pycodestyle bazel_compile_commands tests
+
+pycodestyle:
+	$(PYCODESTYLE_TEST_CMD)
+
+pycodestyle_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(PYCODESTYLE_TEST_CMD)
+
+PYLINT_TEST_CMD = pylint -j0 ./bazel_compile_commands ./tests \
+  --disable=all \
+  --enable=logging-format-interpolation,old-style-class,unused-wildcard-import,unused-import,unused-variable,len-as-condition,bad-indentation
+
+pylint:
+	$(PYLINT_TEST_CMD)
+
+pylint_in_env: venv
+	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
+
+UNIT_TEST_CMD = $(REPO_ROOT) $(TEST_PROJECT) \
+  nosetests $(NOSECFG) tests/unit
+
+test_unit:
+	$(UNIT_TEST_CMD)
+
+test_unit_in_env: venv_dev
+	$(ACTIVATE_DEV_VENV) && $(UNIT_TEST_CMD)

--- a/tools/bazel/tests/projects/BUILD
+++ b/tools/bazel/tests/projects/BUILD
@@ -1,0 +1,20 @@
+# cc_binary for simple test_main
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_binary",
+    "cc_library",
+)
+
+# Test for strip_include_prefix
+cc_library(
+    name = "inc",
+    hdrs = glob(["inc/*.h"]),
+    strip_include_prefix = "inc",
+)
+
+# Simplest C++ test
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+    deps = ["inc"],
+)

--- a/tools/bazel/tests/projects/inc/inc.h
+++ b/tools/bazel/tests/projects/inc/inc.h
@@ -1,0 +1,1 @@
+#define THING 0

--- a/tools/bazel/tests/projects/main.cc
+++ b/tools/bazel/tests/projects/main.cc
@@ -1,0 +1,10 @@
+#include "inc.h"
+
+int main(void)
+{
+  // Defect example:
+  int a = 0;
+  int b = 1 / a;
+
+  return 0;
+}

--- a/tools/bazel/tests/unit/__init__.py
+++ b/tools/bazel/tests/unit/__init__.py
@@ -1,0 +1,7 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------

--- a/tools/bazel/tests/unit/test_compile_commands.py
+++ b/tools/bazel/tests/unit/test_compile_commands.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Unit tests for bazel_compile_commands tool
+"""
+
+import os
+import json
+import shutil
+import unittest
+
+from bazel_compile_commands import bazel_compile_commands
+
+
+class BazelCompileCommandsTest(unittest.TestCase):
+    """ Test class for bazel compile commands generator. """
+
+    TEST_COMPILE_COMMANDS_FILENAME = "test_compile_commands.json"
+
+    @classmethod
+    def setUpClass(self):
+        """ Initialize test files. """
+        self.initial_dir = os.getcwd()
+        self.test_proj_dir = os.path.abspath(os.environ["TEST_PROJ"])
+
+    def setUp(self):
+        """ Restore initial state. """
+        os.chdir(self.test_proj_dir)
+
+    def tearDown(self):
+        """ Restore initial state. """
+        if os.path.exists(self.TEST_COMPILE_COMMANDS_FILENAME):
+            os.remove(self.TEST_COMPILE_COMMANDS_FILENAME)
+        os.chdir(self.initial_dir)
+
+    def test_run_command(self):
+        """ Test run_command() function. """
+        self.assertEqual(bazel_compile_commands.run_command("echo 1"), "1\n")
+
+    def test_empty_run(self):
+        """ Test run() function with no arguments. """
+        self.assertFalse(bazel_compile_commands.run("", ""))
+
+    @unittest.skipUnless(shutil.which("bazel"), "bazel binary not found!")
+    def test_run_bazel(self):
+        """ Test run() function with bazel build ... """
+        self.assertTrue(bazel_compile_commands.run(
+            "bazel build ...", self.TEST_COMPILE_COMMANDS_FILENAME))
+        with open(self.TEST_COMPILE_COMMANDS_FILENAME, "r",
+                  encoding="utf-8", errors="ignore") as compile_commands_file:
+            compile_commands = json.load(compile_commands_file)
+            self.assertTrue(compile_commands)


### PR DESCRIPTION
The tool takes bazel build command as an input parameter
and executes Bazel Action Query (bazel aquery)
to extract all compile commands then saves them
to compile_commands.json file.