### PR TITLE
[server][gui] Escape values for v-html attributes

### DIFF
--- a/web/tests/functional/export_import/test_export_import.py
+++ b/web/tests/functional/export_import/test_export_import.py
@@ -11,7 +11,6 @@
 Report exporting and importing tests
 """
 
-
 import os
 import unittest
 import logging
@@ -89,7 +88,7 @@ class TestExport(unittest.TestCase):
         comments = self._cc_client.getComments(bug.reportId)
         self.assertEqual(len(comments), 0)
 
-        comment1 = CommentData(author='anybody', message='First msg')
+        comment1 = CommentData(author='anybody', message='First msg <img />')
         success = self._cc_client.addComment(bug.reportId, comment1)
         self.assertTrue(success)
         logging.debug('Bug commented successfully')

--- a/web/tests/functional/store/test_store.py
+++ b/web/tests/functional/store/test_store.py
@@ -10,7 +10,7 @@
 store tests.
 """
 
-
+import html
 import json
 import os
 import shlex
@@ -181,6 +181,15 @@ class TestStore(unittest.TestCase):
             '-d', 'core.DivideZero', '-e', 'deadcode.DeadStores']
         codechecker.analyze(cfg, self._divide_zero_workspace)
 
+        with open(os.path.join(report_dir1, 'metadata.json'), 'r+',
+                  encoding="utf-8", errors="ignore") as f:
+            data = json.load(f)
+            data["tools"][0]["command"].append("<img />")
+
+            f.seek(0)
+            f.truncate()
+            json.dump(data, f)
+
         cfg['reportdir'] = report_dir2
         cfg['checkers'] = [
             '-e', 'core.DivideZero', '-d', 'deadcode.DeadStores']
@@ -234,6 +243,11 @@ class TestStore(unittest.TestCase):
                 any(report_dir1 in i.analyzerCommand for i in analysis_info))
             self.assertTrue(
                 any(report_dir2 in i.analyzerCommand for i in analysis_info))
+
+            self.assertTrue(all(
+                '<' not in i.analyzerCommand for i in analysis_info))
+            self.assertTrue(any(
+                html.escape('<') in i.analyzerCommand for i in analysis_info))
 
             # Get analysis info for a report.
             analysis_info_filter = AnalysisInfoFilter(


### PR DESCRIPTION
We are using [`v-html`](https://vuejs.org/v2/api/#v-html) attribute on the UI side to dinamically rendering comments and analyzer commands. This can be very dangerous because it can easily lead to XSS vulnerabilities. To solve this problem the server will always return the escaped version of these values which can be safely rendered on the UI.