### PR TITLE
[analyzer] Fix check for response files

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1178,7 +1178,7 @@ def extend_compilation_database_entries(compilation_database):
 
             entry['command'] = ' '.join(cmd)
 
-            if '@' in entry['file']:
+            if entry['file'].startswith('@'):
                 for source_file in source_files:
                     new_entry = dict(entry)
                     new_entry['file'] = source_file


### PR DESCRIPTION
Instead of checking for `@` in the file name, check if a file name
starts with `@`.
Fixes #3463.

Codechecker supports response files. These are files which you can pass to
clang to work around limits in command line length.
Those files names start with a `@`.
The CI/CD solution "Jenkins" creates workspaces by putting `@` in the path name.
A file entry in compile_commands.json could look like:
"file": "/home/workspace/branchname@2/somefile.cpp"

In this case all files in the compile data base are treated as response file.
And the analyzer skips all files and does nothing.

With the help of @csordasmarton this got fixed by checking if a file starts with an `@`.