### PR TITLE
Fix 'make: warning: jobserver unavailable: using -j1'

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -41,7 +41,8 @@ def execute_buildcmd(command, silent=False, env=None, cwd=None):
         shell=True,
         universal_newlines=True,
         encoding="utf-8",
-        errors="ignore")
+        errors="ignore",
+        close_fds=False)
 
     while True:
         line = proc.stdout.readline()

--- a/bin/CodeChecker
+++ b/bin/CodeChecker
@@ -55,7 +55,8 @@ def run_codechecker(checker_env, subcommand=None):
     proc = subprocess.Popen(checker_cmd,
                             encoding="utf=8",
                             errors="ignore",
-                            env=checker_env)
+                            env=checker_env,
+                            close_fds=False)
     global proc_pid
     proc_pid = proc.pid
 


### PR DESCRIPTION
In a project with CodeChecker, the 'make' utility prints the warning 'gmake[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule." and builds in one thread.
This happens because the "main" make calls the bash script, which calls the CodeChecker, which calls make again.
Like this: [make -j32] -> [bash_script.sh] -> [CodeChecker log -o "$tmp_log" -b "$make_cmd"] -> [make]
It was found that the CodeChecker closes the file descriptors required for make jobserver.
(MAKEFLAGS=' --jobserver-fds=3,4 -j --')
Adding the 'close_fds=False' argument to 'subprocess.Popen' solves this issue.