### PR TITLE
[fix] Fix chunks function not working on certain iterables

### DIFF
--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -35,6 +35,7 @@ def chunks(iterator, n):
     Yield the next chunk if an iterable object. A chunk consists of maximum n
     elements.
     """
+    iterator = iter(iterator)
     for first in iterator:
         rest_of_chunk = itertools.islice(iterator, 0, n - 1)
         yield itertools.chain([first], rest_of_chunk)


### PR DESCRIPTION
When called with a set, the chunks function gave back as many chunks, as the length of the list.