### PR TITLE
[gui] Set filter properly when clicking on the diff count in the statistics page

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
@@ -139,6 +139,7 @@
       <report-diff-count
         :num-of-new-reports="item.unreviewed.new"
         :num-of-resolved-reports="item.unreviewed.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -159,6 +160,7 @@
       <report-diff-count
         :num-of-new-reports="item.confirmed.new"
         :num-of-resolved-reports="item.confirmed.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -181,6 +183,7 @@
       <report-diff-count
         :num-of-new-reports="item.outstanding.new"
         :num-of-resolved-reports="item.outstanding.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -201,6 +204,7 @@
       <report-diff-count
         :num-of-new-reports="item.falsePositive.new"
         :num-of-resolved-reports="item.falsePositive.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -221,6 +225,7 @@
       <report-diff-count
         :num-of-new-reports="item.intentional.new"
         :num-of-resolved-reports="item.intentional.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -243,6 +248,7 @@
       <report-diff-count
         :num-of-new-reports="item.suppressed.new"
         :num-of-resolved-reports="item.suppressed.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 
@@ -261,6 +267,7 @@
       <report-diff-count
         :num-of-new-reports="item.reports.new"
         :num-of-resolved-reports="item.reports.resolved"
+        :extra-query-params="getBaseQueryParams(item)"
       />
     </template>
 

--- a/web/server/vue-cli/src/components/Statistics/Overview/ComponentSeverityStatistics/ComponentSeverityStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/ComponentSeverityStatistics/ComponentSeverityStatistics.vue
@@ -70,6 +70,10 @@
                 <report-diff-count
                   :num-of-new-reports="item[i[0]].new"
                   :num-of-resolved-reports="item[i[0]].resolved"
+                  :extra-query-params="{
+                    'source-component': item.component,
+                    'severity': severityFromCodeToString(i[1])
+                  }"
                 />
               </span>
             </template>


### PR DESCRIPTION
Problem: at the Checker statistics page clicking on the red diff number in
the cells when comparing results do not contain for example the checker
name filter.