### PR TITLE
[cmd] Allow escaping `:` in run names with `\:`

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -1102,7 +1102,8 @@ optional arguments:
                         run-a-1, run-a-2 and run-b-1 then "run-a*" selects the
                         first two. In case of run names tag labels can also be
                         used separated by a colon (:) character:
-                        "run_name:tag_name".
+                        "run_name:tag_name". A run name containing a literal
+                        colon (:) must be escaped: "run\:name".
   -n NEW_RUNS [NEW_RUNS ...], --newname NEW_RUNS [NEW_RUNS ...]
                         The 'new' (right) side of the difference: these
                         analysis runs are compared to the -b/--basename runs.
@@ -1115,7 +1116,8 @@ optional arguments:
                         So if you have run-a-1, run-a-2 and run-b-1 then
                         "run-a*" selects the first two. In case of run names
                         tag labels can also be used separated by a colon (:)
-                        character: "run_name:tag_name".
+                        character: "run_name:tag_name". A run name containing
+                        a literal colon (:) must be escaped: "run\:name".
   -o {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...], --output {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...]
                         The output format(s) to use in showing the data.
                         - html: multiple html files will be generated in the

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -501,7 +501,9 @@ def __register_diff(parser):
                              "run-a-1, run-a-2 and run-b-1 then \"run-a*\" "
                              "selects the first two. In case of run names tag "
                              "labels can also be used separated by a colon "
-                             "(:) character: \"run_name:tag_name\".")
+                             "(:) character: \"run_name:tag_name\". A run "
+                             "name containing a literal colon (:) must be "
+                             "escaped: \"run\\:name\".")
 
     parser.add_argument('-n', '--newname',
                         type=str,
@@ -523,7 +525,9 @@ def __register_diff(parser):
                              "\"run-a*\" selects the first two. In case of "
                              "run names tag labels can also be used separated "
                              "by a colon (:) character: "
-                             "\"run_name:tag_name\".")
+                             "\"run_name:tag_name\". A run "
+                             "name containing a literal colon (:) must be "
+                             "escaped: \"run\\:name\".")
 
     __add_filtering_arguments(parser, DEFAULT_FILTER_VALUES, True)
 

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -139,14 +139,20 @@ def process_run_args(client, run_args_with_tag: Iterable[str]):
     """Process the argument and returns run ids and run tag ids.
 
     The elemnts inside the given run_args_with_tag list has the following
-    format: <run_name>:<run_tag>
+    format: `<run_name>:<run_tag>`.
+    If the run name is containing a literal ':', it should be escaped with a
+    backslash escape character before the `:`.
     """
+    # (The documentation comment above means \:, but Python would want to
+    # understand that as an escape sequence immediately.)
+
     run_ids = []
     run_names = []
     run_tags = []
 
     for run_arg_with_tag in run_args_with_tag:
-        run_with_tag = run_arg_with_tag.split(':')
+        run_with_tag = list(map(lambda n: n.replace(r"\:", ":"),
+                                re.split(r"(?<!\\):", run_arg_with_tag)))
         run_name = run_with_tag[0]
         run_filter = ttypes.RunFilter(names=[run_name])
 

--- a/web/tests/functional/diff_remote/__init__.py
+++ b/web/tests/functional/diff_remote/__init__.py
@@ -100,6 +100,7 @@ def setup_package():
     ret = codechecker.log_and_analyze(codechecker_cfg, test_proj_path_base)
     if ret:
         sys.exit(1)
+    print('Analyzing base was successful.')
 
     # Store base results.
     codechecker_cfg['reportdir'] = os.path.join(test_proj_path_base,
@@ -109,7 +110,11 @@ def setup_package():
     ret = codechecker.store(codechecker_cfg, test_project_name_base)
     if ret:
         sys.exit(1)
-    print('Analyzing base was successful.')
+
+    # Store with a literal ':' in the name.
+    ret = codechecker.store(codechecker_cfg, test_project_name_base + ":base")
+    if ret:
+        sys.exit(1)
 
     # New analysis
     altered_file = os.path.join(test_proj_path_new, "call_and_message.cpp")
@@ -130,6 +135,11 @@ def setup_package():
 
     test_project_name_new = project_info['name'] + '_' + uuid.uuid4().hex
     ret = codechecker.store(codechecker_cfg, test_project_name_new)
+    if ret:
+        sys.exit(1)
+
+    # Store with a literal ':' in the name.
+    ret = codechecker.store(codechecker_cfg, test_project_name_new + ":new")
     if ret:
         sys.exit(1)
 

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -539,6 +539,25 @@ class DiffRemote(unittest.TestCase):
                                '--resolved', 'json', ["--url", self._url])
         self.assertEqual(len(out[0]), 0)
 
+    def test_diff_between_literal_colon_in_name(self):
+        """Count remote diff compared to a name which contains a literal ':'
+        but does not refer to a tag.
+        """
+        # Name order matters from __init__ !
+        base_to_new = get_diff_results([self._test_runs[0].name],
+                                       [self._test_runs[1].name],
+                                       '--new', 'json', ["--url", self._url])
+
+        colon_base_name = self._test_runs[0].name + r"\:base"
+        colon_new_name = self._test_runs[1].name + r"\:new"
+
+        colon_base_to_new = get_diff_results([colon_base_name],
+                                             [colon_new_name],
+                                             '--new', 'json',
+                                             ["--url", self._url])
+
+        self.assertEqual(len(base_to_new[0]), len(colon_base_to_new[0]))
+
     def test_max_compound_select(self):
         """Test the maximum number of compound select query."""
         base_run_id = self._test_runs[0].runId


### PR DESCRIPTION
> Fixes #3535.

In certain scenarios, the run name might contain a `:` character that does NOT separate a tag from a name.
Commands such as `server` and `cmd results` accept `:` as a literal in the name, but `cmd diff` previously cut it as the "run tag" separator.