### PR TITLE
[fix] Fix HTML generation for CodeChecker cmd diff command

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1115,7 +1115,7 @@ def handle_diff_results(args):
                 LOG.info("Generating HTML output files to file://%s "
                          "directory:", output_dir)
 
-                for file_path in file_report_map:
+                for file_path, file_reports in file_report_map.items():
                     file_name = os.path.basename(file_path)
                     h = int(
                         hashlib.md5(
@@ -1124,7 +1124,7 @@ def handle_diff_results(args):
 
                     output_file_path = os.path.join(
                         output_dir, f"{file_name}_ {str(h)}.html")
-                    html_builder.create(output_file_path, reports)
+                    html_builder.create(output_file_path, file_reports)
 
             if output_format in ['csv', 'rows', 'table']:
                 header = ['File', 'Checker', 'Severity', 'Msg', 'Source']

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -244,6 +244,15 @@ class LocalRemote(unittest.TestCase):
 
             self.assertIn(file_name, checked_files)
 
+        # Check reports in the index.html file.
+        index_html = os.path.join(html_reports, 'index.html')
+        divide_zero_count = 0
+        with open(index_html, 'r', encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if re.search("core.DivideZero", line):
+                    divide_zero_count += 1
+        self.assertEqual(divide_zero_count, 10)
+
     def test_different_basename_types(self):
         """ Test different basename types.
 


### PR DESCRIPTION
If the diff contained reports from multiple source files (e.g.: a.cpp + b.cpp)
the `CodeChecker cmd diff` command in HTML format generated HTML files for
each source file but inserted the same list of reports in all of the HTML files.

This can be easily reproduced by creating two source files and insert a report in both
of the source file. Create a compilation database with 2 translation units, analyze
this project and use the diff command to generate HTML output files to a run which is
empty.

This patch will solve this problem and will insert only those reports to a generated
HTML files which are really related to that file.