### PR TITLE
Update SOURCE_ALPHA doc comment

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1184,7 +1184,7 @@ class CompileCommandEncoder(json.JSONEncoder):
 class CompileActionUniqueingType(Enum):
     NONE = 0  # Full Action text
     SOURCE_ALPHA = 1  # Based on source file, uniqueing by
-    # on alphanumerically first target
+    # alphabetically first output object file name
     SOURCE_REGEX = 2  # Based on source file, uniqueing by regex filter
     STRICT = 3  # Gives error in case of duplicate
 


### PR DESCRIPTION
It turns out that it is used `analyzer/codechecker_analyzer/buildlog/log_parser.py:1312` as follows:

```python
elif build_action_uniqueing ==\
    CompileActionUniqueingType.SOURCE_ALPHA:
if action.source not in uniqued_build_actions:
    uniqued_build_actions[action.source] = action
elif action.output <\
        uniqued_build_actions[action.source].output:
    uniqued_build_actions[action.source] = action
```

Thus, the original comment was misleading. Let's fix that.