### PR TITLE
[clang-tidy][cfg] Remove an alias from the extreme profile

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -4624,7 +4624,6 @@
     ],
     "cppcoreguidelines-narrowing-conversions": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-narrowing-conversions.html",
-      "profile:extreme",
       "severity:MEDIUM"
     ],
     "cppcoreguidelines-no-malloc": [


### PR DESCRIPTION
It seems like that `bugprone-narrowing-conversions` check is the same as
the `cppcoreguidelines-narrowing-conversions` check.

Check this:
https://github.com/llvm/llvm-project/blob/c63522e6ba7782c335043893ae7cbd37eca24fe5/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp#L136-L137

It seems like both of these checks were included in the `extreme`
profile, thus each of these reports were duplicated basically.

Hereby I'm proposing to keep only one of them in the profile to
workaround this issue.

According to Compiler Explorer, clang-tidy reports these issues only
once, with the `[check,alias,alias...]` schema, thus it does the right
thing. However, PR #3238 introduced a logic that splits these reports
into individual reports.

I'm not sure if that is the right way of dealing with check aliases, but
we definitely need something more robust than including/excluding checks
from profiles.