### PR TITLE
[cfg] Remove the MallocOverflow checker from the sensitive profile

### DIFF
--- a/config/checker_profile_map.json
+++ b/config/checker_profile_map.json
@@ -36,7 +36,6 @@
         "alpha.core.SizeofPtr",
         "alpha.core.TestAfterDivZero",
         "alpha.cplusplus",
-        "alpha.security.MallocOverflow",
         "alpha.security.MmapWriteExec",
         "alpha.security.ReturnPtrRange",
         "alpha.security.taint",


### PR DESCRIPTION
The `MallocOverflow` checker is somewhat controversial, it will warn for a
lot of legitim usage patterns.
E.g.: when the operand of the multiplication of the malloc's parameter
is bounded but the caller's side.
```
  if (n > 100)
    return;
  p = do_allocation=(n);

where do_allocation(n):
  return malloc(n * sizeof(MyType));
                ~ ^ ~~~~~~~~~~~~~~
```
Since the checker is AST-based, it has no way of detecting these cases,
thus it will issue false-positive reports.

As of now, I and @dkrupp decided that this should be removed even from
the sensitive profile until we decide otherwise.