### PR TITLE
[refactor] Rename and fix load_json_or_empty

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -16,11 +16,10 @@ from distutils.spawn import find_executable
 import os
 import sys
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common import logger
 from codechecker_common.checker_labels import CheckerLabels
 from codechecker_common.singleton import Singleton
+from codechecker_common.util import load_json
 
 from . import env
 
@@ -80,7 +79,7 @@ class Context(metaclass=Singleton):
             self._data_files_dir_path, "config", "config.json")
 
         LOG.debug('Reading config: %s', pckg_config_file)
-        cfg_dict = load_json_or_empty(pckg_config_file)
+        cfg_dict = load_json(pckg_config_file)
 
         if not cfg_dict:
             raise ValueError(f"No configuration file '{pckg_config_file}' can "
@@ -95,7 +94,7 @@ class Context(metaclass=Singleton):
             self._data_files_dir_path, "config", "package_layout.json")
 
         LOG.debug('Reading config: %s', layout_cfg_file)
-        lcfg_dict = load_json_or_empty(layout_cfg_file)
+        lcfg_dict = load_json(layout_cfg_file)
 
         if not lcfg_dict:
             raise ValueError(f"No configuration file '{layout_cfg_file}' can "
@@ -117,7 +116,7 @@ class Context(metaclass=Singleton):
         """
         Get the package version from the version config file.
         """
-        vfile_data = load_json_or_empty(self.version_file)
+        vfile_data = load_json(self.version_file)
 
         if not vfile_data:
             sys.exit(1)

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -23,11 +23,10 @@ import tempfile
 import traceback
 from typing import Dict, List, Optional
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_analyzer.analyzers import clangsa
 
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 from .. import gcc_toolchain
 from .build_action import BuildAction
@@ -542,7 +541,7 @@ class ImplicitCompilerInfo:
         ICI = ImplicitCompilerInfo
         ICI.compiler_info = {}
 
-        contents = load_json_or_empty(file_path, {})
+        contents = load_json(file_path, {})
         for k, v in contents.items():
             k = json.loads(k)
             ICI.compiler_info[

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -22,7 +22,6 @@ import sys
 
 from typing import List
 
-from codechecker_report_converter.util import load_json_or_empty
 from tu_collector import tu_collector
 
 from codechecker_analyzer import analyzer, analyzer_context, env
@@ -34,6 +33,7 @@ from codechecker_analyzer.buildlog import log_parser
 from codechecker_common import arg, logger, cmd_config
 from codechecker_common.skiplist_handler import SkipListHandler, \
     SkipListHandlers
+from codechecker_common.util import load_json
 
 
 LOG = logger.get_logger('system')
@@ -933,7 +933,7 @@ def main(args):
             sys.exit(1)
         compiler_info_file = args.compiler_info_file
 
-    compile_commands = load_json_or_empty(args.logfile)
+    compile_commands = load_json(args.logfile)
     if compile_commands is None:
         sys.exit(1)
     __change_args_to_command_in_comp_db(compile_commands)
@@ -1052,7 +1052,7 @@ def main(args):
     metadata_file = os.path.join(args.output_path, 'metadata.json')
     metadata_prev = None
     if os.path.exists(metadata_file):
-        metadata_prev = load_json_or_empty(metadata_file)
+        metadata_prev = load_json(metadata_file)
         metadata_tool['result_source_files'] = \
             __get_result_source_files(metadata_prev)
 

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -16,8 +16,7 @@ import os
 import sys
 from typing import Dict, Optional, Set
 
-from codechecker_report_converter.util import dump_json_output, \
-    load_json_or_empty
+from codechecker_report_converter.util import dump_json_output
 from codechecker_report_converter.report import report_file, \
     reports as reports_helper
 from codechecker_report_converter.report.output import baseline, codeclimate, \
@@ -34,6 +33,7 @@ from codechecker_analyzer import analyzer_context, suppress_handler
 from codechecker_common import arg, logger, cmd_config
 from codechecker_common.skiplist_handler import SkipListHandler, \
     SkipListHandlers
+from codechecker_common.util import load_json
 
 
 LOG = logger.get_logger('system')
@@ -257,7 +257,7 @@ def get_metadata(dir_path: str) -> Optional[Dict]:
     """ Get metadata from the given dir path or None if not exists. """
     metadata_file = os.path.join(dir_path, "metadata.json")
     if os.path.exists(metadata_file):
-        return load_json_or_empty(metadata_file)
+        return load_json(metadata_file)
 
     return None
 

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -15,11 +15,10 @@ import shutil
 import tempfile
 import unittest
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_analyzer.buildlog import log_parser
 from codechecker_common.skiplist_handler import SkipListHandler, \
     SkipListHandlers
+from codechecker_common.util import load_json
 
 
 class LogParserTest(unittest.TestCase):
@@ -77,7 +76,7 @@ class LogParserTest(unittest.TestCase):
         # define being considered a file and ignored, for now.
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -97,7 +96,7 @@ class LogParserTest(unittest.TestCase):
         # and --target=x86_64-linux-gnu.
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -110,7 +109,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a b.cpp')
@@ -120,7 +119,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "ldlogger-new-at.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -129,7 +128,7 @@ class LogParserTest(unittest.TestCase):
 
         # Test the same stuff with response files.
         logfile = os.path.join(self.__test_files, "ldlogger-new-response.json")
-        logjson = load_json_or_empty(logfile)
+        logjson = load_json(logfile)
         # Make it relative to the response file.
         logjson[0]['directory'] = self.__test_files
 
@@ -154,7 +153,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "intercept-old.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -169,7 +168,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
@@ -191,7 +190,7 @@ class LogParserTest(unittest.TestCase):
         # The define is passed to the analyzer properly.
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -204,7 +203,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
@@ -278,7 +277,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.__test_files, "include.json")
 
         build_actions, _ = log_parser.\
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
@@ -511,7 +510,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.compile_command_file_path)
 
         build_actions, _ = log_parser. \
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertEqual(build_action.analyzer_options[0],
@@ -537,7 +536,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.compile_command_file_path)
 
         build_actions, _ = log_parser. \
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -576,7 +575,7 @@ class LogParserTest(unittest.TestCase):
         logfile = os.path.join(self.compile_command_file_path)
 
         build_actions, _ = log_parser. \
-            parse_unique_log(load_json_or_empty(logfile), self.__this_dir)
+            parse_unique_log(load_json(logfile), self.__this_dir)
 
         self.assertEqual(len(build_actions), 2)
 
@@ -610,7 +609,7 @@ class LogParserTest(unittest.TestCase):
                     file=src_file_path
                 )]))
 
-        build_actions, _ = log_parser.parse_unique_log(load_json_or_empty(
+        build_actions, _ = log_parser.parse_unique_log(load_json(
             self.compile_command_file_path), self.__this_dir)
 
         self.assertEqual(len(build_actions), 1)

--- a/codechecker_common/checker_labels.py
+++ b/codechecker_common/checker_labels.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Any, cast, DefaultDict, Dict, Iterable, List, Optional, \
     Set, Tuple, Union
 
-from codechecker_report_converter.util import load_json_or_empty
+from codechecker_common.util import load_json
 
 
 # TODO: Most of the methods of this class get an optional analyzer name. If
@@ -31,7 +31,7 @@ class CheckerLabels:
         self.__descriptions = {}
 
         if 'descriptions.json' in os.listdir(checker_labels_dir):
-            self.__descriptions = load_json_or_empty(os.path.join(
+            self.__descriptions = load_json(os.path.join(
                 checker_labels_dir, 'descriptions.json'))
 
         label_json_files = map(
@@ -63,7 +63,7 @@ class CheckerLabels:
         all_labels = {}
 
         for label_file in label_files:
-            data = load_json_or_empty(label_file)
+            data = load_json(label_file)
             analyzer_labels = defaultdict(list)
 
             for checker, labels in data['labels'].items():

--- a/codechecker_common/cmd_config.py
+++ b/codechecker_common/cmd_config.py
@@ -11,9 +11,8 @@ import yaml
 
 from typing import List
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common import logger
+from codechecker_common.util import load_json
 
 LOG = logger.get_logger('system')
 
@@ -63,7 +62,7 @@ def process_config_file(args, subcommand_name):
             with open(config_file, encoding='utf-8', errors='ignore') as f:
                 cfg = yaml.load(f, Loader=yaml.BaseLoader)
         else:
-            cfg = load_json_or_empty(config_file, default={})
+            cfg = load_json(config_file, default={})
 
         # The subcommand name is analyze but the
         # configuration section name is analyzer.

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -11,6 +11,8 @@ Util module.
 
 
 import itertools
+import json
+import portalocker
 
 from codechecker_common.logger import get_logger
 
@@ -39,3 +41,35 @@ def chunks(iterator, n):
     for first in iterator:
         rest_of_chunk = itertools.islice(iterator, 0, n - 1)
         yield itertools.chain([first], rest_of_chunk)
+
+
+def load_json(path: str, default=None, lock=False):
+    """
+    Load the contents of the given file as a JSON and return it's value,
+    or default if the file can't be loaded.
+    """
+
+    ret = default
+    try:
+        with open(path, 'r', encoding='utf-8', errors='ignore') as handle:
+            if lock:
+                portalocker.lock(handle, portalocker.LOCK_SH)
+
+            ret = json.load(handle)
+
+            if lock:
+                portalocker.unlock(handle)
+    except IOError as ex:
+        LOG.warning("Failed to open json file: %s", path)
+        LOG.warning(ex)
+    except OSError as ex:
+        LOG.warning("Failed to open json file: %s", path)
+        LOG.warning(ex)
+    except ValueError as ex:
+        LOG.warning("%s is not a valid json file.", path)
+        LOG.warning(ex)
+    except TypeError as ex:
+        LOG.warning('Failed to process json file: %s', path)
+        LOG.warning(ex)
+
+    return ret

--- a/tools/report-converter/codechecker_report_converter/util.py
+++ b/tools/report-converter/codechecker_report_converter/util.py
@@ -9,7 +9,6 @@
 import json
 import logging
 import os
-import portalocker
 import sys
 import fnmatch
 import re
@@ -98,46 +97,6 @@ def trim_path_prefixes(path: str, prefixes: Optional[List[str]]) -> str:
         return path
 
     return path[len(longest_matching_prefix):]
-
-
-def load_json_or_empty(path: str, default=None, kind=None, lock=False):
-    """
-    Load the contents of the given file as a JSON and return it's value,
-    or default if the file can't be loaded.
-    """
-
-    ret = default
-    try:
-        with open(path, 'r', encoding='utf-8', errors='ignore') as handle:
-            if lock:
-                portalocker.lock(handle, portalocker.LOCK_SH)
-
-            ret = json.loads(handle.read())
-
-            if lock:
-                portalocker.unlock(handle)
-    except IOError as ex:
-        LOG.warning("Failed to open %s file: %s",
-                    kind if kind else 'json',
-                    path)
-        LOG.warning(ex)
-    except OSError as ex:
-        LOG.warning("Failed to open %s file: %s",
-                    kind if kind else 'json',
-                    path)
-        LOG.warning(ex)
-    except ValueError as ex:
-        LOG.warning("'%s' is not a valid %s file.",
-                    kind if kind else 'json',
-                    path)
-        LOG.warning(ex)
-    except TypeError as ex:
-        LOG.warning('Failed to process %s file: %s',
-                    kind if kind else 'json',
-                    path)
-        LOG.warning(ex)
-
-    return ret
 
 
 def dump_json_output(

--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -35,11 +35,11 @@ from codechecker_report_converter.report import Report, report_file, \
 from codechecker_report_converter.report.hash import HashType
 from codechecker_report_converter.source_code_comment_handler import \
     SourceCodeCommentHandler
-from codechecker_report_converter.util import load_json_or_empty
 
 from codechecker_client import client as libclient
 from codechecker_common import arg, logger, cmd_config
 from codechecker_common.checker_labels import CheckerLabels
+from codechecker_common.util import load_json
 
 from codechecker_web.shared import webserver_context, host_check
 from codechecker_web.shared.env import get_default_workspace
@@ -299,7 +299,7 @@ def __get_run_name(input_list):
     for input_path in input_list:
         metafile = os.path.join(input_path, "metadata.json")
         if os.path.isdir(input_path) and os.path.exists(metafile):
-            metajson = load_json_or_empty(metafile)
+            metajson = load_json(metafile)
 
             if 'version' in metajson and metajson['version'] >= 2:
                 for tool in metajson.get('tools', {}):

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -31,11 +31,11 @@ from codechecker_report_converter.report.output import baseline, codeclimate, \
 from codechecker_report_converter.report.output.html import \
     html as report_to_html
 from codechecker_report_converter.report.statistics import Statistics
-from codechecker_report_converter.util import dump_json_output, \
-    load_json_or_empty
+from codechecker_report_converter.util import dump_json_output
 
 from codechecker_common import logger
 from codechecker_common.checker_labels import CheckerLabels
+from codechecker_common.util import load_json
 
 from codechecker_web.shared import convert, webserver_context
 
@@ -1619,7 +1619,7 @@ def handle_import(args):
 
     client = setup_client(args.product_url)
 
-    data = load_json_or_empty(args.input, default=None)
+    data = load_json(args.input, default=None)
     if not data:
         LOG.error("Failed to import data!")
         sys.exit(1)

--- a/web/client/codechecker_client/credential_manager.py
+++ b/web/client/codechecker_client/credential_manager.py
@@ -17,9 +17,8 @@ import stat
 
 import portalocker
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 from codechecker_web.shared.env import check_file_owner_rw, get_password_file,\
     get_session_file
@@ -73,8 +72,7 @@ class UserCredentials:
 
         if os.path.exists(session_cfg_file):
             check_file_owner_rw(session_cfg_file)
-            scfg_dict = load_json_or_empty(session_cfg_file, {},
-                                           "user authentication")
+            scfg_dict = load_json(session_cfg_file, {})
             scfg_dict['credentials'] = \
                 simplify_credentials(scfg_dict['credentials'])
             if not scfg_dict['credentials']:

--- a/web/client/codechecker_client/metadata.py
+++ b/web/client/codechecker_client/metadata.py
@@ -9,9 +9,8 @@
 Helpers to manage metadata.json file.
 """
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 LOG = get_logger('system')
 
@@ -63,7 +62,7 @@ def merge_metadata_json(metadata_files, num_of_report_dir=1):
 
     for metadata_file in metadata_files:
         try:
-            metadata_dict = load_json_or_empty(metadata_file, {})
+            metadata_dict = load_json(metadata_file, {})
             metadata = metadata_v1_to_v2(metadata_dict)
             for tool in metadata['tools']:
                 ret['tools'].append(tool)

--- a/web/codechecker_web/shared/webserver_context.py
+++ b/web/codechecker_web/shared/webserver_context.py
@@ -15,11 +15,10 @@ import os
 import re
 import sys
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common import logger
 from codechecker_common.checker_labels import CheckerLabels
 from codechecker_common.singleton import Singleton
+from codechecker_common.util import load_json
 
 LOG = logger.get_logger('system')
 
@@ -72,8 +71,7 @@ class Context(metaclass=Singleton):
             labels_dir = os.environ['CC_TEST_LABELS_DIR']
 
         self._checker_labels = CheckerLabels(labels_dir)
-        self.__system_comment_map = \
-            load_json_or_empty(self.system_comment_map_file, {})
+        self.__system_comment_map = load_json(self.system_comment_map_file, {})
         self.__git_commit_urls = self.__get_git_commit_urls()
         self.__package_version = None
         self.__package_build_date = None
@@ -87,7 +85,7 @@ class Context(metaclass=Singleton):
 
     def __get_git_commit_urls(self):
         """ Get commit urls from the configuration file. """
-        git_commit_urls = load_json_or_empty(self.git_commit_urls_file, [])
+        git_commit_urls = load_json(self.git_commit_urls_file, [])
 
         for git_commit_url in git_commit_urls:
             git_commit_url["regex"] = re.compile(git_commit_url["regex"])
@@ -100,7 +98,7 @@ class Context(metaclass=Singleton):
             self._data_files_dir_path, "config", "package_layout.json")
 
         LOG.debug('Reading config: %s', layout_cfg_file)
-        lcfg_dict = load_json_or_empty(layout_cfg_file)
+        lcfg_dict = load_json(layout_cfg_file)
 
         if not lcfg_dict:
             raise ValueError(f"No configuration file '{layout_cfg_file}' can "
@@ -112,7 +110,7 @@ class Context(metaclass=Singleton):
         """
         Get the package version from the version config file.
         """
-        vfile_data = load_json_or_empty(self.version_file)
+        vfile_data = load_json(self.version_file)
 
         if not vfile_data:
             sys.exit(1)

--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -24,10 +24,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import codechecker_api_shared
 from codechecker_api.codeCheckerDBAccess_v6 import ttypes
 
-from codechecker_common import skiplist_handler, util
+from codechecker_common import skiplist_handler
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
-from codechecker_report_converter import util
+from codechecker_report_converter.util import trim_path_prefixes
 from codechecker_report_converter.report import report_file, Report
 from codechecker_report_converter.report.hash import get_report_path_hash
 from codechecker_report_converter.source_code_comment_handler import \
@@ -181,7 +182,7 @@ def get_blame_file_data(
     tracking_branch = None
 
     if os.path.isfile(blame_file):
-        data = util.load_json_or_empty(blame_file)
+        data = load_json(blame_file)
         if data:
             remote_url = data.get("remote_url")
             tracking_branch = data.get("tracking_branch")
@@ -392,7 +393,7 @@ class MassStoreRun:
             source_file_name = os.path.join(source_root, file_name.strip("/"))
             source_file_name = os.path.realpath(source_file_name)
             LOG.debug("Storing source file: %s", source_file_name)
-            trimmed_file_path = util.trim_path_prefixes(
+            trimmed_file_path = trim_path_prefixes(
                 file_name, self.__trim_path_prefixes)
 
             if not os.path.isfile(source_file_name):
@@ -1103,8 +1104,7 @@ class MassStoreRun:
                 content_hash_file = os.path.join(
                     zip_dir, 'content_hashes.json')
 
-                filename_to_hash = \
-                    util.load_json_or_empty(content_hash_file, {})
+                filename_to_hash = load_json(content_hash_file, {})
 
                 with LogTask(run_name=self.__name,
                              message="Store source files"):

--- a/web/server/codechecker_server/instance_manager.py
+++ b/web/server/codechecker_server/instance_manager.py
@@ -20,9 +20,8 @@ import stat
 
 import portalocker
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 LOG = get_logger('system')
 
@@ -135,6 +134,6 @@ def get_instances(folder=None):
     # This method does NOT write the descriptor file.
 
     descriptor = __get_instance_descriptor_path(folder)
-    instances = load_json_or_empty(descriptor, {}, lock=True)
+    instances = load_json(descriptor, {}, lock=True)
 
     return [i for i in instances if __check_instance(i['hostname'], i['pid'])]

--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -12,9 +12,8 @@ Helpers to parse metadata.json file.
 from typing import Any, Dict, List, Optional, Set, Union
 import os
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 
 LOG = get_logger('system')
@@ -64,7 +63,7 @@ class MetadataInfoParser:
 
         self.__metadata_dict = {}
         if os.path.isfile(metadata_file_path):
-            self.__metadata_dict = load_json_or_empty(metadata_file_path, {})
+            self.__metadata_dict = load_json(metadata_file_path, {})
 
             if 'version' in self.__metadata_dict:
                 self.__process_metadata_info_v2()

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -18,9 +18,8 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from codechecker_report_converter.util import load_json_or_empty
-
 from codechecker_common.logger import get_logger
+from codechecker_common.util import load_json
 
 from codechecker_web.shared.env import check_file_owner_rw
 from codechecker_web.shared.version import SESSION_COOKIE_NAME as _SCN
@@ -262,8 +261,7 @@ class SessionManager:
         ValueError if the configuration file is invalid.
         """
         LOG.debug(self.__configuration_file)
-        cfg_dict = load_json_or_empty(self.__configuration_file, {},
-                                      'server configuration')
+        cfg_dict = load_json(self.__configuration_file, {})
         if cfg_dict != {}:
             check_file_owner_rw(self.__configuration_file)
         else:

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -19,7 +19,7 @@ import socket
 import stat
 import subprocess
 
-from codechecker_report_converter.util import load_json_or_empty
+from codechecker_common.util import load_json
 
 from .thrift_client_to_db import get_auth_client
 from .thrift_client_to_db import get_config_client
@@ -348,7 +348,7 @@ def enable_auth(workspace):
     server_cfg_file = os.path.join(workspace,
                                    server_config_filename)
 
-    scfg_dict = load_json_or_empty(server_cfg_file, {})
+    scfg_dict = load_json(server_cfg_file, {})
     scfg_dict["authentication"]["enabled"] = True
     scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
     scfg_dict["authentication"]["method_dictionary"]["auths"] = \
@@ -388,7 +388,7 @@ def enable_storage_of_analysis_statistics(workspace):
     server_cfg_file = os.path.join(workspace,
                                    server_config_filename)
 
-    scfg_dict = load_json_or_empty(server_cfg_file, {})
+    scfg_dict = load_json(server_cfg_file, {})
     scfg_dict["store"]["analysis_statistics_dir"] = \
         os.path.join(workspace, 'analysis_statistics')
 


### PR DESCRIPTION
"load_json_or_empty" is a too long name for this function, and the
second part doesn't carry any information.

This function is only used for opening JSON files, so "kind" parameter
is not necessary.

Also move this load_json() function to codechecker_common.util module
because originally it was under report converter tool, but most usages
were in all other parts of CodeChecker. Many times this was the only
dependency towards report_converter.