### PR TITLE
[html] Fix static HTML report files

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/output/html/html.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/html.py
@@ -79,6 +79,7 @@ HTMLReports = List[HTMLReport]
 
 
 class FileSource(TypedDict):
+    id: str
     filePath: str
     content: str
 
@@ -170,7 +171,7 @@ class HtmlBuilder:
             file_content = InvalidFileContentMsg
 
         self.files[file.id] = {
-            'filePath': file.path, 'content': file_content}
+            'id': file.id, 'filePath': file.path, 'content': file_content}
 
         return self.files[file.id]
 


### PR DESCRIPTION
> Closes #3565.

Previously `id` attribute was not set for source files when generated static
HTML report files for example with the `CodeChecker parse` command.
The JavaScript part used this attributes but it was always `undefined`.
This way if a user opened a report which bug step referenced mulitple different
source files, changing between the bug steps didn't change the source file.