### PR TITLE
[gui] Fix console error on reports page

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CleanupPlanFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CleanupPlanFilter.vue
@@ -15,7 +15,7 @@
     >
       <template v-slot:prepend-toolbar-items>
         <v-btn
-          v-if="currentProduct.administrating"
+          v-if="administrating"
           class="manage-cleanup-plan-btn"
           icon
           small
@@ -63,7 +63,11 @@ export default {
   computed: {
     ...mapGetters([
       "currentProduct"
-    ])
+    ]),
+
+    administrating() {
+      return this.currentProduct?.administrating;
+    }
   },
 
   watch: {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
@@ -16,7 +16,7 @@
     >
       <template v-slot:prepend-toolbar-items>
         <v-btn
-          v-if="currentProduct.administrating"
+          v-if="administrating"
           class="manage-components-btn"
           icon
           small
@@ -84,7 +84,11 @@ export default {
   computed: {
     ...mapGetters([
       "currentProduct"
-    ])
+    ]),
+
+    administrating() {
+      return this.currentProduct?.administrating;
+    }
   },
 
   watch: {


### PR DESCRIPTION
On the report filter bar for source component and cleanup plans filters
we show a pencil edit icon only if the current user has rights to manage
it. We set the `currentProduct` variable asynchronously, so it is possible
that it will be `null` when we try to get it by using the vuex getter method
and we will try to get the `administrating` property on a `null` value which
is of course throws an error.