### PR TITLE
[analyzer] Change the log level to debug when overwriting plist files

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -633,8 +633,8 @@ def check(check_data):
                      action.analyzer_type, source_file_name)
 
             if result_file_exists:
-                LOG.warning("Previous analysis results in '%s' has been "
-                            "overwritten.", rh.analyzer_result_file)
+                LOG.debug("Previous analysis results in '%s' has been "
+                          "overwritten.", rh.analyzer_result_file)
         else:
             LOG.error("Analyzing %s with %s %s failed!",
                       source_file_name,
@@ -678,9 +678,9 @@ def check(check_data):
                              source_file_name)
 
                     if result_file_exists:
-                        LOG.warning("Previous analysis results in '%s' has "
-                                    "been overwritten.",
-                                    rh.analyzer_result_file)
+                        LOG.debug("Previous analysis results in '%s' has "
+                                  "been overwritten.",
+                                  rh.analyzer_result_file)
 
                 else:
                     LOG.error("Analyzing '%s' with %s without CTU failed.",


### PR DESCRIPTION
When CodeChecker does an analysis, it collects the results in a folder in plist files. However, when a new analysis is run where the result folder is the same, FOR EACH RESULT FILE a warning is issued about it being overwritten.

This is completely overkill, especially when this is the expected behaviour, like in the case of incremental analysis.

I changed these to debug level. I didn't change the 'info' level for when the '-c' flag is used (that also issues a log message, but in a lower severity), because that feels appropriate.