### PR TITLE
[fix] Fix ldlogger escaping a bunch of characters

### DIFF
--- a/analyzer/tools/build-logger/tests/unit/test_escaping.py
+++ b/analyzer/tools/build-logger/tests/unit/test_escaping.py
@@ -3,7 +3,6 @@
 import json
 import os
 import tempfile
-import unittest
 from . import BasicLoggerTest, empty_env, run_command, REPO_ROOT
 
 
@@ -159,9 +158,6 @@ int main() {
             if os.path.isfile(file):
                 os.remove(file)
 
-    # Currently we don't escape correctly:
-    # '\a', '\e', '\t', '\t', '\b', '\f', '\r', '\v', '\n'.
-    @unittest.expectedFailure
     def test_control_characters(self):
         """
         Test if control-characters are escaped.
@@ -195,9 +191,6 @@ int main() {
             file=file,
         )
 
-    # Currently we don't escape correctly:
-    # '\a', '\e', '\t', '\t', '\b', '\f', '\r', '\v', '\n'.
-    @unittest.expectedFailure
     def test_control_characters2(self):
         """
         Test the more esoteric control-characters.


### PR DESCRIPTION
Affected characters:
'\a', '\e', '\t', '\t', '\b', '\f', '\r', '\v', '\n'
And any other control characters between ASCII 0-32.

Keep in mind that we still don't escape Unicode characters.

For reference I recommend the LLVM's implementation:
https://github.com/llvm/llvm-project/blob/ce8022faa365e0a48c2d77085d67bd9800bedb0a/llvm/lib/Support/YAMLParser.cpp#L682-L746
Which is called from https://github.com/llvm/llvm-project/blob/ce8022faa365e0a48c2d77085d67bd9800bedb0a/clang/lib/Driver/ToolChains/Clang.cpp#L2371