### PR TITLE
[gui] Fix exporting checker statistics to CSV

### DIFF
--- a/web/server/vue-cli/src/mixins/to-csv.mixin.js
+++ b/web/server/vue-cli/src/mixins/to-csv.mixin.js
@@ -7,7 +7,13 @@ export default {
      * @param {string} fileName - default file name for export.
      */
     toCSV(data, fileName) {
-      const content = data.map(d => d.join(",") + "\r\n").join("");
+      const content = data
+        .map(d => d.join(",") + "\r\n")
+        .join("")
+        // Hashmark (#) is a valid URL character but it starts the hash
+        // fragment and for this reason it needs to be escaped.
+        .replaceAll("#", encodeURIComponent("#"));
+
       const csvContent = `data:text/csv;charset=utf-8,${content}`;
 
       const link = document.createElement("a");


### PR DESCRIPTION
It is possible that a checker name contains a hashmark character
(`clang-diagnostic-#warnings`, `clang-diagnostic-#pragma-messages`).
Hashmark is a valid URL character but it starts the hash fragment and
for this reason it needs to be escaped when we export the statistics
to CSV.