### PR TITLE
Add core.StackAddrEscapeBase checker as HIGH.

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -154,6 +154,7 @@
   "core.DynamicTypePropagation":                                "MEDIUM",
   "core.NonNullParamChecker":                                   "HIGH",
   "core.NullDereference":                                       "HIGH",
+  "core.StackAddrEscapeBase":                                   "HIGH",
   "core.StackAddressEscape":                                    "HIGH",
   "core.UndefinedBinaryOperatorResult":                         "HIGH",
   "core.uninitialized.ArraySubscript":                          "HIGH",


### PR DESCRIPTION
This adds the `core.StackAddrEscapeBase` checker severity as `HIGH`.

The error is currently `Unspecified` and catches dangling references:

> Address of stack memory associated with local variable "Thing" is still referred to by the global variable "thing" upon returning to the caller. This will be a dangling reference.
