### PR TITLE
[server] Fix getting checker labels for 'unknown' analyzer

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1999,12 +1999,25 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
-    def getCheckerLabels(self, checkers):
-        return [
-            list(map(lambda x: f'{x[0]}:{x[1]}',
-                     self._context.checker_labels.labels_of_checker(
-                        checker.checkerId, checker.analyzerName)))
-            for checker in checkers]
+    def getCheckerLabels(
+        self,
+        checkers: List[ttypes.Checker]
+    ) -> List[List[str]]:
+        """ Return the list of labels to each checker. """
+        labels = []
+        for checker in checkers:
+            # Analyzer default value in the database is 'unknown' which is not
+            # a valid analyzer name. So this code handles this use case.
+            analyzer_name = None
+            if checker.analyzerName != "unknown":
+                analyzer_name = checker.analyzerName
+
+            labels.append(list(map(
+                lambda x: f'{x[0]}:{x[1]}',
+                self._context.checker_labels.labels_of_checker(
+                    checker.checkerId, analyzer_name))))
+
+        return labels
 
     @exc_to_thrift_reqfail
     @timeit

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -373,6 +373,11 @@ class RunResults(unittest.TestCase):
         self.assertEqual(set(checker_labels[0]), div_zero_labels)
 
         checker_labels = self._cc_client.getCheckerLabels([
+            Checker('unknown', 'core.DivideZero')])
+        self.assertEqual(len(checker_labels), 1)
+        self.assertEqual(set(checker_labels[0]), div_zero_labels)
+
+        checker_labels = self._cc_client.getCheckerLabels([
             Checker('clangsa', 'core.DivideZero'),
             Checker('clang-tidy', 'dummy-checker')])
         self.assertEqual(len(checker_labels), 2)


### PR DESCRIPTION
Analyzer default value in the database is `unknown` string  which is not
a valid analyzer name. In this commit we will handle this use case.