### PR TITLE
[cmd] Change exit codes

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -55,6 +55,12 @@ epilog_env_var = f"""
                          Default: {_severity_map_file}
 """
 
+epilog_exit_status = """
+0 - No report
+1 - CodeChecker error
+2 - At least one report emitted by an analyzer
+"""
+
 
 class PlistToPlaintextFormatter(object):
     """
@@ -392,6 +398,10 @@ printed by the `parse` command.""",
 Environment variables
 ------------------------------------------------
 {epilog_env_var}
+
+Exit status
+------------------------------------------------
+{epilog_exit_status}
 """,
 
         # Help is shown when the "parent" CodeChecker command lists the
@@ -905,3 +915,6 @@ def main(args):
                     "reports!", changed_files)
 
     os.chdir(original_cwd)
+
+    if report_count != 0:
+        sys.exit(2)

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -166,7 +166,7 @@ class TestAnalyze(unittest.TestCase):
 
         # THEN
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
         info_File = os.path.join(reports_dir, 'compiler_info.json')
         self.assertEqual(os.path.exists(info_File), True)
@@ -276,7 +276,7 @@ class TestAnalyze(unittest.TestCase):
         print(out)
         print(err)
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
         # We expect the sucess stderr file in the success directory.
         success_files = os.listdir(success_dir)
@@ -600,7 +600,7 @@ class TestAnalyze(unittest.TestCase):
         process.communicate()
 
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
 
         self.unique_json_helper(unique_json, True, False, True)
@@ -619,7 +619,7 @@ class TestAnalyze(unittest.TestCase):
         process.communicate()
 
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
 
         self.unique_json_helper(unique_json, False, True, True)
@@ -676,7 +676,7 @@ class TestAnalyze(unittest.TestCase):
         process.communicate()
 
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
         self.unique_json_helper(unique_json, True, True, True)
 
@@ -712,7 +712,7 @@ class TestAnalyze(unittest.TestCase):
         self.assertTrue("non-existing-checker-name" in out)
 
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
     def test_disable_all_warnings(self):
         """Test disabling warnings as checker groups."""
@@ -778,7 +778,7 @@ class TestAnalyze(unittest.TestCase):
         self.assertTrue("non-existing-checker-name" in out)
 
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
     def test_multiple_invalid_checker_names(self):
         """Warn in case of multiple invalid checker names."""
@@ -819,7 +819,7 @@ class TestAnalyze(unittest.TestCase):
 
         errcode = process.returncode
 
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
     def test_makefile_generation(self):
         """ Test makefile generation. """

--- a/analyzer/tests/functional/fixit/test_fixit.py
+++ b/analyzer/tests/functional/fixit/test_fixit.py
@@ -102,7 +102,7 @@ int main()
 
         # THEN
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
         fixit_dir = os.path.join(self.report_dir, 'fixit')
         self.assertTrue(os.path.isdir(fixit_dir))
@@ -194,7 +194,7 @@ int main()
 
         # THEN
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
         fixit_dir = os.path.join(self.report_dir, 'fixit')
         self.assertTrue(os.path.isdir(fixit_dir))

--- a/analyzer/tests/functional/skip/test_skip.py
+++ b/analyzer/tests/functional/skip/test_skip.py
@@ -163,7 +163,7 @@ class TestSkip(unittest.TestCase):
         print(out)
         print(err)
         errcode = process.returncode
-        self.assertEqual(errcode, 2)
+        self.assertEqual(errcode, 0)
 
         # Check if file is skipped.
         report_dir_files = os.listdir(self.report_dir)

--- a/analyzer/tests/functional/suppress/test_suppress_export.py
+++ b/analyzer/tests/functional/suppress/test_suppress_export.py
@@ -66,7 +66,7 @@ class TestSuppress(unittest.TestCase):
         ret = call_cmd(extract_cmd,
                        self._test_project_path,
                        env.test_env(self._test_workspace))
-        self.assertEqual(ret, 0, "Failed to generate suppress file.")
+        self.assertEqual(ret, 2, "Failed to generate suppress file.")
 
         with open(generated_file, 'r',
                   encoding='utf-8', errors='ignore') as generated:

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -506,9 +506,8 @@ https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/report_identif
 
 Exit status
 ------------------------------------------------
-0 - Successful analysis and no new reports
+0 - Successful analysis
 1 - CodeChecker error
-2 - At least one report emitted by an analyzer and there is no analyzer failure
 3 - Analysis of at least one translation unit failed
 128+signum - Terminating on a fatal signal whose number is signum
 
@@ -1650,6 +1649,12 @@ Environment variables
                          generating gerrit output.
   CC_SEVERITY_MAP_FILE   Path of the checker-severity mapping config file.
                          Default: <package>/config/checker_severity_map.json
+
+Exit status
+------------------------------------------------
+0 - No report
+1 - CodeChecker error
+2 - At least one report emitted by an analyzer
 ```
 </details>
 

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -1298,6 +1298,12 @@ envionment variables:
   CC_CHANGED_FILES    Path of changed files json from Gerrit. Use it when
                       generating gerrit output.
 
+Exit status
+------------------------------------------------
+0 - No difference between baseline and newrun
+1 - CodeChecker error
+2 - There is at least one report difference between baseline and newrun
+
 Example scenario: Compare multiple analysis runs
 ------------------------------------------------
 Compare two runs and show results that didn't exist in the 'run1' but appear in

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -1324,6 +1324,12 @@ envionment variables:
   CC_CHANGED_FILES    Path of changed files json from Gerrit. Use it when
                       generating gerrit output.
 
+Exit status
+------------------------------------------------
+0 - No difference between baseline and newrun
+1 - CodeChecker error
+2 - There is at least one report difference between baseline and newrun
+
 Example scenario: Compare multiple analysis runs
 ------------------------------------------------
 Compare two runs and show results that didn't exist in the 'run1' but appear in

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1388,6 +1388,9 @@ def handle_diff_results(args):
                  ', '.join(newname_run_names),
                  ', '.join(matching_new_run_names))
 
+    if len(reports) != 0:
+        sys.exit(2)
+
 
 def handle_list_result_types(args):
     # If the given output format is not 'table', redirect logger's output to

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -60,7 +60,7 @@ class DiffLocal(unittest.TestCase):
         core.CallAndMessage checker was disabled in the new run, those
         reports should be listed as resolved.
         """
-        resolved_results = get_diff_results(
+        resolved_results, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--resolved', 'json')
         print(resolved_results)
 
@@ -73,7 +73,7 @@ class DiffLocal(unittest.TestCase):
         core.StackAddressEscape checker was enabled in the new run, those
         reports should be listed as new.
         """
-        new_results = get_diff_results(
+        new_results, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', 'json')
         print(new_results)
 
@@ -86,16 +86,9 @@ class DiffLocal(unittest.TestCase):
         Displays detailed information about base and new directories when
         any of them are not exist.
         """
-        error_output = ''
-        return_code = 0
-        try:
-            get_diff_results([self.base_reports], ['unexistent-dir-name'],
-                             '--new', extra_args=[
-                                 '--url',
-                                 f"localhost:{env.get_free_port()}/Default"])
-        except subprocess.CalledProcessError as process_error:
-            return_code = process_error.returncode
-            error_output = process_error.stderr
+        _, error_output, return_code = get_diff_results(
+            [self.base_reports], ['unexistent-dir-name'], '--new',
+            extra_args=['--url', f"localhost:{env.get_free_port()}/Default"])
 
         self.assertEqual(return_code, 1,
                          "Exit code should be 1 if directory does not exist.")
@@ -108,7 +101,7 @@ class DiffLocal(unittest.TestCase):
         core.StackAddressEscape checker was enabled in the new run, those
         reports should be listed as new.
         """
-        low_severity_res = get_diff_results(
+        low_severity_res, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', 'json',
             ['--severity', 'low'])
         print(low_severity_res)
@@ -121,10 +114,10 @@ class DiffLocal(unittest.TestCase):
         core.StackAddressEscape checker (high severity) was enabled
         in the new run, those reports should be listed.
         """
-        high_severity_res = get_diff_results(
+        high_severity_res, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', 'json',
             ['--severity', 'high'])
-        self.assertEqual((len(high_severity_res)), 4)
+        self.assertEqual(len(high_severity_res), 4)
 
     def test_filter_severity_high_text(self):
         """Get the high severity new reports.
@@ -132,7 +125,7 @@ class DiffLocal(unittest.TestCase):
         core.StackAddressEscape checker (high severity) was enabled
         in the new run, those reports should be listed.
         """
-        out = get_diff_results(
+        out, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', None,
             ['--severity', 'high'])
         print(out)
@@ -141,7 +134,7 @@ class DiffLocal(unittest.TestCase):
 
     def test_filter_severity_high_low_text(self):
         """Get the high and low severity unresolved reports."""
-        out = get_diff_results(
+        out, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--unresolved', None,
             ['--severity', 'high', 'low'])
         self.assertEqual(len(re.findall(r'\[HIGH\]', out)), 18)
@@ -151,7 +144,7 @@ class DiffLocal(unittest.TestCase):
                    "available in the json output.")
     def test_filter_severity_high_low_json(self):
         """Get the high and low severity unresolved reports in json."""
-        high_low_unresolved_results = get_diff_results(
+        high_low_unresolved_results, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--unresolved', 'json',
             ['--severity', 'high', 'low'])
         print(high_low_unresolved_results)
@@ -160,7 +153,7 @@ class DiffLocal(unittest.TestCase):
 
     def test_multiple_dir(self):
         """ Get unresolved reports from muliple local directories. """
-        unresolved_results = get_diff_results(
+        unresolved_results, _, _ = get_diff_results(
             [self.base_reports, self.new_reports],
             [self.new_reports, self.base_reports],
             '--unresolved', 'json',
@@ -262,15 +255,15 @@ int main()
         codechecker.log_and_analyze(cfg, self._test_dir)
 
         # Run the diff command and check the results.
-        res = get_diff_results(
+        res, _, _ = get_diff_results(
             [report_dir_base], [report_dir_new], '--new', 'json')
         print(res)
         self.assertEqual(len(res), 2)
 
-        res = get_diff_results(
+        res, _, _ = get_diff_results(
             [report_dir_base], [report_dir_new], '--unresolved', 'json')
         self.assertEqual(len(res), 1)
 
-        res = get_diff_results(
+        res, _, _ = get_diff_results(
             [report_dir_base], [report_dir_new], '--resolved', 'json')
         self.assertEqual(len(res), 2)

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -80,20 +80,22 @@ class LocalRemote(unittest.TestCase):
 
         return get_diff_results([self._local_reports], [self._run_names[0]],
                                 '--unresolved', None,
-                                ['--url', self._url, *extra_args])
+                                ['--url', self._url, *extra_args])[0]
 
     def test_local_to_remote_compare_count_new(self):
         """Count the new results with no filter in local compare mode."""
-        out = get_diff_results([self._local_reports], [self._run_names[0]],
-                               '--new', None, ["--url", self._url])
+        out, _, _ = get_diff_results([self._local_reports],
+                                     [self._run_names[0]],
+                                     '--new', None, ["--url", self._url])
 
         count = len(re.findall(r'\[core\.NullDereference\]', out))
         self.assertEqual(count, 4)
 
     def test_remote_to_local_compare_count_new(self):
         """Count the new results with no filter."""
-        out = get_diff_results([self._run_names[0]], [self._local_reports],
-                               '--new', None, ["--url", self._url])
+        out, _, _ = get_diff_results([self._run_names[0]],
+                                     [self._local_reports],
+                                     '--new', None, ["--url", self._url])
 
         # 5 new core.CallAndMessage issues.
         # 1 is suppressed in code
@@ -107,8 +109,9 @@ class LocalRemote(unittest.TestCase):
 
     def test_local_compare_count_unres(self):
         """Count the unresolved results with no filter."""
-        out = get_diff_results([self._local_reports], [self._run_names[0]],
-                               '--unresolved', None, ["--url", self._url])
+        out, _, _ = get_diff_results(
+            [self._local_reports], [self._run_names[0]],
+            '--unresolved', None, ["--url", self._url])
         print(out)
 
         count = len(re.findall(r'\[core\.CallAndMessage\]', out))
@@ -124,8 +127,9 @@ class LocalRemote(unittest.TestCase):
 
     def test_local_compare_count_unres_rgx(self):
         """Count the unresolved results with no filter and run name regex."""
-        out = get_diff_results([self._local_reports], [self._run_names[0]],
-                               '--unresolved', None, ["--url", self._url])
+        out, _, _ = get_diff_results(
+            [self._local_reports], [self._run_names[0]],
+            '--unresolved', None, ["--url", self._url])
         print(out)
 
         count = len(re.findall(r'\[core\.CallAndMessage\]', out))
@@ -346,7 +350,7 @@ class LocalRemote(unittest.TestCase):
         env["CC_REPO_DIR"] = ''
         env["CC_CHANGED_FILES"] = ''
 
-        review_data = get_diff_results(
+        review_data, _, _ = get_diff_results(
             [self._run_names[0]], [self._local_reports],
             '--new', 'gerrit',
             ["--url", self._url],
@@ -405,14 +409,14 @@ class LocalRemote(unittest.TestCase):
 
         env["CC_CHANGED_FILES"] = changed_file_path
 
-        with self.assertRaises(subprocess.CalledProcessError):
-            out = get_diff_results([self._run_names[0]], [self._local_reports],
-                                   '--unresolved', 'gerrit',
-                                   ["--url", self._url, "-e", export_dir])
+        _, err, _ = get_diff_results(
+            [self._run_names[0]], [self._local_reports],
+            '--unresolved', 'gerrit',
+            ["--url", self._url, "-e", export_dir])
 
-            self.assertIn("'CC_REPO_DIR'", out)
-            self.assertIn("'CC_CHANGED_FILES'", out)
-            self.assertIn("needs to be set", out)
+        self.assertIn("'CC_REPO_DIR'", err)
+        self.assertIn("'CC_CHANGED_FILES'", err)
+        self.assertIn("needs to be set", err)
 
         get_diff_results([self._run_names[0]], [self._local_reports],
                          '--unresolved', 'gerrit',
@@ -525,12 +529,13 @@ class LocalRemote(unittest.TestCase):
         env["CC_REPO_DIR"] = ''
         env["CC_CHANGED_FILES"] = ''
 
-        out = get_diff_results([self._run_names[0]], [self._local_reports],
-                               '--resolved', None,
-                               ["-o", "html", "gerrit", "plaintext",
-                                "-e", export_dir,
-                                "--url", self._url],
-                               env)
+        out, _, _ = get_diff_results(
+            [self._run_names[0]], [self._local_reports],
+            '--resolved', None,
+            ["-o", "html", "gerrit", "plaintext",
+             "-e", export_dir,
+             "--url", self._url],
+            env)
 
         # Check the plaintext output.
         count = len(re.findall(r'\[core\.NullDereference\]', out))
@@ -548,6 +553,7 @@ class LocalRemote(unittest.TestCase):
 
     def test_diff_remote_local_resolved_same(self):
         """ Test for resolved reports on same list remotely and locally. """
-        out = get_diff_results([self._run_names[0]], [self._remote_reports],
-                               '--resolved', 'json', ["--url", self._url])
+        out, _, _ = get_diff_results(
+            [self._run_names[0]], [self._remote_reports],
+            '--resolved', 'json', ["--url", self._url])
         self.assertEqual(out, [])

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -505,7 +505,7 @@ class DiffRemote(unittest.TestCase):
                                None, ["--url", self._url], self._env)
 
         # 4 disappeared core.CallAndMessage issues
-        count = len(re.findall(r'\[core\.CallAndMessage\]', out))
+        count = len(re.findall(r'\[core\.CallAndMessage\]', out[0]))
         self.assertEqual(count, 4)
 
     def test_diff_to_tag(self):
@@ -517,27 +517,27 @@ class DiffRemote(unittest.TestCase):
 
         out = get_diff_results([f'{run_name}:t1'], [report_dir],
                                '--new', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 5)
+        self.assertEqual(len(out[0]), 5)
 
         out = get_diff_results([f'{run_name}:t2'], [report_dir],
                                '--new', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 0)
+        self.assertEqual(len(out[0]), 0)
 
         out = get_diff_results([f'{run_name}:t1'], [report_dir],
                                '--unresolved', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 26)
+        self.assertEqual(len(out[0]), 26)
 
         out = get_diff_results([f'{run_name}:t2'], [report_dir],
                                '--unresolved', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 31)
+        self.assertEqual(len(out[0]), 31)
 
         out = get_diff_results([f'{run_name}:t1'], [report_dir],
                                '--resolved', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 0)
+        self.assertEqual(len(out[0]), 0)
 
         out = get_diff_results([f'{run_name}:t2'], [report_dir],
                                '--resolved', 'json', ["--url", self._url])
-        self.assertEqual(len(out), 0)
+        self.assertEqual(len(out[0]), 0)
 
     def test_max_compound_select(self):
         """Test the maximum number of compound select query."""
@@ -686,4 +686,4 @@ class DiffRemote(unittest.TestCase):
                              [new_run_name, base_run_name],
                              '--unresolved', 'json', ["--url", self._url])
 
-        self.assertNotEqual(len(unresolved_results), 0)
+        self.assertNotEqual(len(unresolved_results[0]), 0)

--- a/web/tests/functional/source_change/test_source_change.py
+++ b/web/tests/functional/source_change/test_source_change.py
@@ -71,7 +71,7 @@ class TestSkeleton(unittest.TestCase):
                                     test_proj_path)
 
         ret, out, _ = codechecker.parse(self._codechecker_cfg)
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 2)
 
         # Need to wait a little before updating the last modification time.
         # If we do not wait, not enough time will be past
@@ -80,7 +80,7 @@ class TestSkeleton(unittest.TestCase):
         touch(null_deref_file)
 
         ret, out, _ = codechecker.parse(self._codechecker_cfg)
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 2)
 
         msg = 'did change since the last analysis.'
         self.assertTrue(msg in out,

--- a/web/tests/functional/suppress/test_suppress_generation.py
+++ b/web/tests/functional/suppress/test_suppress_generation.py
@@ -88,7 +88,7 @@ class TestSuppress(unittest.TestCase):
         ret = call_cmd(extract_cmd,
                        self._test_project_path,
                        env.test_env(self._test_workspace))
-        self.assertEqual(ret, 0, "Failed to generate suppress file.")
+        self.assertEqual(ret, 2, "Failed to generate suppress file.")
 
         codechecker_cfg = env.import_test_cfg(
             self._test_workspace)['codechecker_cfg']

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -16,7 +16,7 @@ import os
 import shlex
 import stat
 import subprocess
-from subprocess import CalledProcessError, PIPE
+from subprocess import CalledProcessError
 import time
 
 from codechecker_api_shared.ttypes import Permission
@@ -96,13 +96,15 @@ def get_diff_results(basenames, newnames, diff_type, format_type=None,
     if extra_args:
         diff_cmd.extend(extra_args)
 
-    out = subprocess.check_output(
-        diff_cmd, encoding="utf-8", errors="ignore", env=cc_env, stderr=PIPE)
+    proc = subprocess.Popen(
+        diff_cmd, encoding="utf-8", errors="ignore", env=cc_env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
 
     if format_type == "json":
-        return json.loads(out)
+        return json.loads(out), err, proc.returncode
 
-    return out
+    return out, err, proc.returncode
 
 
 def login(codechecker_cfg, test_project_path, username, password,


### PR DESCRIPTION
It is not possible to compute exit code 2 at "CodeChecker analyze"
command efficiently taking suppression into account. So according to the
new exit codes we indicate only the success and failure of analysis by
zero and non-zero exit codes respectively.

Moreover "diff" and "parse" commands have an exit status depending on
whether there is a resulting report.