### PR TITLE
[fix] Fix remote diff behavior

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -453,6 +453,7 @@ def get_open_reports_date_filter_query(tbl=Report, date=RunHistory.time):
 def get_diff_bug_id_query(session, run_ids, tag_ids, open_reports_date):
     """ Get bug id query for diff. """
     q = session.query(Report.bug_id.distinct())
+    q = q.filter(Report.fixed_at.is_(None))
     if run_ids:
         q = q.filter(Report.run_id.in_(run_ids))
 

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -190,8 +190,8 @@ class DiffRemote(unittest.TestCase):
                                                  None,
                                                  cmp_data,
                                                  False)
-        # 5 resolved core.CallAndMessage
-        self.assertEqual(len(diff_res), 5)
+        # 4 resolved core.CallAndMessage
+        self.assertEqual(len(diff_res), 4)
 
     def test_get_diff_checker_counts_core_resolved(self):
         """
@@ -211,7 +211,7 @@ class DiffRemote(unittest.TestCase):
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
         # Resolved core checkers.
-        test_res = {'core.CallAndMessage': 5}
+        test_res = {'core.CallAndMessage': 4}
         self.assertDictEqual(diff_dict, test_res)
 
     def test_get_diff_results_unresolved(self):
@@ -419,8 +419,7 @@ class DiffRemote(unittest.TestCase):
                                                     cmp_data)
 
         print(res)
-        test_res = {ReviewStatus.UNREVIEWED: 4,
-                    ReviewStatus.FALSE_POSITIVE: 1}
+        test_res = {ReviewStatus.UNREVIEWED: 4}
         self.assertDictEqual(res, test_res)
 
     def test_get_diff_res_types_resolved(self):
@@ -440,7 +439,7 @@ class DiffRemote(unittest.TestCase):
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
-        test_res = {'core.CallAndMessage': 5}
+        test_res = {'core.CallAndMessage': 4}
         self.assertDictEqual(diff_dict, test_res)
 
     def test_get_diff_res_types_unresolved(self):
@@ -617,7 +616,7 @@ class DiffRemote(unittest.TestCase):
                                                  tag_filter,
                                                  cmp_data,
                                                  False)
-        self.assertEqual(len(diff_res), 3)
+        self.assertEqual(len(diff_res), 0)
 
         cmp_data.diffType = DiffType.UNRESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
@@ -686,7 +685,7 @@ class DiffRemote(unittest.TestCase):
                                                  tag_filter,
                                                  cmp_data,
                                                  False)
-        self.assertEqual(len(diff_res), 3)
+        self.assertEqual(len(diff_res), 0)
 
         cmp_data.diffType = DiffType.UNRESOLVED
         diff_res = self._cc_client.getRunResults([run_id],


### PR DESCRIPTION
When two runs are compared then reports should be considered as closed
even if their review status is false positive or intentional. Generally
any event that sets "fixed_at" date of a report makes it closed. This
should be taken into account when comparing two runs remotely.