### PR TITLE
[bugfix] Old client has different behavior with new server

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -431,6 +431,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
                             self.auth_session,
                             self.server.config_session,
                             version,
+                            api_ver,
                             self.server.context)
                         processor = ReportAPI_v6.Processor(acc_handler)
                     else:


### PR DESCRIPTION
This getDiffResultsHash() function is returning a set of reports based on what are they compared to in a "CodeChecker cmd diff" command. Earlier this function didn't consider false positive and intentional reports as closed reports. The client's behavior also changed from CodeChecker 6.20.0 and this behavior is adapted to the new server behavior. The problem is that the old client works correcly only with the old server. For this reason we are branching based on the client's version.