### PR TITLE
[docker] Change permission of helper script in docker image

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -89,6 +89,8 @@ RUN apt-get update -qq  && \
     python3-dev \
     # gcc is needed to build psutil.
     gcc \
+    # netcat is needed for 'wait-for' script.
+    netcat \
   \
   # Install necessary runtime environment files.
   && pip3 install -r /requirements_py/requirements.txt \
@@ -126,10 +128,10 @@ RUN chmod a+x /usr/local/bin/entrypoint.sh \
   && chown codechecker:codechecker /usr/local/bin/entrypoint.sh
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+RUN chmod 755 /tini
 
-ADD https://github.com/eficode/wait-for/blob/${WAIT_FOR_VERSION}/wait-for /usr/local/bin/wait-for
-RUN chmod +x /usr/local/bin/wait-for
+ADD https://raw.githubusercontent.com/eficode/wait-for/${WAIT_FOR_VERSION}/wait-for /usr/local/bin/wait-for
+RUN chmod 755 /usr/local/bin/wait-for
 
 EXPOSE 8001
 


### PR DESCRIPTION
Change permission of the tini and wait-for scripts in the docker image
to have r+w permission for all users.