### PR TITLE
[gui] Fix run name link in report info

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
+++ b/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
@@ -99,7 +99,7 @@ export default {
     links() {
       return {
         "runName": { name: "runs", query: {
-          "name": this.runName } },
+          "run": this.runName } },
         "bugHash": { name: "reports", query: {
           "report-hash": this.value.bugHash } },
         "checkedFile": { name: "reports", query: {


### PR DESCRIPTION
Use `run` instead of `name` for query parameter when clicking on the
run name link in the report info pop-up.