### PR TITLE
[test] Fix non existen report directory test

### DIFF
--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -81,7 +81,7 @@ class DiffLocal(unittest.TestCase):
             self.assertEqual(new_result['checkerId'], "core.NullDereference")
 
     def test_non_existent_reports_directory(self):
-        """Hadles non existent directory well
+        """Handles non existent directory well
 
         Displays detailed information about base and new directories when
         any of them are not exist.
@@ -90,7 +90,9 @@ class DiffLocal(unittest.TestCase):
         return_code = 0
         try:
             get_diff_results([self.base_reports], ['unexistent-dir-name'],
-                             '--new')
+                             '--new', extra_args=[
+                                 '--url',
+                                 f"localhost:{env.get_free_port()}/Default"])
         except subprocess.CalledProcessError as process_error:
             return_code = process_error.returncode
             error_output = process_error.stderr


### PR DESCRIPTION
> This problem comes from this PR: #3240

The `test_non_existent_reports_directory` test assumes that on the default
url (localhost:8001) doesn't run any server. Unfortunately for me a
CodeChecker server was started on this port and this test cases is failed
because the connection between the client and server was successfully
created. To solve this problem we should get a free port on the host
and we need to try to connect to this server. So this test case will
always pass.