### PR TITLE
[gui] Fix weird file path filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
@@ -87,7 +87,7 @@ export default {
               return {
                 id : file,
                 title: file,
-                count : res[file]
+                count: res[file]?.toNumber() || 0
               };
             }));
             this.loading = false;


### PR DESCRIPTION
Sometimes the file path filter at the selected items shows weird strings
for report count (`{"buffer": ...}`). This can be reproduced with the
following steps:
  - Filter `File path filter` with a regex which matches only one
  file path (e.g: `*main.cpp`) and apply the filter.
  - Filter again with the same value but now select and apply the regex
  filter option.

This commit will solve this problem and converts the report count value
to number properly.