### PR TITLE
[req] Upgrade `lxml` to `4.9.1`

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 portalocker==2.2.1
 psutil==5.8.0
 PyYAML==5.4.1

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 nose==1.3.7
 pycodestyle==2.7.0
 psutil==5.8.0

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 portalocker==2.2.1
 psutil==5.8.0
 scan-build==2.0.19

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 sqlalchemy==1.3.23
 alembic==1.5.5
 portalocker==2.2.1

--- a/web/requirements_py/db_pg8000/requirements.txt
+++ b/web/requirements_py/db_pg8000/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 sqlalchemy==1.3.23
 alembic==1.5.5
 pg8000==1.15.2

--- a/web/requirements_py/db_psycopg2/requirements.txt
+++ b/web/requirements_py/db_psycopg2/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 sqlalchemy==1.3.23
 alembic==1.5.5
 psycopg2-binary==2.8.6

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 sqlalchemy==1.3.23
 pycodestyle==2.7.0
 alembic==1.5.5

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.7.1
+lxml==4.9.1
 alembic==1.5.5
 portalocker==2.2.1
 psutil==5.8.0


### PR DESCRIPTION
* This change is necessary but not sufficient for Python `3.11` support because `lxml` versions below `4.9.0` are incompatible
* See the `lxml` changelog section about adaptation to `3.10` & `3.11` : https://github.com/lxml/lxml/blob/ff82753bd09408ecfd6cacf7da67257495dc1335/CHANGES.txt#L35

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>