### PR TITLE
[test] Fix non-deterministic test in plist to html

### DIFF
--- a/tools/report-converter/tests/unit/output/html/plist_to_html_test.py
+++ b/tools/report-converter/tests/unit/output/html/plist_to_html_test.py
@@ -79,7 +79,11 @@ class PlistToHtmlTest(unittest.TestCase):
             report_to_html.convert(
                 file_path, reports, output_dir, html_builder)
 
-            self.assertTrue(os.path.exists(output_path))
+            html_file_exists = os.path.exists(output_path)
+            if reports:
+                self.assertTrue(html_file_exists)
+            else:
+                self.assertFalse(html_file_exists)
 
         html_builder.create_index_html(output_dir)
         html_builder.create_statistics_html(output_dir)


### PR DESCRIPTION
In one test case related to plist to html conversion we iterate
over multiple plist files, we convert it to HTML files and we also
skip duplicates.

So let's assume that I have two plist files a.plist and b.plist and both
plist files contains the same results. Let's assume that I process the a.plist
file first and convert the reports to HTML. Next if I process the b.plist I will
do not generate HTML file from it because the same reports are already in the HTML
file what we generated for a.plist and we do not generate empty HTML files anymore.

To solve this problem in the test case we will check if we have report, and in this
case the HTML file has to be exist otherwise it hasn't.