### PR TITLE
[test] Fix fixit test

### DIFF
--- a/analyzer/tests/functional/fixit/test_fixit.py
+++ b/analyzer/tests/functional/fixit/test_fixit.py
@@ -396,10 +396,11 @@ int main()
             fixit_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
             cwd=self.test_workspace,
             encoding="utf-8",
             errors="ignore")
-        process.communicate()
+        process.communicate(input='[]')
 
         new_hash_1 = content_hash(source_file1)
         new_hash_2 = content_hash(source_file2)


### PR DESCRIPTION
In some environments/Python versions the standard input given to subprocess.Popen is handled differently. This fix uses the standard input parameter in a way that it works in every environment.