### PR TITLE
[ctu] Don't silently ignore exceptions thrown in pre-analysis

### DIFF
--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -206,13 +206,18 @@ def run_pre_analysis(actions, context, clangsa_config,
         #        proxy objects before passing them to other processes via
         #        map_async.
         #        Note that even deep-copying is known to be insufficient.
-        pool.map_async(pre_analyze, collect_actions)
+        result = pool.map_async(pre_analyze, collect_actions)
         pool.close()
     except Exception:
         pool.terminate()
         raise
     finally:
         pool.join()
+        # Return whether the call completed without raising an exception.
+        if not result.successful():
+            # If the remote call raised an exception then that exception will
+            # be reraised by get().
+            result.get()
 
     # Postprocessing the pre analysis results.
     if ctu_data:


### PR DESCRIPTION
Exceptions thrown in a thread pool by default stay in the thread pool
(won't be re-raised at the call to map_async or similar functions).
However, you can query whether an exception occured with the help of
AsyncResult.successful().

This patch is simple -- don't pretend that pre-analysis exceptions can
be ignored, just because they run asyncronously, exceptions there are
just as severe as elsewhere.