### PR TITLE
[bugfix] Invalid SQL query when filter for file and source component.

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2715,12 +2715,12 @@ class ThriftRequestHandler:
             # The File table is joined explicitly in the next query. Joining it
             # twice results an ambiguous reference to this table in the SQL
             # query.
-            # TODO: It is not an elegant solution that rocess_report_filter()
+            # TODO: It is not an elegant solution that process_report_filter()
             # returns the list of tables to join and the caller needs to join
             # them. It would be better if it's automatic and every table is
             # joined once.
-            if File in join_tables:
-                join_tables.remove(File)
+
+            join_tables = [t for t in join_tables if t != File]
 
             unique = report_filter is not None and report_filter.isUnique
             stmt = session.query(

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -271,6 +271,30 @@ class TestReportFilter(unittest.TestCase):
         self.assertEqual(len(res), len(self.run1_files))
         self.assertDictEqual(res, self.run1_files)
 
+    def test_filter_by_file_and_source_component(self):
+        """
+        File and source component filter in getFileCounts().
+
+        Earlier this function resulted an SQL error due to an invalid SQL
+        statement (File table was ambiguously used, because it was joined
+        multiple times).
+
+        On the other hand we test here that getFileCounts() returns the number
+        of reports in all files regardless the filter fields. The reason is
+        that it wouldn't be possible on the GUI to display the options of the
+        file path filter which doesn't contain a report (i.e. their endpoint is
+        not in that file). In the future it would be enough to ignore the
+        filter only if "anywhere on bugpath" option is used (TODO?).
+        """
+        runid = self._runids[0]
+        run_filter = ReportFilter(
+            filepath="call*",
+            componentNames=["doesn't exist"])
+        file_counts = self._cc_client.getFileCounts(
+            [runid], run_filter, None, None, 0)
+
+        self.assertEqual(len(file_counts), 12)
+
     def test_run2_all_file(self):
         """
         Get all the file counts for run2.


### PR DESCRIPTION
The error happened when getFileCounts() function got a filter where both
"filepath" and "componentNames" fields were used.