### PR TITLE
Mention more details in the build instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -281,7 +281,7 @@ or the UI code is changed. If you wouldn't like to build the UI code you can
 set the `BUILD_UI_DIST` environment variable to `NO` before the package build:
 `BUILD_UI_DIST=NO make package`.
 - Use `make standalone_package` instead of `make package` to avoid
-manually activating the environment before running CodeChecker.
+having to manually activate the environment before running CodeChecker.
 
 ### Upgrading environment after system or Python upgrade
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -258,8 +258,9 @@ cd ~/codechecker
 make venv
 source $PWD/venv/bin/activate
 
-# Optional step in case you want LDAP or PAM authentication support.
-#pip3 install -r web/requirements_py/auth/requirements.txt
+# [Optional] If you want to use external authentication methods (LDAP / PAM)
+# follow the instructions in
+# docs/web/authentication.md#external-authentication-methods
 
 # Build and install a CodeChecker package.
 make package

--- a/docs/README.md
+++ b/docs/README.md
@@ -258,6 +258,9 @@ cd ~/codechecker
 make venv
 source $PWD/venv/bin/activate
 
+# Optional step in case you want LDAP or PAM authentication support.
+#pip3 install -r web/requirements_py/auth/requirements.txt
+
 # Build and install a CodeChecker package.
 make package
 
@@ -277,6 +280,8 @@ environment variable to `YES` before the package build:
 or the UI code is changed. If you wouldn't like to build the UI code you can
 set the `BUILD_UI_DIST` environment variable to `NO` before the package build:
 `BUILD_UI_DIST=NO make package`.
+- Use `make standalone_package` instead of `make package` to avoid
+manually activating the environment before running CodeChecker.
 
 ### Upgrading environment after system or Python upgrade
 


### PR DESCRIPTION
Forgetting to install requirements for LDAP or PAM authentication is quite
a subtle problem: the build completes, the server runs fine,
but users can't login. So mention this in the instructions.

Also mention the possibility of building a standalone_package.