### PR TITLE
[fix] Quote command line segment using shlex

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -300,7 +300,10 @@ def handle_reproducer(source_analyzer, rh, zip_file, actions_map):
 
         LOG.debug("[ZIP] Writing extra information...")
         archive.writestr("build-action", action.original_command)
-        archive.writestr("analyzer-command", ' '.join(rh.analyzer_cmd))
+        archive.writestr(
+            "analyzer-command",
+            ' '.join([shlex.quote(x) for x in rh.analyzer_cmd]),
+            )
         archive.writestr("return-code", str(rh.analyzer_returncode))
 
         toolchain = gcc_toolchain.toolchain_in_args(

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
@@ -15,6 +15,7 @@ import os
 import signal
 import subprocess
 import sys
+import shlex
 
 from codechecker_common.logger import get_logger
 
@@ -82,7 +83,8 @@ class SourceAnalyzer(metaclass=ABCMeta):
         """
         LOG.debug('Running analyzer ...')
 
-        LOG.debug_analyzer('\n%s', ' '.join(analyzer_cmd))
+        LOG.debug_analyzer('\n%s',
+                           ' '.join([shlex.quote(x) for x in analyzer_cmd]))
 
         res_handler.analyzer_cmd = analyzer_cmd
         try:

--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -13,6 +13,7 @@ Build and log related functionality.
 import os
 import pickle
 import platform
+import shlex
 import subprocess
 import sys
 from uuid import uuid4
@@ -81,7 +82,7 @@ def perform_build_command(logfile, command, context, keep_link, silent=False,
         final_command = command
         command = ' '.join(["intercept-build",
                             "--cdb", logfile,
-                            "sh -c \"" + final_command + "\""])
+                            "sh -c", shlex.quote(final_command)])
         log_env = original_env
         LOG.debug_analyzer(command)
 

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -968,7 +968,8 @@ def parse_options(compilation_db_entry,
 
     if 'arguments' in compilation_db_entry:
         gcc_command = compilation_db_entry['arguments']
-        details['original_command'] = ' '.join(gcc_command)
+        details['original_command'] = \
+            ' '.join([shlex.quote(x) for x in gcc_command])
     elif 'command' in compilation_db_entry:
         details['original_command'] = compilation_db_entry['command']
         gcc_command = shlex.split(compilation_db_entry['command'])
@@ -1172,10 +1173,10 @@ def extend_compilation_database_entries(compilation_database):
                         continue
 
                     opts, sources = process_response_file(response_file)
-                    cmd.extend(opts)
+                    cmd.extend([shlex.quote(x) for x in opts])
                     source_files.extend(sources)
                 else:
-                    cmd.append(opt)
+                    cmd.append(shlex.quote(opt))
 
             entry['command'] = ' '.join(cmd)
 

--- a/analyzer/tests/libtest/codechecker.py
+++ b/analyzer/tests/libtest/codechecker.py
@@ -29,6 +29,7 @@ def call_command(cmd, cwd, env):
         print("\nTEST execute stderr:\n")
         print(err)
 
+    cmd_log = ' '.join([shlex.quote(x) for x in cmd])
     try:
         proc = subprocess.Popen(
             cmd,
@@ -41,13 +42,13 @@ def call_command(cmd, cwd, env):
         out, err = proc.communicate()
         if proc.returncode != 0:
             show(out, err)
-            print('Unsuccessful run: "' + ' '.join(cmd) + '"')
+            print(f'Unsuccessful run: {cmd_log}')
             print(proc.returncode)
         return out, err, proc.returncode
     except OSError as oerr:
         print(oerr)
         show(out, err)
-        print('Failed to run: "' + ' '.join(cmd) + '"')
+        print(f'Failed to run: {cmd_log}')
         raise
 
 

--- a/analyzer/tests/unit/logparser_test_files/ldlogger response.rsp
+++ b/analyzer/tests/unit/logparser_test_files/ldlogger response.rsp
@@ -1,0 +1,1 @@
+'-DVARIABLE="some value"' '-DVARIABLE2="me@domain.com"'

--- a/analyzer/tests/unit/logparser_test_files/ldlogger-new-at.json
+++ b/analyzer/tests/unit/logparser_test_files/ldlogger-new-at.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "/tmp",
+		"command": "g++ -DVARIABLE=\\\"me@domain.com\\\" /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	}
+]

--- a/analyzer/tests/unit/logparser_test_files/ldlogger-new-response.json
+++ b/analyzer/tests/unit/logparser_test_files/ldlogger-new-response.json
@@ -1,0 +1,7 @@
+[
+	{
+		"directory": "PLACEHOLDER",
+		"command": "g++ @ldlogger\\ response.rsp /tmp/a.cpp -o /tmp/a.out",
+		"file": "/tmp/a.cpp"
+	}
+]

--- a/analyzer/tests/unit/logparser_test_files/ldlogger-new-space.json
+++ b/analyzer/tests/unit/logparser_test_files/ldlogger-new-space.json
@@ -1,7 +1,7 @@
 [
 	{
 		"directory": "/tmp",
-		"command": "g++ /tmp/a b.cpp",
+		"command": "g++ /tmp/a\\ b.cpp",
 		"file": "/tmp/a b.cpp"
 	}
 ]

--- a/analyzer/tests/unit/logparser_test_files/ldlogger-new.json
+++ b/analyzer/tests/unit/logparser_test_files/ldlogger-new.json
@@ -1,7 +1,7 @@
 [
 	{
 		"directory": "/tmp",
-		"command": "g++ -DVARIABLE=\"some value\" /tmp/a.cpp -o /tmp/a.out",
+		"command": "g++ -DVARIABLE=\\\"some\\ value\\\" /tmp/a.cpp -o /tmp/a.out",
 		"file": "/tmp/a.cpp"
 	}
 ]


### PR DESCRIPTION
Simply joining command segments is not enough for acquiring a valid
command. One should escape the necessary characters prior to that.
Escaping can be done manually, but using `shlex` is the preferred way
of doing so.

This patch might not fix all of the issues.

There were multiple places where this was not done adequately:
 * at calling `intercept-build`
 * at parsing the `compile_commands.json`'s `arguments` field
 * at extending the command with the referred response file's content
 * at extending the command without response files
 * at the `libtest/codechecker.py/all_command()` helper function
 * at a bunch of other places where a command is being logged - but
   for brevity, I've just fixed the two most important places of this
   - `analyzer_base.py/analyze()`
   - `analysis_manager.py/handle_reproducer()`