### PR TITLE
[doc] Added link to basic database setup

### DIFF
--- a/docs/web/docker.md
+++ b/docs/web/docker.md
@@ -83,6 +83,8 @@ write a compose file similar to
 
 #### PostgreSQL setup
 
+Follow the instructions [here](postgresql_setup.md) for the general database setup.
+
 #### PostgreSQL (no authentication)
 To run a CodeChecker server and a PostgreSQL database cluster which does not
 require authentication you have to write a compose file similar to


### PR DESCRIPTION
Added link to basid database setup before deployment of postgres setup .

I guess this link at that place would have saved me a lot of tries... hopefully it is helpful for others, too.