### PR TITLE
[bugfix] Fix system include path order

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_triple_arch.py
@@ -24,13 +24,17 @@ def get_compile_command(action, config, source='', output=''):
     if not has_flag('--target', cmd) and action.target != "":
         cmd.append(f"--target={action.target}")
 
-    cmd.extend(prepend_all('-isystem', action.compiler_includes))
     cmd.append('-c')
     if not has_flag('-x', cmd):
         cmd.extend(['-x', action.lang])
 
     cmd.extend(config.analyzer_extra_arguments)
     cmd.extend(action.analyzer_options)
+    # Compilers include a header file from the first(!) directory given by -I,
+    # -isystem, etc. flags where it is found. For this reason we append the
+    # implicit include paths to the end of the analyzer command in order to get
+    # less precedence than the user's explicit include paths.
+    cmd.extend(prepend_all('-isystem', action.compiler_includes))
     if output:
         cmd.extend(['-o', output])
     if source:

--- a/analyzer/tests/functional/ctu/test_files/buildlog.json
+++ b/analyzer/tests/functional/ctu/test_files/buildlog.json
@@ -1,12 +1,12 @@
 [
   {
     "directory": ".",
-    "command": "gcc -c lib.c -o lib.o",
+    "command": "gcc -c lib.c -o lib.o -isystem non_existing",
     "file": "lib.c"
   },
   {
     "directory": ".",
-    "command": "gcc -c main.c -o main.o",
+    "command": "gcc -c main.c -o main.o -isystem non_existing",
     "file": "main.c"
   }
 ]


### PR DESCRIPTION
The implicit include paths should be added after the user-defined flags
and include paths even in the pre-ctu phase, otherwise the build commands
will not be equivalent with the original ones.