### PR TITLE
[cfg] Add the MallocOverflow checker to the extreme profile

### DIFF
--- a/config/checker_profile_map.json
+++ b/config/checker_profile_map.json
@@ -243,6 +243,7 @@
         "misc-misplaced-widening"
       ],
       "extreme": [
+        "alpha.security.MallocOverflow",
         "boost",
         "bugprone",
         "cert",


### PR DESCRIPTION
@whisperity commented at PR #3392 that this checker should be in the
extreme profile. This patch addresses this nuance.

PS: I'm not exactly sure, but it looks weird that this is the only _alpha_ checker within that section.
@dkrupp @csordasmarton 