### PR TITLE
[test] Environment variable on forcing ctu related tests

### DIFF
--- a/analyzer/tests/functional/ctu/test_ctu.py
+++ b/analyzer/tests/functional/ctu/test_ctu.py
@@ -18,7 +18,8 @@ from subprocess import run
 from typing import IO
 
 from libtest import env
-from libtest.codechecker import call_command
+from libtest.codechecker import call_command, is_ctu_capable, \
+    is_ctu_on_demand_capable
 from libtest.ctu_decorators import makeSkipUnlessCTUCapable, \
     makeSkipUnlessCTUOnDemandCapable
 
@@ -53,11 +54,11 @@ class TestCtu(unittest.TestCase):
         cmd = [self._codechecker_cmd, 'analyze', '-h']
         output, _, result = call_command(cmd, cwd=self.test_dir, env=self.env)
         self.assertEqual(result, 0, "Analyzing failed.")
-        setattr(self, CTU_ATTR, '--ctu-' in output)
+        setattr(self, CTU_ATTR, is_ctu_capable(output))
         print("'analyze' reported CTU-compatibility? " +
               str(getattr(self, CTU_ATTR)))
 
-        setattr(self, ON_DEMAND_ATTR, '--ctu-ast-mode' in output)
+        setattr(self, ON_DEMAND_ATTR, is_ctu_on_demand_capable(output))
         print("'analyze' reported CTU-on-demand-compatibility? " +
               str(getattr(self, ON_DEMAND_ATTR)))
 

--- a/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
+++ b/analyzer/tests/functional/ctu_failure/test_ctu_failure.py
@@ -15,11 +15,10 @@ import shutil
 import unittest
 import zipfile
 
-from codechecker_analyzer import host_check
-
 from libtest import env
 from libtest import project
-from libtest.codechecker import call_command
+from libtest.codechecker import call_command, is_ctu_capable, \
+    is_ctu_on_demand_capable, is_ctu_display_progress_capable
 from libtest.ctu_decorators import makeSkipUnlessCTUCapable, \
     makeSkipUnlessCTUOnDemandCapable, makeSkipUnlessCTUDisplayCapable
 
@@ -57,17 +56,17 @@ class TestCtuFailure(unittest.TestCase):
         output, _, result = call_command(cmd, cwd=self.test_workspace,
                                          env=self.env)
         self.assertEqual(result, 0, "Analyzing failed.")
-        setattr(self, CTU_ATTR, '--ctu-' in output)
+        setattr(self, CTU_ATTR, is_ctu_capable(output))
         print("'analyze' reported CTU compatibility? " +
               str(getattr(self, CTU_ATTR)))
 
-        setattr(self, ON_DEMAND_ATTR, '--ctu-ast-mode' in output)
+        setattr(self, ON_DEMAND_ATTR, is_ctu_on_demand_capable(output))
         print("'analyze' reported CTU-on-demand-compatibility? " +
               str(getattr(self, ON_DEMAND_ATTR)))
 
         setattr(self, DISPLAY_PROGRESS_ATTR,
-                host_check.has_analyzer_config_option(
-                    self.__getClangSaPath(), 'display-ctu-progress', self.env))
+                is_ctu_display_progress_capable(
+                    self.__getClangSaPath(), self.env))
 
         print("Has display-ctu-progress=true? " +
               str(getattr(self, DISPLAY_PROGRESS_ATTR)))


### PR DESCRIPTION
CTU related tests should be forced in an environment which contains
an underlying Clang that supports this feature. Automatic detection
is not enough because there may be a bug in the automatic
detection itself.