### PR TITLE
[docker] New build argument (`CC_REPO`) for docker image

### DIFF
--- a/docs/web/docker.md
+++ b/docs/web/docker.md
@@ -30,6 +30,9 @@ docker build -t codechecker-web:latest web/docker
 
 Multiple build-time variables can be specified:
 
+- `CC_REPO` (default: *https://github.com/Ericsson/CodeChecker.git*):
+repository which will be cloned from Git. Use it when you would like to build
+an image from a custom CodeChecker repository.
 - `CC_VERSION` (default: *master*): branch or tag version which will be cloned
 from Git. Use `master` if you would like to build an image from the latest
 CodeChecker.

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM python:3.6-slim-stretch as builder
 
+ARG CC_REPO=https://github.com/Ericsson/CodeChecker.git
+ENV CC_REPO ${CC_REPO}
+
 ARG CC_VERSION=master
 ENV CC_VERSION ${CC_VERSION}
 
@@ -20,7 +23,7 @@ RUN set -x && apt-get update -qq \
     && apt-get install -y nodejs
 
 # Download CodeChecker release.
-RUN git clone https://github.com/Ericsson/CodeChecker.git /codechecker
+RUN git clone ${CC_REPO} /codechecker
 WORKDIR /codechecker
 RUN git checkout ${CC_VERSION}
 


### PR DESCRIPTION
Introduce a new build argument for the docker image called `CC_REPO` which can be used if you would like to build an image from a custom CodeChecker repository, for example from your fork.