### PR TITLE
[analyzer] Add comiple option to log_parser.py

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -105,6 +105,7 @@ IGNORED_OPTIONS_GCC = [
     '-frerun-cse-after-loop',
     '-fs$',
     '-fsched-spec',
+    '-fstack-usage',
     '-fstack-reuse',
     '-fthread-jumps',
     '-ftree-pre',


### PR DESCRIPTION
> Closes #3444

Add -fstack-usage to IGNORED_OPTIONS_GCC as they are not recognized by clang