### PR TITLE
[fix][db][web] Correctly decrease the num_of_run field in the config db when runs are deleted

### DIFF
--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -84,7 +84,10 @@ def __add_output_formats(parser, output_formats=None,
         output_formats = DEFAULT_OUTPUT_FORMATS
 
     if not help_msg:
-        help_msg = "The output format(s) to use in showing the data."
+        help_msg = \
+                "The output format(s) to use in showing the data. Mind that " \
+                "some output formats are (like 'json') more verbose than " \
+                "others (like 'plaintext')."
 
     if allow_multiple_outputs:
         parser.add_argument('-o', '--output',


### PR DESCRIPTION
In order to improve the load times of certain pages of the CodeChecker
GUI, we cache some information instead of querrying it. For instance, we
don't make a query for how many runs there are in each product every
time when the product page is opened, but rather have a config database
that already has this number.

The idea was that every time a run is added, the num_of_run column is
incremented, and whenever one or more runs were deleted, it is
appropriately decreased. However, this latter operation was faulty, and
no matter how many runs were deleted, the number was only decreased by
one.

Since this number was never actualized by the real number of runs, over
the course of months, these numbers could have (and did!) diverge by
hundreds.

This patch, in addition to fixing the run deletion not decreasing the
counter appropriately, also syncs the num_of_run column at every server
startup.