### PR TITLE
[fix] File filter count for files with 0 reports

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2721,11 +2721,12 @@ class ThriftRequestHandler:
             unique = report_filter is not None and report_filter.isUnique
             stmt = session.query(
                 File.filepath,
-                func.count(
-                    Report.bug_id.distinct() if unique else Report.bug_id)) \
-                .join(Report, File.id == Report.file_id)
+                func.count(Report.bug_id.distinct()
+                           if unique else Report.bug_id).label('report_num')) \
+                .join(Report, File.id == Report.file_id, isouter=True)
             stmt = apply_report_filter(stmt, filter_expression, join_tables) \
-                .group_by(File.filepath)
+                .group_by(File.filepath) \
+                .order_by(desc('report_num'))
 
             if limit:
                 stmt = stmt.limit(limit).offset(offset)


### PR DESCRIPTION
When filtering for reports that occur anywhere on the bugpath (i.e.
not just the last point is in a given file) then searching for files
containing no reports is necessary.