### PR TITLE
[analyzer] Fix uniqueing compilation commands

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1297,8 +1297,8 @@ def parse_unique_log(compilation_database,
             if action.action_type != BuildAction.COMPILE:
                 continue
             if build_action_uniqueing == CompileActionUniqueingType.NONE:
-                if action.__hash__ not in uniqued_build_actions:
-                    uniqued_build_actions[action.__hash__] = action
+                if action not in uniqued_build_actions:
+                    uniqued_build_actions[action] = action
             elif build_action_uniqueing == CompileActionUniqueingType.STRICT:
                 if action.source not in uniqued_build_actions:
                     uniqued_build_actions[action.source] = action

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -292,7 +292,7 @@ def add_arguments_to_parser(parser):
                              "compilation target. "
                              "If none of the above given, "
                              "this parameter should "
-                             "be a python regular expression."
+                             "be a python regular expression. "
                              "If there is more than one compilation action "
                              "for a source, "
                              "only the one is kept which matches the "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -221,7 +221,7 @@ used to generate a log file on the fly.""")
                              "compilation target. "
                              "If none of the above given, "
                              "this parameter should "
-                             "be a python regular expression."
+                             "be a python regular expression. "
                              "If there is more than one compilation action "
                              "for a source, "
                              "only the one is kept which matches the "

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -608,10 +608,20 @@ class TestAnalyze(unittest.TestCase):
 
         self.assertIn("Dereference of null pointer", out)
 
-    def unique_json_helper(self, unique_json, is_a, is_b, is_s):
-        with open(unique_json,
+    def check_unique_compilation_db(
+        self,
+        compilation_db_file_path: str,
+        num_of_compile_commands: int,
+        is_a: bool,
+        is_b: bool,
+        is_s: bool
+    ):
+        """ """
+        with open(compilation_db_file_path,
                   encoding="utf-8", errors="ignore") as json_file:
             data = json.load(json_file)
+            self.assertEqual(len(data), num_of_compile_commands)
+
             simple_a = False
             simple_b = False
             success = False
@@ -647,6 +657,10 @@ class TestAnalyze(unittest.TestCase):
                       " -Iincludes -o simple_a.o",
                       "file": source_file},
                      {"directory": self.test_dir,
+                      "command": "cc -c " + source_file +
+                      " -Iincludes -o simple_a.o",
+                      "file": source_file},
+                     {"directory": self.test_dir,
                       "command": "cc -c " + source_file2 +
                       " -Iincludes -o success.o",
                       "file": source_file2}]
@@ -673,7 +687,7 @@ class TestAnalyze(unittest.TestCase):
         self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
 
-        self.unique_json_helper(unique_json, True, False, True)
+        self.check_unique_compilation_db(unique_json, 2, True, False, True)
 
         # Testing regex mode.
         analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
@@ -692,7 +706,7 @@ class TestAnalyze(unittest.TestCase):
         self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
 
-        self.unique_json_helper(unique_json, False, True, True)
+        self.check_unique_compilation_db(unique_json, 2, False, True, True)
 
         # Testing regex mode.error handling
         analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
@@ -748,7 +762,7 @@ class TestAnalyze(unittest.TestCase):
         errcode = process.returncode
         self.assertEqual(errcode, 0)
         self.assertFalse(os.path.isdir(failed_dir))
-        self.unique_json_helper(unique_json, True, True, True)
+        self.check_unique_compilation_db(unique_json, 3, True, True, True)
 
     def test_invalid_enabled_checker_name(self):
         """Warn in case of an invalid enabled checker."""

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -161,7 +161,7 @@ optional arguments:
                         compilation action for a source file, only the one is
                         kept that belongs to the alphabetically first
                         compilation target. If none of the above given, this
-                        parameter should be a python regular expression.If
+                        parameter should be a python regular expression. If
                         there is more than one compilation action for a
                         source, only the one is kept which matches the given
                         python regex. If more than one matches an error is
@@ -916,7 +916,7 @@ optional arguments:
                         compilation action for a source file, only the one is
                         kept that belongs to the alphabetically first
                         compilation target. If none of the above given, this
-                        parameter should be a python regular expression.If
+                        parameter should be a python regular expression. If
                         there is more than one compilation action for a
                         source, only the one is kept which matches the given
                         python regex. If more than one matches an error is


### PR DESCRIPTION
We are storing unique compilation actions in a map which uses the overriden
`__hash__` and `__eq__` methods on the `BuildAction` class.

For this we used the following logic:

```py
if action.__hash__ not in uniqued_build_actions:
    uniqued_build_actions[action.__hash__] = action
```

In this case we didn't called the function but we checked whether the
function is in the map. Before `Python 3.9` this solution somehow worked
but in later Python versions it will not unique compilation actions properly.

To solve this problem we will use the following logic:

```py
if action not in uniqued_build_actions:
    uniqued_build_actions[action] = action
```

Under the hood the Python interpreter will call the overriden dunder functions.