### PR TITLE
[analyzer] Use `-imacros` flag instead of `-macros`

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -220,7 +220,7 @@ COMPILE_OPTIONS_MERGED = [
     '-[DIUF]',
     '-idirafter',
     '-isystem',
-    '-macros',
+    '-imacros',
     '-isysroot',
     '-iprefix',
     '-iwithprefix',


### PR DESCRIPTION
This was seemingly last touched in Ericsson/codechecker#2449 (Ericsson/codechecker@7d93b32edcbe885c391cb59d4e13c3aa4163463a) but it seems like a typo. There's no such flag as `-macros` in neither Clang nor GCC.

> via @steakhal 