### PR TITLE
[analyzer] Handle getting options for old analyzer version

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -15,6 +15,8 @@ import re
 import shlex
 import subprocess
 
+from typing import Dict, List
+
 from codechecker_common.logger import get_logger
 
 from codechecker_analyzer import env
@@ -33,7 +35,11 @@ from .result_handler import ResultHandlerClangSA
 LOG = get_logger('analyzer')
 
 
-def parse_clang_help_page(command, start_label, environ):
+def parse_clang_help_page(
+    command: List[str],
+    start_label: str,
+    environ: Dict[str, str]
+) -> List[str]:
     """
     Parse the clang help page starting from a specific label.
     Returns a list of (flag, description) tuples.
@@ -41,11 +47,13 @@ def parse_clang_help_page(command, start_label, environ):
     try:
         help_page = subprocess.check_output(
             command,
+            stderr=subprocess.STDOUT,
             env=environ,
             universal_newlines=True,
             encoding="utf-8",
             errors="ignore")
     except (subprocess.CalledProcessError, OSError):
+        LOG.debug("Failed to run '%s' command!", command)
         return []
 
     help_page = help_page[help_page.index(start_label) + len(start_label):]
@@ -131,7 +139,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         self.__checker_configs.append(checker_cfg)
 
     @classmethod
-    def get_analyzer_checkers(cls, cfg_handler, environ):
+    def get_analyzer_checkers(
+        cls,
+        cfg_handler: config_handler.ClangSAConfigHandler,
+        environ: Dict[str, str]
+    ) -> List[str]:
         """Return the list of the supported checkers."""
         checker_list_args = clang_options.get_analyzer_checkers_cmd(
             cfg_handler,
@@ -139,7 +151,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         return parse_clang_help_page(checker_list_args, 'CHECKERS:', environ)
 
     @classmethod
-    def get_checker_config(cls, cfg_handler, environ):
+    def get_checker_config(
+        cls,
+        cfg_handler: config_handler.ClangSAConfigHandler,
+        environ: Dict[str, str]
+    ) -> List[str]:
         """Return the list of checker config options."""
         checker_config_args = clang_options.get_checker_config_cmd(
             cfg_handler,
@@ -147,7 +163,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         return parse_clang_help_page(checker_config_args, 'OPTIONS:', environ)
 
     @classmethod
-    def get_analyzer_config(cls, cfg_handler, environ):
+    def get_analyzer_config(
+        cls,
+        cfg_handler: config_handler.ClangSAConfigHandler,
+        environ: Dict[str, str]
+    ) -> List[str]:
         """Return the list of analyzer config options."""
         analyzer_config_args = clang_options.get_analyzer_config_cmd(
             cfg_handler)

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -13,6 +13,7 @@ analyzers available in CodeChecker.
 
 import argparse
 import subprocess
+import sys
 
 from codechecker_analyzer import analyzer_context
 from codechecker_analyzer import env
@@ -173,6 +174,12 @@ def main(args):
 
         configs = analyzer_class.get_analyzer_config(config_handler,
                                                      analyzer_environment)
+        if not configs:
+            LOG.error("Failed to get analyzer configuration options for '%s' "
+                      "analyzer! Please try to upgrade your analyzer version "
+                      "to use this feature.", analyzer)
+            sys.exit(1)
+
         rows = [(':'.join((analyzer, c[0])), c[1]) if 'details' in args
                 else (':'.join((analyzer, c[0])),) for c in configs]
 


### PR DESCRIPTION
> Closes #3296

In case of Clang Static Analyzer we try to get analyzer / checker configuration options by using the `-analyzer-config-help` / `-analyzer-checker-option-help` options which were introduced in Clang 8.

The problem can be reproduced with clang <7 and with the following commands:
```
CodeChecker analyzers --analyzer-config clangsa
CodeChecker checkers --checker-config --analyzers clangsa
```

With this patch we will handle the use case when someone is using an older version of clang which doesn't support these options.