### PR TITLE
[feat] Add dev_package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,19 @@ package: package_dir_structure set_git_commit_template package_gerrit_skiplist
 	# Copy license file.
 	cp $(ROOT)/LICENSE.TXT $(CC_BUILD_DIR)
 
+dev_package: package
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_common && \
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_analyzer && \
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_web && \
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_server && \
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_client
+
+	ln -fsv $(ROOT)/codechecker_common $(CC_BUILD_LIB_DIR) && \
+	ln -fsv $(CC_ANALYZER)/codechecker_analyzer $(CC_BUILD_LIB_DIR) && \
+	ln -fsv $(CC_WEB)/codechecker_web $(CC_BUILD_LIB_DIR) && \
+	ln -fsv $(CC_SERVER)/codechecker_server $(CC_BUILD_LIB_DIR) && \
+	ln -fsv $(CC_CLIENT)/codechecker_client $(CC_BUILD_LIB_DIR)
+
 package_api:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) package_api
 

--- a/codechecker_common/cli.py
+++ b/codechecker_common/cli.py
@@ -93,8 +93,9 @@ def main():
     """
     CodeChecker main command line.
     """
-    os.environ['CC_LIB_DIR'] = os.path.dirname(os.path.dirname(
-        os.path.realpath(__file__)))
+    if not os.environ.get('CC_LIB_DIR'):
+        os.environ['CC_LIB_DIR'] = \
+                os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
     data_files_dir_path = get_data_files_dir_path()
     os.environ['CC_DATA_FILES_DIR'] = data_files_dir_path


### PR DESCRIPTION
Created a new target for easier and probably faster development
workflow. Instead of copying the modules of CodeCheker in the build
directory, this target will create a symbolic link to them.

Invoking make with the new `dev_package` and setting the `CC_LIB_DIR`
environment variable with
`export CC_LIB_DIR=/path/to/codechecker/build/CodeChecker/lib/python3`
makes your build folder in a way, that your changes in the python
source code takes effect immediately in CodeChecker (upon restarting
the CodeChecker service  and without invoking `make package` again).