### PR TITLE
[analyzer] Make parse subcommand to work with --skip option correctly

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -611,11 +611,12 @@ class TrimPathPrefixHandler:
         return util.trim_path_prefixes(source_file_path, self.__prefixes)
 
 
-def _parse_convert_reports(input_dirs: List[str],
-                           out_format: str,
-                           severity_map: Dict,
-                           trim_path_prefixes: List[str],
-                           skip_handler: Callable[[str], bool]) \
+def _parse_convert_reports(
+    input_dirs: List[str],
+    out_format: str,
+    severity_map: Dict,
+    trim_path_prefixes: List[str],
+    skip_handler: Callable[[str], bool]) \
         -> Tuple[Union[Dict, List], int]:
     """Parse and convert the reports from the input dirs to the out_format.
 
@@ -769,10 +770,9 @@ def main(args):
     trim_path_prefixes = args.trim_path_prefix if \
         'trim_path_prefix' in args else None
 
+    output_path = None
     if 'output_path' in args:
         output_path = os.path.abspath(args.output_path)
-    else:
-        output_path = None
 
     if export:
         # The HTML part will be handled separately below.

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -428,8 +428,6 @@ class AnalyzeParseTestCase(
 
         self.assertEqual(result_from_stdout, result_from_file)
 
-    # TODO: Fix issue what this test catches.
-    @unittest.skip
     def test_codeclimate_export_exit_code(self):
         """ Test exporting codeclimate output into the filesystem. """
         test_project_notes = os.path.join(self.test_workspaces['NORMAL'],
@@ -485,4 +483,3 @@ class AnalyzeParseTestCase(
         out, _, result = call_command(extract_cmd, cwd=self.test_dir,
                                       env=self.env)
         self.assertEqual(result, 0, "Parsing should not found any issue.")
-

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -485,3 +485,4 @@ class AnalyzeParseTestCase(
         out, _, result = call_command(extract_cmd, cwd=self.test_dir,
                                       env=self.env)
         self.assertEqual(result, 0, "Parsing should not found any issue.")
+

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -13,8 +13,8 @@ Util module.
 import itertools
 import json
 import os
-
 import portalocker
+from typing import List
 
 from codechecker_common.logger import get_logger
 
@@ -124,7 +124,7 @@ def get_last_mod_time(file_path):
         return None
 
 
-def trim_path_prefixes(path, prefixes):
+def trim_path_prefixes(path: str, prefixes: List[str]) -> bool:
     """
     Removes the longest matching leading path from the file path.
     """
@@ -149,6 +149,21 @@ def trim_path_prefixes(path, prefixes):
         return path
 
     return path[len(longest_matching_prefix):]
+
+
+class TrimPathPrefixHandler:
+    """
+    Functor to remove the longest matching leading path from the file path.
+    """
+    def __init__(self, prefixes: List[str]):
+        self.__prefixes = prefixes
+
+    def __call__(self, source_file_path: str) -> str:
+        """
+        Callback to trim_path_prefixes to prevent module dependency
+        of plist_to_html.
+        """
+        return trim_path_prefixes(source_file_path, self.__prefixes)
 
 
 def chunks(iterator, n):


### PR DESCRIPTION
> Closes #3322

Parse subcommand did not apply filter of skip files when --export option  specified a JSON based output format (json, codeclimate, gerrit).
