### PR TITLE
[cmd] Fix html generation for report directory without plists

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -395,8 +395,13 @@ def main(args):
     changed_files: Set[str] = set()
     processed_path_hashes = set()
     processed_file_paths = set()
-    html_builder: Optional[report_to_html.HtmlBuilder] = None
     print_steps = 'print_steps' in args
+
+    html_builder: Optional[report_to_html.HtmlBuilder] = None
+    if export == 'html':
+        html_builder = report_to_html.HtmlBuilder(
+            context.path_plist_to_html_dist,
+            context.checker_labels)
 
     for dir_path, file_paths in report_file.analyzer_result_files(args.input):
         metadata = get_metadata(dir_path)
@@ -427,11 +432,6 @@ def main(args):
                 plaintext.convert(
                     file_report_map, processed_file_paths, print_steps)
             elif export == 'html':
-                if not html_builder:
-                    html_builder = report_to_html.HtmlBuilder(
-                        context.path_plist_to_html_dist,
-                        context.checker_labels)
-
                 print(f"Parsing input file '{file_path}'.")
                 report_to_html.convert(
                     file_path, reports, output_dir_path,

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -409,6 +409,25 @@ class AnalyzeParseTestCase(
         self.assertTrue('Summary' in out)
         self.assertTrue('Statistics' in out)
 
+    def test_html_output_for_empty_dir(self):
+        """ Test parse HTML output for an empty directory. """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = os.path.join(self.test_workspaces['OUTPUT'], 'html')
+            extract_cmd = [
+                'CodeChecker', 'parse',
+                '-e', 'html',
+                '-o', output_path,
+                tmp_dir]
+
+            out, err, result = call_command(
+                extract_cmd, cwd=self.test_dir, env=self.env)
+            self.assertEqual(result, 0)
+            self.assertFalse(err)
+
+            self.assertTrue('Summary' in out)
+            self.assertFalse('Html file was generated' in out)
+            self.assertFalse('Statistics' in out)
+
     def test_codeclimate_export(self):
         """ Test exporting codeclimate output. """
         test_project_notes = os.path.join(self.test_workspaces['NORMAL'],


### PR DESCRIPTION
> Closes #3606

Fix HTML generation for report directory which doesn't contain any analyzer result (plist) file.