### PR TITLE
include package data files in python package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include build_dist/CodeChecker/lib/python3/plist_to_html/static *


### PR DESCRIPTION
https://pypi.org/project/codechecker/ is missing package data files, resulting in errors when running
```
CodeChecker parse -e html ...
```
This PR makes sure the relevant static data files are included.