### PR TITLE
[refactor] Use python3 new style classes

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -248,7 +248,7 @@ class GuidelineMap(Mapping):
 
 
 # -----------------------------------------------------------------------------
-class Context(object, metaclass=Singleton):
+class Context(metaclass=Singleton):
     """ Generic package specific context. """
 
     def __init__(self):

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
@@ -21,7 +21,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('analyzer')
 
 
-class SourceAnalyzer(object, metaclass=ABCMeta):
+class SourceAnalyzer(metaclass=ABCMeta):
     """
     Base class for different source analyzers.
     """

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_autodetection.py
@@ -50,7 +50,7 @@ def invoke_binary_checked(binary_path, args=None, environ=None):
     return output
 
 
-class CTUAutodetection(object):
+class CTUAutodetection:
     """
     CTUAutodetection is responsible for providing the availability information
     of CTU feature, the the relevant mapping tool path and the mapping file

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -12,7 +12,7 @@ import re
 import subprocess
 
 
-class ClangVersionInfo(object):
+class ClangVersionInfo:
     """ClangVersionInfo holds the version information of the used Clang."""
 
     def __init__(self,
@@ -29,7 +29,7 @@ class ClangVersionInfo(object):
         self.vendor = str(vendor)
 
 
-class ClangVersionInfoParser(object):
+class ClangVersionInfoParser:
     """
     ClangVersionInfoParser is responsible for creating ClangVersionInfo
     instances from the version output of Clang.

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/output_converter.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/output_converter.py
@@ -23,7 +23,7 @@ from codechecker_report_hash.hash import get_report_hash, HashType
 LOG = get_logger('analyzer.tidy')
 
 
-class Note(object):
+class Note:
     """
     Represents a note and also this is the base class of Message.
     """
@@ -70,7 +70,7 @@ class Message(Note):
                 [str(note) for note in self.notes])
 
 
-class OutputParser(object):
+class OutputParser:
     """
     Parser for clang-tidy console output.
     """
@@ -215,7 +215,7 @@ class OutputParser(object):
         return line
 
 
-class PListConverter(object):
+class PListConverter:
     """
     Clang-tidy messages to plist converter.
     """

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -39,7 +39,7 @@ class CheckerState(Enum):
     enabled = 2
 
 
-class AnalyzerConfigHandler(object, metaclass=ABCMeta):
+class AnalyzerConfigHandler(metaclass=ABCMeta):
     """
     Handle the checker configurations and enabled disabled checkers lists.
     """

--- a/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
@@ -20,7 +20,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('analyzer')
 
 
-class ResultHandler(object, metaclass=ABCMeta):
+class ResultHandler(metaclass=ABCMeta):
     """
     Handle and store the results at runtime for the analyzer:
     stdout, stderr, temporarily generated files.

--- a/analyzer/codechecker_analyzer/buildlog/build_action.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_action.py
@@ -8,7 +8,7 @@
 """"""
 
 
-class BuildAction(object):
+class BuildAction:
     """
     The objects of this class hold information which is the input of the
     analyzer engines.

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -281,7 +281,7 @@ def filter_compiler_includes_extra_args(compiler_flags):
     return extra_opts
 
 
-class ImplicitCompilerInfo(object):
+class ImplicitCompilerInfo:
     """
     This class helps to fetch and set some additional compiler flags which are
     implicitly added when using GCC.
@@ -602,7 +602,7 @@ class ImplicitCompilerInfo(object):
         return ImplicitCompilerInfo.compiler_info
 
 
-class OptionIterator(object):
+class OptionIterator:
 
     def __init__(self, args):
         self._item = None

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -62,7 +62,7 @@ epilog_exit_status = """
 """
 
 
-class PlistToPlaintextFormatter(object):
+class PlistToPlaintextFormatter:
     """
     Parse and format plist reports to a more human readable format.
     """

--- a/analyzer/codechecker_analyzer/makefile.py
+++ b/analyzer/codechecker_analyzer/makefile.py
@@ -29,7 +29,7 @@ from .analyzers.clangtidy.analyzer import ClangTidy
 LOG = get_logger('analyzer')
 
 
-class MakeFileCreator(object):
+class MakeFileCreator:
     """ Creates a Makefile from analyzer actions. """
 
     def __init__(self, analyzers, output_path, config_map, context,

--- a/analyzer/codechecker_analyzer/suppress_handler.py
+++ b/analyzer/codechecker_analyzer/suppress_handler.py
@@ -20,7 +20,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('system')
 
 
-class GenericSuppressHandler(object):
+class GenericSuppressHandler:
 
     def __init__(self, suppress_file, allow_write, src_comment_status_filter):
         """

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -20,8 +20,8 @@ from codechecker_analyzer.analyzers.config_handler import CheckerState
 from codechecker_analyzer.buildlog import log_parser
 
 
-class MockContextSA(object):
-    class ProfileMap(object):
+class MockContextSA:
+    class ProfileMap:
         def __getitem__(self, key):
             return 'profile1'
 
@@ -34,7 +34,7 @@ class MockContextSA(object):
         def available_profiles(self):
             return {'default': 'description', 'security': 'description'}
 
-    class GuidelineMap(object):
+    class GuidelineMap:
         def __getitem__(self, key):
             return {'sei-cert': ['rule1', 'rule2']}
 
@@ -228,8 +228,8 @@ class CheckerHandlingClangSATest(unittest.TestCase):
                         (cfg_handler.checks(), cert_guideline))
 
 
-class MockContextTidy(object):
-    class ProfileMap(object):
+class MockContextTidy:
+    class ProfileMap:
         def __getitem__(self, key):
             return 'profile1'
 

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -363,7 +363,7 @@ class OptionParserTest(unittest.TestCase):
             'command': 'clang++ -c -MF deps.txt main.cpp',
             'directory': ''}
 
-        class FakeClangVersion(object):
+        class FakeClangVersion:
             installed_dir = "/tmp/clang/install"
             major_version = "9"
 
@@ -400,7 +400,7 @@ class OptionParserTest(unittest.TestCase):
             'command': "clang++ {} main.cpp".format(' '.join(keep)),
             'directory': ''}
 
-        class FakeClangVersion(object):
+        class FakeClangVersion:
             installed_dir = "/tmp/clang/install"
             major_version = "9"
 

--- a/analyzer/tools/statistics_collector/codechecker_statistics_collector/collectors/return_value.py
+++ b/analyzer/tools/statistics_collector/codechecker_statistics_collector/collectors/return_value.py
@@ -14,7 +14,7 @@ import os
 import re
 
 
-class ReturnValueCollector(object):
+class ReturnValueCollector:
     """ Collect return value statistics.
 
     This script lists functions of which the return value is mostly checked.

--- a/analyzer/tools/statistics_collector/codechecker_statistics_collector/collectors/special_return_value.py
+++ b/analyzer/tools/statistics_collector/codechecker_statistics_collector/collectors/special_return_value.py
@@ -15,7 +15,7 @@ import os
 import re
 
 
-class SpecialReturnValueCollector(object):
+class SpecialReturnValueCollector:
     """ Collect special return value statistics.
 
     This script lists functions of which the return value is checked for

--- a/codechecker_common/logger.py
+++ b/codechecker_common/logger.py
@@ -118,7 +118,7 @@ def validate_loglvl(log_level):
     return log_level
 
 
-class LOG_CFG_SERVER(object):
+class LOG_CFG_SERVER:
     """
     Initialize a log configuration server for dynamic log configuration.
     The log config server will only be started if the

--- a/codechecker_common/plist_parser.py
+++ b/codechecker_common/plist_parser.py
@@ -46,7 +46,7 @@ from codechecker_report_hash.hash import get_report_hash, HashType
 LOG = get_logger('report')
 
 
-class LXMLPlistEventHandler(object):
+class LXMLPlistEventHandler:
     """
     Basic lxml event handler.
     """

--- a/codechecker_common/report.py
+++ b/codechecker_common/report.py
@@ -22,7 +22,7 @@ from codechecker_common import util
 LOG = get_logger('report')
 
 
-class Report(object):
+class Report:
     """Represents an analyzer report.
 
     The main section is where the analyzer reported the issue.

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -18,7 +18,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('system')
 
 
-class SkipListHandler(object):
+class SkipListHandler:
     """
     Skiplist file format:
 

--- a/codechecker_common/source_code_comment_handler.py
+++ b/codechecker_common/source_code_comment_handler.py
@@ -43,7 +43,7 @@ class SpellException(Exception):
     pass
 
 
-class SourceCodeCommentHandler(object):
+class SourceCodeCommentHandler:
     """
     Handle source code comments.
     """

--- a/scripts/debug_tools/failure_lib.py
+++ b/scripts/debug_tools/failure_lib.py
@@ -56,7 +56,7 @@ def change_paths(string, pathModifierFun):
     return ''.join(result)
 
 
-class IncludePathModifier(object):
+class IncludePathModifier:
     def __init__(self, sources_root):
         self.sources_root = sources_root
 

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -20,7 +20,7 @@ def get_first_line_of_file(fname):
         return f.readline()
 
 
-class AnalyzerCommandPathModifier(object):
+class AnalyzerCommandPathModifier:
     def __init__(self, opts):
         self.opts = opts
 
@@ -63,7 +63,7 @@ class AnalyzerCommandPathModifier(object):
                     os.path.sep)))
 
 
-class PathOptions(object):
+class PathOptions:
     def __init__(
             self,
             sources_root,

--- a/scripts/test/run_server_performance_test.py
+++ b/scripts/test/run_server_performance_test.py
@@ -117,7 +117,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-class StatManager(object):
+class StatManager:
     """
     This class stores the statistics of the single user events and prints them
     in CSV format. To produce a nice output the users should do the same tasks
@@ -157,7 +157,7 @@ class StatManager(object):
                 writer.writerow([user_id] + [x[1] for x in durations])
 
 
-class UserSimulator(object):
+class UserSimulator:
     """
     This class simulates a user who performs actions one after the other. The
     durations of the single actions are stored in the statistics.

--- a/tools/plist_to_html/plist_to_html/PlistToHtml.py
+++ b/tools/plist_to_html/plist_to_html/PlistToHtml.py
@@ -153,7 +153,7 @@ def twodim_to_table(
     return '\n'.join(str_parts)
 
 
-class HtmlBuilder(object):
+class HtmlBuilder:
     """
     Helper class to create html file from a report data.
     """

--- a/tools/report-converter/codechecker_report_converter/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzer_result.py
@@ -20,7 +20,7 @@ from . import __title__, __version__
 LOG = logging.getLogger('ReportConverter')
 
 
-class AnalyzerResult(object, metaclass=ABCMeta):
+class AnalyzerResult(metaclass=ABCMeta):
     """ Base class to transform analyzer result. """
 
     # Short name of the analyzer.

--- a/tools/report-converter/codechecker_report_converter/output_parser.py
+++ b/tools/report-converter/codechecker_report_converter/output_parser.py
@@ -18,7 +18,7 @@ def get_next(it):
         return ''
 
 
-class Event(object):
+class Event:
     """ Represents an event message. """
 
     def __init__(self, path, line, column, message):
@@ -67,7 +67,7 @@ class Message(Event):
                 [str(fixit) for fixit in self.fixits])
 
 
-class BaseParser(object, metaclass=ABCMeta):
+class BaseParser(metaclass=ABCMeta):
     """ Warning message parser. """
 
     def __init__(self):

--- a/tools/report-converter/codechecker_report_converter/plist_converter.py
+++ b/tools/report-converter/codechecker_report_converter/plist_converter.py
@@ -12,7 +12,7 @@ import copy
 import json
 
 
-class PlistConverter(object, metaclass=ABCMeta):
+class PlistConverter(metaclass=ABCMeta):
     """ Warning messages to plist converter. """
 
     def __init__(self, tool_name):

--- a/web/client/codechecker_client/credential_manager.py
+++ b/web/client/codechecker_client/credential_manager.py
@@ -55,7 +55,7 @@ def simplify_credentials(credentials):
     return ret
 
 
-class UserCredentials(object):
+class UserCredentials:
 
     def __init__(self):
         LOG.debug("Loading clientside session config.")

--- a/web/client/codechecker_client/helpers/base.py
+++ b/web/client/codechecker_client/helpers/base.py
@@ -21,7 +21,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('system')
 
 
-class BaseClientHelper(object):
+class BaseClientHelper:
 
     def __init__(self, protocol, host, port, uri, session_token=None,
                  get_new_token=None):

--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -50,7 +50,7 @@ class SeverityMap(Mapping):
 
 
 # -----------------------------------------------------------------------------
-class Context(object, metaclass=Singleton):
+class Context(metaclass=Singleton):
     """ Generic package specific context. """
 
     def __init__(self):

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -30,7 +30,7 @@ from ..session_manager import generate_session_token
 LOG = get_logger('server')
 
 
-class ThriftAuthHandler(object):
+class ThriftAuthHandler:
     """
     Handle Thrift authentication requests.
     """

--- a/web/server/codechecker_server/api/config_handler.py
+++ b/web/server/codechecker_server/api/config_handler.py
@@ -24,7 +24,7 @@ from ..database.database import DBSession
 LOG = get_logger('server')
 
 
-class ThriftConfigHandler(object):
+class ThriftConfigHandler:
     """
     Manages Thrift requests regarding configuration.
     """

--- a/web/server/codechecker_server/api/product_server.py
+++ b/web/server/codechecker_server/api/product_server.py
@@ -31,7 +31,7 @@ from ..routing import is_valid_product_endpoint
 LOG = get_logger('server')
 
 
-class ThriftProductHandler(object):
+class ThriftProductHandler:
     """
     Connect to database and handle thrift client requests.
     """

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -70,7 +70,7 @@ LOG = get_logger('server')
 GEN_OTHER_COMPONENT_NAME = "Other (auto-generated)"
 
 
-class CommentKindValue(object):
+class CommentKindValue:
     USER = 0
     SYSTEM = 1
 
@@ -965,7 +965,7 @@ def get_analysis_statistics_query(session, run_ids, run_history_ids=None):
                    Run.id == RunHistory.run_id)
 
 
-class ThriftRequestHandler(object):
+class ThriftRequestHandler:
     """
     Connect to database and handle thrift client requests.
     """

--- a/web/server/codechecker_server/api/server_info_handler.py
+++ b/web/server/codechecker_server/api/server_info_handler.py
@@ -15,7 +15,7 @@ from codechecker_server.profiler import timeit
 LOG = get_logger('server')
 
 
-class ThriftServerInfoHandler(object):
+class ThriftServerInfoHandler:
     """
     Manages Thrift requests regarding server info.
     """

--- a/web/server/codechecker_server/auth/cc_ldap.py
+++ b/web/server/codechecker_server/auth/cc_ldap.py
@@ -211,7 +211,7 @@ def check_group_membership(connection,
     return False
 
 
-class LDAPConnection(object):
+class LDAPConnection:
     """
     A context manager class to initialize an LDAP connection
     and bind to the LDAP server.

--- a/web/server/codechecker_server/database/database.py
+++ b/web/server/codechecker_server/database/database.py
@@ -56,7 +56,7 @@ def call_command(cmd, env=None, cwd=None):
         return oerr.strerror, oerr.errno
 
 
-class DBSession(object):
+class DBSession:
     """
     Requires a session maker object and creates one session which can be used
     in the context.
@@ -78,7 +78,7 @@ class DBSession(object):
             self.__session.close()
 
 
-class DBContext(object):
+class DBContext:
     """
     Simple helper class to setup and sql engine, a database session
     and a connection.
@@ -138,7 +138,7 @@ class DBContext(object):
             self.db_engine.dispose()
 
 
-class SQLServer(object, metaclass=ABCMeta):
+class SQLServer(metaclass=ABCMeta):
     """
     Abstract base class for database server handling. An SQLServer instance is
     responsible for the connection management towards the database.

--- a/web/server/codechecker_server/permissions.py
+++ b/web/server/codechecker_server/permissions.py
@@ -25,7 +25,7 @@ LOG = get_logger('server')
 config_db_model = None  # Module will be loaded later...
 
 
-class Permission(object, metaclass=ABCMeta):
+class Permission(metaclass=ABCMeta):
     """
     The base class for a permission declaration.
     """
@@ -104,7 +104,7 @@ class Permission(object, metaclass=ABCMeta):
         pass
 
 
-class PermissionHandler(object, metaclass=ABCMeta):
+class PermissionHandler(metaclass=ABCMeta):
     """
     The abstract base class for an object that interfaces with the permission
     database to query and manage permissions.

--- a/web/server/codechecker_server/profiler.py
+++ b/web/server/codechecker_server/profiler.py
@@ -24,7 +24,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('profiler')
 
 
-class Timer(object):
+class Timer:
     """
     Simple timer context manager
     to measure code block execution time.

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -498,7 +498,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         return path
 
 
-class Product(object):
+class Product:
     """
     Represents a product, which is a distinct storage of analysis reports in
     a separate database (and database connection) with its own access control.

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -67,7 +67,7 @@ def get_worker_processes(scfg_dict, default=10):
     return worker_processes
 
 
-class _Session(object):
+class _Session:
     """A session for an authenticated, privileged client connection."""
 
     def __init__(self, token, username, groups,
@@ -150,7 +150,7 @@ class _Session(object):
                     transaction.close()
 
 
-class SessionManager(object):
+class SessionManager:
     """
     Provides the functionality required to handle user authentication on a
     CodeChecker server.

--- a/web/server/codechecker_server/tmp.py
+++ b/web/server/codechecker_server/tmp.py
@@ -22,7 +22,7 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('system')
 
 
-class TemporaryDirectory(object):
+class TemporaryDirectory:
     def __init__(self, suffix='', prefix='tmp', tmp_dir=None):
         self._closed = False
         self.name = tempfile.mkdtemp(suffix, prefix, tmp_dir)

--- a/web/tests/libtest/thrift_client_to_db.py
+++ b/web/tests/libtest/thrift_client_to_db.py
@@ -24,7 +24,7 @@ from codechecker_client.product import create_product_url
 from codechecker_web.shared.version import CLIENT_API as VERSION
 
 
-class ThriftAPIHelper(object):
+class ThriftAPIHelper:
 
     def __init__(self, transport, client, auto_handle_connection=True):
         self._transport = transport


### PR DESCRIPTION
In Python 3 the things are simplified and only new-style classes exist, so we can remove `object` from the inheritance list.