### PR TITLE
[config] Fix pypi github action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create the pypi package
         run: |
-          BUILD_UI_DIST=NO make dist
+          make dist
 
       - uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
> Closes #3460

Do not skip building the UI code when creating a pypi package.