### PR TITLE
docs: fix bullets in usage.md visualizable

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,7 @@ used in the later sections to show CodeChecker usage.
 
 ## Step 0: <a name="step-0"></a>
 There are some prerequisite to successfully take this example:
+
 - [Install](README.md/#install-guide) CodeChecker. 
 - Install analyzer binaries: `clang` / `clang-tidy` (on debian based systems update-alternatives is your friend).
 - Install `gcc` and `make` to compile our example project.


### PR DESCRIPTION
This PR fixes the following page (https://codechecker.readthedocs.io/en/latest/usage/)

<img width="825" alt="image" src="https://user-images.githubusercontent.com/436237/157167632-79e86565-5d9a-4f23-abfc-f911b363a4ad.png">

as follows:

<img width="793" alt="image" src="https://user-images.githubusercontent.com/436237/157167681-c5daf3e3-4a2d-4543-bb52-6845a6d8e381.png">
