### PR TITLE
[cli] Don't generate HTML files for empty plist files

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/output/html/html.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/html.py
@@ -442,16 +442,16 @@ def convert(
     Returns the skipped analyzer result files because of source
     file content change.
     """
+    if not reports:
+        LOG.info(f'No report data in {file_path} file.')
+        return set()
+
     html_filename = f"{os.path.basename(file_path)}.html"
     html_output_path = os.path.join(output_dir_path, html_filename)
-    html_reports, changed_files = html_builder.create(
+    _, changed_files = html_builder.create(
         html_output_path, reports)
 
     if changed_files:
-        return changed_files
-
-    if not html_reports:
-        LOG.info(f'No report data in {file_path} file.')
         return changed_files
 
     LOG.info(f"Html file was generated: {html_output_path}")


### PR DESCRIPTION
> Closes #3537

`CodeChecker parse ./reports -e html -o html` generates static HTML files
which describe reports in the report directory. Such an HTML file is
generated for each source files and each analyzers even if the given
analyzer doesn't emit any report for the given source file. This *empty*
HTML file contains the static frame of the page and its size is `204K`.
Before 6.18.0 release these files were not generated.

With this patch we will also skip generating these HTML files.