### PR TITLE
[gui] Minor label improvements in the GUI

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatistics.vue
@@ -21,12 +21,12 @@
           </v-btn>
         </h3>
 
-        <unique-stat-warning v-if="reportFilter.isUnique" />
-
         <checker-statistics-table
           :items="statistics"
           :loading="loading"
         />
+
+        <unique-stat-warning v-if="reportFilter.isUnique" />
       </v-col>
     </v-row>
   </v-container>

--- a/web/server/vue-cli/src/components/Statistics/Component/ComponentStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Component/ComponentStatistics.vue
@@ -21,13 +21,13 @@
           </v-btn>
         </h3>
 
-        <unique-stat-warning v-if="reportFilter.isUnique" />
-
         <component-statistics-table
           :items="statistics"
           :loading="loading"
           :filters="statisticsFilters"
         />
+
+        <unique-stat-warning v-if="reportFilter.isUnique" />
       </v-col>
     </v-row>
   </v-container>

--- a/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
@@ -60,9 +60,6 @@
               Shows the number of reports which were active in the last
               <i>x</i> months/days.<br><br>
 
-              Reports marked as <b>False positive</b> or <b>Intentional</b>
-              will be <i>excluded</i> from these numbers.<br><br>
-
               The following filters don't affect these values:
               <ul>
                 <li><b>Outstanding reports on a given date</b> filter.</li>

--- a/web/server/vue-cli/src/components/Statistics/Severity/SeverityStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Severity/SeverityStatistics.vue
@@ -21,12 +21,12 @@
           </v-btn>
         </h3>
 
-        <unique-stat-warning v-if="reportFilter.isUnique" />
-
         <severity-statistics-table
           :items="statistics"
           :loading="loading"
         />
+
+        <unique-stat-warning v-if="reportFilter.isUnique" />
       </v-col>
     </v-row>
   </v-container>

--- a/web/server/vue-cli/src/components/Statistics/UniqueStatWarning.vue
+++ b/web/server/vue-cli/src/components/Statistics/UniqueStatWarning.vue
@@ -1,24 +1,61 @@
 <template>
   <v-alert
-    text
-    outlined
-    color="deep-orange"
+    :outlined="show"
+    :color="color"
+    :text="text"
     icon="mdi-alert"
     class="mt-2"
   >
-    It is possible that a report type (i.e. set of reports sharing the same
-    hash) is assigned different review status in different runs. For example,
-    such a report can be both <i>Unreviewed</i> and <i>Confirmed</i>, thus it
-    is counted under both. However, a bug type is counted only once in
-    <b>Outstanding reports</b>, <b>Suppressed reports</b> and
-    <b>All reports</b> columns in <b>Unique reports</b> mode. In this case
-    these summary columns don't add up the values of the corresponding review
-    status columns.
+    <span
+      v-if="!show"
+      @click="display"
+    >
+      Columns containing sum values may be wrong in unique mode.
+      <span class="link">(More)</span>
+    </span>
+    <span v-if="show">
+      It is possible that a report type (i.e. set of reports sharing the same
+      hash) is assigned different review status in different runs. For example,
+      such a report can be both <i>Unreviewed</i> and
+      <i>Confirmed</i>, thus it is counted under both. However, a bug type is
+      counted only once in <b>Outstanding reports</b>,
+      <b>Suppressed reports</b> and <b>All reports</b> columns in
+      <b>Unique reports</b> mode. In this case these summary columns don't add
+      up the values of the corresponding review status columns.
+      <span class="link" @click="display">
+        (Less)
+      </span>
+    </span>
   </v-alert>
 </template>
 
 <script>
 export default {
-  name: "UniqueStatWarning"
+  name: "UniqueStatWarning",
+  data() {
+    return {
+      color: "",
+      show: false,
+      text: false
+    };
+  },
+  methods: {
+    display() {
+      this.show = !this.show;
+      this.text = !this.text;
+      this.color = this.show ? "deep-orange" : "";
+    }
+  }
 };
 </script>
+
+<style lang="scss" scoped>
+.link:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.v-alert {
+  font-size: 14px
+}
+</style>


### PR DESCRIPTION
The help message of "number of outstanding reports" is changed.

Also the information about the interpretation of numbers in unique mode
on the statistics page is less conspicuous.