### PR TITLE
[web] Get CodeChecker API version automatically in webpack

### DIFF
--- a/docs/web/api/README.md
+++ b/docs/web/api/README.md
@@ -60,8 +60,6 @@ already existing functions, only extend the API:
  `codechecker_web/shared/version.py`. This dict stores for each major
  version, which is the highest supported minor version. In this case, simply
  increase the number by `1`.
- 2. Change the `web/server/www/scripts/version.js` file to represent the newest
- version, e.g. `6.1`.
 
 ### Major API changes <a name="major-api-changes"></a>
 

--- a/web/server/vue-cli/config/webpack.common.js
+++ b/web/server/vue-cli/config/webpack.common.js
@@ -6,12 +6,15 @@ const { DefinePlugin } = require('webpack');
 
 const { join } = require('path');
 
+const codeCheckerApi = require('codechecker-api/package.json');
+
 const helpers = require('./helpers');
 
+const apiVersion = codeCheckerApi.version.split('.').slice(0, 2).join('.');
 const METADATA = {
   'CC_SERVER_HOST': null,
   'CC_SERVER_PORT': 80,
-  'CC_API_VERSION': JSON.stringify('6.39')
+  'CC_API_VERSION': JSON.stringify(apiVersion)
 };
 
 function sassLoaderOptions(indentedSyntax=false) {


### PR DESCRIPTION
Getchecker-api` package version automatically during webpack build
from the module instead of changing it manually on every package update.