### PR TITLE
[bugfix] Different behavior of diff when run tags are provided

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -371,6 +371,8 @@ def filter_open_reports_in_tags(results, run_ids, tag_ids):
     """
     Adding filters on "results" query which filter on open reports in
     given runs and tags.
+    For further information see the documentation of
+    filter_open_reports_in_tags_old().
     """
 
     if run_ids:
@@ -381,6 +383,36 @@ def filter_open_reports_in_tags(results, run_ids, tag_ids):
             RunHistory, RunHistory.run_id == Report.run_id) \
             .filter(RunHistory.id.in_(tag_ids)) \
             .filter(get_open_reports_date_filter_query())
+
+    return results
+
+
+def filter_open_reports_in_tags_old(results, run_ids, tag_ids):
+    """
+    Adding filters on "results" query which filter on open reports in
+    given runs and tags.
+
+    This function is almost the same as filter_open_reports_in_tags() except
+    that is uses get_open_reports_date_filter_query_old() for filtering open
+    reports on a given date. This function is duplicated, because we didn't
+    want to add an extra parameter for this function, but express the fact that
+    an old client (i.e. API version before 6.50) should be given a different
+    result set.
+    This function and its duplicate are used in getDiffResultHash() which
+    should behave differently when called by an old client. The reasons of this
+    different behavior is described a previous commit
+    (f6d0fedaf14b583df7bd26078a8a22b557be57c6) where another case of the issue
+    was fixed.
+    """
+
+    if run_ids:
+        results = results.filter(Report.run_id.in_(run_ids))
+
+    if tag_ids:
+        results = results.outerjoin(
+            RunHistory, RunHistory.run_id == Report.run_id) \
+            .filter(RunHistory.id.in_(tag_ids)) \
+            .filter(get_open_reports_date_filter_query_old())
 
     return results
 
@@ -516,6 +548,16 @@ def get_open_reports_date_filter_query(tbl=Report, date=RunHistory.time):
     return and_(tbl.detected_at <= date,
                 or_(tbl.fixed_at.is_(None),
                     tbl.fixed_at > date))
+
+
+def get_open_reports_date_filter_query_old(tbl=Report, date=RunHistory.time):
+    """ Get open reports date filter.
+
+    This function is a dupliation of get_open_reports_date_filter_query().
+    For the reson of duplication see the documentation of
+    filter_open_reports_in_tags_old().
+    """
+    return tbl.detected_at <= date
 
 
 def get_diff_bug_id_query(session, run_ids, tag_ids, open_reports_date):
@@ -1619,12 +1661,13 @@ class ThriftRequestHandler:
                     base_hashes = base_hashes.filter(
                         Report.detection_status.notin_(skip_statuses_str),
                         Report.fixed_at.is_(None))
+                    base_hashes = filter_open_reports_in_tags(
+                        base_hashes, run_ids, tag_ids)
                 else:
                     base_hashes = base_hashes.filter(
                         Report.detection_status.notin_(skip_statuses_str))
-
-                base_hashes = \
-                    filter_open_reports_in_tags(base_hashes, run_ids, tag_ids)
+                    base_hashes = filter_open_reports_in_tags_old(
+                        base_hashes, run_ids, tag_ids)
 
                 if self._product.driver_name == 'postgresql':
                     new_hashes = select([func.unnest(report_hashes)
@@ -1655,12 +1698,13 @@ class ThriftRequestHandler:
                     results = results.filter(or_(
                         Report.bug_id.notin_(report_hashes),
                         Report.fixed_at.isnot(None)))
+                    results = filter_open_reports_in_tags(
+                        results, run_ids, tag_ids)
                 else:
                     results = results.filter(
                         Report.bug_id.notin_(report_hashes))
-
-                results = \
-                    filter_open_reports_in_tags(results, run_ids, tag_ids)
+                    results = filter_open_reports_in_tags_old(
+                        results, run_ids, tag_ids)
 
                 return [res[0] for res in results]
 
@@ -1673,12 +1717,13 @@ class ThriftRequestHandler:
                         .filter(Report.detection_status.notin_(
                             skip_statuses_str)) \
                         .filter(Report.fixed_at.is_(None))
+                    results = filter_open_reports_in_tags(
+                        results, run_ids, tag_ids)
                 else:
                     results = results.filter(
                         Report.detection_status.notin_(skip_statuses_str))
-
-                results = \
-                    filter_open_reports_in_tags(results, run_ids, tag_ids)
+                    results = filter_open_reports_in_tags_old(
+                        results, run_ids, tag_ids)
 
                 return [res[0] for res in results]
 


### PR DESCRIPTION
In a previous commit (f6d0fedaf14b583df7bd26078a8a22b557be57c6) we fixed a bug, which was about getting the difference of false positive reports in a baseline to a local directory. For further details see the message of that commit. However, another bug still remained in the system, when the diff command compared a report directory to a specific run tag. This case is fixed by this commit.