### PR TITLE
[bugfix] Don't update review status date

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -716,6 +716,7 @@ class MassStoreRun:
         review_status_is_in_source: bool,
         detection_status: str,
         detection_time: datetime,
+        run_history_time: datetime,
         analysis_info: AnalysisInfo,
         analyzer_name: Optional[str] = None,
         fixed_at: Optional[datetime] = None
@@ -732,7 +733,7 @@ class MassStoreRun:
                 report.message, checker_name or 'NOT FOUND',
                 report.category, report.type, report.line, report.column,
                 severity, review_status.status, review_status.author,
-                review_status.message, review_status.date,
+                review_status.message, run_history_time,
                 review_status_is_in_source,
                 detection_status, detection_time,
                 len(report.bug_path_events), analyzer_name)
@@ -923,7 +924,6 @@ class MassStoreRun:
             analyzer_name = mip.checker_to_analyzer.get(
                 report.checker_name, report.analyzer_name)
             review_status, scc = get_review_status(report)
-            review_status.date = run_history_time
 
             # False positive and intentional reports are considered as closed
             # reports which is indicated with non-null "fixed_at" date.
@@ -933,12 +933,12 @@ class MassStoreRun:
                         ['false_positive', 'intentional']:
                     fixed_at = old_report.review_status_date
                 else:
-                    fixed_at = review_status.date
+                    fixed_at = run_history_time
 
             report_id = self.__add_report(
                 session, run_id, report, file_path_to_id,
                 review_status, scc, detection_status, detected_at,
-                analysis_info, analyzer_name, fixed_at)
+                run_history_time, analysis_info, analyzer_name, fixed_at)
 
             self.__new_report_hashes.add(report.report_hash)
             self.__already_added_report_hashes.add(report_path_hash)

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -543,13 +543,28 @@ class TestReviewStatus(unittest.TestCase):
             "This is false positive.")
         self.assertIsNone(multi_unreviewed_report)
 
+        rule_filter = ReviewStatusRuleFilter(
+            reportHashes=[UNCOMMENTED_BUG_HASH])
+        review_status_rule_before = self._cc_client.getReviewStatusRules(
+            rule_filter, None, None, 0)[0]
+
         # Storing the report directory of the project inserts further reports
         # to the database with the same bug hashes. The review status of
         # reports without source code comment should get the default review
-        # status set earlier.
+        # status set earlier. In the meantime, the review status rule date must
+        # not change.
 
         test_project_name2 = 'review_status_change2'
         codechecker.store(codechecker_cfg, test_project_name2)
+
+        rule_filter = ReviewStatusRuleFilter(
+            reportHashes=[UNCOMMENTED_BUG_HASH])
+        review_status_rule_after = self._cc_client.getReviewStatusRules(
+            rule_filter, None, None, 0)[0]
+
+        self.assertEqual(
+            review_status_rule_before.reviewData.date,
+            review_status_rule_after.reviewData.date)
 
         run_filter = RunFilter(names=[test_project_name2], exactMatch=True)
         runs = self._cc_client.getRunData(run_filter, None, 0, None)


### PR DESCRIPTION
When a review status is set in the GUI then a new entry is inserted to review_statuses table. Every time the same report is stored, its review status date was updated. This date shouldn't be updated, because not the storage sets a review status rule's date.