### PR TITLE
Prefer ldlogger over intercept-build

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -76,53 +76,63 @@ def perform_build_command(logfile, command, context, keep_link, silent=False,
                     'using a current copy for logging.')
         original_env = os.environ.copy()
 
-    # Run user's commands with intercept.
-    if host_check.check_intercept(original_env):
+    # Run user's commands in shell, and preload ldlogger.
+    # TODO: better platform detection.
+    if host_check.check_ldlogger(os.environ) and platform.system() == 'Linux':
+        LOG.info("Using CodeChecker ld-logger.")
+
+        # Same as linux's touch.
+        open(logfile, 'a', encoding="utf-8", errors="ignore").close()
+        log_env = env.get_log_env(logfile, context, original_env)
+        if 'CC_LOGGER_GCC_LIKE' not in log_env:
+            log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:cc:c++'
+        if keep_link or ('CC_LOGGER_KEEP_LINK' in log_env and
+                         log_env['CC_LOGGER_KEEP_LINK'] == 'true'):
+            log_env['CC_LOGGER_KEEP_LINK'] = 'true'
+
+        is_debug = verbose and verbose in ['debug', 'debug_analyzer']
+        if not is_debug and 'CC_LOGGER_DEBUG_FILE' in log_env:
+            del log_env['CC_LOGGER_DEBUG_FILE']
+        elif is_debug and 'CC_LOGGER_DEBUG_FILE' not in log_env:
+            if 'CC_LOGGER_DEBUG_FILE' in os.environ:
+                log_file = os.environ['CC_LOGGER_DEBUG_FILE']
+            else:
+                log_file = os.path.join(os.path.dirname(logfile),
+                                        'codechecker.logger.debug')
+
+            if os.path.exists(log_file):
+                os.remove(log_file)
+
+            log_env['CC_LOGGER_DEBUG_FILE'] = log_file
+    elif host_check.check_intercept(os.environ):
         LOG.info("Using intercept-build.")
-        final_command = command
         command = ' '.join(["intercept-build",
                             "--cdb", logfile,
-                            "sh -c", shlex.quote(final_command)])
+                            "sh -c", shlex.quote(command)])
         log_env = original_env
         LOG.debug_analyzer(command)
-
-    # Run user's commands in shell.
     else:
-        # TODO: better platform detection.
+        # Print a helpful diagnostic.
         if platform.system() == 'Linux':
-            LOG.info("Using CodeChecker ld-logger.")
-            # Same as linux's touch.
-            open(logfile, 'a', encoding="utf-8", errors="ignore").close()
-            log_env = env.get_log_env(logfile, context, original_env)
-            if 'CC_LOGGER_GCC_LIKE' not in log_env:
-                log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:cc:c++'
-            if keep_link or ('CC_LOGGER_KEEP_LINK' in log_env and
-                             log_env['CC_LOGGER_KEEP_LINK'] == 'true'):
-                log_env['CC_LOGGER_KEEP_LINK'] = 'true'
-
-            is_debug = verbose and verbose in ['debug', 'debug_analyzer']
-            if is_debug and 'CC_LOGGER_DEBUG_FILE' not in log_env:
-                if 'CC_LOGGER_DEBUG_FILE' in os.environ:
-                    log_file = os.environ['CC_LOGGER_DEBUG_FILE']
-                else:
-                    log_file = os.path.join(os.path.dirname(logfile),
-                                            'codechecker.logger.debug')
-
-                if os.path.exists(log_file):
-                    os.remove(log_file)
-
-                log_env['CC_LOGGER_DEBUG_FILE'] = log_file
-        elif platform.system() == 'Windows':
+            LOG.error("Both ldlogger and intercept-build are unavailable.\n"
+                      "Try acquiring the compilation_commands.json in another "
+                      "way.\n"
+                      "Install ldlogger or intercept-build to proceed.")
+            sys.exit(1)
+        if platform.system() == 'Windows':
             LOG.error("This command is not supported on Windows. You can use "
                       "the following tools to generate a compilation "
                       "database: \n"
                       " - CMake (CMAKE_EXPORT_COMPILE_COMMANDS)\n"
                       " - compiledb (https://pypi.org/project/compiledb/)")
             sys.exit(1)
-        else:
+        if platform.system() == 'Darwin':
             LOG.error("Intercept-build is required to run CodeChecker in "
                       "OS X.")
             sys.exit(1)
+        LOG.error("Unrecognized platform. Open a GitHub issue for further "
+                  "guidance.")
+        sys.exit(1)
 
     LOG.debug_analyzer(log_env)
     try:

--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -20,6 +20,7 @@ import os
 from codechecker_analyzer import analyzer_context
 from codechecker_analyzer.buildlog import build_manager
 from codechecker_analyzer.buildlog.host_check import check_intercept
+from codechecker_analyzer.buildlog.host_check import check_ldlogger
 
 from codechecker_common import arg, logger
 
@@ -64,12 +65,14 @@ def get_argparser_ctor_args():
     argparse.ArgumentParser (either directly or as a subparser).
     """
 
-    is_intercept = check_intercept(os.environ)
+    # Prefer using ldlogger over intercept-build.
+    is_ldlogger = check_ldlogger(os.environ)
+    is_intercept = False if is_ldlogger else check_intercept(os.environ)
     ldlogger_settings = """
 ld-logger can be fine-tuned with some environment variables. For details see
 the following documentation:
 https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/
-build-logger/README.md#usage""" if not is_intercept else ""
+build-logger/README.md#usage""" if not is_ldlogger else ""
 
     return {
         'prog': 'CodeChecker log',


### PR DESCRIPTION
> Closes #1091

1st check if LDlogger is available and use that.
2nd check if intercept-build is available and use that.
3rd Otherwise report an error.