### PR TITLE
[cmd] Run name in command line results

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -682,7 +682,8 @@ def handle_list_results(args):
 
     run_filter = ttypes.RunFilter(names=args.names)
 
-    run_ids = [run.runId for run in get_run_data(client, run_filter)]
+    run_data = get_run_data(client, run_filter)
+    run_ids = [run.runId for run in run_data]
     if not run_ids:
         LOG.warning("No runs were found!")
         sys.exit(1)
@@ -703,6 +704,11 @@ def handle_list_results(args):
                                   query_report_details)
 
     if args.output_format == 'json':
+        if 'details' in args:
+            run_id2name = {run.runId: run.name for run in run_data}
+            for report in all_results:
+                report.runName = run_id2name[report.runId]
+
         print(CmdLineOutputEncoder().encode(all_results))
     else:
         header = ['File', 'Checker', 'Severity', 'Message', 'Bug path length',

--- a/web/tests/functional/cmdline/test_cmdline.py
+++ b/web/tests/functional/cmdline/test_cmdline.py
@@ -247,6 +247,23 @@ class TestCmdline(unittest.TestCase):
         ret, _, _ = run_cmd(res_cmd, env=check_env)
         self.assertEqual(0, ret)
 
+    def test_detailed_results_contain_run_names(self):
+        """
+        Test detailed results contain run names.
+        """
+        check_env = self._test_config['codechecker_cfg']['check_env']
+
+        res_cmd = [self._codechecker_cmd, 'cmd', 'results', 'test_files1*',
+                   'test_files1*', '-o', 'json', '--url', str(self.server_url),
+                   '--details']
+
+        ret, out, _ = run_cmd(res_cmd, env=check_env)
+        self.assertEqual(0, ret)
+
+        results = json.loads(out)
+        for result in results:
+            self.assertTrue(result['runName'].startswith('test_files1'))
+
     def test_stderr_results(self):
         """
         Test results command that we redirect logger's output to the stderr if


### PR DESCRIPTION
In detailed view the run name should also be displayed in the JSON output of "CodeChecker cmd results ..." command.