### PR TITLE
[fix] Add static files to the pypi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include build_dist/CodeChecker/lib/python3/plist_to_html/static *
+recursive-include build_dist/CodeChecker/lib/python3/codechecker_report_converter/report/output/html/static *
 include LICENSE.TXT


### PR DESCRIPTION
> Closes #3499

Previously in the `6.18.0` release `plist_to_html` package was removed and
the source code was moved to the `report_converter` module. Unfortunately we
forgot to update the `MANIFEST` file in the root dir of the repository,
so the pypi package isn't contained these static files. This commit will
solve this problem.