### PR TITLE
[fix] Local API package installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,15 +94,15 @@ venv:
 	# Create a virtual environment which can be used to run the build package.
 	python3 -m venv venv --prompt="CodeChecker venv" && \
 		$(ACTIVATE_RUNTIME_VENV) && \
-		pip3 install -r $(CC_ANALYZER)/requirements.txt && \
-		pip3 install -r $(CC_WEB)/requirements.txt
+		cd $(CC_ANALYZER) && pip3 install -r requirements.txt && \
+		cd $(CC_WEB) && pip3 install -r $(CC_WEB)/requirements.txt
 
 venv_osx:
 	# Create a virtual environment which can be used to run the build package.
 	python3 -m venv venv --prompt="CodeChecker venv" && \
 		$(ACTIVATE_RUNTIME_VENV) && \
-		pip3 install -r $(CC_ANALYZER)/requirements_py/osx/requirements.txt && \
-		pip3 install -r $(CC_WEB)/requirements_py/osx/requirements.txt
+		cd $(CC_ANALYZER) && pip3 install -r requirements_py/osx/requirements.txt && \
+		cd $(CC_WEB) && pip3 install -r requirements_py/osx/requirements.txt
 
 clean_venv:
 	rm -rf venv

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,9 +34,6 @@ parts:
     plugin: python
     python-version: python3
     source: https://github.com/Ericsson/codechecker/archive/v6.16.0.tar.gz
-    requirements:
-      - analyzer/requirements.txt
-      - web/requirements.txt
     build-packages:
       - curl
       - gcc-multilib
@@ -47,6 +44,15 @@ parts:
       - node/11/stable
     override-build: |
       snapcraftctl build
+
+      # We install the CodeChecker API dependency from a local package tar file
+      # in the web requirement file relatively to the web directory but
+      # unfortunatelly the python plugin doesn't support to specify a base
+      # directory.
+      cd analyzer && python3 -m pip install -r requirements.txt
+      cd ../web && python3 -m pip install -r requirements.txt
+      cd ..
+
       npm config set scripts-prepend-node-path true
       npm config set unsafe-perm true
       make package

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -72,11 +72,15 @@ COPY --from=builder /codechecker/web/build/CodeChecker /codechecker
 COPY --from=builder /codechecker/web/requirements_py /requirements_py
 COPY --from=builder /codechecker/web/requirements.txt /requirements_py
 
+# Copy local API packages (Python, Node).
+COPY --from=builder /codechecker/web/api /api
+
 # Install python requirements.
-RUN apt-get install -qqy --no-install-recommends \
-  python-dev \
-  # gcc is needed to build psutil.
-  gcc \
+RUN apt-get update -qq  && \
+  apt-get install -qqy --no-install-recommends \
+    python3-dev \
+    # gcc is needed to build psutil.
+    gcc \
   \
   # Install necessary runtime environment files.
   && pip3 install -r /requirements_py/requirements.txt \


### PR DESCRIPTION
- The local CodeChecker API packages are specified relative to the `web`
directory. For this reason we need to move to the `web` directory before
the `pip install` command call.
- Fix docker image file.
- Fix snap file.