### PR TITLE
[fix] Apply all fixits

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -13,6 +13,7 @@ Supported analyzer types.
 
 import os
 import re
+import subprocess
 import sys
 
 from codechecker_analyzer import env
@@ -116,6 +117,22 @@ def is_z3_refutation_capable(context):
     return host_check.has_analyzer_config_option(analyzer_binary,
                                                  'crosscheck-with-z3',
                                                  analyzer_env)
+
+
+def is_ignore_conflict_supported(context):
+    """
+    Detects if clang-apply-replacements supports --ignore-insert-conflict flag.
+    """
+    analyzer_env = env.extend(context.path_env_extra,
+                              context.ld_lib_path_extra)
+
+    proc = subprocess.Popen([context.replacer_binary, '--help'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            env=analyzer_env,
+                            encoding="utf-8", errors="ignore")
+    out, _ = proc.communicate()
+    return '--ignore-insert-conflict' in out
 
 
 def print_unsupported_analyzers(errored):

--- a/analyzer/tests/functional/fixit/test_fixit.py
+++ b/analyzer/tests/functional/fixit/test_fixit.py
@@ -385,7 +385,7 @@ int main()
         orig_hash_1 = content_hash(source_file1)
         orig_hash_2 = content_hash(source_file2)
 
-        # Toudh file so "CodeChecker fixit" doesn't apply on the first file.
+        # Touch file so "CodeChecker fixit" doesn't apply on the first file.
         # We want to test that the other file is changed despite the failure of
         # this first fail.
         os.utime(source_file1, None)


### PR DESCRIPTION
Clang tidy may provide automatically applicable fixits. These can be applied by clang-apply-replacements tool. This tool gets a directory as input which contains .yaml files describing the replacements. If any of these .yaml files can't apply for some reason, then the rest is skipped.

This clang tool is added a flag named --ignore-insert-conflict which ignores the error event and continues the application of further .yaml files. If CodeChecker recognizes the existence of this flag then it will be used, otherwise CodeChecker creates a temporary directory with a single .yaml file and applies them one by one.