### PR TITLE
[report-converter][fix] Fix for SpotBugs Report Conveter with Plugins

### DIFF
--- a/tools/report-converter/codechecker_report_converter/spotbugs/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/spotbugs/output_parser.py
@@ -97,11 +97,12 @@ class SpotBugsParser(BaseParser):
 
         project = root.find('Project')
         for element in project:
-            file_path = element.text
-            if os.path.isdir(file_path):
-                paths.append(file_path)
-            elif os.path.isfile(file_path):
-                paths.append(os.path.dirname(file_path))
+            if element.tag in ['Jar', 'AuxClasspathEntry', 'SrcDir']:
+                file_path = element.text
+                if os.path.isdir(file_path):
+                    paths.append(file_path)
+                elif os.path.isfile(file_path):
+                    paths.append(os.path.dirname(file_path))
 
         return paths
 


### PR DESCRIPTION
The SpotBugs report converter tries to handle every element in the
<Project> section as a file path. However, if a plugin is used, such as
find-sec-bugs an additional element with <Plugin> tag is also included
in this section with empty text part, which crashes the converter because
it expects a non-empty text. This patch fixes this issue by only
considering tags <Jar>, <AuxClasspathEntry> and <SrcDir>.