### PR TITLE
[client] Fix storage of multiple report directory

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -638,6 +638,17 @@ def assemble_zip(inputs, zip_file, client):
         # Add the files to the zip which will be sent to the server.
         for ftc in files_to_compress:
             _, filename = os.path.split(ftc)
+
+            # It is possible that multiple reports directories are given during
+            # the store command which contain the same plist file name but with
+            # different content. For this reason for plist files we need to
+            # generate a more unique file name when putting it to the storage
+            # zip file.
+            if filename.endswith(".plist"):
+                filename = \
+                    (f"{os.path.splitext(filename)[0]}_"
+                     f"{hashlib.md5(ftc.encode('utf-8')).hexdigest()}.plist")
+
             zip_target = os.path.join('reports', filename)
             zipf.write(ftc, zip_target)
 

--- a/web/tests/functional/store/__init__.py
+++ b/web/tests/functional/store/__init__.py
@@ -15,6 +15,7 @@ import shutil
 
 from libtest import codechecker
 from libtest import env
+from libtest import plist_test
 
 # Test workspace initialized at setup for report storage tests.
 TEST_WORKSPACE = None
@@ -30,8 +31,6 @@ def setup_package():
 
     # Configuration options.
     codechecker_cfg = {
-        'suppress_file': None,
-        'skip_list_file': None,
         'check_env': env.test_env(TEST_WORKSPACE),
         'workspace': TEST_WORKSPACE,
         'checkers': [],
@@ -51,6 +50,16 @@ def setup_package():
 
     # Export the test configuration to the workspace.
     env.export_test_cfg(TEST_WORKSPACE, {'codechecker_cfg': codechecker_cfg})
+
+    # Copy test files to a temporary directory not to modify the
+    # files in the repository.
+    # Report files will be overwritten during the tests.
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    dst_dir = os.path.join(TEST_WORKSPACE, "test_proj")
+    shutil.copytree(os.path.join(test_dir, "test_proj"), dst_dir)
+
+    report_file = os.path.join(dst_dir, "divide_zero.plist")
+    plist_test.prefix_file_path(report_file, dst_dir)
 
 
 def teardown_package():

--- a/web/tests/functional/store/test_proj/Makefile
+++ b/web/tests/functional/store/test_proj/Makefile
@@ -2,7 +2,7 @@
 # for the store update tests.
 
 build:
-	$(CXX) divide_zero.cpp -o divide_zero
+	$(CXX) -c divide_zero.cpp -o /dev/null
 
 clean:
 	rm -rf divide_zero

--- a/web/tests/functional/store/test_proj/project_info.json
+++ b/web/tests/functional/store/test_proj/project_info.json
@@ -1,0 +1,5 @@
+{
+    "name": "store",
+    "clean_cmd": "make clean",
+    "build_cmd": "make build"
+}


### PR DESCRIPTION
It is possible that the same project is analyzed with different
configuration (e.g.: ctu, non-ctu) to different report directories and
the user want to store these results with one CodeChecker store command.

This command will create a storage zip file with all the plist files in it
under the reports directory. It is possible the the same file name can be
found in multiple report directories so for this reason we need to create a
unique plist file name when we build the zip file.