### PR TITLE
[server] Fix suppressing bug on the server

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -805,7 +805,6 @@ class MassStoreRun:
             comment.
             """
             checker_name = report.checker_name
-            last_report_event = report.bug_path_events[-1]
 
             # The original file path is needed here, not the trimmed, because
             # the source files are extracted as the original file path.
@@ -818,7 +817,7 @@ class MassStoreRun:
             if not os.path.isfile(source_file_name):
                 return
 
-            report_line = last_report_event.range.end_line
+            report_line = report.line
             source_file = os.path.basename(file_name)
 
             src_comment_data = parse_codechecker_review_comment(

--- a/web/tests/functional/review_status/review_status_files/divide_zero.cpp
+++ b/web/tests/functional/review_status/review_status_files/divide_zero.cpp
@@ -9,8 +9,9 @@
 
 int test1(int z) {
   if (z == 0){
-    // codechecker_intentional [core.DivideZero] intentional divide by zero here
-    int x = 1 / z; // warn
+    // codechecker_intentional [core.DivideZero] intentional multiline divide by zero here
+    int x = 1 /
+      z; // warn
     return x;
   }
 }

--- a/web/tests/functional/review_status/review_status_files/divide_zero.plist
+++ b/web/tests/functional/review_status/review_status_files/divide_zero.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
  <key>clang_version</key>
-<string>clang version 12.0.0 (https://github.com/llvm/llvm-project.git 4f3559db1f313eed8bd84377de0fb2300a58125b)</string>
+<string>clang version 13.0.0</string>
  <key>diagnostics</key>
  <array>
   <dict>
@@ -123,8 +123,8 @@
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>13</integer>
-         <key>col</key><integer>17</integer>
+         <key>line</key><integer>14</integer>
+         <key>col</key><integer>7</integer>
          <key>file</key><integer>0</integer>
         </dict>
        </array>
@@ -141,7 +141,7 @@
    <key>type</key><string>Division by zero</string>
    <key>check_name</key><string>core.DivideZero</string>
    <!-- This hash is experimental and going to change! -->
-   <key>issue_hash_content_of_line_in_context</key><string>0a6cf888769a0abb515c318411009cea</string>
+   <key>issue_hash_content_of_line_in_context</key><string>fbb2cdb4eddba27e931a2f49f69f3fb4</string>
   <key>issue_context_kind</key><string>function</string>
   <key>issue_context</key><string>test1</string>
   <key>issue_hash_function_offset</key><string>3</string>
@@ -158,6 +158,7 @@
     <integer>10</integer>
     <integer>11</integer>
     <integer>13</integer>
+    <integer>14</integer>
    </array>
   </dict>
   </dict>
@@ -172,12 +173,12 @@
         <key>start</key>
          <array>
           <dict>
-           <key>line</key><integer>19</integer>
+           <key>line</key><integer>20</integer>
            <key>col</key><integer>3</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>19</integer>
+           <key>line</key><integer>20</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -185,12 +186,12 @@
         <key>end</key>
          <array>
           <dict>
-           <key>line</key><integer>21</integer>
+           <key>line</key><integer>22</integer>
            <key>col</key><integer>13</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>21</integer>
+           <key>line</key><integer>22</integer>
            <key>col</key><integer>13</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -202,7 +203,7 @@
      <key>kind</key><string>event</string>
      <key>location</key>
      <dict>
-      <key>line</key><integer>21</integer>
+      <key>line</key><integer>22</integer>
       <key>col</key><integer>13</integer>
       <key>file</key><integer>0</integer>
      </dict>
@@ -210,12 +211,12 @@
      <array>
        <array>
         <dict>
-         <key>line</key><integer>21</integer>
+         <key>line</key><integer>22</integer>
          <key>col</key><integer>11</integer>
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>21</integer>
+         <key>line</key><integer>22</integer>
          <key>col</key><integer>15</integer>
          <key>file</key><integer>0</integer>
         </dict>
@@ -239,7 +240,7 @@
   <key>issue_hash_function_offset</key><string>3</string>
   <key>location</key>
   <dict>
-   <key>line</key><integer>21</integer>
+   <key>line</key><integer>22</integer>
    <key>col</key><integer>13</integer>
    <key>file</key><integer>0</integer>
   </dict>
@@ -247,9 +248,9 @@
   <dict>
    <key>0</key>
    <array>
-    <integer>18</integer>
     <integer>19</integer>
-    <integer>21</integer>
+    <integer>20</integer>
+    <integer>22</integer>
    </array>
   </dict>
   </dict>


### PR DESCRIPTION
It is possible that the *start line* and *end line* of a bug reported by the analyzer are different.

Example:
```cpp
int main()
{
  // codechecker_suppress [all] This will not be suppressed because of a bug.
  int x = 1 /
    0;
  return x;
}
```

In the above example the bug start line is where `x` variable is declared and the *end line* is in the next line.

On the server we stored the start line as the line where the report can be found but for suppression we checked whether there is a source code comment above the end line. So if someone inserted a source code comment above the start line the server hasn't suppressed that report.

With this patch we will solve this problem and we will check the source code comment above the start line and not the end line.