### PR TITLE
[analyzer] Ignore flag '-mword-relocations'

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -120,6 +120,7 @@ IGNORED_OPTIONS_GCC = [
     '-m(no-)?dsbt',
     '-m(no-)?fixed-ssp',
     '-m(no-)?pointers-to-nested-functions',
+    '-m(no-)?word-relocations',
     '-mno-fp-ret-in-387',
     '-mpreferred-stack-boundary',
     '-mpcrel-func-addr',


### PR DESCRIPTION
Exactly what it says on the tin! This flag, as I understand it, only affects the backend of the compiler.