### PR TITLE
[cli] Add `print-steps` option to `CodeChecker cmd diff`

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -1060,7 +1060,7 @@ from the comparison of two runs.
 
 ```
 usage: CodeChecker cmd diff [-h] [-b BASE_RUNS [BASE_RUNS ...]]
-                            [-n NEW_RUNS [NEW_RUNS ...]]
+                            [-n NEW_RUNS [NEW_RUNS ...]] [--print-steps]
                             [--uniqueing {on,off}]
                             [--report-hash [REPORT_HASH [REPORT_HASH ...]]]
                             [--review-status [REVIEW_STATUS [REVIEW_STATUS ...]]]
@@ -1118,6 +1118,8 @@ optional arguments:
                         tag labels can also be used separated by a colon (:)
                         character: "run_name:tag_name". A run name containing
                         a literal colon (:) must be escaped: "run\:name".
+  --print-steps         Print the steps the analyzers took in finding the
+                        reported defect.
   -o {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...], --output {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...]
                         The output format(s) to use in showing the data.
                         - html: multiple html files will be generated in the

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -529,6 +529,14 @@ def __register_diff(parser):
                              "name containing a literal colon (:) must be "
                              "escaped: \"run\\:name\".")
 
+    parser.add_argument('--print-steps',
+                        dest="print_steps",
+                        action="store_true",
+                        required=False,
+                        default=argparse.SUPPRESS,
+                        help="Print the steps the analyzers took in finding "
+                             "the reported defect.")
+
     __add_filtering_arguments(parser, DEFAULT_FILTER_VALUES, True)
 
     group = parser.add_argument_group("comparison modes")

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -389,3 +389,13 @@ int main()
             "Couldn't get local reports for the following baseline report "
             "hashes: ",
             err)
+
+    def test_print_bug_steps(self):
+        """ Test printing the steps the analyzers took. """
+        out, _, ret = get_diff_results(
+            [self.base_reports], [self.new_reports], '--unresolved', None,
+            ['--print-steps'])
+
+        self.assertTrue("Steps:" in out)
+        self.assertTrue("Report hash:" in out)
+        self.assertEqual(ret, 2)

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -664,3 +664,13 @@ class LocalRemote(unittest.TestCase):
         self.assertSetEqual(
             {r['report_hash'] for r in resolved_results}, resolved_hashes)
         self.assertEqual(returncode, 2)
+
+    def test_print_bug_steps(self):
+        """ Test printing the steps the analyzers took. """
+        out, _, ret = get_diff_results(
+            [self._run_names[0]], [self._local_reports], '--resolved', None,
+            ["--url", self._url, "--print-steps"])
+
+        self.assertTrue("Steps:" in out)
+        self.assertTrue("Report hash:" in out)
+        self.assertEqual(ret, 2)

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -745,3 +745,16 @@ class DiffRemote(unittest.TestCase):
                 self.assertNotIn(InvalidFileContentMsg, f.read())
 
         shutil.rmtree(html_reports, ignore_errors=True)
+
+    def test_print_bug_steps(self):
+        """ Test printing the steps the analyzers took. """
+        base_run_name = self._test_runs[0].name
+        new_run_name = self._test_runs[1].name
+
+        out, _, ret = get_diff_results(
+            [base_run_name], [new_run_name], '--resolved', None,
+            ["--url", self._url, "--print-steps"])
+
+        self.assertTrue("Steps:" in out)
+        self.assertTrue("Report hash:" in out)
+        self.assertEqual(ret, 2)


### PR DESCRIPTION
> Closes #1424

Without bug steps it is hard to understood the problem by a programmer.
With this commit we will introduce a new option for the diff command
which can be used to print bug steps similar what we are doing at the
`CodeChecker parse` command.

This patch also solve the problem to print bug steps in HTML files for
reports which comes from a CodeChecker server.