### PR TITLE
[cli] Override argparse error code

### DIFF
--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -84,6 +84,12 @@ class TestCmdline(unittest.TestCase):
         parse_help = [env.codechecker_cmd(), 'parse', '--help']
         self.assertEqual(0, run_cmd(parse_help)[0])
 
+    def test_invalid_subcommand(self):
+        """ Call CodeChecker with and invalid subcommand. """
+
+        dummy_cmd = [env.codechecker_cmd(), "dummy"]
+        self.assertEqual(1, run_cmd(dummy_cmd)[0])
+
     def test_checkers(self):
         """ Listing available checkers. """
 

--- a/codechecker_common/cli.py
+++ b/codechecker_common/cli.py
@@ -19,6 +19,18 @@ import signal
 import sys
 
 
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        """
+        By default argparse will exit with error code 2 in case of error, but
+        we are using this error code for different purposes. For this reason
+        we will override this function, so we will exit with error code 1 in
+        such cases too.
+        """
+        self.print_usage(sys.stderr)
+        self.exit(1, f"{self.prog}: error: {message}\n")
+
+
 def add_subcommand(subparsers, sub_cmd, cmd_module_path, lib_dir_path):
     """
     Load the subcommand module and then add the subcommand to the available
@@ -106,7 +118,7 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
 
     try:
-        parser = argparse.ArgumentParser(
+        parser = ArgumentParser(
             prog="CodeChecker",
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description="""Run the CodeChecker sourcecode analyzer framework.


### PR DESCRIPTION
> Closes #3406

By default argparse will exit with error code 2 in case of error, but
we are using this error code for different purposes. For this reason
we will override the ArgumentParser class, so we will exit with error
code 1 in such cases too to identify a CodeChecker error.