### PR TITLE
[cmd] Deprecate --warnings flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/config_handler.py
@@ -36,6 +36,12 @@ class CppcheckConfigHandler(config_handler.AnalyzerConfigHandler):
         # all the possible checkers. All the checkers that are in the default
         # profile (or configured othewise, eg.: from the cli) should be
         # already enabled at this point.
-        for checker_name, data in self.checks().items():
-            if data[0] == CheckerState.default:
-                self.set_checker_enabled(checker_name, enabled=False)
+        # This happens in two phases in order to avoid iterator invalidation.
+        # (self.set_checker_enabled() removes elements, so we can't use it
+        # while iterating over the checker list.)
+        default_state_checkers = [
+            checker_name for checker_name, data in
+            self.checks().items() if data[0] == CheckerState.default]
+
+        for checker_name in default_state_checkers:
+            self.set_checker_enabled(checker_name, enabled=False)

--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -169,7 +169,17 @@ class TestCmdline(unittest.TestCase):
         self.assertEqual(retcode, 0)
         self.assertIn('clang-diagnostic-vla', out)
         # Make sure the header from `diagtool --tree` is ignored.
-        self.assertNotIn('EEN', out)
+        self.assertNotIn('GREEN', out)
+
+        # --warnings flag is deprecated. Warnings are included in checker list
+        # by default.
+        checkers_cmd = [env.codechecker_cmd(), 'checkers']
+        retcode, out, _ = run_cmd(checkers_cmd)
+
+        self.assertEqual(retcode, 0)
+        self.assertIn('clang-diagnostic-vla', out)
+        # Make sure the header from `diagtool --tree` is ignored.
+        self.assertNotIn('GREEN', out)
 
     def test_clangsa_checkers_description(self):
         """


### PR DESCRIPTION
--warnings flag made "CodeChecker checkers" print clang-diagnostic... checkers. Now this is deprecated, because all these warnings are considered as normal checker names.

The corresponding codes have been moved under clang-tidy config handler instead of the top-level file.