### PR TITLE
[cli] Fix skipping reports

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/report/__init__.py
@@ -512,12 +512,10 @@ class Report:
 
     def skip(self, skip_handler: Optional[SkipListHandler]) -> bool:
         """ True if the report should be skipped. """
-        if skip_handler:
-            for file_path in self.original_files:
-                if skip_handler(file_path):
-                    return True
+        if not skip_handler:
+            return False
 
-        return False
+        return skip_handler(self.file.original_path)
 
     def to_json(self) -> Dict:
         """ Creates a JSON dictionary. """


### PR DESCRIPTION
If a skip file was given to the `CodeChecker parse` command and one of
the mentioned file from the bug path was on the skip list we skipped that
report.

Example:
`main.cpp`:
```cpp
#include "lib.h"

int main() {
  return foo(0);
}
```

`lib.h`:
```
double foo(int param) {
  return 1 / param;
}

```

`skip file content`:
```txt
+*/lib.h
-*
```

In this case if we analyzed this project and run on of the following
command, it returned with no results:
- `CodeChecker parse ./reports --skip skipfile.txt`
- `CodeChecker parse ./reports --file "*/lib.h"`

With this patch we will skip a report only if the last bug step is on the
skip list.