### PR TITLE
[cli] Log options in the configuration file

### DIFF
--- a/codechecker_common/cli.py
+++ b/codechecker_common/cli.py
@@ -155,6 +155,14 @@ output.
         # extend the system argument list with these options and try to parse
         # the argument list again to validate it.
         if 'func_process_config_file' in args:
+            # Import logger module here after 'CC_DATA_FILES_DIR' environment
+            # variable is set, so 'setup_logger' will be able to initialize
+            # the logger properly.
+            from codechecker_common import logger
+            logger.setup_logger(
+                args.verbose if 'verbose' in args else None,
+                'stderr')
+
             if len(sys.argv) > 1:
                 called_sub_command = sys.argv[1]
 

--- a/codechecker_common/cmd_config.py
+++ b/codechecker_common/cmd_config.py
@@ -14,16 +14,16 @@ LOG = logger.get_logger('system')
 
 
 def process_config_file(args, subcommand_name):
-    """
-    Handler to get config file options.
-    """
+    """ Handler to get config file options. """
     if 'config_file' not in args:
         return {}
+
     if args.config_file and os.path.exists(args.config_file):
         cfg = load_json_or_empty(args.config_file, default={})
 
         # The subcommand name is analyze but the
         # configuration section name is analyzer.
+        options = None
         if subcommand_name == 'analyze':
             # The config value can be 'analyze' or 'analyzer'
             # for backward compatibility.
@@ -36,11 +36,18 @@ def process_config_file(args, subcommand_name):
                                 "file. Please use the 'analyze' value to be "
                                 "in sync with the subcommands.\n"
                                 "Using the 'analyze' configuration.")
-                return analyze_cfg
-            if analyzer_cfg:
-                return analyzer_cfg
+                options = analyze_cfg
+            elif analyzer_cfg:
+                options = analyzer_cfg
+        else:
+            options = cfg.get(subcommand_name, [])
 
-        return cfg.get(subcommand_name, [])
+        if options:
+            LOG.info("Extending command line options with %s options from "
+                     "'%s' file: %s", subcommand_name, args.config_file,
+                     ' '.join(options))
+
+        return options
 
 
 def check_config_file(args):


### PR DESCRIPTION
Multiple cli commands accepts a configuration file paramter (--config).
If someone is using it, from the logs we will not see the full command
what was executed, so it will be hard to start debugging the problem.
For this reason with this patch we will print out the extra options
from this configuration.