### PR TITLE
[config][CLI] Merge, and don't override when multiple --analyzer-configs are specified

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -362,7 +362,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             LOG.debug_analyzer(aerr)
 
         analyzer_config = {}
-        # TODO: This extra "isinsrance" check is needed for
+        # TODO: This extra "isinstance" check is needed for
         # CodeChecker analyzers --analyzer-config. This command also
         # runs this function in order to construct a config handler.
         if 'analyzer_config' in args and \
@@ -394,7 +394,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             del handler.analyzer_extra_arguments[i:i + arg_num]
             break
 
-        # TODO: This extra "isinsrance" check is needed for
+        # TODO: This extra "isinstance" check is needed for
         # CodeChecker checkers --checker-config. This command also
         # runs this function in order to construct a config handler.
         if 'checker_config' in args and isinstance(args.checker_config, list):

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -36,6 +36,38 @@ class OrderedCheckersAction(argparse.Action):
         if 'ordered_checkers' not in namespace:
             namespace.ordered_checkers = []
         ordered_checkers = namespace.ordered_checkers
+        # Map each checker to whether its enabled or not.
         ordered_checkers.append((value, self.dest == 'enable'))
 
         namespace.ordered_checkers = ordered_checkers
+
+
+class OrderedConfigAction(argparse.Action):
+    """
+    Action to store --analyzer-config and --checker-config values. These may
+    come from many sources, including the CLI, the CodeChecker config file,
+    the saargs file and the tidyargs file, or some other places.
+    """
+
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not '*':
+            raise ValueError("nargs must be '*' for backward compatibility "
+                             "reasons!")
+        super(OrderedConfigAction, self).__init__(option_strings, dest,
+                                                  nargs, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+
+        assert isinstance(value, list), \
+               f"--analyzer-config or --checker-config value ({value}) is " \
+               "not a list, but should be if nargs is not None!"
+
+        if not hasattr(namespace, self.dest):
+            setattr(namespace, self.dest, [])
+
+        dest = getattr(namespace, self.dest)
+
+        for flag in value:
+            if flag in dest:
+                dest.remove(flag)
+            dest.append(flag)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -26,7 +26,8 @@ from tu_collector import tu_collector
 
 from codechecker_analyzer import analyzer, analyzer_context, env
 from codechecker_analyzer.analyzers import analyzer_types, clangsa
-from codechecker_analyzer.arg import OrderedCheckersAction
+from codechecker_analyzer.arg import \
+        OrderedCheckersAction, OrderedConfigAction
 from codechecker_analyzer.buildlog import log_parser
 
 from codechecker_common import arg, logger, cmd_config
@@ -401,6 +402,7 @@ def add_arguments_to_parser(parser):
     analyzer_opts.add_argument('--analyzer-config',
                                dest='analyzer_config',
                                nargs='*',
+                               action=OrderedConfigAction,
                                default=["clang-tidy:HeaderFilterRegex=.*"],
                                help="Analyzer configuration options in the "
                                     "following format: analyzer:key=value. "
@@ -423,6 +425,7 @@ def add_arguments_to_parser(parser):
     analyzer_opts.add_argument('--checker-config',
                                dest='checker_config',
                                nargs='*',
+                               action=OrderedConfigAction,
                                default=argparse.SUPPRESS,
                                help="Checker configuration options in the "
                                     "following format: analyzer:key=value. "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -20,7 +20,8 @@ import tempfile
 
 from codechecker_analyzer import analyzer_context
 from codechecker_analyzer.analyzers import analyzer_types
-from codechecker_analyzer.arg import OrderedCheckersAction
+from codechecker_analyzer.arg import \
+        OrderedCheckersAction, OrderedConfigAction
 
 from codechecker_common import arg, cmd_config, logger
 from codechecker_report_converter.source_code_comment_handler import \
@@ -349,6 +350,7 @@ used to generate a log file on the fly.""")
     analyzer_opts.add_argument('--analyzer-config',
                                dest='analyzer_config',
                                nargs='*',
+                               action=OrderedConfigAction,
                                default=["clang-tidy:HeaderFilterRegex=.*"],
                                help="Analyzer configuration options in the "
                                     "following format: analyzer:key=value. "
@@ -371,6 +373,7 @@ used to generate a log file on the fly.""")
     analyzer_opts.add_argument('--checker-config',
                                dest='checker_config',
                                nargs='*',
+                               action=OrderedConfigAction,
                                default=argparse.SUPPRESS,
                                help="Checker configuration options in the "
                                     "following format: analyzer:key=value. "


### PR DESCRIPTION
Previous to this patch, multiple analyzer configs could be specified
like this:

CodeChecker analyze ./compile_commands.json -o ./reports -c --verbose debug \
  --analyzers clang-tidy \
  --analyzer-config clang-tidy:HeaderFilterRegex=".*" clang-tidy:AnalyzeTemporaryDtors="true"

However, if you specifiy --analyzer-config more than once, the only the
last one counts, like many other flags.

The problem is that --analyzer-config may be specified from both the CLI
and a CodeChecker config file, and even in this case, only one of these
would count.

Also, the -analyzer-config flag from the Clang Static Analyzer works
differently, as multiple -analyzer-configs in the invocation and
appended, not overwritten. Coming from that space, that philosophy feels
more intuitive to me, and I think other users might be just as surprised
by this behaviour.

This patch merges --analyzer-config (we append the list of configs)
values instead of overwriting them.