### PR TITLE
[cmd] One analyzer for CheckerLabel methods

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -290,7 +290,10 @@ def __guideline_to_label(
     "--label guideline:sei-cert" and "--guideline sei-cert:str38-c" is the same
     as "--label sei-cert:str38-c".
     """
-    guidelines = cl.occurring_values('guideline', args.analyzers)
+    guidelines = []
+    for analyzer in args.analyzers:
+        guidelines.extend(cl.occurring_values('guideline', analyzer))
+
     if args.guideline in guidelines:
         return f'guideline:{args.guideline}'
     else:
@@ -580,7 +583,7 @@ def __print_checkers(args: argparse.Namespace, cl: CheckerLabels):
     result = []
     for analyzer in args.analyzers:
         if labels:
-            checkers = cl.checkers_by_labels(labels, [analyzer])
+            checkers = cl.checkers_by_labels(labels, analyzer)
             result.extend(
                 filter(lambda x: x[1] in checkers, checker_info[analyzer]))
         else:


### PR DESCRIPTION
This is a refactoring commit. Some CheckerLabel methods can be given
analyzer names which filter the result to the checkers of the given
analyzers. This parameter was required to be an iterable, however,
string is also an iterable. If accidentaly an analyzer name was given
instead of a list of analyzers then it was also accepted mistakenly with
some strange interpretation. This is now fixed.