### PR TITLE
[web] Remove analysis info migration for reports

### DIFF
--- a/web/server/codechecker_server/migrations/report/versions/dabc6998b8f0_analysis_info_table.py
+++ b/web/server/codechecker_server/migrations/report/versions/dabc6998b8f0_analysis_info_table.py
@@ -87,24 +87,6 @@ def upgrade():
 
         op.bulk_insert(
             run_history_analysis_info_tbl, run_history_analysis_info)
-
-        reports = conn.execute("""
-            SELECT id, run_id
-            FROM reports
-        """).fetchall()
-
-        report_analysis_info = []
-        for report_id, run_id in reports:
-            if run_id not in run_analysis_info:
-                continue
-
-            report_analysis_info.append({
-                'report_id': report_id,
-                'analysis_info_id': run_analysis_info[run_id]
-            })
-
-        op.bulk_insert(
-            report_analysis_info_tbl, report_analysis_info)
     except:
         print("Analyzer command data migration failed!")
     else:


### PR DESCRIPTION
If a product contains too many reports (>5 millions) the analysis info
migration for reports may fail. To prevent this we remove this from
the migration script but keep the analysis info for the run history.