### PR TITLE
[cli] Do not print sensitive information when exception happens

### DIFF
--- a/web/client/codechecker_client/thrift_call.py
+++ b/web/client/codechecker_client/thrift_call.py
@@ -92,11 +92,14 @@ def ThriftClientCall(function):
                 LOG.error('Thrift bad version error.')
             LOG.error(funcName)
 
-            # It is possible that one of the argument is too large to log the
-            # full content of it (for example the 'b64zip' parameter of the
+            # Do not print the argument list if it contains sensitive
+            # information such as passwords.
+            # Also it is possible that one of the argument is too large to log
+            # the full content of it (for example the 'b64zip' parameter of the
             # 'massStoreRun' API function). For this reason we have to truncate
             # the arguments.
-            LOG.error([truncate_arg(arg) for arg in args])
+            if funcName != "performLogin":
+                LOG.error([truncate_arg(arg) for arg in args])
 
             LOG.error(kwargs)
             LOG.exception("Request failed.")


### PR DESCRIPTION
> Closes #3354

It is possible that the `performLogin` API functions throws an exception.
On the client side we print the API function name and the argument list
if an exception happens. The argument list may contain sensitive
information such as password. In this patch we will skip printing
the argument list in this situation.