### PR TITLE
[test] Compile test project with c++11 explicitly

### DIFF
--- a/web/tests/projects/cpp/Makefile
+++ b/web/tests/projects/cpp/Makefile
@@ -1,6 +1,6 @@
 OBJS = $(SRCS:.cpp=.o)
 
-CXXFLAGS = -Wno-all -Wno-extra
+CXXFLAGS = -Wno-all -Wno-extra -std=c++11
 
 SRCS = call_and_message.cpp \
 	   divide_zero.cpp \


### PR DESCRIPTION
If an old GCC compiler is installed on a machine which doesn't use C++11
by default, the tests may fail. There are some checkers (e.g.
misc-definitions-in-headers) which report only from C++11. If these
reports are missing with an old compiler then the number of reports will
not be as expected.