### PR TITLE
Add "bugprone-suspicious-memory-comparison" to the list of severity

### DIFF
--- a/config/checker_severity_map.json
+++ b/config/checker_severity_map.json
@@ -100,6 +100,7 @@
   "bugprone-string-literal-with-embedded-nul":                  "MEDIUM",
   "bugprone-suspicious-enum-usage":                             "HIGH",
   "bugprone-suspicious-include":                                "LOW",
+  "bugprone-suspicious-memory-comparison":                      "MEDIUM",
   "bugprone-suspicious-memset-usage":                           "HIGH",
   "bugprone-suspicious-missing-comma":                          "HIGH",
   "bugprone-suspicious-semicolon":                              "HIGH",


### PR DESCRIPTION
Using the severity from
https://wiki.sei.cmu.edu/confluence/display/c/EXP42-C.+Do+not+compare+padding+data