### PR TITLE
Fix error using Clang option '-stdlib=libc++'

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -101,8 +101,10 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         # * --std c99
         # * -std=c99
         # * --std=c99
-        # BUT NOT: -std c99
-        std_regex = re.compile("-?-std.*")
+        # BUT NOT:
+        # * -std c99
+        # * -stdlib=libc++
+        std_regex = re.compile("-?-std[ |=].*")
         for i, analyzer_option in enumerate(self.buildaction.analyzer_options):
             if interesting_option.match(analyzer_option):
                 params.extend([analyzer_option])

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -96,7 +96,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         Any other parameter different from the above list will be dropped.
         """
         params = []
-        interesting_option = re.compile("-[I|U|D].*")
+        interesting_option = re.compile("-[IUD].*")
         # the std flag is different. the following are all valid flags:
         # * --std c99
         # * -std=c99
@@ -104,7 +104,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         # BUT NOT:
         # * -std c99
         # * -stdlib=libc++
-        std_regex = re.compile("-?-std[ |=].*")
+        std_regex = re.compile("-(-std$|-?std=.*)")
         for i, analyzer_option in enumerate(self.buildaction.analyzer_options):
             if interesting_option.match(analyzer_option):
                 params.extend([analyzer_option])


### PR DESCRIPTION
Using Clang option "-stdlib=libc++" failed with:
cppcheck: error: unrecognized command line option: "--std=libc++"