### PR TITLE
Allow make "venv" and "standalone_package" in both analyzer and web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,69 +33,16 @@ default: package
 
 package_dir_structure:
 	mkdir -p $(BUILD_DIR) && \
-	mkdir -p $(CC_BUILD_DIR)/bin && \
+	mkdir -p $(CC_BUILD_BIN_DIR) && \
 	mkdir -p $(CC_BUILD_LIB_DIR)
 
 mkdocs_build:
 	mkdocs build
 
-build_plist_to_html:
-	$(MAKE) -C $(ROOT)/tools/plist_to_html build
-
-package_plist_to_html: build_plist_to_html package_dir_structure
-	# Copy plist-to-html files.
-	cp -r $(CC_TOOLS)/plist_to_html/build/plist_to_html/plist_to_html $(CC_BUILD_LIB_DIR)
-
-build_tu_collector:
-	$(MAKE) -C $(ROOT)/tools/tu_collector build
-
-package_tu_collector: build_tu_collector package_dir_structure
-	# Copy tu_collector files.
-	cp -rp $(CC_TOOLS)/tu_collector/build/tu_collector/tu_collector $(CC_BUILD_LIB_DIR) && \
-	chmod u+x $(CC_BUILD_LIB_DIR)/tu_collector/tu_collector.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/tu_collector/tu_collector.py bin/tu_collector
-
-build_report_converter:
-	$(MAKE) -C $(ROOT)/tools/report-converter build
-
-package_report_converter: build_report_converter package_dir_structure
-	# Copy tu_collector files.
-	cp -rp $(CC_TOOLS)/report-converter/build/report_converter/codechecker_report_converter $(CC_BUILD_LIB_DIR) && \
-	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_report_converter/cli.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/codechecker_report_converter/cli.py bin/report-converter
-
-build_report_hash:
-	$(MAKE) -C $(ROOT)/tools/codechecker_report_hash build
-
-package_report_hash: build_report_hash package_dir_structure
-	cp -r $(CC_TOOLS)/codechecker_report_hash/build/codechecker_report_hash/codechecker_report_hash $(CC_BUILD_LIB_DIR)
-
-build_merge_clang_extdef_mappings:
-	$(MAKE) -C $(CC_ANALYZER)/tools/merge_clang_extdef_mappings build
-
-package_merge_clang_extdef_mappings: build_merge_clang_extdef_mappings package_dir_structure
-	# Copy merge-clang-extdef-mappings files.
-	cp -r $(CC_ANALYZER)/tools/merge_clang_extdef_mappings/build/merge_clang_extdef_mappings/codechecker_merge_clang_extdef_mappings $(CC_BUILD_LIB_DIR) && \
-	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_merge_clang_extdef_mappings/cli.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/codechecker_merge_clang_extdef_mappings/cli.py bin/merge-clang-extdef-mappings
-
-build_statistics_collector:
-	$(MAKE) -C $(CC_ANALYZER_TOOLS)/statistics_collector build
-
-package_statistics_collector: build_statistics_collector package_dir_structure
-	# Copy statistics-collector files.
-	cp -r $(CC_ANALYZER_TOOLS)/statistics_collector/build/statistics_collector/codechecker_statistics_collector $(CC_BUILD_LIB_DIR) && \
-	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_statistics_collector/cli.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/codechecker_statistics_collector/cli.py bin/post-process-stats
-
 package_gerrit_skiplist:
-	cp -p scripts/gerrit_changed_files_to_skipfile.py $(CC_BUILD_DIR)/bin
+	cp -p scripts/gerrit_changed_files_to_skipfile.py $(CC_BUILD_BIN_DIR)
 
-package: package_dir_structure set_git_commit_template package_plist_to_html package_tu_collector package_report_converter package_report_hash package_merge_clang_extdef_mappings package_statistics_collector package_gerrit_skiplist
+package: package_dir_structure set_git_commit_template package_gerrit_skiplist
 	BUILD_DIR=$(BUILD_DIR) BUILD_LOGGER_64_BIT_ONLY=$(BUILD_LOGGER_64_BIT_ONLY) $(MAKE) -C $(CC_ANALYZER) package_analyzer
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) package_web
 
@@ -118,7 +65,7 @@ package: package_dir_structure set_git_commit_template package_plist_to_html pac
 
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
 	${PYTHON_BIN} ./scripts/build/create_commands.py -b $(BUILD_DIR) \
-	  --cmd-dir codechecker_common/cmd \
+	  --cmd-dir $(ROOT)/codechecker_common/cmd \
 	    $(CC_WEB)/codechecker_web/cmd \
 	    $(CC_SERVER)/codechecker_server/cmd \
 	    $(CC_CLIENT)/codechecker_client/cmd \

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -5,15 +5,19 @@ BUILD_DIR ?= $(CURRENT_DIR)/build
 PYTHON_BIN ?= python3
 
 CC_BUILD_DIR = $(BUILD_DIR)/CodeChecker
+CC_BUILD_BIN_DIR = $(CC_BUILD_DIR)/bin
 CC_BUILD_LIB_DIR = $(CC_BUILD_DIR)/lib/python3
 
 # Root of the repository.
 ROOT = $(CURRENT_DIR)/..
 
 CC_TOOLS = $(ROOT)/tools
+CC_ANALYZER = $(ROOT)/analyzer
 
+ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 
+VENV_REQ_FILE ?= requirements.txt
 VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 
 # Set it to YES if you would like to build and package 64 bit only shared
@@ -25,17 +29,25 @@ include tests/Makefile
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
+venv:
+	# Create a virtual environment which can be used to run the build package.
+	python3 -m venv venv --prompt="CodeChecker analyze venv" && \
+		$(ACTIVATE_RUNTIME_VENV) && pip3 install -r $(VENV_REQ_FILE)
+
 venv_dev:
 	# Create a virtual environment for development.
-	python3 -m venv venv_dev && \
+	python3 -m venv venv_dev --prompt="CodeChecker analyze venv-dev" && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
+
+clean_venv:
+	rm -rf venv
 
 clean_venv_dev:
 	rm -rf venv_dev
 
 package_dir_structure:
 	mkdir -p $(BUILD_DIR) && \
-	mkdir -p $(CC_BUILD_DIR)/bin && \
+	mkdir -p $(CC_BUILD_BIN_DIR) && \
 	mkdir -p $(CC_BUILD_LIB_DIR)
 
 build_plist_to_html:
@@ -52,35 +64,50 @@ package_tu_collector: build_tu_collector package_dir_structure
 	# Copy tu_collector files.
 	cp -rp $(CC_TOOLS)/tu_collector/build/tu_collector/tu_collector $(CC_BUILD_LIB_DIR) && \
 	chmod u+x $(CC_BUILD_LIB_DIR)/tu_collector/tu_collector.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/tu_collector/tu_collector.py bin/tu_collector
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../lib/python3/tu_collector/tu_collector.py tu_collector
+
+build_report_hash:
+	$(MAKE) -C $(CC_TOOLS)/codechecker_report_hash build
+
+package_report_hash: build_report_hash package_dir_structure
+	cp -rp $(CC_TOOLS)/codechecker_report_hash/build/codechecker_report_hash/codechecker_report_hash $(CC_BUILD_LIB_DIR)
+
+build_report_converter:
+	$(MAKE) -C $(CC_TOOLS)/report-converter build
+
+package_report_converter: build_report_converter package_dir_structure
+	cp -rp $(CC_TOOLS)/report-converter/build/report_converter/codechecker_report_converter $(CC_BUILD_LIB_DIR) && \
+	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_report_converter/cli.py && \
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../lib/python3/codechecker_report_converter/cli.py report-converter
 
 build_merge_clang_extdef_mappings:
-	$(MAKE) -C tools/merge_clang_extdef_mappings build
+	$(MAKE) -C $(CC_ANALYZER)/tools/merge_clang_extdef_mappings build
 
 package_merge_clang_extdef_mappings: build_merge_clang_extdef_mappings package_dir_structure
 	# Copy plist-to-html files.
 	cp -r tools/merge_clang_extdef_mappings/build/merge_clang_extdef_mappings/codechecker_merge_clang_extdef_mappings $(CC_BUILD_LIB_DIR) && \
 	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_merge_clang_extdef_mappings/cli.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/codechecker_merge_clang_extdef_mappings/cli.py bin/merge-clang-extdef-mappings
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../lib/python3/codechecker_merge_clang_extdef_mappings/cli.py merge-clang-extdef-mappings
 
 build_statistics_collector:
-	$(MAKE) -C $(CC_ANALYZER_TOOLS)/statistics_collector build
+	$(MAKE) -C $(CC_ANALYZER)/tools/statistics_collector build
 
 package_statistics_collector: build_statistics_collector package_dir_structure
 	# Copy statistics-collector files.
 	cp -r tools/statistics_collector/build/statistics_collector/codechecker_statistics_collector $(CC_BUILD_LIB_DIR) && \
 	chmod u+x $(CC_BUILD_LIB_DIR)/codechecker_statistics_collector/cli.py && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../lib/python3/codechecker_statistics_collector/cli.py bin/post-process-stats
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../lib/python3/codechecker_statistics_collector/cli.py post-process-stats
 
 # This target should be used from the top level Makefile to build the package
 # together with the web part. This way we will not build plist-to-html
 # multiple times.
-package_analyzer: package_dir_structure
+package_analyzer: package_dir_structure package_plist_to_html package_tu_collector package_report_hash package_merge_clang_extdef_mappings package_report_converter package_statistics_collector
 
-package: package_plist_to_html package_tu_collector package_analyzer package_merge_clang_extdef_mappings package_statistics_collector
+package: package_analyzer
 	# Copy libraries.
 	cp -r $(ROOT)/codechecker_common $(CC_BUILD_LIB_DIR) && \
 	cp -r $(CURRENT_DIR)/codechecker_analyzer $(CC_BUILD_LIB_DIR)
@@ -94,7 +121,7 @@ package: package_plist_to_html package_tu_collector package_analyzer package_mer
 	# Copy CodeChecker entry point sub-commands.
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
 	${PYTHON_BIN} $(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
-	  --cmd-dir codechecker_common/cmd \
+	  --cmd-dir $(ROOT)/codechecker_common/cmd \
 	    $(CC_ANALYZER)/codechecker_analyzer/cmd \
 	  --bin-file $(ROOT)/bin/CodeChecker \
 	  --cc-bin-file $(ROOT)/bin/CodeChecker.py
@@ -102,12 +129,20 @@ package: package_plist_to_html package_tu_collector package_analyzer package_mer
 	# Copy license file.
 	cp $(ROOT)/LICENSE.TXT $(CC_BUILD_DIR)
 
+standalone_package: venv package
+	cd $(CC_BUILD_BIN_DIR) && \
+	mv CodeChecker _CodeChecker && \
+	${PYTHON_BIN} $(ROOT)/scripts/build/wrap_binary_in_venv.py \
+		-e $(CURRENT_DIR)/venv \
+		-b _CodeChecker \
+		-o CodeChecker
+
 package_ld_logger:
 	mkdir -p $(CC_BUILD_DIR)/ld_logger && \
-	mkdir -p $(CC_BUILD_DIR)/bin && \
+	mkdir -p $(CC_BUILD_BIN_DIR) && \
 	cp -r $(CURRENT_DIR)/tools/build-logger/build/* $(CC_BUILD_DIR)/ld_logger && \
-	cd $(CC_BUILD_DIR) && \
-	ln -sf ../ld_logger/bin/ldlogger bin/ldlogger
+	cd $(CC_BUILD_BIN_DIR) && \
+	ln -sf ../ld_logger/bin/ldlogger ldlogger
 
 define LOGGER_BUILD_ERROR_MSG
 Failed to compile logger for 32bit and 64bit targets please check if

--- a/web/Makefile
+++ b/web/Makefile
@@ -10,6 +10,7 @@ PYTHON_BIN ?= python3
 CC_BUILD_DIR = $(BUILD_DIR)/CodeChecker
 CC_BUILD_WEB_DIR = $(CC_BUILD_DIR)/www
 CC_BUILD_PLUGIN_DIR = $(CC_BUILD_DIR)/plugin
+CC_BUILD_BIN_DIR = $(CC_BUILD_DIR)/bin
 CC_BUILD_LIB_DIR = $(CC_BUILD_DIR)/lib/python3
 CC_BUILD_DOCS_DIR = $(CC_BUILD_WEB_DIR)/docs
 CC_BUILD_SCRIPTS_DIR = $(CC_BUILD_WEB_DIR)/scripts
@@ -24,9 +25,12 @@ CC_CLIENT = $(CURRENT_DIR)/client/
 ROOT = $(CURRENT_DIR)/..
 
 CC_TOOLS = $(ROOT)/tools
+CC_WEB = $(ROOT)/web
 
+ACTIVATE_RUNTIME_VENV ?= . venv/bin/activate
 ACTIVATE_DEV_VENV ?= . venv_dev/bin/activate
 
+VENV_REQ_FILE ?= requirements.txt
 VENV_DEV_REQ_FILE ?= requirements_py/dev/requirements.txt
 
 DIST_DIR = $(CC_SERVER)/vue-cli/dist
@@ -47,10 +51,18 @@ include client/tests/Makefile
 pip_dev_deps:
 	pip3 install -r $(VENV_DEV_REQ_FILE)
 
+venv:
+	# Create a virtual environment which can be used to run the build package.
+	python3 -m venv venv --prompt="CodeChecker web venv" && \
+		$(ACTIVATE_RUNTIME_VENV) && pip3 install -r $(VENV_REQ_FILE)
+
 venv_dev:
 	# Create a virtual environment for development.
-	python3 -m venv venv_dev && \
+	python3 -m venv venv_dev --prompt="CodeChecker web venv-dev" && \
 		$(ACTIVATE_DEV_VENV) && pip3 install -r $(VENV_DEV_REQ_FILE)
+
+clean_venv:
+	rm -rf venv
 
 clean_venv_dev:
 	rm -rf venv_dev
@@ -60,7 +72,7 @@ build_dir:
 
 package_dir_structure:
 	mkdir -p $(BUILD_DIR) && \
-	mkdir -p $(CC_BUILD_DIR)/bin && \
+	mkdir -p $(CC_BUILD_BIN_DIR) && \
 	mkdir -p $(CC_BUILD_LIB_DIR)
 
 package_docs:
@@ -97,7 +109,7 @@ build_report_hash:
 package_report_hash: build_report_hash package_dir_structure
 	cp -r $(CC_TOOLS)/codechecker_report_hash/build/codechecker_report_hash/codechecker_report_hash $(CC_BUILD_LIB_DIR)
 
-package: package_plist_to_html package_report_hash package_web
+package: package_dir_structure package_plist_to_html package_report_hash package_web
 	# Copy libraries.
 	cp -r $(ROOT)/codechecker_common $(CC_BUILD_LIB_DIR) && \
 	cp -r $(CURRENT_DIR)/codechecker_web $(CC_BUILD_LIB_DIR) && \
@@ -114,7 +126,7 @@ package: package_plist_to_html package_report_hash package_web
 	# Copy CodeChecker entry point sub-commands.
 	mkdir -p $(CC_BUILD_DIR)/cc_bin && \
 	${PYTHON_BIN} $(ROOT)/scripts/build/create_commands.py -b $(BUILD_DIR) \
-	  --cmd-dir codechecker_common/cmd \
+	  --cmd-dir $(ROOT)/codechecker_common/cmd \
 	    $(CC_WEB)/codechecker_web/cmd \
 	    $(CC_SERVER)/codechecker_server/cmd \
 	    $(CC_CLIENT)/codechecker_client/cmd \
@@ -123,6 +135,14 @@ package: package_plist_to_html package_report_hash package_web
 
 	# Copy license file.
 	cp $(ROOT)/LICENSE.TXT $(CC_BUILD_DIR)
+
+standalone_package: venv package
+	cd $(CC_BUILD_BIN_DIR) && \
+	mv CodeChecker _CodeChecker && \
+	${PYTHON_BIN} $(ROOT)/scripts/build/wrap_binary_in_venv.py \
+		-e $(CURRENT_DIR)/venv \
+		-b _CodeChecker \
+		-o CodeChecker
 
 # This target will check that 'codecheck_api' and 'codechecker_api_shared'
 # python packages are up to date. If not, it will update these packages and


### PR DESCRIPTION
> Fixes #3223.

Add the `venv` and `standalone_package` targets for both the `analyze` and the `web` directories.
This allows building only the particular part of CodeCheckerí even for release and use.
This is especially useful if the client doens't want to run the web server. Installing Node and running the Node parts for the web part takes multiple minutes which is not needed if I only want to analyze.

A few missing instructions or badly relative arguments had to be fixed in the existing `package` target for the files.



The analyzer build:

~~~~
whisperity@cc:~/CCh/analyzer$ build/CodeChecker/bin/CodeChecker version
CodeChecker analyzer version:
---------------------------------------------------------------
Kind                 | Version
---------------------------------------------------------------
Base package version | 6.16.0
Package build date   | 2021-03-16T17:17
Git commit ID (hash) | e02baa734ab58c696170c7289477b2ebee1d5b06
Git tag information  | 6.16
---------------------------------------------------------------

positional arguments:
  {analyze,analyzer-version,analyzers,check,checkers,fixit,log,parse,version}
                        commands
    analyze             Execute the supported code analyzers for the files
                        recorded in a JSON Compilation Database.
    analyzer-version    Print the version of CodeChecker analyzer package that
                        is being used.
    analyzers           List supported and available analyzers.
    check               Perform analysis on a project and print results to
                        standard output.
    checkers            List the checkers available for code analysis.
    fixit               Apply automatic fixes based on the suggestions of the
                        analyzers
    log                 Run a build command and collect the executed
                        compilation commands, storing them in a JSON file.
    parse               Print analysis summary and results in a human-readable
                        format.
    version             Print the version of CodeChecker package that is being
                        used.
~~~~


The web build:


~~~~
whisperity@cc:~/CCh/web$ build/CodeChecker/bin/CodeChecker version
CodeChecker web version:
------------------------------------------------------------------------
Kind                          | Version
------------------------------------------------------------------------
Base package version          | 6.16.0
Package build date            | 2021-03-16T17:19
Git commit ID (hash)          | e02baa734ab58c696170c7289477b2ebee1d5b06
Git tag information           | 6.16
Server supported API (Thrift) | 6.39
Client API (Thrift)           | 6.39
------------------------------------------------------------------------

positional arguments:
  {cmd,server,store,version,web-version}
                        commands
    cmd                 View analysis results on a running server from the
                        command line.
    server              Start and manage the CodeChecker Web server.
    store               Save analysis results to a database.
    version             Print the version of CodeChecker package that is being
                        used.
    web-version         Print the version of CodeChecker server package that
                        is being used.
~~~~