### PR TITLE
[server] Fix setting analysis_info_id_seq

### DIFF
--- a/web/server/codechecker_server/migrations/report/versions/f8291ab1d6be_fix_setting_analysis_info_id_seq.py
+++ b/web/server/codechecker_server/migrations/report/versions/f8291ab1d6be_fix_setting_analysis_info_id_seq.py
@@ -1,0 +1,28 @@
+"""Fix setting analysis_info_id_seq
+
+Revision ID: f8291ab1d6be
+Revises: a24461972d2e
+Create Date: 2021-07-15 16:49:05.354455
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f8291ab1d6be'
+down_revision = 'a24461972d2e'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade():
+    ctx = op.get_context()
+    dialect = ctx.dialect.name
+
+    if dialect == 'postgresql':
+        op.execute("""
+            SELECT SETVAL(
+                'analysis_info_id_seq',
+                (SELECT MAX(id) + 1 FROM analysis_info)
+            )
+        """)


### PR DESCRIPTION
In the previous release with the analysis info table we introduced a
bug on data migration that the analysis_info_id_seq value is not set
properly and when the database contained some data before migration,
after migration the user will not be able to store data to the database
and he will get an error.