### PR TITLE
[fix] Fix compiler params with space for Cppcheck

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -45,3 +45,7 @@ cppcheck_args:
 	$(CXX) -w cppcheck_args.cpp -o /dev/null
 cppcheck_undef_args:
 	$(CXX) -w cppcheck_args.cpp -UHAVE_NULL_DEREFERENCE -o /dev/null
+cppcheck_include:
+	$(CXX) -w cppcheck_include.cpp -I ./includes/ -o /dev/null
+cppcheck_undef_include:
+	$(CXX) -w cppcheck_include.cpp -I./includes/ -U HAVE_NULL_DEREFERENCE -o /dev/null

--- a/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_include.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_include.cpp
@@ -1,0 +1,14 @@
+#include "simple.h"
+
+int main()
+{
+
+#ifdef HAVE_NULL_DEREFERENCE
+  int *ptr = nullptr;
+#else
+  int x = 0;
+  int *ptr = &x;
+#endif
+
+  return *ptr;
+}

--- a/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_include.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_include.output
@@ -1,0 +1,57 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make cppcheck_include" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers cppcheck
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make cppcheck_include" --output $OUTPUT$ --quiet --analyzers cppcheck
+-----------------------------------------------
+[] - Starting build...
+[] - Using CodeChecker ld-logger.
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] cppcheck analyzed cppcheck_include.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   cppcheck: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+[HIGH] cppcheck_include.cpp:13:11: Null pointer dereference: ptr [cppcheck-nullPointer]
+  return *ptr;
+          ^
+
+Found 1 defect(s) in cppcheck_include.cpp
+
+
+----==== Severity Statistics ====----
+----------------------------
+Severity | Number of reports
+----------------------------
+HIGH     |                 1
+----------------------------
+----=================----
+
+----==== Checker Statistics ====----
+---------------------------------------------------
+Checker name         | Severity | Number of reports
+---------------------------------------------------
+cppcheck-nullPointer | HIGH     |                 1
+---------------------------------------------------
+----=================----
+
+----==== File Statistics ====----
+----------------------------------------
+File name            | Number of reports
+----------------------------------------
+cppcheck_include.cpp |                 1
+----------------------------------------
+----=================----
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 1
+---------------------------------------------
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_undef_include.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/cppcheck_undef_include.output
@@ -1,0 +1,28 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make cppcheck_undef_include" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers cppcheck
+NORMAL#CodeChecker parse $OUTPUT$
+CHECK#CodeChecker check --build "make cppcheck_undef_include" --output $OUTPUT$ --quiet --analyzers cppcheck
+-----------------------------------------------
+[] - Starting build...
+[] - Using CodeChecker ld-logger.
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] cppcheck analyzed cppcheck_include.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   cppcheck: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+Found no defects in cppcheck_include.cpp
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 0
+---------------------------------------------
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/includes/simple.h
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/includes/simple.h
@@ -1,0 +1,1 @@
+#define SIMPLE 1


### PR DESCRIPTION
Compiler paramters in format of -I </path/to/file> were handled
incorrectly in Cppcheck. Only the -I part were included in the analyzer
command resulting in a failing analysis.