### PR TITLE
[CI] Add a job that checks coverage of checker labelling

### DIFF
--- a/.github/workflows/config_coverage.yml
+++ b/.github/workflows/config_coverage.yml
@@ -1,0 +1,150 @@
+name: checker-config-coverage
+
+on:
+  push:
+    paths:
+      - '.github/workflow/config_coverage.yml'
+      - '.github/workflow/config_label_check.py'
+      - 'config/labels/analyzers/clang-tidy.json'
+      - 'config/labels/analyzers/clangsa.json'
+  pull_request:
+    paths:
+      - '.github/workflow/config_coverage.yml'
+      - '.github/workflow/config_label_check.py'
+      - 'config/labels/analyzers/clang-tidy.json'
+      - 'config/labels/analyzers/clangsa.json'
+  schedule:
+    # Run every Sunday at 21:30 (to latest master at that time).
+    - cron: '30 21 * * SUN'
+  # Allow running this job manually from either API or GitHub UI.
+  workflow_dispatch:
+
+jobs:
+  checker-config-coverage:
+    name: "Config coverage of checkers"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: "Install dependencies"
+        run: |
+          sudo apt-get -qy update
+          sudo apt-get -y --no-install-recommends install \
+            build-essential \
+            curl            \
+            gcc-multilib    \
+            python3-dev     \
+            python3-venv
+      - name: "Get latest LLVM binary package from the community PPA"
+        run: |
+          export DISTRO_FANCYNAME="$(lsb_release -c | awk '{ print $2 }')"
+
+          echo "::group::Setup LLVM PPA"
+          curl -sL http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$DISTRO_FANCYNAME/ llvm-toolchain-$DISTRO_FANCYNAME main"
+          echo "::endgroup::"
+
+          # Get the largest Clang package number available.
+          export LLVM_VER="$(apt-cache search --full 'clang-[[:digit:]]*$' | grep '^Package: clang' | cut -d ' ' -f 2 | sort -V | tail -n 1 | sed 's/clang-//')"
+          echo "::group::Install Clang and Clang-Tidy version ${LLVM_VER}"
+          sudo apt-get -y --no-install-recommends install \
+            clang-$LLVM_VER      \
+            clang-tidy-$LLVM_VER
+          sudo update-alternatives --install                   \
+            /usr/bin/clang clang /usr/bin/clang-$LLVM_VER 1000 \
+            --slave                                            \
+              /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VER
+          echo "::endgroup::"
+
+          echo "Installed Clang:"
+          update-alternatives --query clang
+      - name: "Package CodeChecker"
+        id: codechecker
+        run: |
+          pushd analyzer
+
+          echo "::group::venv"
+          make venv
+          source venv/bin/activate
+          echo "::endgroup::"
+
+          echo "::group::CodeChecker package"
+          make standalone_package
+          deactivate
+          echo "::endgroup::"
+
+          echo "::set-output name=CODECHECKER_PATH::$(readlink -f ./build/CodeChecker/bin)"
+          popd # analyzer
+      - name: "Dump checker list"
+        run: |
+          export PATH="${{ steps.codechecker.outputs.CODECHECKER_PATH }}:$PATH"
+          CodeChecker analyzers --details
+          CodeChecker checkers \
+            --analyzer clangsa clang-tidy \
+            --output rows \
+              > checker_list_normal.txt
+          CodeChecker checkers \
+            --analyzer clangsa clang-tidy \
+            --warnings \
+            --output rows \
+              > checker_list_diagnostics.txt
+      - name: "Perform checker config coverage check (--warnings)"
+        continue-on-error: true
+        run: |
+          set +e # Do not hard exit on an erroring call!
+          .github/workflows/config_label_check.py \
+            "checker_list_diagnostics.txt" \
+            "config/labels/analyzers/clangsa.json" \
+            "config/labels/analyzers/clang-tidy.json" \
+            --existing-filter "clang-diagnostic-" \
+            --new-filter "clang-diagnostic-"
+          EXIT_STATUS=$?
+          echo "Coverage check returned: $EXIT_STATUS."
+          # Explicitly check if the bit for "8" is set in the result,
+          # indicating new checkers without severity set.
+          if [[ $(($EXIT_STATUS & 8)) -eq 8 ]]
+          then
+            echo "::warning title=New unconfigured diagnostics::The checker label config files lack some new diagnostic report (\"warning\") kinds."
+            exit 0
+          elif [[ $EXIT_STATUS -eq 1 || $EXIT_STATUS -eq 2 ]]
+          then
+            # Script execution error.
+            exit $EXIT_STATUS
+          else
+            # We do not wish to fail if only removed checkers are reported.
+            exit 0
+          fi
+      - name: "Perform checker config coverage check"
+        run: |
+          set +e # Do not hard exit on an erroring call!
+          .github/workflows/config_label_check.py \
+            "checker_list_normal.txt" \
+            "config/labels/analyzers/clangsa.json" \
+            "config/labels/analyzers/clang-tidy.json" \
+            --existing-ignore "clang-diagnostic-" \
+            --new-ignore \
+              "clang-diagnostic-" \
+              "alpha." \
+              "apiModeling." \
+              "debug." \
+              "optin.osx." \
+              "osx." \
+              "darwin-" \
+              "objc-"
+          EXIT_STATUS=$?
+          echo "Coverage check returned: $EXIT_STATUS."
+          # Explicitly check if the bit for "8" is set in the result,
+          # indicating new checkers without severity set.
+          if [[ $(($EXIT_STATUS & 8)) -eq 8 ]]
+          then
+            exit 8
+          elif [[ $EXIT_STATUS -eq 1 || $EXIT_STATUS -eq 2 ]]
+          then
+            # Script execution error.
+            exit $EXIT_STATUS
+          else
+            # We do not wish to fail if only removed checkers are reported.
+            exit 0
+          fi

--- a/.github/workflows/config_label_check.py
+++ b/.github/workflows/config_label_check.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Checks the config/labels/<analyzer>.json files against the list of checkers
+reported from actually inquiring the analyzers, and reports if there is a
+checker missing from the config file.
+"""
+import argparse
+import json
+import sys
+
+
+def filter_namelist(names, filter_prefixes=None, ignore_prefixes=None,
+                    ignore_suffixes=None):
+    """Filters the names list for entries that match the filter_prefixes,
+    and do not match the ignore_prefixes or ignore_suffixes.
+    """
+    ret = set(names)
+    if filter_prefixes:
+        ret = set(e for e in ret
+                  if e.startswith(tuple(filter_prefixes)))
+    if ignore_prefixes:
+        ret = set(e for e in ret
+                  if not e.startswith(tuple(ignore_prefixes)))
+    if ignore_suffixes:
+        ret = set(e for e in ret
+                  if not e.endswith(tuple(ignore_suffixes)))
+    return ret
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""
+Check a list of checkers (usually the output of "CodeChecker checkers -o rows")
+and the checker severity map for missing or stale entries.
+""",
+        epilog="""
+The tool exits with 0 if the list of checkers is fully covered.
+An exit status of 1 is reserved for errors escaping the interpreter.
+An exit status of 2 indicates bad invocation (from 'argparse').
+An exit status of 4 indicates that checkers were removed from upstream but
+still have a severity, and 8 indicates that there are checkers missing
+severity settings.
+An exit status of 12 (4 + 8) indicates both.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("checker_name_list",
+                        type=argparse.FileType('rt'),
+                        help="The file that lists the checkers available in "
+                             "the analyzer(s). The file must exist!")
+    parser.add_argument("checker_label_map",
+                        type=argparse.FileType('rt'),
+                        nargs='+',
+                        help="Path of configuration files that list labels "
+                             "for checkers. More files can be specified. All "
+                             "files must exist!")
+
+    existing = parser.add_argument_group(
+        "filtering options for existing (only configured) checks")
+    existing.add_argument("--report-removed",
+                          dest="report_removed",
+                          action="store_true",
+                          help="Whether to report checks that went missing, "
+                               "i.e. only exist in the configuration file(s) "
+                               "but not in the analyzers.")
+    existing.add_argument("--existing-filter",
+                          nargs='*',
+                          default=list(),
+                          help="The checker prefixes (such as \"alpha.\" or "
+                               "\"debug.\") to positively filter for when "
+                               "searching for removed checkers.")
+    existing.add_argument("--existing-ignore",
+                          nargs='*',
+                          default=list(),
+                          help="The checker prefixes (such as \"alpha.\" or "
+                               "\"debug.\") to ignore from the coverage check "
+                               "when searching for removed checkers.")
+    existing.add_argument("--existing-ignore-suffix",
+                          nargs='*',
+                          default=list(),
+                          help="The checker suffixes (such as \"Sanitizer\""
+                               "or \"-name\") to ignore from the coverage "
+                               "check when searching for removed checkers.")
+
+    new = parser.add_argument_group(
+        "filtering options for new (not configured) checks")
+    new.add_argument("--no-report-new",
+                     dest="report_new",
+                     action="store_false",
+                     help="Whether to *NOT* report checks that are new: "
+                          "they do not exist in the configuration "
+                          "file(s), only in the analyzers.")
+    new.add_argument("--new-filter",
+                     nargs='*',
+                     default=list(),
+                     help="The checker prefixes (such as \"alpha.\" or "
+                          "\"debug.\") to positively filter for when "
+                          "searching for unknown/new checkers.")
+    new.add_argument("--new-ignore",
+                     nargs='*',
+                     default=list(),
+                     help="The checker prefixes (such as \"alpha.\" or "
+                          "\"debug.\") to ignore from the coverage check "
+                          "when searching for unknown/new checkers.")
+    new.add_argument("--new-ignore-suffix",
+                     nargs='*',
+                     default=list(),
+                     help="The checker suffixes (such as \"Sanitizer\" or "
+                          "\"-name\") to ignore from the coverage check "
+                          "when searching for unknown/new checkers.")
+
+    args = parser.parse_args()
+
+    dumped_checkers = set(line.strip() for line in args.checker_name_list)
+    available_checkers = filter_namelist(dumped_checkers,
+                                         args.new_filter,
+                                         args.new_ignore,
+                                         args.new_ignore_suffix)
+
+    all_known_checkers = set()
+    for config in args.checker_label_map:
+        checkers_in_cfg = json.load(config)["labels"].keys()
+        checkers = filter_namelist(checkers_in_cfg,
+                                   args.existing_filter,
+                                   args.existing_ignore,
+                                   args.existing_ignore_suffix)
+        all_known_checkers.update(checkers)
+
+    print("Checkers REMOVED from upstream, with CodeChecker still "
+          "assigning labels:")
+    any_removed = False
+    if args.report_removed:
+        for removed_checker in sorted(all_known_checkers - available_checkers):
+            print(" - {}".format(removed_checker))
+            any_removed = True
+        if not any_removed:
+            print("    No such results.")
+    else:
+        print("Skipped! Specify '--report-removed' to execute.")
+
+    print()
+
+    print("Checkers ADDED to upstream, without labels in CodeChecker:")
+    any_new = False
+    if args.report_new:
+        for missing_checker in sorted(available_checkers - all_known_checkers):
+            print(" + {}".format(missing_checker))
+            any_new = True
+        if not any_new:
+            print("    No such results.")
+    else:
+        print("Skipped! Do **NOT** specify '--no-report-new' to execute.")
+
+    return_code = 0
+    if any_removed:
+        return_code += 4
+    if any_new:
+        return_code += 8
+    return return_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
A CI job which we can use to check if the latest LLVM version (as available in the official PPA) has some checkers added which we haven't set a severity for. The job fails if this list is not empty. :slightly_smiling_face: I added the option to filter checkers, groups, etc. we don't seem to care about.

~~In addition, the job also lists all the checkers we know a severity for, but the checker no longer exists. While these are reported, the CI isn't set up to fail if this is the case.~~ This option exists in the script, but is disabled by default.