### PR TITLE
[report-converter][fix] Fix for the SpotBugs report converter

### DIFF
--- a/tools/report-converter/codechecker_report_converter/spotbugs/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/spotbugs/output_parser.py
@@ -132,6 +132,11 @@ class SpotBugsParser(BaseParser):
             if event:
                 events.append(event)
 
+        # If <SourceLine> did not contain a 'start' attribute, take the last
+        # of the events.
+        if line is None:
+            line = next(e.line for e in reversed(events) if e.line > 0)
+
         return SpotBugsMessage(source_path, int(line), col, long_message,
                                checker_name, report_hash, events)
 
@@ -148,7 +153,7 @@ class SpotBugsParser(BaseParser):
         if not source_path:
             return
 
-        line = source_line.attrib.get('start')
+        line = source_line.attrib.get('start', 0)
         col = 0
 
         return Event(source_path, int(line), col, message)
@@ -166,7 +171,7 @@ class SpotBugsParser(BaseParser):
         if not source_path:
             return
 
-        line = source_line.attrib.get('start')
+        line = source_line.attrib.get('start', 0)
         col = 0
 
         return Event(source_path, int(line), col, message)

--- a/tools/report-converter/tests/unit/spotbugs_output_test_files/Makefile
+++ b/tools/report-converter/tests/unit/spotbugs_output_test_files/Makefile
@@ -1,5 +1,5 @@
 all:
 	javac files/Assign.java
-	spotbugs -xml:withMessages -output ./assign.xml -textui files/Assign.class
+	spotbugs -xml:withMessages -effort:max -low -output ./assign.xml -textui files/Assign.class
 clean:
 	rm Assign.class

--- a/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.plist
+++ b/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.plist
@@ -13,8 +13,6 @@
 			<string>Dead store to $L1 in Assign.main(String[])</string>
 			<key>issue_hash_content_of_line_in_context</key>
 			<string>85a884ed377cf0e258abe7cf9acbbd81</string>
-			<key>orig_issue_hash_content_of_line_in_context</key>
-			<string>31d25c93ca824a832958c47cb869f2dd</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -22,8 +20,10 @@
 				<key>file</key>
 				<integer>0</integer>
 				<key>line</key>
-				<integer>4</integer>
+				<integer>6</integer>
 			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>31d25c93ca824a832958c47cb869f2dd</string>
 			<key>path</key>
 			<array>
 				<dict>
@@ -55,7 +55,7 @@
 						<key>file</key>
 						<integer>0</integer>
 						<key>line</key>
-						<integer>4</integer>
+						<integer>6</integer>
 					</dict>
 					<key>message</key>
 					<string>In method Assign.main(String[])</string>
@@ -72,7 +72,7 @@
 									<key>file</key>
 									<integer>0</integer>
 									<key>line</key>
-									<integer>4</integer>
+									<integer>6</integer>
 								</dict>
 								<dict>
 									<key>col</key>
@@ -80,7 +80,7 @@
 									<key>file</key>
 									<integer>0</integer>
 									<key>line</key>
-									<integer>4</integer>
+									<integer>6</integer>
 								</dict>
 							</array>
 							<key>start</key>
@@ -119,10 +119,194 @@
 						<key>file</key>
 						<integer>0</integer>
 						<key>line</key>
-						<integer>4</integer>
+						<integer>6</integer>
 					</dict>
 					<key>message</key>
 					<string>Dead store to $L1 in Assign.main(String[])</string>
+				</dict>
+			</array>
+			<key>type</key>
+			<string>spotbugs</string>
+		</dict>
+		<dict>
+			<key>category</key>
+			<string>unknown</string>
+			<key>check_name</key>
+			<string>DLS_DEAD_LOCAL_STORE</string>
+			<key>description</key>
+			<string>Dead store to $L1 in Assign.main(String[])</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>85a884ed377cf0e258abe7cf9acbbd81</string>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>0</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>6</integer>
+			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>31d25c93ca824a832958c47cb869f2dd</string>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>In class Assign</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>6</integer>
+					</dict>
+					<key>message</key>
+					<string>In method Assign.main(String[])</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
+						<dict>
+							<key>end</key>
+							<array>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>6</integer>
+								</dict>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>6</integer>
+								</dict>
+							</array>
+							<key>start</key>
+							<array>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>1</integer>
+								</dict>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>1</integer>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>6</integer>
+					</dict>
+					<key>message</key>
+					<string>Dead store to $L1 in Assign.main(String[])</string>
+				</dict>
+			</array>
+			<key>type</key>
+			<string>spotbugs</string>
+		</dict>
+		<dict>
+			<key>category</key>
+			<string>unknown</string>
+			<key>check_name</key>
+			<string>NM_FIELD_NAMING_CONVENTION</string>
+			<key>description</key>
+			<string>The field name Assign.CapitalAttribute doesn't start with a lower case letter</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>2008de45162aee2770ac24c9dfd8fca7</string>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>0</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>1</integer>
+			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>b83078cc9ee341727b6080508d3ea647</string>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>In class Assign</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>The field name Assign.CapitalAttribute doesn't start with a lower case letter</string>
 				</dict>
 			</array>
 			<key>type</key>
@@ -137,8 +321,6 @@
 			<string>Double assignment of $L1 in Assign.main(String[])</string>
 			<key>issue_hash_content_of_line_in_context</key>
 			<string>30270e7a3c1846a0590977d42b599b4d</string>
-			<key>orig_issue_hash_content_of_line_in_context</key>
-			<string>e1cf1dc4a9b1c3d79dd9c35d9c7ce70f</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>
@@ -146,8 +328,10 @@
 				<key>file</key>
 				<integer>0</integer>
 				<key>line</key>
-				<integer>4</integer>
+				<integer>6</integer>
 			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>e1cf1dc4a9b1c3d79dd9c35d9c7ce70f</string>
 			<key>path</key>
 			<array>
 				<dict>
@@ -179,7 +363,7 @@
 						<key>file</key>
 						<integer>0</integer>
 						<key>line</key>
-						<integer>4</integer>
+						<integer>6</integer>
 					</dict>
 					<key>message</key>
 					<string>In method Assign.main(String[])</string>
@@ -196,7 +380,7 @@
 									<key>file</key>
 									<integer>0</integer>
 									<key>line</key>
-									<integer>4</integer>
+									<integer>6</integer>
 								</dict>
 								<dict>
 									<key>col</key>
@@ -204,7 +388,7 @@
 									<key>file</key>
 									<integer>0</integer>
 									<key>line</key>
-									<integer>4</integer>
+									<integer>6</integer>
 								</dict>
 							</array>
 							<key>start</key>
@@ -243,10 +427,194 @@
 						<key>file</key>
 						<integer>0</integer>
 						<key>line</key>
-						<integer>4</integer>
+						<integer>6</integer>
 					</dict>
 					<key>message</key>
 					<string>Double assignment of $L1 in Assign.main(String[])</string>
+				</dict>
+			</array>
+			<key>type</key>
+			<string>spotbugs</string>
+		</dict>
+		<dict>
+			<key>category</key>
+			<string>unknown</string>
+			<key>check_name</key>
+			<string>UC_USELESS_VOID_METHOD</string>
+			<key>description</key>
+			<string>Method Assign.main(String[]) seems to be useless</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>59a6fcef60c5ebd9d0fcfbca8983f932</string>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>0</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>7</integer>
+			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>70d8a57a28b1c7b40c2e2f8d20e2524</string>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>In class Assign</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>6</integer>
+					</dict>
+					<key>message</key>
+					<string>In method Assign.main(String[])</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
+						<dict>
+							<key>end</key>
+							<array>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>6</integer>
+								</dict>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>6</integer>
+								</dict>
+							</array>
+							<key>start</key>
+							<array>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>1</integer>
+								</dict>
+								<dict>
+									<key>col</key>
+									<integer>0</integer>
+									<key>file</key>
+									<integer>0</integer>
+									<key>line</key>
+									<integer>1</integer>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>7</integer>
+					</dict>
+					<key>message</key>
+					<string>Method Assign.main(String[]) seems to be useless</string>
+				</dict>
+			</array>
+			<key>type</key>
+			<string>spotbugs</string>
+		</dict>
+		<dict>
+			<key>category</key>
+			<string>unknown</string>
+			<key>check_name</key>
+			<string>UUF_UNUSED_FIELD</string>
+			<key>description</key>
+			<string>Unused field: Assign.CapitalAttribute</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>d40721a8732ea43f5dc132fe621bc686</string>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>0</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>1</integer>
+			</dict>
+			<key>orig_issue_hash_content_of_line_in_context</key>
+			<string>ee93958ba842675fc1c80739679e2031</string>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>In class Assign</string>
+				</dict>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>0</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>1</integer>
+					</dict>
+					<key>message</key>
+					<string>Unused field: Assign.CapitalAttribute</string>
 				</dict>
 			</array>
 			<key>type</key>

--- a/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.xml
+++ b/tools/report-converter/tests/unit/spotbugs_output_test_files/assign.xml
@@ -1,53 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<BugCollection version="3.1.12" sequence="0" timestamp="1580211159677" analysisTimestamp="1580211244005" release="">
+<BugCollection version="4.2.2-SNAPSHOT" sequence="0" timestamp="1616512489543" analysisTimestamp="1616512491288" release="">
   <Project projectName="">
     <Jar>files</Jar>
   </Project>
-  <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="2" rank="17" abbrev="DLS" category="STYLE" instanceHash="31d25c93ca824a832958c47cb869f2dd" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="563">
+  <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="2" rank="17" abbrev="DLS" category="STYLE" instanceHash="31d25c93ca824a832958c47cb869f2dd" instanceOccurrenceNum="0" instanceOccurrenceMax="1" cweid="563">
     <ShortMessage>Dead store to local variable</ShortMessage>
     <LongMessage>Dead store to $L1 in Assign.main(String[])</LongMessage>
     <Class classname="Assign" primary="true">
-      <SourceLine classname="Assign" start="1" end="5" sourcefile="Assign.java" sourcepath="Assign.java">
-        <Message>At Assign.java:[lines 1-5]</Message>
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
       </SourceLine>
       <Message>In class Assign</Message>
     </Class>
     <Method classname="Assign" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="Assign" start="4" end="5" startBytecode="0" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java"/>
+      <SourceLine classname="Assign" start="6" end="7" startBytecode="0" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java"/>
       <Message>In method Assign.main(String[])</Message>
     </Method>
     <LocalVariable name="?" register="1" pc="4" role="LOCAL_VARIABLE_UNKNOWN">
       <Message>Local variable stored in JVM register 1</Message>
     </LocalVariable>
-    <SourceLine classname="Assign" primary="true" start="4" end="4" startBytecode="4" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java">
-      <Message>At Assign.java:[line 4]</Message>
+    <SourceLine classname="Assign" primary="true" start="6" end="6" startBytecode="4" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java">
+      <Message>At Assign.java:[line 6]</Message>
     </SourceLine>
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.BASE_VALUE" value="true"/>
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.KILLED_BY_SUBSEQUENT_STORE" value="true"/>
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.LOCAL_NAME" value="?"/>
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.NO_LOADS" value="true"/>
   </BugInstance>
-  <BugInstance type="SA_LOCAL_DOUBLE_ASSIGNMENT" priority="2" rank="17" abbrev="SA" category="STYLE" instanceHash="e1cf1dc4a9b1c3d79dd9c35d9c7ce70f" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Double assignment of local variable </ShortMessage>
-    <LongMessage>Double assignment of $L1 in Assign.main(String[])</LongMessage>
+  <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="3" rank="20" abbrev="DLS" category="STYLE" instanceHash="31d25c93ca824a832958c47cb869f2dd" instanceOccurrenceNum="1" instanceOccurrenceMax="1" cweid="563">
+    <ShortMessage>Dead store to local variable</ShortMessage>
+    <LongMessage>Dead store to $L1 in Assign.main(String[])</LongMessage>
     <Class classname="Assign" primary="true">
-      <SourceLine classname="Assign" start="1" end="5" sourcefile="Assign.java" sourcepath="Assign.java">
-        <Message>At Assign.java:[lines 1-5]</Message>
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
       </SourceLine>
       <Message>In class Assign</Message>
     </Class>
     <Method classname="Assign" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="Assign" start="4" end="5" startBytecode="0" endBytecode="33" sourcefile="Assign.java" sourcepath="Assign.java"/>
+      <SourceLine classname="Assign" start="6" end="7" startBytecode="0" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java"/>
+      <Message>In method Assign.main(String[])</Message>
+    </Method>
+    <LocalVariable name="?" register="1" pc="5" role="LOCAL_VARIABLE_UNKNOWN">
+      <Message>Local variable stored in JVM register 1</Message>
+    </LocalVariable>
+    <SourceLine classname="Assign" primary="true" start="6" end="6" startBytecode="3" endBytecode="3" sourcefile="Assign.java" sourcepath="Assign.java">
+      <Message>At Assign.java:[line 6]</Message>
+    </SourceLine>
+    <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.BASE_VALUE" value="true"/>
+    <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.LOCAL_NAME" value="?"/>
+    <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.NO_LOADS" value="true"/>
+  </BugInstance>
+  <BugInstance type="NM_FIELD_NAMING_CONVENTION" priority="3" rank="19" abbrev="Nm" category="BAD_PRACTICE" instanceHash="b83078cc9ee341727b6080508d3ea647" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Field names should start with a lower case letter</ShortMessage>
+    <LongMessage>The field name Assign.CapitalAttribute doesn&apos;t start with a lower case letter</LongMessage>
+    <Class classname="Assign" primary="true">
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
+      </SourceLine>
+      <Message>In class Assign</Message>
+    </Class>
+    <Field classname="Assign" name="CapitalAttribute" signature="I" isStatic="true" primary="true">
+      <SourceLine classname="Assign" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>In Assign.java</Message>
+      </SourceLine>
+      <Message>Field Assign.CapitalAttribute</Message>
+    </Field>
+    <SourceLine classname="Assign" sourcefile="Assign.java" sourcepath="Assign.java" synthetic="true">
+      <Message>In Assign.java</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="SA_LOCAL_DOUBLE_ASSIGNMENT" priority="2" rank="17" abbrev="SA" category="STYLE" instanceHash="e1cf1dc4a9b1c3d79dd9c35d9c7ce70f" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Double assignment of local variable</ShortMessage>
+    <LongMessage>Double assignment of $L1 in Assign.main(String[])</LongMessage>
+    <Class classname="Assign" primary="true">
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
+      </SourceLine>
+      <Message>In class Assign</Message>
+    </Class>
+    <Method classname="Assign" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
+      <SourceLine classname="Assign" start="6" end="7" startBytecode="0" endBytecode="33" sourcefile="Assign.java" sourcepath="Assign.java"/>
       <Message>In method Assign.main(String[])</Message>
     </Method>
     <LocalVariable name="?" register="1" pc="4" role="LOCAL_VARIABLE_UNKNOWN">
       <Message>Local variable stored in JVM register 1</Message>
     </LocalVariable>
-    <SourceLine classname="Assign" primary="true" start="4" end="4" startBytecode="4" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java">
-      <Message>At Assign.java:[line 4]</Message>
+    <SourceLine classname="Assign" primary="true" start="6" end="6" startBytecode="4" endBytecode="4" sourcefile="Assign.java" sourcepath="Assign.java">
+      <Message>At Assign.java:[line 6]</Message>
     </SourceLine>
   </BugInstance>
+  <BugInstance type="UC_USELESS_VOID_METHOD" priority="3" rank="20" abbrev="UC" category="STYLE" instanceHash="70d8a57a28b1c7b40c2e2f8d20e2524" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Useless non-empty void method</ShortMessage>
+    <LongMessage>Method Assign.main(String[]) seems to be useless</LongMessage>
+    <Class classname="Assign" primary="true">
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
+      </SourceLine>
+      <Message>In class Assign</Message>
+    </Class>
+    <Method classname="Assign" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
+      <SourceLine classname="Assign" start="6" end="7" startBytecode="0" endBytecode="33" sourcefile="Assign.java" sourcepath="Assign.java"/>
+      <Message>In method Assign.main(String[])</Message>
+    </Method>
+    <SourceLine classname="Assign" primary="true" start="7" end="7" startBytecode="5" endBytecode="5" sourcefile="Assign.java" sourcepath="Assign.java">
+      <Message>At Assign.java:[line 7]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="UUF_UNUSED_FIELD" priority="2" rank="18" abbrev="UuF" category="PERFORMANCE" instanceHash="ee93958ba842675fc1c80739679e2031" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Unused field</ShortMessage>
+    <LongMessage>Unused field: Assign.CapitalAttribute</LongMessage>
+    <Class classname="Assign" primary="true">
+      <SourceLine classname="Assign" start="1" end="7" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>At Assign.java:[lines 1-7]</Message>
+      </SourceLine>
+      <Message>In class Assign</Message>
+    </Class>
+    <Field classname="Assign" name="CapitalAttribute" signature="I" isStatic="true" primary="true">
+      <SourceLine classname="Assign" sourcefile="Assign.java" sourcepath="Assign.java">
+        <Message>In Assign.java</Message>
+      </SourceLine>
+      <Message>Field Assign.CapitalAttribute</Message>
+    </Field>
+    <SourceLine classname="Assign" sourcefile="Assign.java" sourcepath="Assign.java" synthetic="true">
+      <Message>In Assign.java</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugCategory category="BAD_PRACTICE">
+    <Description>Bad practice</Description>
+  </BugCategory>
+  <BugCategory category="PERFORMANCE">
+    <Description>Performance</Description>
+  </BugCategory>
   <BugCategory category="STYLE">
     <Description>Dodgy code</Description>
   </BugCategory>
@@ -69,8 +153,42 @@ there is no easy way to eliminate these false positives.
 
     ]]></Details>
   </BugPattern>
+  <BugPattern type="NM_FIELD_NAMING_CONVENTION" abbrev="Nm" category="BAD_PRACTICE">
+    <ShortDescription>Field names should start with a lower case letter</ShortDescription>
+    <Details><![CDATA[
+
+  <p>
+Names of fields that are not final should be in mixed case with a lowercase first letter and the first letters of subsequent words capitalized.
+</p>
+
+    ]]></Details>
+  </BugPattern>
+  <BugPattern type="UUF_UNUSED_FIELD" abbrev="UuF" category="PERFORMANCE">
+    <ShortDescription>Unused field</ShortDescription>
+    <Details><![CDATA[
+
+  <p> This field is never used.&nbsp; Consider removing it from the class.</p>
+
+    ]]></Details>
+  </BugPattern>
+  <BugPattern type="UC_USELESS_VOID_METHOD" abbrev="UC" category="STYLE">
+    <ShortDescription>Useless non-empty void method</ShortDescription>
+    <Details><![CDATA[
+
+<p>Our analysis shows that this non-empty void method does not actually perform any useful work.
+Please check it: probably there's a mistake in its code or its body can be fully removed.
+</p>
+<p>We are trying to reduce the false positives as much as possible, but in some cases this warning might be wrong.
+Common false-positive cases include:</p>
+<ul>
+<li>The method is intended to trigger loading of some class which may have a side effect.</li>
+<li>The method is intended to implicitly throw some obscure exception.</li>
+</ul>
+
+    ]]></Details>
+  </BugPattern>
   <BugPattern type="SA_LOCAL_DOUBLE_ASSIGNMENT" abbrev="SA" category="STYLE">
-    <ShortDescription>Double assignment of local variable </ShortDescription>
+    <ShortDescription>Double assignment of local variable</ShortDescription>
     <Details><![CDATA[
 
 <p> This method contains a double assignment of a local variable; e.g.
@@ -84,29 +202,38 @@ there is no easy way to eliminate these false positives.
 
     ]]></Details>
   </BugPattern>
+  <BugCode abbrev="UuF">
+    <Description>Unused field</Description>
+  </BugCode>
   <BugCode abbrev="DLS" cweid="563">
     <Description>Dead local store</Description>
   </BugCode>
   <BugCode abbrev="SA">
     <Description>Useless self-operation</Description>
   </BugCode>
+  <BugCode abbrev="UC">
+    <Description>Useless code</Description>
+  </BugCode>
+  <BugCode abbrev="Nm">
+    <Description>Confusing method name</Description>
+  </BugCode>
   <Errors errors="0" missingClasses="0"></Errors>
-  <FindBugsSummary timestamp="Tue, 28 Jan 2020 12:32:39 +0100" total_classes="1" referenced_classes="11" total_bugs="2" total_size="6" num_packages="1" java_version="11.0.5" vm_version="11.0.5+10-post-Ubuntu-0ubuntu1.118.04" cpu_seconds="4.41" clock_seconds="0.97" peak_mbytes="122.70" alloc_mbytes="768.00" gc_seconds="0.01" priority_2="2">
-    <FileStats path="Assign.java" bugCount="2" size="6" bugHash="64e76c35ee68a428193cf6e7af447a59"/>
-    <PackageStats package="" total_bugs="2" total_types="1" total_size="6" priority_2="2">
-      <ClassStats class="Assign" sourceFile="Assign.java" interface="false" size="6" bugs="2" priority_2="2"/>
+  <FindBugsSummary timestamp="Tue, 23 Mar 2021 16:14:49 +0100" total_classes="1" referenced_classes="11" total_bugs="6" total_size="7" num_packages="1" java_version="11.0.10" vm_version="11.0.10+9-Ubuntu-0ubuntu1.18.04" cpu_seconds="10.94" clock_seconds="1.34" peak_mbytes="261.89" alloc_mbytes="768.00" gc_seconds="0.04" priority_3="3" priority_2="3">
+    <FileStats path="Assign.java" bugCount="6" size="7" bugHash="f4cd1389238386a996e59a9d629eece1"/>
+    <PackageStats package="" total_bugs="6" total_types="1" total_size="7" priority_3="3" priority_2="3">
+      <ClassStats class="Assign" sourceFile="Assign.java" interface="false" size="7" bugs="6" priority_3="3" priority_2="3"/>
     </PackageStats>
     <FindBugsProfile>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine" totalMilliseconds="252" invocations="304" avgMicrosecondsPerInvocation="829" maxMicrosecondsPerInvocation="19808" standardDeviationMicrosecondsPerInvocation="1838"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FieldItemSummary" totalMilliseconds="34" invocations="11" avgMicrosecondsPerInvocation="3178" maxMicrosecondsPerInvocation="16600" standardDeviationMicrosecondsPerInvocation="5174"/>
-      <ClassProfile name="edu.umd.cs.findbugs.OpcodeStack$JumpInfoFactory" totalMilliseconds="30" invocations="39" avgMicrosecondsPerInvocation="788" maxMicrosecondsPerInvocation="4175" standardDeviationMicrosecondsPerInvocation="897"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassDataAnalysisEngine" totalMilliseconds="29" invocations="306" avgMicrosecondsPerInvocation="97" maxMicrosecondsPerInvocation="3262" standardDeviationMicrosecondsPerInvocation="214"/>
-      <ClassProfile name="edu.umd.cs.findbugs.util.TopologicalSort" totalMilliseconds="28" invocations="270" avgMicrosecondsPerInvocation="105" maxMicrosecondsPerInvocation="1671" standardDeviationMicrosecondsPerInvocation="189"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.MethodGenFactory" totalMilliseconds="25" invocations="2" avgMicrosecondsPerInvocation="12638" maxMicrosecondsPerInvocation="25091" standardDeviationMicrosecondsPerInvocation="12453"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindNoSideEffectMethods" totalMilliseconds="21" invocations="11" avgMicrosecondsPerInvocation="1913" maxMicrosecondsPerInvocation="9248" standardDeviationMicrosecondsPerInvocation="2797"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.JavaClassAnalysisEngine" totalMilliseconds="19" invocations="25" avgMicrosecondsPerInvocation="777" maxMicrosecondsPerInvocation="10854" standardDeviationMicrosecondsPerInvocation="2182"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.OverridingEqualsNotSymmetrical" totalMilliseconds="14" invocations="11" avgMicrosecondsPerInvocation="1322" maxMicrosecondsPerInvocation="10207" standardDeviationMicrosecondsPerInvocation="2882"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.NoteDirectlyRelevantTypeQualifiers" totalMilliseconds="14" invocations="11" avgMicrosecondsPerInvocation="1312" maxMicrosecondsPerInvocation="9057" standardDeviationMicrosecondsPerInvocation="2539"/>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine" totalMilliseconds="376" invocations="304" avgMicrosecondsPerInvocation="1238" maxMicrosecondsPerInvocation="19158" standardDeviationMicrosecondsPerInvocation="2457"/>
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FieldItemSummary" totalMilliseconds="48" invocations="11" avgMicrosecondsPerInvocation="4418" maxMicrosecondsPerInvocation="17804" standardDeviationMicrosecondsPerInvocation="6365"/>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.UnconditionalValueDerefDataflowFactory" totalMilliseconds="45" invocations="2" avgMicrosecondsPerInvocation="22969" maxMicrosecondsPerInvocation="45592" standardDeviationMicrosecondsPerInvocation="22623"/>
+      <ClassProfile name="edu.umd.cs.findbugs.OpcodeStack$JumpInfoFactory" totalMilliseconds="39" invocations="39" avgMicrosecondsPerInvocation="1012" maxMicrosecondsPerInvocation="4156" standardDeviationMicrosecondsPerInvocation="920"/>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassDataAnalysisEngine" totalMilliseconds="37" invocations="306" avgMicrosecondsPerInvocation="122" maxMicrosecondsPerInvocation="4507" standardDeviationMicrosecondsPerInvocation="305"/>
+      <ClassProfile name="edu.umd.cs.findbugs.detect.FindNoSideEffectMethods" totalMilliseconds="36" invocations="11" avgMicrosecondsPerInvocation="3303" maxMicrosecondsPerInvocation="21381" standardDeviationMicrosecondsPerInvocation="6062"/>
+      <ClassProfile name="edu.umd.cs.findbugs.util.TopologicalSort" totalMilliseconds="35" invocations="270" avgMicrosecondsPerInvocation="132" maxMicrosecondsPerInvocation="1605" standardDeviationMicrosecondsPerInvocation="240"/>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.MethodGenFactory" totalMilliseconds="33" invocations="2" avgMicrosecondsPerInvocation="16680" maxMicrosecondsPerInvocation="33081" standardDeviationMicrosecondsPerInvocation="16401"/>
+      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.JavaClassAnalysisEngine" totalMilliseconds="27" invocations="25" avgMicrosecondsPerInvocation="1084" maxMicrosecondsPerInvocation="16174" standardDeviationMicrosecondsPerInvocation="3212"/>
+      <ClassProfile name="edu.umd.cs.findbugs.detect.NoteDirectlyRelevantTypeQualifiers" totalMilliseconds="21" invocations="11" avgMicrosecondsPerInvocation="1983" maxMicrosecondsPerInvocation="11696" standardDeviationMicrosecondsPerInvocation="3390"/>
     </FindBugsProfile>
   </FindBugsSummary>
   <ClassFeatures></ClassFeatures>

--- a/tools/report-converter/tests/unit/spotbugs_output_test_files/files/Assign.java
+++ b/tools/report-converter/tests/unit/spotbugs_output_test_files/files/Assign.java
@@ -1,4 +1,6 @@
 public class Assign {
+  private static int CapitalAttribute;
+
   public static void main(String args[]) {
     int x,y;
     x = x = 17;


### PR DESCRIPTION
Some SpotBugs bug reports lack the 'start' and 'end' attributes in
their <SourceLine> tags. The converter must not crash in such cases,
but instead take line number in the <SourceLine> tag in the innermost
block. If neither the blocks constin 'start' and 'end' attributes then
take 0 instead. This patch fixes this issue.