### PR TITLE
[web] Add 'thrift==0.13.0' dependency explicitly

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,6 +4,7 @@ alembic==1.5.5
 portalocker==2.2.1
 psutil==5.8.0
 mypy_extensions==0.4.3
+thrift==0.13.0
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz
 ./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -12,6 +12,7 @@ mockldap==0.3.0
 mkdocs==1.1.2
 mypy_extensions==0.4.3
 coverage==5.5.0
+thrift==0.13.0
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz
 ./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -4,6 +4,7 @@ portalocker==2.2.1
 psutil==5.8.0
 sqlalchemy==1.3.23
 mypy_extensions==0.4.3
+thirft==0.13.0
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz
 ./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz


### PR DESCRIPTION
> Fixes #3387.

Hopefully this will fix the generated PyPI package missing this dependency and thus not working in a clean venv.