### PR TITLE
[analyzer] Tests for Cppcheck standard handling

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -115,7 +115,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
                     params.extend(
                         [self.buildaction.analyzer_options[i+1]]
                     )
-            if std_regex.match(analyzer_option):
+            elif std_regex.match(analyzer_option):
                 standard = ""
                 if "=" in analyzer_option:
                     standard = analyzer_option.split("=")[-1]

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -938,6 +938,57 @@ class TestAnalyze(unittest.TestCase):
 
         self.assertEqual(errcode, 0)
 
+    def test_cppcheck_standard(self):
+        """
+        Testing the standard ("--std") compiler paramater translation
+        to cppcheck input parameter.
+        Cppcheck can only understand a subset of the available options.
+        """
+        build_json = os.path.join(self.test_workspace, "cppcheck_std.json")
+        analyze_cmd = [self._codechecker_cmd, "analyze",
+                       build_json,
+                       "--analyzers", "cppcheck",
+                       "-o", self.report_dir, "--verbose",
+                       "debug_analyzer"]
+        source_file = os.path.join(self.test_dir, "simple.c")
+
+        build_log = [{"directory": self.test_workspace,
+                      "command": "gcc -c -std=c99 " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w',
+                  encoding="utf-8", errors="ignore") as outfile:
+            json.dump(build_log, outfile)
+
+        out = subprocess.run(analyze_cmd,
+                             cwd=self.test_dir,
+                             # env=self.env,
+                             stdout=subprocess.PIPE).stdout.decode()
+
+        # Test correct handover.
+        self.assertTrue("--std=c99" in out)
+
+        # Cppcheck does not support gnu variants of the standards,
+        # These are transformed into their respective c and c++
+        # varinats inside CodeChecker
+        build_log = [{"directory": self.test_workspace,
+                      "command": "gcc -c -std=gnu99 " + source_file,
+                      "file": source_file
+                      }]
+
+        with open(build_json, 'w',
+                  encoding="utf-8", errors="ignore") as outfile:
+            json.dump(build_log, outfile)
+
+        out = subprocess.run(analyze_cmd,
+                             cwd=self.test_dir,
+                             # env=self.env,
+                             stdout=subprocess.PIPE).stdout.decode()
+
+        # Test if the standard is correctly transformed
+        self.assertTrue("--std=c99" in out)
+
     def test_makefile_generation(self):
         """ Test makefile generation. """
         build_json = os.path.join(self.test_workspace, "build_extra_args.json")


### PR DESCRIPTION
Analyzer tests were missing for the cppcheck standard forwarding. The standard translation is also tested in case of a gnu** standard is given.
Also added a small change in the business logic for handling the standard parameter. This should make it more robust against future refactoring.