### PR TITLE
Include cppcoreguidelines-virtual-class-destructor in profiles

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -4719,6 +4719,9 @@
     ],
     "cppcoreguidelines-virtual-class-destructor": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-virtual-class-destructor.html",
+      "profile:default",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "darwin-avoid-spinlock": [


### PR DESCRIPTION
This patch partially reverts #3494

The https://github.com/llvm/llvm-project/commit/0685e83534ef8917f277b394da2927cabff8129f fixed the issue about the `cppcoreguidelines-virtual-base-class-destructor` checker, so we can safely include this in the intended profiles.

Special thanks @whisperity for reminding me.