### PR TITLE
[test][cfg] Use clang-13 in the CI, uplift tests accordingly

### DIFF
--- a/.github/workflows/install-deps.sh
+++ b/.github/workflows/install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main' -y
+sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main' -y
 
 sudo apt-get update -q
 
@@ -13,9 +13,9 @@ sudo apt-get install \
   libldap2-dev \
   libsasl2-dev \
   libssl-dev \
-  clang-11 \
-  clang-tidy-11
+  clang-13 \
+  clang-tidy-13
 
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 9999
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 9999
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 9999
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 9999

--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -34,7 +34,7 @@ compiler_warning_unused:
 compiler_error:
 	$(CXX) -w compiler_error.cpp -o /dev/null
 context_hash:
-	$(CXX) -w context_hash.cpp -o /dev/null
+	$(CXX) -w context_hash.cpp -Wno-unused-but-set-variable -Wno-unused-but-set-parameter -o /dev/null
 collision:
 	$(CXX) -w filename_collision/main.cpp filename_collision/a/f.cpp filename_collision/b/f.cpp -o /dev/null
 tidy_alias:

--- a/scripts/test/check_clang.py
+++ b/scripts/test/check_clang.py
@@ -17,8 +17,8 @@ import subprocess
 import sys
 
 # clang an clang tidy versions to run the tests
-_CLANG_MIN_VERSION = {"major": 11, "minor": 0}
-_TIDY_MIN_VERSION = {"major": 11, "minor": 0}
+_CLANG_MIN_VERSION = {"major": 13, "minor": 0}
+_TIDY_MIN_VERSION = {"major": 13, "minor": 0}
 
 
 def eprint(*args, **kwargs):


### PR DESCRIPTION
The `-Wunused-but-set-variable` and `-Wunused-but-set-parameter` warnings were introduced by https://reviews.llvm.org/D100581, so had to suppress these warnings in the test file to make them forward compatible.

Let's see if the build bots are happy.