### PR TITLE
[server] Fix getting git commit url

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -978,7 +978,8 @@ def get_commit_url(
         if m:
             url = git_commit_url["url"]
             for key, value in m.groupdict().items():
-                url = url.replace(f"${key}", value)
+                if value is not None:
+                    url = url.replace(f"${key}", value)
 
             return url
 

--- a/web/server/tests/unit/test_git_commit_url.py
+++ b/web/server/tests/unit/test_git_commit_url.py
@@ -40,6 +40,13 @@ class GetCommitUrlTestCase(unittest.TestCase):
                 'https://user@gerrit.ericsson.se/a/team/proj.git',
                 self.__git_commit_urls))
 
+        self.assertEqual(
+            "https://gerrit.ericsson.se/"
+            "gitweb?p=team/proj.git;a=commit;h=$commit",
+            get_commit_url(
+                'https://gerrit.ericsson.se/a/team/proj.git',
+                self.__git_commit_urls))
+
     def test_bitbucket_url(self):
         """ Get commit url for a bitbucket repository. """
         self.assertEqual(


### PR DESCRIPTION
It is possible that a git commit url regex contains a group, which is optional, so the value can be None. In this case when replacing the group name with the value in the url will fail, because None can't be used in replace. For this reason if the value is None, we will skip it from the replacement.