### PR TITLE
Avoid plist filenames being the same

### DIFF
--- a/docs/tools/report-converter.md
+++ b/docs/tools/report-converter.md
@@ -84,14 +84,15 @@ optional arguments:
                         file name output of this tool. This tool can produce
                         multiple plist files on the given code analyzer output
                         result file. The problem is if we run this tool
-                        multiple times on the same directory, it may override
-                        some plist files. To prevent this we can generate a
-                        unique hash into the plist file names with this
-                        option. For example: '{source_file}_{analyzer}_xxxxx'.
-                        {source_file} and {analyzer} are special values which
-                        will be replaced with the current analyzer and source
-                        file name where the bug was found. (default:
-                        {source_file}_{analyzer})
+                        multiple times on the same file, it may override some
+                        plist files. To prevent this we can generate a unique
+                        hash into the plist file names with this option. For
+                        example: '{source_file}_{analyzer}_{file_hash}_xxxxx'.
+                        {source_file}, {analyzer} and {file_hash} are special
+                        values which will be replaced with the current
+                        analyzer, source file name and hash of the absolute
+                        file path where the bug was found. (default:
+                        {source_file}_{analyzer}_{file_hash})
   -c, --clean           Delete files stored in the output directory. (default:
                         False)
   -v, --verbose         Set verbosity level. (default: False)

--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -172,20 +172,22 @@ def __add_arguments_to_parser(parser):
                         type=str,
                         dest='filename',
                         metavar='FILENAME',
-                        default="{source_file}_{analyzer}",
+                        default="{source_file}_{analyzer}_{file_hash}",
                         help="This option can be used to override the default "
                              "plist file name output of this tool. This tool "
                              "can produce multiple plist files on the given "
                              "code analyzer output result file. The problem "
                              "is if we run this tool multiple times on the "
-                             "same directory, it may override some plist "
-                             "files. To prevent this we can generate a unique "
-                             "hash into the plist file names with this "
-                             "option. For example: "
-                             "'{source_file}_{analyzer}_xxxxx'. {source_file} "
-                             "and {analyzer} are special values which will "
-                             "be replaced with the current analyzer and "
-                             "source file name where the bug was found.")
+                             "same file, it may override some plist files. To "
+                             "prevent this we can generate a unique hash into "
+                             "the plist file names with this option. For "
+                             "example: "
+                             "'{source_file}_{analyzer}_{file_hash}_xxxxx'. "
+                             "{source_file}, {analyzer} and {file_hash} are "
+                             "special values which will be replaced with the "
+                             "current analyzer, source file name and hash of "
+                             "the absolute file path where the bug was "
+                             "found. ")
 
     parser.add_argument('-c', '--clean',
                         dest="clean",

--- a/tools/report-converter/tests/functional/cmdline/test_cmdline.py
+++ b/tools/report-converter/tests/functional/cmdline/test_cmdline.py
@@ -10,6 +10,7 @@
 This module tests the report-converter tool.
 """
 
+import glob
 import json
 import os
 import subprocess
@@ -38,6 +39,9 @@ class TestCmdline(unittest.TestCase):
                                    'analyzer_version=' + analyzer_version,
                                    'analyzer_command=' + analyzer_command])
             self.assertEqual(0, ret)
+
+            self.assertEqual(
+                len(glob.glob(os.path.join(tmp_dir, '*.plist'))), 2)
 
             metadata_file = os.path.join(tmp_dir, "metadata.json")
             self.assertTrue(os.path.exists(metadata_file))

--- a/tools/report-converter/tests/functional/cmdline/test_files/Makefile
+++ b/tools/report-converter/tests/functional/cmdline/test_files/Makefile
@@ -1,2 +1,2 @@
 all:
-	golint ./files/simple.go > simple.out
+	golint ./files/simple.go ./files/b/simple.go > simple.out

--- a/tools/report-converter/tests/functional/cmdline/test_files/files/b/simple.go
+++ b/tools/report-converter/tests/functional/cmdline/test_files/files/b/simple.go
@@ -1,0 +1,5 @@
+package pgk
+
+type T2 int
+
+var Y2, Z2 int

--- a/tools/report-converter/tests/functional/cmdline/test_files/simple.out
+++ b/tools/report-converter/tests/functional/cmdline/test_files/simple.out
@@ -1,2 +1,4 @@
 ./files/simple.go:3:6: exported type T should have comment or be unexported
 ./files/simple.go:5:5: exported var Z should have its own declaration
+./files/b/simple.go:3:6: exported type T2 should have comment or be unexported
+./files/b/simple.go:5:5: exported var Z2 should have its own declaration

--- a/tools/report-converter/tests/unit/analyzers/test_asan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_asan_parser.py
@@ -52,7 +52,8 @@ class ASANAnalyzerResultTestCase(unittest.TestCase):
     def test_asan(self):
         """ Test for the asan.plist file. """
         self.analyzer_result.transform(
-            'asan.out', self.cc_result_dir, plist.EXTENSION)
+            'asan.out', self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         with open('asan.plist', mode='rb') as pfile:
             exp = plistlib.load(pfile)

--- a/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
@@ -54,7 +54,8 @@ class ClangTidyAnalyzerResultTestCase(unittest.TestCase):
                                 source_files, expected_plist):
         """ Check the result of the analyzer transformation. """
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir, analyzer_result_plist)
         with open(plist_file, mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/analyzers/test_coccinelle_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_coccinelle_parser.py
@@ -43,7 +43,8 @@ class CoccinelleAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -51,14 +52,16 @@ class CoccinelleAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'sample.c_coccinelle.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_cppcheck_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_cppcheck_parser.py
@@ -59,7 +59,8 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
                                        'divide_zero.cpp')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_no_plist_dir(self):
@@ -67,7 +68,8 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'non_existing')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
@@ -75,7 +77,8 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(
             self.test_files, 'out', 'divide_zero.plist')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'divide_zero.cpp_cppcheck.plist')
@@ -99,7 +102,8 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming a directory of plist files. """
         analyzer_result = os.path.join(self.test_files, 'out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'divide_zero.cpp_cppcheck.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_cpplint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_cpplint_parser.py
@@ -42,7 +42,8 @@ class CpplintAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.cpp')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class CpplintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'sample.cpp_cpplint.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_eslint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_eslint_parser.py
@@ -42,7 +42,8 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
                                        'index.js')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'reports.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'index.js_eslint.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_golint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_golint_parser.py
@@ -42,7 +42,8 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.go')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'simple.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'simple.go_golint.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_infer_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_infer_parser.py
@@ -57,7 +57,8 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'infer-out-dead_store')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
         plist_file = os.path.join(self.cc_result_dir,
@@ -85,7 +86,8 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'report.json')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
         plist_file = os.path.join(self.cc_result_dir,
@@ -112,7 +114,8 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'infer-out-null_dereference')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
         plist_file = os.path.join(self.cc_result_dir,
@@ -141,7 +144,8 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'report.json')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_kerneldoc_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_kerneldoc_parser.py
@@ -43,7 +43,8 @@ class KernelDocAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -51,14 +52,16 @@ class KernelDocAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'sample.c_kernel-doc.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_lsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_lsan_parser.py
@@ -55,7 +55,8 @@ class LSANPListConverterTestCase(unittest.TestCase):
     def test_san(self):
         """ Test for the lsan.plist file. """
         self.analyzer_result.transform(
-            'lsan.out', self.cc_result_dir, plist.EXTENSION)
+            'lsan.out', self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         with open('lsan.plist', mode='rb') as pfile:
             exp = plistlib.load(pfile)

--- a/tools/report-converter/tests/unit/analyzers/test_mdl_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_mdl_parser.py
@@ -42,7 +42,8 @@ class MarkdownlintAnalyzerResultTestCase(unittest.TestCase):
                                        'readme.md')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class MarkdownlintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'readme.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'readme.md_mdl.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_msan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_msan_parser.py
@@ -54,7 +54,8 @@ class MSANPListConverterTestCase(unittest.TestCase):
     def test_msan(self):
         """ Test for the msan.plist file. """
         self.analyzer_result.transform(
-            'msan.out', self.cc_result_dir, plist.EXTENSION)
+            'msan.out', self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         with open('msan.plist', mode='rb') as pfile:
             exp = plistlib.load(pfile)

--- a/tools/report-converter/tests/unit/analyzers/test_pyflakes_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_pyflakes_parser.py
@@ -42,7 +42,8 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.py')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'simple.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'simple.py_pyflakes.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_pylint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_pylint_parser.py
@@ -42,7 +42,8 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.py')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single json file. """
         analyzer_result = os.path.join(self.test_files, 'simple.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'simple.py_pylint.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_smatch_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_smatch_parser.py
@@ -41,7 +41,8 @@ class SmatchAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -49,14 +50,16 @@ class SmatchAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'sample.c_smatch.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_sparse_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_sparse_parser.py
@@ -41,7 +41,8 @@ class SparseAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -49,14 +50,16 @@ class SparseAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         for test_file in ['sample.c', 'sample.h']:
             # Test sample.c plist file

--- a/tools/report-converter/tests/unit/analyzers/test_sphinx_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_sphinx_parser.py
@@ -42,7 +42,8 @@ class SphinxResultTestCase(unittest.TestCase):
                                        'sample.rst')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class SphinxResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'sample.rst_sphinx.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_spotbugs_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_spotbugs_parser.py
@@ -58,7 +58,8 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
                                        'Assign.java')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_parsing_dir(self):
@@ -66,14 +67,16 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'files')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'assign.xml')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'Assign.java_spotbugs.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_tsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_tsan_parser.py
@@ -54,7 +54,8 @@ class TSANAnalyzerResultTestCase(unittest.TestCase):
     def test_tsan(self):
         """ Test for the tsan.plist file. """
         self.analyzer_result.transform(
-            'tsan.out', self.cc_result_dir, plist.EXTENSION)
+            'tsan.out', self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         with open('tsan.plist', mode='rb') as pfile:
             exp = plistlib.load(pfile)

--- a/tools/report-converter/tests/unit/analyzers/test_tslint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_tslint_parser.py
@@ -42,7 +42,8 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
                                        'index.ts')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_dir(self):
@@ -50,14 +51,16 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
     def test_transform_single_file(self):
         """ Test transforming single json file. """
         analyzer_result = os.path.join(self.test_files, 'reports.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
                                   'index.ts_tslint.plist')

--- a/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
@@ -55,7 +55,8 @@ class UBSANPListConverterTestCase(unittest.TestCase):
                                 source_files, expected_plist):
         """ Check the result of the analyzer transformation. """
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION)
+            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir, analyzer_result_plist)
         with open(plist_file, mode='rb') as pfile:


### PR DESCRIPTION
This makes the filenames of plist format reports generated by
report-converter include the names of the parent and grandparent
directories as well as the filename, since before if two different
plist files had the same name there was only one of the reports in
the database. Fixes #3436 .