### PR TITLE
[cmd] Gracefully exit instead of crashing when cmd diff is missing a param

### DIFF
--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -489,6 +489,7 @@ def __register_diff(parser):
                         type=str,
                         nargs='+',
                         dest="base_run_names",
+                        required=True,
                         metavar='BASE_RUNS',
                         default=argparse.SUPPRESS,
                         help="The 'base' (left) side of the difference: these "
@@ -512,6 +513,7 @@ def __register_diff(parser):
                         type=str,
                         nargs='+',
                         dest="new_run_names",
+                        required=True,
                         metavar='NEW_RUNS',
                         default=argparse.SUPPRESS,
                         help="The 'new' (right) side of the difference: these "

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -67,6 +67,26 @@ class DiffLocal(unittest.TestCase):
         for resolved in resolved_results:
             self.assertEqual(resolved['checker_name'], "core.CallAndMessage")
 
+    def test_missing_new_run(self):
+        """
+        Don't crash, but gracefully exit if -n is not specified.
+        """
+        _, err, return_code = get_diff_results(
+            [self.base_reports], [], '--resolved', 'json')
+        self.assertEqual(return_code, 1)
+        self.assertIn("the following arguments are required: -n/--newname",
+                      err)
+
+    def test_missing_base_run(self):
+        """
+        Don't crash, but gracefully exit if -b is not specified.
+        """
+        _, err, return_code = get_diff_results(
+            [], [self.new_reports], '--resolved', 'json')
+        self.assertEqual(return_code, 1)
+        self.assertIn("the following arguments are required: -b/--basename",
+                      err)
+
     def test_new_json(self):
         """Get the new reports.
 

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -90,8 +90,10 @@ def get_diff_results(basenames, newnames, diff_type, format_type=None,
     if format_type:
         diff_cmd.extend(['-o', format_type])
 
-    diff_cmd.extend(['--basename'] + basenames)
-    diff_cmd.extend(['--newname'] + newnames)
+    if len(basenames) != 0:
+        diff_cmd.extend(['--basename'] + basenames)
+    if len(newnames) != 0:
+        diff_cmd.extend(['--newname'] + newnames)
 
     if extra_args:
         diff_cmd.extend(extra_args)
@@ -101,7 +103,7 @@ def get_diff_results(basenames, newnames, diff_type, format_type=None,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
 
-    if format_type == "json":
+    if proc.returncode != 1 and format_type == "json":
         return json.loads(out)['reports'], err, proc.returncode
 
     return out, err, proc.returncode


### PR DESCRIPTION
When CodeChecker cmd diff is invoked like this:

CodeChecker cmd diff -n new_run

it will crash instead of gracefully exiting and warning about the
missing -b flag. This patch fixes that.