### PR TITLE
[cfg] Allow for release candidate status to be also specified

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -130,7 +130,8 @@ class Context(metaclass=Singleton):
 
         self.__package_version = package_version['major'] + '.' + \
             package_version['minor'] + '.' + \
-            package_version['revision']
+            package_version['revision'] + \
+            ('-rc' + package_version['rc'] if 'rc' in package_version else '')
 
         self.__package_build_date = package_build_date
         self.__package_git_hash = package_git_hash

--- a/analyzer/config/analyzer_version.json
+++ b/analyzer/config/analyzer_version.json
@@ -2,6 +2,7 @@
     "version": {
         "major" : "6",
         "minor" : "21",
-        "revision" : "0"
+        "revision" : "0",
+        "rc" : ""
     }
 }

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -1067,9 +1067,12 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        print(out)
-
         # It's printed as a found report and in the checker statistics.
+        # Note: If this test case fails, its pretty sure that something totally
+        # unrelated to the analysis broke in CodeChecker. Comment out the line
+        # starting with 'nocapture' in 'analyzer/.noserc', and print both the
+        # stdout and stderr streams from the above communicate() call (the
+        # latter of which is ignored with _ above)
         self.assertEqual(out.count('hicpp-use-nullptr'), 2)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,

--- a/scripts/build/extend_version_file.py
+++ b/scripts/build/extend_version_file.py
@@ -37,6 +37,8 @@ def extend_with_git_information(repository_root, version_json_data):
         version_string += ".{0}".format(version['minor'])
     if int(version['revision']) != 0:
         version_string += ".{0}".format(version['revision'])
+    if version['rc'] != '' and int(version['rc']) != 0:
+        version_string += "-rc{0}".format(version['rc'])
 
     LOG.info("This is CodeChecker v%s", version_string)
 

--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -125,7 +125,8 @@ class Context(metaclass=Singleton):
 
         self.__package_version = package_version['major'] + '.' + \
             package_version['minor'] + '.' + \
-            package_version['revision']
+            package_version['revision'] + \
+            ('-rc' + package_version['rc'] if 'rc' in package_version else '')
 
         self.__package_build_date = package_build_date
         self.__package_git_hash = package_git_hash

--- a/web/config/web_version.json
+++ b/web/config/web_version.json
@@ -2,6 +2,7 @@
     "version": {
         "major" : "6",
         "minor" : "21",
-        "revision" : "0"
+        "revision" : "0",
+        "rc" : ""
     }
 }


### PR DESCRIPTION
This patch is largely the same as d24c22cd, but without the rc fields actually being used in the json files. Credit to Tibor Brunner.