### PR TITLE
[github] Fix pypi package github action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/download-artifact@master
         with:
           name: pypi-package
-          path: ./dist/
+          path: ./
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Download the artifactory to the root folder when running the publish job
to make sure `dist` directory exists.