### PR TITLE
[feat] Comment lines in skipfile

### DIFF
--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -335,6 +335,37 @@ class LogParserTest(unittest.TestCase):
 
         self.assertEqual(len(build_actions), 0)
 
+    def test_skip_everything_from_parse_with_comment(self):
+        """
+        Same skip file for pre analysis and analysis. Skip everything.
+        Comment used in skipfile.
+        """
+        cmp_cmd_json = [
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/a.cpp",
+             "file": "a.cpp"},
+            {"directory": "/tmp/lib1",
+             "command": "g++ /tmp/lib1/b.cpp",
+             "file": "b.cpp"},
+            {"directory": "/tmp/lib2",
+             "command": "g++ /tmp/lib2/a.cpp",
+             "file": "a.cpp"}]
+
+        skip_list = """
+        -*/lib1/*
+        #+*/lib2/*
+        -*/lib2/*
+        """
+        analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
+        pre_analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
+
+        build_actions, _ = log_parser.\
+            parse_unique_log(cmp_cmd_json, self.__this_dir,
+                             analysis_skip_handlers=analysis_skip,
+                             pre_analysis_skip_handlers=pre_analysis_skip)
+
+        self.assertEqual(len(build_actions), 0)
+
     def test_skip_everything_from_parse_relative_path(self):
         """
         Same skip file for pre analysis and analysis. Skip everything.

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -38,7 +38,8 @@ class SkipListHandler:
 
         self.__skip_file_lines = [line.strip() for line
                                   in skip_file_content.splitlines()
-                                  if line.strip()]
+                                  if line.strip() and
+                                  not line.strip().startswith('#')]
 
         valid_lines = self.__check_line_format(self.__skip_file_lines)
         self.__gen_regex(valid_lines)

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1035,6 +1035,9 @@ checked, `+` means that it should be.
  * Path parts should start and end with `*`.
  * To skip everything use the `-*` mark. **Watch out for the order!**
 
+Comments can also be used in skipfiles: a line starting with `#` will not be
+taken into account.
+
 ##### Absolute path examples
 
 ```


### PR DESCRIPTION
Hashmark (#) character can be used for commenting lines out in skipfiles. Earlier these lines were excluded with the following message:
"Skipping malformed skipfile pattern: ..."