### PR TITLE
[analyze] Proper exit code for CodeChecker check in case of exception

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -780,6 +780,7 @@ def main(args):
         os.makedirs(output_dir)
 
     logfile = None
+    analysis_exit_status = 1  # CodeChecker error.
     try:
         # --- Step 1.: Perform logging if build command was specified.
         if 'command' in args:


### PR DESCRIPTION
If some exception happens during the `CodeChecker check` command we
will get the following exception:
```
UnboundLocalError: local variable 'analysis_exit_status' referenced before assignment
```

This commit solves this problem and initialize this variable to `1` which
identifies a CodeChecker error.