### PR TITLE
[setup.py] Add the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include build_dist/CodeChecker/lib/python3/plist_to_html/static *
+include LICENSE.TXT

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,8 @@ setuptools.setup(
     long_description_content_type = "text/markdown",
     url="https://github.com/Ericsson/CodeChecker",
     keywords=['codechecker', 'plist'],
-    license='LICENSE.TXT',
+    license='Apache-2.0 WITH LLVM-exception',
+    license_files = ['LICENSE.TXT'],
     packages=packages,
     package_dir={
         "": lib_dir

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,6 @@ setuptools.setup(
     url="https://github.com/Ericsson/CodeChecker",
     keywords=['codechecker', 'plist'],
     license='Apache-2.0 WITH LLVM-exception',
-    license_files = ['LICENSE.TXT'],
     packages=packages,
     package_dir={
         "": lib_dir


### PR DESCRIPTION
This merge request fix the license declaration in setup.py

The license field should be set to the license identifier and not point to the license file.
Adding the license_files field should be sufficient to include the license in the tarball distribued by PyPi
EDIT: After a test with `make dist`, setting `license_files` in `setup.py` is not enough. The license file should also be included in `MANIFEST.in`

Using the license_files field require setuptools >= v42.0.0, as noted in the [documentation](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#metadata) 

Close https://github.com/Ericsson/codechecker/issues/3416