### PR TITLE
[gui] Fix number of outstanding reports chart

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Overview/OutstandingReportsChart.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/OutstandingReportsChart.vue
@@ -1,8 +1,8 @@
 <script>
 import _ from "lodash";
 import {
-  endOfMonth, endOfWeek, endOfYear, format, subDays, subMonths, subWeeks,
-  subYears
+  endOfMonth, endOfToday, endOfWeek, endOfYear, format, subDays, subMonths,
+  subWeeks, subYears
 } from "date-fns";
 import { Line, mixins } from "vue-chartjs";
 import ChartDataLabels from "chartjs-plugin-datalabels";
@@ -135,7 +135,7 @@ export default {
       let dateFormat = "yyyy. MMM. dd";
 
       if (this.resolution === "days") {
-        const today = new Date();
+        const today = endOfToday();
         this.dates = [ ...new Array(interval).keys() ].map(i =>
           subDays(today, i));
       }


### PR DESCRIPTION
Let's assume that a bug was detected yesterday at 3PM and I want to view
this chart today at 1PM. In day resolution we used the current date as a
starting point and based on the interval length (e.g.: 7 days) we subtract
x days from the current date. For this reason the grap will not show me this
bug which was detected yesteday, but it assumes that is was detected today.

With this patch we will set the starting date to the end of the current date
which will solve this issue.