### PR TITLE
[CI] Fix install of PPA `clang-tidy` in config coverage job

### DIFF
--- a/.github/workflows/config_coverage.yml
+++ b/.github/workflows/config_coverage.yml
@@ -3,14 +3,14 @@ name: checker-config-coverage
 on:
   push:
     paths:
-      - '.github/workflow/config_coverage.yml'
-      - '.github/workflow/config_label_check.py'
+      - '.github/workflows/config_coverage.yml'
+      - '.github/workflows/config_label_check.py'
       - 'config/labels/analyzers/clang-tidy.json'
       - 'config/labels/analyzers/clangsa.json'
   pull_request:
     paths:
-      - '.github/workflow/config_coverage.yml'
-      - '.github/workflow/config_label_check.py'
+      - '.github/workflows/config_coverage.yml'
+      - '.github/workflows/config_label_check.py'
       - 'config/labels/analyzers/clang-tidy.json'
       - 'config/labels/analyzers/clangsa.json'
   schedule:
@@ -50,16 +50,17 @@ jobs:
           export LLVM_VER="$(apt-cache search --full 'clang-[[:digit:]]*$' | grep '^Package: clang' | cut -d ' ' -f 2 | sort -V | tail -n 1 | sed 's/clang-//')"
           echo "::group::Install Clang and Clang-Tidy version ${LLVM_VER}"
           sudo apt-get -y --no-install-recommends install \
-            clang-$LLVM_VER      \
+            clang-$LLVM_VER \
             clang-tidy-$LLVM_VER
-          sudo update-alternatives --install                   \
-            /usr/bin/clang clang /usr/bin/clang-$LLVM_VER 1000 \
-            --slave                                            \
-              /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VER
+          sudo update-alternatives --install \
+            /usr/bin/clang clang /usr/bin/clang-$LLVM_VER 10000
+          sudo update-alternatives --install \
+            /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$LLVM_VER 10000
           echo "::endgroup::"
 
           echo "Installed Clang:"
           update-alternatives --query clang
+          update-alternatives --query clang-tidy
       - name: "Package CodeChecker"
         id: codechecker
         run: |


### PR DESCRIPTION
GitHub seems to have modified the base Ubuntu image which now comes with a specific version of `clang-tidy` pre-installed.

The change happened last week because the job 10 days ago was successfully executed, while 3 days ago (last Sunday), we started observing the following failures across multiple projects:

```
  update-alternatives: error: alternative clang-tidy can't be slave of clang: it is a master alternative
  Error: Process completed with exit code 2.
```

Changing over to registering two top-level alternatives entries fixes the issue.

> Mirrors whisperity/CodeChecker-Action#3