### PR TITLE
[bugfix] Disappearing --stats flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -66,7 +66,8 @@ def is_statistics_capable(context):
     check_env = env.extend(context.path_env_extra,
                            context.ld_lib_path_extra)
 
-    checkers = ClangSA.get_analyzer_checkers(clangsa_cfg, check_env)
+    checkers = ClangSA.get_analyzer_checkers(
+        clangsa_cfg, check_env, True, True)
 
     stat_checkers_pattern = re.compile(r'.+statisticscollector.+')
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -145,13 +145,15 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     def get_analyzer_checkers(
         cls,
         cfg_handler: config_handler.ClangSAConfigHandler,
-        environ: Dict[str, str]
+        environ: Dict[str, str],
+        alpha: bool = True,
+        debug: bool = False
     ) -> List[str]:
         """Return the list of the supported checkers."""
         checker_list_args = clang_options.get_analyzer_checkers_cmd(
             cfg_handler,
-            alpha=True,
-            debug=False)
+            alpha=alpha,
+            debug=debug)
         return parse_clang_help_page(checker_list_args, 'CHECKERS:', environ)
 
     @classmethod

--- a/web/tests/functional/statistics/test_statistics.py
+++ b/web/tests/functional/statistics/test_statistics.py
@@ -10,6 +10,7 @@
 """ statistics collector feature test.  """
 
 
+from distutils import util
 import os
 import unittest
 import shlex
@@ -47,6 +48,13 @@ class TestSkeleton(unittest.TestCase):
         self.stats_capable = '--stats' in output
         print("'analyze' reported statistics collector-compatibility? " +
               str(self.stats_capable))
+
+        if not self.stats_capable:
+            try:
+                self.stats_capable = bool(util.strtobool(
+                    os.environ['CC_TEST_FORCE_STATS_CAPABLE']))
+            except (ValueError, KeyError):
+                pass
 
         test_project_path = self._testproject_data['project_path']
         test_project_build = shlex.split(self._testproject_data['build_cmd'])


### PR DESCRIPTION
CodeChecker analyze command has --stats flag if there is at least one
checker contating "statisticsbased" in its name. We are using the
checker listing function to determine the list of checkers but by
default it excludes modeling checkers. This default behavior should be
overridden when checking if underlying Clang supports statistics based
checkers.