### PR TITLE
[server] Unzip storage zip file to workspace directory

### DIFF
--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -69,6 +69,10 @@ class Context(metaclass=Singleton):
         self.__package_build_date = None
         self.__package_git_hash = None
 
+        # This should be initialized in command line scripts based on the
+        # given CLI options.
+        self.codechecker_workspace = None
+
         self.__set_version()
 
     def __get_package_layout(self):

--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -17,6 +17,7 @@ import zlib
 from collections import defaultdict
 from datetime import datetime
 from hashlib import sha256
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, NamedTuple, Optional, Set
 
 import codechecker_api_shared
@@ -37,7 +38,6 @@ from ..database.run_db_model import AnalysisInfo, AnalyzerStatistic, \
     Report, Run, RunHistory, RunLock
 from ..metadata import checker_is_unavailable, get_analyzer_name, \
     MetadataInfoParser
-from ..tmp import TemporaryDirectory
 
 from .report_server import ThriftRequestHandler
 from .thrift_enum_helper import report_extended_data_type_str
@@ -316,8 +316,6 @@ class MassStoreRun:
         self.__wrong_src_code_comments: List[str] = []
         self.__already_added_report_hashes: Set[str] = set()
         self.__new_report_hashes: Set[str] = set()
-        self.__enabled_checkers: Set[str] = set()
-        self.__disabled_checkers: Set[str] = set()
         self.__all_report_checkers: Set[str] = set()
 
     @property
@@ -1114,7 +1112,9 @@ class MassStoreRun:
             self.__store_run_lock(session)
 
         try:
-            with TemporaryDirectory() as zip_dir:
+            with TemporaryDirectory(
+                dir=self.__context.codechecker_workspace
+            ) as zip_dir:
                 LOG.info("[%s] Unzip storage file...", self.__name)
                 zip_size = unzip(self.__b64zip, zip_dir)
                 LOG.info("[%s] Unzip storage file done.", self.__name)

--- a/web/server/codechecker_server/tmp.py
+++ b/web/server/codechecker_server/tmp.py
@@ -13,37 +13,11 @@ Temporary directory module.
 import datetime
 import hashlib
 import os
-import shutil
-import tempfile
 
 
 from codechecker_common.logger import get_logger
 
 LOG = get_logger('system')
-
-
-class TemporaryDirectory:
-    def __init__(self, suffix='', prefix='tmp', tmp_dir=None):
-        self._closed = False
-        self.name = tempfile.mkdtemp(suffix, prefix, tmp_dir)
-
-    def __enter__(self):
-        return self.name
-
-    def __cleanup(self):
-        if self.name and not self._closed:
-            try:
-                shutil.rmtree(self.name)
-            except (TypeError, AttributeError) as ex:
-                print("ERROR: {0} while cleaning up {1}".format(ex, self.name))
-                return
-            self._closed = True
-
-    def __exit__(self, *args):
-        self.__cleanup()
-
-    def __del__(self, *args):
-        self.__cleanup()
 
 
 def get_tmp_dir_hash():

--- a/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
+++ b/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
@@ -18,9 +18,9 @@ import subprocess
 import unittest
 import zipfile
 
+from tempfile import TemporaryDirectory
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter
 
-from codechecker_server.tmp import TemporaryDirectory
 
 from libtest import codechecker
 from libtest import env


### PR DESCRIPTION
Previously the storage zip file is unzipped to the `/tmp` folder. It is
possible that the disk size of the host machine is not so big and when
the unzipped / decompressed zip size is too big that the user will
get `No space left on device` exception.

For this reason we will unzip the zip file to the workspace folder which
can be configured during a server start and it can point to an extra
network drive which size can be bigger than the host machine drive.

This patch also removes our `TemporaryDirectory` class because it is
available in the `tempfile` module since `Python 3.2`.