### PR TITLE
Don't hardcode GCC in build-logger Makefile

### DIFF
--- a/analyzer/tools/build-logger/Makefile.manual
+++ b/analyzer/tools/build-logger/Makefile.manual
@@ -12,7 +12,7 @@
 .PHONY: test
 
 # C compiler
-CC = gcc
+CC ?= gcc
 # Preprocessor flags
 CPPFLAGS = -D_GNU_SOURCE
 # C flags


### PR DESCRIPTION
There may not be a `gcc` program, and `CC` may be pointing
at the right one, but this would completely override it,
failing the build.