### PR TITLE
[clang-tidy] Handle Clang Tidy aliases in plist files

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -37,3 +37,5 @@ context_hash:
 	$(CXX) -w context_hash.cpp -o /dev/null
 collision:
 	$(CXX) -w filename_collision/main.cpp filename_collision/a/f.cpp filename_collision/b/f.cpp -o /dev/null
+tidy_alias:
+	$(CXX) -w tidy_alias.cpp -o /dev/null

--- a/analyzer/tests/functional/analyze_and_parse/test_files/tidy_alias.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/tidy_alias.cpp
@@ -1,0 +1,9 @@
+double circleArea(double radius)
+{
+  return 3.1415926535 * radius * radius;
+}
+
+int main()
+{
+  return 0;
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/tidy_alias.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/tidy_alias.output
@@ -1,0 +1,44 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make tidy_alias" --quiet 
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -e cppcoreguidelines-avoid-magic-numbers -e readability-magic-numbers
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make tidy_alias" --output $OUTPUT$ --quiet --analyzers clang-tidy -e cppcoreguidelines-avoid-magic-numbers -e readability-magic-numbers
+--------------------------------------------------------------------------------
+[] - Starting build ...
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clang-tidy analyzed tidy_alias.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clang-tidy: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[STYLE] tidy_alias.cpp:3:10: 3.1415926535 is a magic number; consider replacing it with a named constant [cppcoreguidelines-avoid-magic-numbers]
+  return 3.1415926535 * radius * radius;
+         ^
+
+[STYLE] tidy_alias.cpp:3:10: 3.1415926535 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
+  return 3.1415926535 * radius * radius;
+         ^
+
+Found 2 defect(s) in tidy_alias.cpp
+
+
+----==== Summary ====----
+-----------------------------
+Filename       | Report count
+-----------------------------
+tidy_alias.cpp |            2
+-----------------------------
+-----------------------
+Severity | Report count
+-----------------------
+STYLE    |            2
+-----------------------
+----=================----
+Total number of reports: 2
+----=================----


### PR DESCRIPTION
> Closes #2886

When a checker name and the alias of this checker is turned on, Clang Tidy (>v11)
will generate only one report where the checker names are concatenated with `,` mark.
With this patch we will generate multiple reports for each checker name / alias.