### PR TITLE
[docs] Fix plist generator command for leak sanitizer

### DIFF
--- a/docs/tools/report-converter.md
+++ b/docs/tools/report-converter.md
@@ -198,7 +198,7 @@ clang -fsanitize=address -g lsan.c
 ASAN_OPTIONS=detect_leaks=1 ./a.out > lsan.output 2>&1
 
 # Generate plist files from the output.
-report-converter -t lsan ./lsan_results lsan.output
+report-converter -t lsan -o ./lsan_results lsan.output
 ```
 
 ## [Cppcheck](http://cppcheck.sourceforge.net/)


### PR DESCRIPTION
Update the documentation for Leak Sanitizer by adding the `-o` to the command for generating the plist files using the `report-converter` command as mentioned in https://github.com/Ericsson/codechecker/pull/3368#discussion_r665882971