### PR TITLE
add -sdkroot option to COMPILE_FLAGS structure

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -213,6 +213,7 @@ COMPILE_OPTIONS = [
     '-m',
     '-Wno-',
     '--sysroot=',
+    '-sdkroot',
     '--gcc-toolchain='
 ]
 
@@ -220,6 +221,7 @@ COMPILE_OPTIONS = re.compile('|'.join(COMPILE_OPTIONS))
 
 COMPILE_OPTIONS_MERGED = [
     '--sysroot',
+    '-sdkroot',
     '--include',
     '-include',
     '-iquote',


### PR DESCRIPTION
A special downstream compiler duplicated the --sysroot option, and
CodeChecker is not aware of the option chosen by this downstream
compiler. Adding these entries enables CodeChecker to not drop or strip
the arguments to this option when interpreted and driven from a
compile_commands.json file.