### PR TITLE
[report-converter] Use codechecker_report_hash module

### DIFF
--- a/tools/report-converter/Makefile
+++ b/tools/report-converter/Makefile
@@ -40,7 +40,7 @@ include tests/Makefile
 
 package:
 	# Install package in 'development mode'.
-	${PYTHON_BIN} setup.py develop
+	${PYTHON_BIN} -m pip install -e . ../codechecker_report_hash/
 
 build:
 	${PYTHON_BIN} setup.py build --build-purelib $(REPORT_CONVERTER_DIR)

--- a/tools/report-converter/codechecker_report_converter/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzer_result.py
@@ -13,8 +13,9 @@ import logging
 import os
 import plistlib
 
+from codechecker_report_hash.hash import get_report_hash, HashType
+
 from . import __title__, __version__
-from .report import generate_report_hash
 
 LOG = logging.getLogger('ReportConverter')
 
@@ -104,9 +105,9 @@ class AnalyzerResult(object, metaclass=ABCMeta):
         """ Generate report hash for the given plist data. """
         files = plist_obj['files']
         for diag in plist_obj['diagnostics']:
-            report_hash = \
-                generate_report_hash(diag,
-                                     files[diag['location']['file']])
+            report_hash = get_report_hash(
+                diag, files[diag['location']['file']], HashType.CONTEXT_FREE)
+
             diag['issue_hash_content_of_line_in_context'] = report_hash
 
     def _add_metadata(self, plist_obj):

--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -22,7 +22,7 @@ import sys
 # dependencies.
 if __name__ == '__main__':
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    os.sys.path.append(os.path.dirname(current_dir))
+    os.sys.path.insert(0, os.path.dirname(current_dir))
 
 from codechecker_report_converter.clang_tidy.analyzer_result import \
     ClangTidyAnalyzerResult  # noqa

--- a/tools/report-converter/codechecker_report_converter/cppcheck/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/cppcheck/analyzer_result.py
@@ -14,8 +14,9 @@ import plistlib
 
 from xml.parsers.expat import ExpatError
 
+from codechecker_report_hash.hash import get_report_hash, HashType
+
 from codechecker_report_converter.analyzer_result import AnalyzerResult
-from codechecker_report_converter.report import generate_report_hash
 
 
 LOG = logging.getLogger('ReportConverter')
@@ -82,9 +83,10 @@ class CppcheckAnalyzerResult(AnalyzerResult):
         for diag in plist_data['diagnostics']:
             report_hash = diag.get('issue_hash_content_of_line_in_context')
             if not report_hash or report_hash == '0':
-                report_hash = \
-                    generate_report_hash(diag,
-                                         files[diag['location']['file']])
+                report_hash = get_report_hash(
+                    diag, files[diag['location']['file']],
+                    HashType.CONTEXT_FREE)
+
                 diag['issue_hash_content_of_line_in_context'] = report_hash
 
     def _write(self, file_to_plist_data, output_dir, file_name):

--- a/tools/report-converter/codechecker_report_converter/report.py
+++ b/tools/report-converter/codechecker_report_converter/report.py
@@ -13,10 +13,8 @@ Multiple bug identification hash-es can be generated.
 All hash generation algorithms should be documented and implemented here.
 """
 
-
-import hashlib
 import logging
-import os
+
 
 LOG = logging.getLogger('ReportConverter')
 
@@ -72,61 +70,3 @@ def remove_whitespace(line_content, old_col):
 
     return ''.join(line_content.split()), \
            old_col - line_strip_len
-
-
-def generate_report_hash(main_section, source_file):
-    """ Generate unique hashes for reports.
-
-    Hash generation algoritm for older plist versions where no issue hash was
-    generated or for the plists generated where the issue hash generation
-    feature is still missing.
-
-    High level overview of the hash content:
-     * file_name from the main diag section
-     * checker message
-     * line content from the source file if can be read up
-     * column numbers from the main diag sections location
-     * all the whitespaces from the source content are removed
-
-    """
-
-    try:
-        m_loc = main_section.get('location')
-        source_line = m_loc.get('line')
-
-        from_col = m_loc.get('col')
-        until_col = m_loc.get('col')
-
-        # WARNING!!! Changing the error handling type for encoding errors
-        # can influence the hash content!
-        line_content = get_line(source_file, source_line, errors='ignore')
-
-        # Remove whitespaces so the hash will be independet of the
-        # source code indentation.
-        line_content, new_col = \
-            remove_whitespace(line_content, from_col)
-        # Update the column number in sync with the
-        # removed whitespaces.
-        until_col = until_col - (from_col-new_col)
-        from_col = new_col
-
-        if line_content == '' and not os.path.isfile(source_file):
-            LOG.error("Failed to include soruce line in the report hash.")
-            LOG.error('%s does not exists!', source_file)
-
-        file_name = os.path.basename(source_file)
-        msg = main_section.get('description')
-
-        hash_content = [file_name,
-                        msg,
-                        line_content,
-                        str(from_col),
-                        str(until_col)]
-
-        string_to_hash = '|||'.join(hash_content)
-        return hashlib.md5(string_to_hash.encode()).hexdigest()
-
-    except Exception as ex:
-        LOG.error("Hash generation failed")
-        LOG.error(ex)
-        return ''

--- a/tools/report-converter/setup.py
+++ b/tools/report-converter/setup.py
@@ -19,6 +19,9 @@ setuptools.setup(
     license='LICENSE.txt',
     packages=setuptools.find_packages(),
     include_package_data=True,
+    install_requires=[
+        "codechecker_report_hash"
+    ],
     classifiers=[
         "Environment :: Console",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Use the `codechecker_report_hash` module to generate a hash in the `report-converter` to remove code duplication.