### PR TITLE
Pin the number of jobs in some Make targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         working-directory: analyzer/tools/build-logger
         run: |
           pip install -r requirements_py/dev/requirements.txt
+          make all
           make test
 
       - name: Run merge-clang-extdef-mappings tests

--- a/analyzer/tools/build-logger/tests/Makefile
+++ b/analyzer/tools/build-logger/tests/Makefile
@@ -5,9 +5,9 @@ REPO_ROOT ?= REPO_ROOT=$(ROOT)
 # Nose test runner configuration options.
 NOSECFG = --config .noserc
 
-test: all pycodestyle pylint test_unit
+test: pycodestyle pylint test_unit
 
-test_in_env: all pycodestyle_in_env pylint_in_env test_unit_in_env
+test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env
 
 PYCODESTYLE_TEST_CMD = pycodestyle tests/unit
 


### PR DESCRIPTION
If someone runs `make -j16 test_unit test_analyzer test_web_sqlite`,
then the command would spuriously fail due to a filesystem race-condition.

The `cp ldlogger build/bin` would basically try to copy a not-yet-existing file,
causing a failure immediately, or later in the test pipeline, when it
exercises the logger. Causing an error similar to this:
```
make[1]: Leaving directory `codechecker/analyzer'
make: *** [test_analyzer] Error 2
make: *** Waiting for unfinished jobs....
```

Let's work around the issue by omitting the `all` target from the `test*` targets.
This way if it's already built, tests should just pass.