### PR TITLE
[analyzer][cfg] Don't acknowledge apiModeling checkers

### DIFF
--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -327,51 +327,6 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-webkit-uncountedlocalvarschecker",
       "profile:extreme"
     ],
-    "apiModeling.Errno": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive",
-      "severity:LOW"
-    ],
-    "apiModeling.StdCLibraryFunctions": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive",
-      "severity:LOW"
-    ],
-    "apiModeling.StdCLibraryFunctionArgs": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive",
-      "severity:LOW"
-    ],
-    "apiModeling.TrustNonnull": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive"
-    ],
-    "apiModeling.google.GTest": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive"
-    ],
-    "apiModeling.llvm.CastValue": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive"
-    ],
-    "apiModeling.llvm.ReturnValue": [
-      "profile:default",
-      "profile:extreme",
-      "profile:portability",
-      "profile:sensitive"
-    ],
     "core.CallAndMessage": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage-c-c-objc",
       "guideline:sei-cert",


### PR DESCRIPTION
As I complained in
https://github.com/Ericsson/codechecker/issues/2289 back in the day, apiModeling checkers should NEVER be explicitly disabled or enabled. CodeChecker seems to somewhat agree, because all apiModeling checkers we do have records on are present in all profiles. This is still incorrect though.

ApiModeling checkers are similar to core checkers, namely that if you disable them, you cannot expect the analyzer to function properly. However, we have even fewer excuses to disable them, because they are incapable of emitting reports (there is an assert that fires if they would).

However, if they are a part of profile, they can be unintentionally disabled through them.

Removing them from this file wouldn't prevent powerusers from disabling them however, just prevents unintentional misuse.