### PR TITLE
Import the suppressions per report

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1842,10 +1842,11 @@ class ThriftRequestHandler:
     def _setReviewStatus(self, session, report_hash, status,
                          message, date=None):
         """
-        This function sets the review status of the given report. This is the
-        implementation of changeReviewStatus(), but it is also extended with
-        a session parameter which represents a database transaction. This is
-        needed because during storage a specific session object has to be used.
+        This function sets the review status of all the reports of a
+        given hash. This is the implementation of addReviewStatusRule(),
+        but it is also extended with a session parameter which represents a
+        database transaction. This is needed because during storage a specific
+        session object has to be used.
         """
         review_status = session.query(ReviewStatus).get(report_hash)
         if review_status is None:
@@ -1957,21 +1958,41 @@ class ThriftRequestHandler:
     @timeit
     def changeReviewStatus(self, report_id, status, message):
         """
-        Change review status of the bug by report id.
+        Change the review status of a report by report id.
         """
         self.__require_permission([permissions.PRODUCT_ACCESS,
                                    permissions.PRODUCT_STORE])
 
-        if self.isReviewStatusChangeDisabled():
-            msg = "Review status change is disabled!"
-            raise codechecker_api_shared.ttypes.RequestFailed(
-                codechecker_api_shared.ttypes.ErrorCode.GENERAL, msg)
-
         with DBSession(self._Session) as session:
             report = session.query(Report).get(report_id)
             if report:
-                self._setReviewStatus(
-                    session, report.bug_id, status, message)
+                # False positive and intentional reports are considered closed,
+                # so their "fix date" is set. The reports are reopened when
+                # they become unreviewed or confirmed again.
+                # Don't change "fix date" for closed
+                # report which remain closed.
+                if status in ["false_positive", "intentional"]:
+                    if report.detection_status in [
+                            "unresolved", "new", "reopened"]\
+                        and report.review_status not in [
+                            "false_positive", "intentional"]:
+                        session.query(Report).filter(
+                            Report.id == report_id).update(
+                                {"fixed_at": datetime.now()})
+                else:
+                    if report.detection_status in [
+                        "unresolved", "new", "reopened"]\
+                        and report.review_status in [
+                                "false_positive", "intentional"]:
+                        session.query(Report).filter(
+                            Report.id == report_id).update({"fixed_at": None})
+
+                session.query(Report).filter(Report.id == report_id).update({
+                        'review_status': review_status_str(status),
+                        'review_status_author': self._get_username(),
+                        'review_status_message': bytes(message, 'utf-8'),
+                        'review_status_date': datetime.now()
+                        })
             else:
                 raise codechecker_api_shared.ttypes.RequestFailed(
                     codechecker_api_shared.ttypes.ErrorCode.DATABASE,
@@ -2059,6 +2080,11 @@ class ThriftRequestHandler:
     def addReviewStatusRule(self, report_hash, review_status, message):
         self.__require_permission([permissions.PRODUCT_ACCESS,
                                    permissions.PRODUCT_STORE])
+
+        if self.isReviewStatusChangeDisabled():
+            msg = "Review status change is disabled!"
+            raise codechecker_api_shared.ttypes.RequestFailed(
+                codechecker_api_shared.ttypes.ErrorCode.GENERAL, msg)
 
         with DBSession(self._Session) as session:
             self._setReviewStatus(

--- a/web/server/vue-cli/src/assets/userguide/userguide.md
+++ b/web/server/vue-cli/src/assets/userguide/userguide.md
@@ -93,7 +93,7 @@ In the product list table you can see the following information:
 belongs to.
 - `Description`: short description of the product.
 - `Administrator names`: product admins have the right to allow access for
-individual people or LDAP groups. 
+individual people or LDAP groups.
 - `Number of runs`: number of runs in the product.
 - `Latest store to the product`: date of the latest run storage.
 - `Run store in progress`: show run names if a storage is in progress.
@@ -400,17 +400,26 @@ This report is a bug but we don't want to fix it.
 ![Review statuses](images/reports/review_statuses.png)
 
 
-Review statuses are connected to
-[report hashes](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/report_identification.md).
-If the same report can be found in multiple runs it will have the same review
-status.
-
-It can be changed on the [GUI](#userguide-change-review-status) or by using
+Review status can be set on the [GUI](#userguide-change-review-status) or by using
 [source code comments ](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#source-code-comments)
 (*codechecker_false_positive*, *codechecker_confirmed*, etc.)
 
+Review status set in source comments are applied on the individual report
+review status set in the GUI are added as Review Status Rules connected to
+[report hashes](https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/report_identification.md).
+If the same report can be found in multiple runs it will have the same review
+status. Reports stored in the future with the same hash will also get the
+same review status. So once you set the review status in the GUI,
+there is no need to set the same review status again in other runs.
+
+
 **Note**: source code comment is stronger and can overwrite the value in the
 database.
+
+Review status values added in the WEB GUI are stored as Review Status Rules
+and can be managed in the Configuration/ReviewStatusRules tab.
+![Filter run history events](images/review_status_rules/review_status.rules.png)
+
 
 ## Detection status
 The detection status is the state of a bug report in a run.

--- a/web/tests/functional/suppress/__init__.py
+++ b/web/tests/functional/suppress/__init__.py
@@ -82,9 +82,10 @@ def setup_package():
     if ret:
         sys.exit(1)
     print("Analyzing the test project was successful.")
+    test_project_name_dup = test_project_name + "_duplicate"
+    ret = codechecker.store(codechecker_cfg, test_project_name_dup)
 
-    codechecker_cfg['run_names'] = [test_project_name]
-
+    codechecker_cfg['run_names'] = [test_project_name, test_project_name_dup]
     test_config['codechecker_cfg'] = codechecker_cfg
 
     env.export_test_cfg(TEST_WORKSPACE, test_config)


### PR DESCRIPTION
CodeChecker cmd suppress run_name -i <import_file>
will only import suppressions for the run indicated by run_name,
and not all reports.

Suppressions are imported as single report suppressions
instead of suppression rules.

This is the behaviour the user expects when run name is given
as a parameter to the command.

This patch also fixes the changeReviewStatus(report_id, status, message)
API function to change the review status of a single report only
instead of all reports with the same hash.