### PR TITLE
[server] Add index for report and run history id columns

### DIFF
--- a/web/server/codechecker_server/database/run_db_model.py
+++ b/web/server/codechecker_server/database/run_db_model.py
@@ -134,7 +134,8 @@ RunHistoryAnalysisInfo = Table(
         ForeignKey('run_histories.id',
                    deferrable=True,
                    initially="DEFERRED",
-                   ondelete="CASCADE")),
+                   ondelete="CASCADE"),
+        index=True),
     Column('analysis_info_id', Integer, ForeignKey('analysis_info.id'))
 )
 
@@ -314,7 +315,8 @@ ReportAnalysisInfo = Table(
         ForeignKey('reports.id',
                    deferrable=True,
                    initially="DEFERRED",
-                   ondelete="CASCADE")),
+                   ondelete="CASCADE"),
+        index=True),
     Column('analysis_info_id', Integer, ForeignKey('analysis_info.id'))
 )
 

--- a/web/server/codechecker_server/migrations/report/versions/a24461972d2e_add_index_for_report_and_history_id_columns.py
+++ b/web/server/codechecker_server/migrations/report/versions/a24461972d2e_add_index_for_report_and_history_id_columns.py
@@ -1,0 +1,39 @@
+"""Add index for report and history id columns
+
+Revision ID: a24461972d2e
+Revises: dabc6998b8f0
+Create Date: 2021-06-10 15:38:59.504534
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a24461972d2e'
+down_revision = 'dabc6998b8f0'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index(
+        op.f('ix_report_analysis_info_report_id'),
+        'report_analysis_info',
+        ['report_id'],
+        unique=False)
+
+    op.create_index(
+        op.f('ix_run_history_analysis_info_run_history_id'),
+        'run_history_analysis_info',
+        ['run_history_id'],
+        unique=False)
+
+
+def downgrade():
+    op.drop_index(
+        op.f('ix_run_history_analysis_info_run_history_id'),
+        table_name='run_history_analysis_info')
+
+    op.drop_index(
+        op.f('ix_report_analysis_info_report_id'),
+        table_name='report_analysis_info')


### PR DESCRIPTION
Removing a run got slow after we introduced the analysis info table
in the previous 6.16.0. CodeChecker release. Doing some measurement
on the database I tried to run the following query:
```sh
begin;
explain (analyze,buffers,timing) delete from runs where id=1;
rollback;
```

The output looked like this:
```
 QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------
 Delete on runs  (cost=0.00..1.51 rows=1 width=6) (actual time=0.048..0.050 rows=0 loops=1)
   Buffers: shared hit=3
   ->  Seq Scan on runs  (cost=0.00..1.51 rows=1 width=6) (actual time=0.020..0.024 rows=1 loops=1)
         Filter: (id = 1
         Rows Removed by Filter: 40
         Buffers: shared hit=1
 Planning Time: 0.077 ms
 Trigger for constraint fk_reports_run_id_runs on runs: time=1.728 calls=1
 Trigger for constraint fk_run_histories_run_id_runs on runs: time=0.062 calls=1
 Trigger for constraint fk_bug_path_events_report_id_reports on reports: time=23.935 calls=578
 Trigger for constraint fk_bug_report_points_report_id_reports on reports: time=7.960 calls=578
 Trigger for constraint fk_extended_report_data_report_id_reports on reports: time=6.060 calls=578
 Trigger for constraint fk_report_analysis_info_report_id_reports on reports: time=22042.053 calls=578
 Trigger for constraint fk_analyzer_statistics_run_history_id_run_histories on run_histories: time=0.046 calls=2
 Trigger for constraint fk_run_history_analysis_info_run_history_id_run_histories on run_histories: time=0.033 calls=2
 Execution Time: 22082.691 ms
```

From this we can see that the bottleneck is the
 `fk_report_analysis_info_report_id_reports` contstraint. Adding indices on
the `report_id` and `run_history_id` columns on the join tables (`report_analysis_info`,
run_history_analysis_info`) solves this problem and reduces the amount of query
time drastically.