### PR TITLE
[web] Fix storage of control points

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/plist.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/plist.py
@@ -475,16 +475,17 @@ class Parser(BaseParser):
             if report.analyzer_name:
                 diagnostic['type'] = report.analyzer_name
 
-            control_edges = []
+            path = []
             if report.bug_path_positions:
                 for i in range(len(report.bug_path_positions) - 1):
                     start = report.bug_path_positions[i]
                     end = report.bug_path_positions[i + 1]
                     if start.range and end.range:
-                        control_edges.append(self._create_control_edge(
+                        edge = self._create_control_edge(
                             start.range, start.file,
                             end.range, end.file,
-                            file_index_map))
+                            file_index_map)
+                        path.append(self._create_control_edges([edge]))
             elif len(report.bug_path_events) > 1:
                 # Create bug path positions from bug path events.
                 for i in range(len(report.bug_path_events) - 1):
@@ -497,14 +498,11 @@ class Parser(BaseParser):
                     if start_range == end_range:
                         continue
 
-                    control_edges.append(self._create_control_edge(
+                    edge = self._create_control_edge(
                         start_range, start.file,
                         end_range, end.file,
-                        file_index_map))
-
-            path = []
-            if control_edges:
-                path.append(self._create_control_edges(control_edges))
+                        file_index_map)
+                    path.append(self._create_control_edges([edge]))
 
             # Add bug path events after control points.
             if report.bug_path_events:
@@ -572,8 +570,8 @@ class Parser(BaseParser):
             'message': event.message}
 
         if event.range:
-            data['range'] = self._create_range(
-                event.range, file_index_map[event.file.original_path])
+            data['ranges'] = [self._create_range(
+                event.range, file_index_map[event.file.original_path])]
 
         return data
 
@@ -609,8 +607,8 @@ class Parser(BaseParser):
             'message': note.message}
 
         if note.range:
-            data['range'] = self._create_range(
-                note.range, file_index_map[note.file.original_path])
+            data['ranges'] = [self._create_range(
+                note.range, file_index_map[note.file.original_path])]
 
         return data
 

--- a/tools/report-converter/tests/unit/analyzers/cppcheck_output_test_files/divide_zero.expected.plist
+++ b/tools/report-converter/tests/unit/analyzers/cppcheck_output_test_files/divide_zero.expected.plist
@@ -40,24 +40,26 @@
 					</dict>
 					<key>message</key>
 					<string>Division by zero</string>
-					<key>range</key>
+					<key>ranges</key>
 					<array>
-						<dict>
-							<key>col</key>
-							<integer>13</integer>
-							<key>file</key>
-							<integer>0</integer>
-							<key>line</key>
-							<integer>17</integer>
-						</dict>
-						<dict>
-							<key>col</key>
-							<integer>13</integer>
-							<key>file</key>
-							<integer>0</integer>
-							<key>line</key>
-							<integer>17</integer>
-						</dict>
+						<array>
+							<dict>
+								<key>col</key>
+								<integer>13</integer>
+								<key>file</key>
+								<integer>0</integer>
+								<key>line</key>
+								<integer>17</integer>
+							</dict>
+							<dict>
+								<key>col</key>
+								<integer>13</integer>
+								<key>file</key>
+								<integer>0</integer>
+								<key>line</key>
+								<integer>17</integer>
+							</dict>
+						</array>
 					</array>
 				</dict>
 			</array>

--- a/tools/report-converter/tests/unit/analyzers/infer_output_test_files/NullDereference.java.plist
+++ b/tools/report-converter/tests/unit/analyzers/infer_output_test_files/NullDereference.java.plist
@@ -67,6 +67,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>
@@ -107,6 +114,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>
@@ -147,6 +161,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>

--- a/tools/report-converter/tests/unit/analyzers/spotbugs_output_test_files/assign.plist
+++ b/tools/report-converter/tests/unit/analyzers/spotbugs_output_test_files/assign.plist
@@ -491,6 +491,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>

--- a/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy2.plist
+++ b/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy2.plist
@@ -108,6 +108,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>

--- a/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy3_hh.plist
+++ b/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy3_hh.plist
@@ -67,6 +67,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>
@@ -107,6 +114,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>
@@ -147,6 +161,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>
@@ -187,6 +208,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>

--- a/tools/report-converter/tests/unit/analyzers/tsan_output_test_files/tsan.plist
+++ b/tools/report-converter/tests/unit/analyzers/tsan_output_test_files/tsan.plist
@@ -89,6 +89,13 @@
 								</dict>
 							</array>
 						</dict>
+					</array>
+					<key>kind</key>
+					<string>control</string>
+				</dict>
+				<dict>
+					<key>edges</key>
+					<array>
 						<dict>
 							<key>end</key>
 							<array>

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -352,6 +352,22 @@ class RunResults(unittest.TestCase):
 
         self.assertTrue(any(res.details for res in run_results))
 
+    def test_report_path_and_events(self):
+        """
+        Test that bug path events and control points are stored properly.
+        """
+        sort_mode = SortMode(SortType.FILENAME, Order.ASC)
+
+        report_filter = ReportFilter(
+            checkerName=['core.DivideZero'],
+            filepath=['*path_begin.cpp'])
+
+        report = self._cc_client.getRunResults(
+            [self._runid], 1, 0, [sort_mode], report_filter, None, True)[0]
+
+        self.assertEqual(len(report.details.executionPath), 7)
+        self.assertEqual(len(report.details.pathEvents), 5)
+
     def test_get_checker_labels(self):
         checker_labels = self._cc_client.getCheckerLabels([])
         self.assertEqual(len(checker_labels), 0)


### PR DESCRIPTION
In the `6.18.0` release #3462 patch introduced a bug that not all of the control points were stored to the server, because the plist format what the report converter produced and the plist parser expected was invalid:
- `range` key was used instead of `ranges`.
- Control events are not stored as separated items but as a single control event.

**Previously:**
<img src="https://user-images.githubusercontent.com/6695818/148963194-6464d78b-a699-4314-a521-02a5f29d238f.png" width="400" />

**After this patch:**
<img src="https://user-images.githubusercontent.com/6695818/148963286-c57b18dc-c2fb-4d8b-b60d-91c99f79114f.png" width="400" />
