### PR TITLE
[cli] Fix link in gerrit output

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -360,7 +360,7 @@ class AnalyzeParseTestCase(
         self.assertEqual(lbls["Code-Review"], -1)
         self.assertEqual(review_data["message"],
                          "CodeChecker found 1 issue(s) in the code. "
-                         "See: '{0}'".format(report_url))
+                         "See: {0}".format(report_url))
         self.assertEqual(review_data["tag"], "jenkins")
 
         # Because the CC_CHANGED_FILES is set we will see reports only for

--- a/tools/report-converter/codechecker_report_converter/report/output/gerrit.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/gerrit.py
@@ -121,7 +121,7 @@ def __convert_reports(reports: List[Report],
                         report_messages_in_unchanged_files)))
 
     if report_url:
-        message += " See: '{0}'".format(report_url)
+        message += f" See: {report_url}"
 
     review = {"tag": "jenkins",
               "message": message,

--- a/tools/report-converter/tests/unit/output/gerrit/test_gerrit_converter.py
+++ b/tools/report-converter/tests/unit/output/gerrit/test_gerrit_converter.py
@@ -110,7 +110,7 @@ class TestReportToGerrit(unittest.TestCase):
         expected = {
             "tag": "jenkins",
             "message": "CodeChecker found 1 issue(s) in the code. "
-            "See: 'localhost:8080/index.html'",
+            "See: localhost:8080/index.html",
             "labels": {"Code-Review": -1, "Verified": -1},
             "comments": {
                 "main.cpp": [

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -433,7 +433,7 @@ class LocalRemote(unittest.TestCase):
         self.assertIn(
             "CodeChecker found 25 issue(s) in the code.",
             review_data["message"])
-        self.assertIn(f"See: '{report_url}'", review_data["message"])
+        self.assertIn(f"See: {report_url}", review_data["message"])
         self.assertEqual(review_data["tag"], "jenkins")
 
         # Because the CC_CHANGED_FILES is set we will see reports only for


### PR DESCRIPTION
> Closes #3571

If `CC_REPORT_URL` is defined and `gerrit` format is used at `CodeChecker parse`
or `CodeChecker cmd diff` commands, the output will contain the value of this
environment variable wrapped inside quotes. When this output is sent to gerrit,
it will convert URL links to HTML `a` tags. Unfortunately gerrit will think that
the ending quote is part of the URL, so it will not remove it. This way the
URL will be invalid.

To solve this problem in this patch we will remove the quotes around the URL link.