### PR TITLE
[server] Comment date collision

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2778,7 +2778,7 @@ class ThriftRequestHandler:
             comment_data_list = defaultdict(list)
             comment_query = session.query(Comment, Report.bug_id) \
                 .outerjoin(Report, Report.bug_id == Comment.bug_hash) \
-                .order_by(Comment.created_at.desc())
+                .order_by(Comment.created_at.desc(), Comment.id.desc())
 
             if run_filter:
                 comment_query = process_run_filter(session, comment_query,

--- a/web/tests/functional/export_import/test_export_import.py
+++ b/web/tests/functional/export_import/test_export_import.py
@@ -153,5 +153,5 @@ class TestExport(unittest.TestCase):
             print(new_comments)
 
             # Check if the last and second last comments
-            self.assertEqual(new_comments[-1].message, comment1.message)
-            self.assertEqual(new_comments[-2].message, updated_message)
+            self.assertEqual(new_comments[-2].message, comment1.message)
+            self.assertEqual(new_comments[-1].message, updated_message)


### PR DESCRIPTION
It is possible that "comments" table contains two comments with the
same date field. It can occur when importing comments from a file which
contains a comment that has the same date as an existing comment.
The list of comments is returned ordered by dates, however, the order
of comments with the same date is not deterministic. This made the
tests fail sometimes.