### PR TITLE
[refactor] Change the regex search to string search

### DIFF
--- a/tools/report-converter/codechecker_report_converter/source_code_comment_handler.py
+++ b/tools/report-converter/codechecker_report_converter/source_code_comment_handler.py
@@ -34,7 +34,8 @@ def contains_codechecker_comment(fp):
     pos_before_read = fp.tell()
     if pos_before_read != 0:
         fp.seek(0)
-    match = re.search(".*codechecker_.*", fp.read())
+    source_text = fp.read()
+    match = "codechecker_" in source_text
     fp.seek(pos_before_read)
     if not match:
         return False


### PR DESCRIPTION
The regex search() which intent to find codechecker source code comments are swappable with a much faster string.find() method. This will greatly improve performance of retrieving source code comments from the source files.