### PR TITLE
[web] Fix exceptions during blame information storage

### DIFF
--- a/web/client/codechecker_client/blame_info.py
+++ b/web/client/codechecker_client/blame_info.py
@@ -16,6 +16,27 @@ LOG = get_logger('system')
 FileBlameInfo = Dict[str, Optional[Dict]]
 
 
+def __get_tracking_branch(repo: Repo) -> Optional[str]:
+    """
+    Get the tracking branch name or the current commit hash from the given
+    repository.
+    """
+    try:
+        # If a commit is checked out, accessing the active_branch member will
+        # throw an error.
+        return str(repo.active_branch.tracking_branch())
+    except Exception:
+        pass
+
+    try:
+        # Use the current commit hash if it's available.
+        return repo.head.commit.hexsha
+    except Exception:
+        pass
+
+    return None
+
+
 def __get_blame_info(file_path: str):
     """ Get blame info for the given file. """
     try:
@@ -23,19 +44,13 @@ def __get_blame_info(file_path: str):
     except InvalidGitRepositoryError:
         return
 
-    tracking_branch = None
-    try:
-        # If a commit is checked out, accessing the active_branch member will
-        # throw a type error. In this case we will use the current commit hash.
-        tracking_branch = str(repo.active_branch.tracking_branch())
-    except TypeError:
-        tracking_branch = repo.head.commit.hexsha
+    tracking_branch = __get_tracking_branch(repo)
 
     remote_url = None
     try:
         # Handle the use case when a repository doesn't have a remote url.
         remote_url = next(repo.remote().urls, None)
-    except ValueError:
+    except Exception:
         pass
 
     try:


### PR DESCRIPTION
The python git library may throw not only `TypeError` exceptions but
`ValueError` exceptions as well. For example when the `HEAD` file exists
in the `.git` directory but the user who is running the `CodeChecker store`
command doesn't have permission to this file.

To solve this problem we will catch all the exceptions when getting the
tracking branch and remote url.