### PR TITLE
[web] Downgrade python-ldap

### DIFF
--- a/web/requirements_py/auth/requirements.txt
+++ b/web/requirements_py/auth/requirements.txt
@@ -1,2 +1,2 @@
-python-ldap==3.3.1
+python-ldap==3.2.0
 python-pam==1.8.4


### PR DESCRIPTION
python-ldap Python dependency seems to be too new for handling the
currently installed OpenLDAP library.