### PR TITLE
[cli] Use print_exc at store command

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -777,7 +777,7 @@ def main(args):
         sys.exit(1)
     except Exception as ex:
         import traceback
-        traceback.print_stack()
+        traceback.print_exc()
         LOG.info("Storage failed: %s", str(ex))
         sys.exit(1)
     finally:


### PR DESCRIPTION
Use `print_exc` instead of `print_stack` at the CodeChecker store
command to get proper information about the error.