### PR TITLE
Multiroot

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -451,7 +451,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             handler.ctu_on_demand = \
                 'ctu_ast_mode' in args and \
                 args.ctu_ast_mode == 'parse-on-demand'
-            handler.log_file = args.logfile
 
         try:
             with open(args.clangsa_args_cfg_file, 'r', encoding='utf8',

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -28,7 +28,6 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
         super(ClangSAConfigHandler, self).__init__()
         self.ctu_dir = ''
         self.ctu_on_demand = False
-        self.log_file = ''
         self.enable_z3 = False
         self.enable_z3_refutation = False
         self.environ = environ

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -9,6 +9,7 @@
 
 
 import argparse
+import os
 
 
 class OrderedCheckersAction(argparse.Action):
@@ -71,3 +72,18 @@ class OrderedConfigAction(argparse.Action):
             if flag in dest:
                 dest.remove(flag)
             dest.append(flag)
+
+
+def existing_abspath(path: str) -> str:
+    """
+    This function can be used at "type" argument of argparse.add_argument()
+    function. It returns the absolute path of the given path if exists
+    otherwise raises an argparse.ArgumentTypeError which constitutes in a
+    graceful error message automatically by argparse module.
+    """
+    path = os.path.abspath(path)
+
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError(f"File doesn't exist: {path}")
+
+    return path

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -800,7 +800,7 @@ def main(args):
 
         # --- Step 2.: Perform the analysis.
         analyze_args = argparse.Namespace(
-            logfile=logfile,
+            input=logfile,
             output_path=output_dir,
             output_format='plist',
             jobs=args.jobs,

--- a/analyzer/codechecker_analyzer/compilation_database.py
+++ b/analyzer/codechecker_analyzer/compilation_database.py
@@ -1,0 +1,209 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Utilities for compilation database handling.
+"""
+
+
+import os
+import shlex
+from typing import Callable, Dict, List, Optional
+
+from codechecker_common.util import load_json
+
+
+# For details see
+# https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Overall-Options.html#Overall-Options
+C_CPP_OBJC_OBJCPP_EXTS = [
+    '.c', '.i', '.ii', '.m', '.mi', '.mm', '.M', '.mii',
+    '.cc', '.cp', '.cxx', '.cpp', '.CPP', 'c++', '.C',
+    '.hh', '.H', '.hp', '.hxx', '.hpp', '.HPP', '.h++', '.tcc'
+]
+
+
+# Compilation database is conventionally stored in this file. Many Clang-based
+# tools rely on this file name, and CMake exports this too.
+COMPILATION_DATABASE = "compile_commands.json"
+
+
+def find_closest_compilation_database(path: str) -> Optional[str]:
+    """
+    Traverse the parent directories of the given path and find the closest
+    compile_commands.json. If no JSON file exists with this name up to the root
+    then None returns.
+    The path of the first compilation database is returned even if it doesn't
+    contain a corresponding entry for the given source file in "path".
+    """
+    path = os.path.abspath(path)
+    root = os.path.abspath(os.sep)
+
+    while True:
+        path = os.path.dirname(path)
+        compile_commands_json = os.path.join(path, COMPILATION_DATABASE)
+
+        if os.path.isfile(compile_commands_json):
+            return compile_commands_json
+
+        if path == root:
+            break
+
+
+def change_args_to_command_in_comp_db(compile_commands: List[Dict]):
+    """
+    In CodeChecker we support compilation databases where the JSON object of a
+    build action contains "file", "directory" and "command" fields. However,
+    compilation databases from intercept build contain "arguments" instead of
+    "command" which is a list of command-line arguments instead of the same
+    command as a single string. This function make this appropriate conversion.
+    """
+    for cc in compile_commands:
+        if 'command' not in cc:
+            # TODO: shlex.join(cmd) would be more elegant after upgrading to
+            # Python 3.8.
+            cc['command'] = ' '.join(map(shlex.quote, cc['arguments']))
+            del cc['arguments']
+
+
+def find_all_compilation_databases(path: str) -> List[str]:
+    """
+    Collect all compilation database paths that may be relevant for the source
+    files at the given path. This means compilation databases anywhere under
+    this path and in the parent directories up to the root.
+    """
+    dirs = []
+
+    for root, _, files in os.walk(path):
+        if COMPILATION_DATABASE in files:
+            dirs.append(os.path.join(root, COMPILATION_DATABASE))
+
+    path = os.path.abspath(path)
+    root = os.path.abspath(os.sep)
+
+    while True:
+        path = os.path.dirname(path)
+        compile_commands_json = os.path.join(path, COMPILATION_DATABASE)
+
+        if os.path.isfile(compile_commands_json):
+            dirs.append(compile_commands_json)
+
+        if path == root:
+            break
+
+    return dirs
+
+
+def build_action_describes_file(file_path: str) -> Callable[[Dict], bool]:
+    """
+    Returns a function which checks whether a build action belongs to the
+    given file_path. This returned function can be used for filtering
+    build actions in a compilation database to find build actions belonging
+    to the given source file.
+    """
+    def describes_file(build_action) -> bool:
+        return os.path.abspath(file_path) == os.path.abspath(
+            os.path.join(build_action['directory'], build_action['file']))
+    return describes_file
+
+
+def is_c_lang_source_file(source_file_path: str) -> bool:
+    """
+    A file is candidate if a build action may belong to it in some
+    compilation database, i.e. it is a C/C++/Obj-C source file.
+    """
+    return os.path.isfile(source_file_path) and \
+        os.path.splitext(source_file_path)[1] in C_CPP_OBJC_OBJCPP_EXTS
+
+
+def find_build_actions_for_file(file_path: str) -> List[Dict]:
+    """
+    Find the corresponding compilation database belonging to the given
+    source file and return a list of build actions that describe its
+    compilation.
+    """
+    comp_db = find_closest_compilation_database(file_path)
+
+    if comp_db is None:
+        return []
+
+    return list(filter(
+        build_action_describes_file(file_path),
+        load_json(comp_db)))
+
+
+def gather_compilation_database(analysis_input: str) -> Optional[List[Dict]]:
+    """
+    Return a compilation database that describes the build of the given
+    analysis_input:
+
+    - If analysis_input is a compilation database JSON file then its entries
+      return.
+    - If analysis_input is a C/C++/Obj-C source file then the corresponding
+      build command is found from the compilation database. Only the innermost
+      compilation database is checked (see find_closest_compilation_database()
+      for details).
+    - If analysis_input is a directory then a compilation database with the
+      build commands of all C/C++/Obj-C files in it return.
+
+    If none of these apply (e.g. analysis_input is a Python source file which
+    doesn't have a compilation database) then None returns.
+    """
+    def __select_compilation_database(
+        comp_db_paths: List[str],
+        source_file: str
+    ) -> Optional[str]:
+        """
+        Helper function for selecting the corresponding compilation database
+        for the given source file, i.e. the compilation database in the closest
+        parent directory, even if it doesn't contain a build action belonging
+        to this file.
+        """
+        comp_db_paths = list(map(os.path.dirname, comp_db_paths))
+        longest = os.path.commonpath(comp_db_paths + [source_file])
+        if longest in comp_db_paths:
+            return os.path.join(longest, COMPILATION_DATABASE)
+
+    # Case 1: analysis_input is a compilation database JSON file.
+
+    build_actions = load_json(analysis_input, display_warning=False)
+
+    if build_actions is not None:
+        pass
+
+    # Case 2: analysis_input is a C/C++/Obj-C source file.
+
+    elif is_c_lang_source_file(analysis_input):
+        build_actions = find_build_actions_for_file(analysis_input)
+
+    # Case 3: analysis_input is a directory.
+
+    elif os.path.isdir(analysis_input):
+        compilation_database_files = \
+            find_all_compilation_databases(analysis_input)
+
+        build_actions = []
+
+        for comp_db_file in compilation_database_files:
+            comp_db = load_json(comp_db_file)
+
+            if not comp_db:
+                continue
+
+            for ba in comp_db:
+                file_path = os.path.join(ba["directory"], ba["file"])
+
+                if os.path.commonpath([file_path, analysis_input]) \
+                        == analysis_input and __select_compilation_database(
+                        compilation_database_files,
+                        file_path) == comp_db_file:
+                    build_actions.append(ba)
+
+    # Compilation database transformation.
+    if build_actions is not None:
+        change_args_to_command_in_comp_db(build_actions)
+
+    return build_actions

--- a/analyzer/tests/unit/test_compilation_database.py
+++ b/analyzer/tests/unit/test_compilation_database.py
@@ -1,0 +1,174 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""Test compilation database collection."""
+
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from codechecker_analyzer import compilation_database
+
+
+class TestCompilationDatabase(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        """
+        Make a temporary directory which contains a sample project to test.
+        """
+
+        # /tmp/project_dir             (cls.project_dir)
+        #   |-sub                      (cls.project_dir)
+        #   |  |-compile_commands.json (cls.comp_db_outer) (contains: inner.c)
+        #   |  |-inner.c
+        #   |  `-main.c
+        #   |-compile_commands.json    (cls.comp_db_inner) (contains: outer.c,
+        #                                                             inner.c)
+        #   `-outer.c
+
+        cls.project_dir = tempfile.mkdtemp()
+        cls.project_sub_dir = os.path.join(cls.project_dir, "sub")
+
+        cls.comp_db_outer = \
+            os.path.join(cls.project_dir, "compile_commands.json")
+        cls.comp_db_inner = \
+            os.path.join(cls.project_sub_dir, "compile_commands.json")
+
+        cls.source_file_outer = os.path.join(cls.project_dir, "outer.c")
+        cls.source_file_inner = os.path.join(cls.project_sub_dir, "inner.c")
+        cls.source_file_main = os.path.join(cls.project_sub_dir, "main.c")
+
+        os.makedirs(cls.project_sub_dir)
+
+        comp_db = [{
+            "directory": cls.project_dir,
+            "command": "gcc outer.c",
+            "file": "outer.c"
+        }, {
+            "directory": cls.project_sub_dir,
+            "command": "gcc inner.c",
+            "file": "inner.c"
+        }]
+
+        comp_db_sub = [{
+            "directory": cls.project_sub_dir,
+            "command": "gcc inner.c",
+            "file": "inner.c"
+        }]
+
+        def write_to_file(content: str, filename: str):
+            with open(filename, "w", encoding="utf-8", errors="ignore") as f:
+                f.write(content)
+
+        write_to_file(json.dumps(comp_db), cls.comp_db_outer)
+        write_to_file(json.dumps(comp_db_sub), cls.comp_db_inner)
+        write_to_file("int main() {}", cls.source_file_outer)
+        write_to_file("int main() {}", cls.source_file_inner)
+        write_to_file("int main() {}", cls.source_file_main)
+
+    @classmethod
+    def teardown_class(cls):
+        """
+        Clean temporary directory and files.
+        """
+        shutil.rmtree(cls.project_dir)
+
+    def test_find_closest_compilation_database(self):
+        """
+        Find the closest compilation database to each test source file.
+        """
+        closest = compilation_database.find_closest_compilation_database(
+            TestCompilationDatabase.source_file_outer)
+
+        self.assertEqual(closest, TestCompilationDatabase.comp_db_outer)
+
+        closest = compilation_database.find_closest_compilation_database(
+            TestCompilationDatabase.source_file_inner)
+
+        self.assertEqual(closest, TestCompilationDatabase.comp_db_inner)
+
+        closest = compilation_database.find_closest_compilation_database(
+            TestCompilationDatabase.source_file_main)
+
+        self.assertEqual(closest, TestCompilationDatabase.comp_db_inner)
+
+    def test_gather_compilation_database(self):
+        """
+        Test if the correct set of build actions return to each test source
+        file.
+
+        WARNING! compilation_database.gather_compilation_database() function is
+        looking for compile_commands.json up to the root directory. In this
+        test-case we assume that the test project is somewhere under
+        /tmp/<tempdir>/... This test project directory is created by
+        setup_class(). If this test fails then it is possible that there is
+        another compile_commands.json in the file system on the path up to the
+        root.
+        """
+        def compile_commands(comp_db):
+            return set([comp_action["command"] for comp_action in comp_db])
+
+        # Check the assumption described in the function's documentation.
+        self.assertTrue(
+            all(db.startswith(self.project_dir)
+                for db in compilation_database.find_all_compilation_databases(
+                    self.project_dir)),
+            "There must not be a compile_commands.json file on the path to "
+            f"{self.project_dir}")
+
+        # Build actions for files.
+
+        comp_db = compilation_database.gather_compilation_database(
+            TestCompilationDatabase.source_file_outer)
+
+        self.assertEqual(len(comp_db), 1)
+        self.assertIn("gcc outer.c", compile_commands(comp_db))
+
+        comp_db = compilation_database.gather_compilation_database(
+            TestCompilationDatabase.source_file_inner)
+
+        self.assertEqual(len(comp_db), 1)
+        self.assertIn("gcc inner.c", compile_commands(comp_db))
+
+        comp_db = compilation_database.gather_compilation_database(
+            TestCompilationDatabase.source_file_main)
+
+        # In case a compile_commands.json is found outside of the project dir.
+        if len(comp_db) != 0:
+            for comp_action in comp_db:
+                self.assertNotEqual(
+                    comp_action["directory"],
+                    self.project_dir)
+                self.assertNotEqual(
+                    comp_action["directory"],
+                    self.project_sub_dir)
+
+        # Build actions for directories.
+
+        comp_db = compilation_database.gather_compilation_database(
+            TestCompilationDatabase.project_dir)
+
+        self.assertEqual(len(comp_db), 2)
+        self.assertIn("gcc outer.c", compile_commands(comp_db))
+        self.assertIn("gcc inner.c", compile_commands(comp_db))
+
+        comp_db = compilation_database.gather_compilation_database(
+            TestCompilationDatabase.project_sub_dir)
+
+        self.assertEqual(len(comp_db), 1)
+        self.assertIn("gcc inner.c", compile_commands(comp_db))
+
+        # Non-existing file or directory.
+
+        comp_db = compilation_database.gather_compilation_database(
+            os.path.join(TestCompilationDatabase.project_dir, "non_existing"))
+
+        self.assertIsNone(comp_db)

--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -43,10 +43,17 @@ def chunks(iterator, n):
         yield itertools.chain([first], rest_of_chunk)
 
 
-def load_json(path: str, default=None, lock=False):
+def load_json(path: str, default=None, lock=False, display_warning=True):
     """
     Load the contents of the given file as a JSON and return it's value,
     or default if the file can't be loaded.
+
+    path -- JSON file path to load.
+    defaut -- Value to return if JSON can't be loaded for some reason (e.g
+              file doesn't exist, bad JSON format, etc.)
+    lock -- Use portalocker to lock the JSON file for exclusive use.
+    display_warning -- Display warning messages why the JSON file can't be
+                       loaded (e.g. bad format, failed to open file, etc.)
     """
 
     ret = default
@@ -60,16 +67,20 @@ def load_json(path: str, default=None, lock=False):
             if lock:
                 portalocker.unlock(handle)
     except IOError as ex:
-        LOG.warning("Failed to open json file: %s", path)
-        LOG.warning(ex)
+        if display_warning:
+            LOG.warning("Failed to open json file: %s", path)
+            LOG.warning(ex)
     except OSError as ex:
-        LOG.warning("Failed to open json file: %s", path)
-        LOG.warning(ex)
+        if display_warning:
+            LOG.warning("Failed to open json file: %s", path)
+            LOG.warning(ex)
     except ValueError as ex:
-        LOG.warning("%s is not a valid json file.", path)
-        LOG.warning(ex)
+        if display_warning:
+            LOG.warning("%s is not a valid json file.", path)
+            LOG.warning(ex)
     except TypeError as ex:
-        LOG.warning('Failed to process json file: %s', path)
-        LOG.warning(ex)
+        if display_warning:
+            LOG.warning('Failed to process json file: %s', path)
+            LOG.warning(ex)
 
     return ret

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -865,15 +865,23 @@ for printing an overview in the terminal (`CodeChecker parse`) or storing
 (`CodeChecker store`) analysis results in a database, which can later on be
 viewed in a browser.
 
-Example:
+Examples:
 
 ```sh
 CodeChecker analyze ../codechecker_myProject_build.log -o my_plists
+CodeChecker analyze main.cpp -o my_plists
+CodeChecker analyze project_root -o my_plists
 ```
 
 **Note**: If your compilation database log file contains relative paths you
 have to make sure that you run the analysis command from the same directory
 as the logger was run (i.e. that paths are relative to).
+
+In case a source file or a project directory is given as analysis input, the
+process still relies on the compilation database JSON file, because CodeChecker
+tries to find it implicitly. So make sure that a `compile_commands.json`
+describing the build commands of analyzed modules is available in the project
+tree.
 
 `CodeChecker analyze` supports a myriad of fine-tuning arguments, explained
 below:
@@ -905,16 +913,15 @@ usage: CodeChecker analyze [-h] [-j JOBS]
                            [-e checker/group/profile]
                            [-d checker/group/profile] [--enable-all]
                            [--verbose {info,debug,debug_analyzer}]
-                           logfile
+                           input
 
 Use the previously created JSON Compilation Database to perform an analysis on
 the project, outputting analysis results in a machine-readable format.
 
 positional arguments:
-  logfile               Path to the JSON compilation command database files
-                        which were created during the build. The analyzers
-                        will check only the files registered in these build
-                        databases.
+  input                 The input of the analysis can be either a compilation
+                        database JSON file, a path to a source file or a path
+                        to a directory containing source files.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,6 +131,18 @@ During analysis, CodeChecker compiles/analyses sources again. The analysis
 process generally uses more time. If you want to speed up analysis specify a
 higher value for the `--jobs` option.
 
+The input of the analysis can be either a compilation database JSON file like
+in the example above or a source file or a project/module directory. In all
+cases the analysis relies on the compilation database, but with a file/directory
+input the `compile_commands.json` is searched automatically by CodeChecker in
+the parent directories:
+
+```sh
+CodeChecker analyze my_source_file.cpp
+CodeChecker analyze project_dir
+CodeChecker analyze project_dir/sub_module_dir
+```
+
 In the above command the `--enable sensitive` means that a subset of checker
 are run. `sensitive` chooses a predefined "group" of checkers. For further
 info on available checkers use these commands:


### PR DESCRIPTION
[cmd] Multiroot directory analysis support

Currently the input of analysis is a compilation database JSON file. The
purpose of this PR is to support the following analysis invocations:

```
# Analyze one source file.
CodeChecker analyze main.c -o reports

#analyze all source files under a directory.
CodeChecker analyze my_project -o reports
```

This way the analysisa project with multiple root directories (i.e.
separate compilation databases for submodules in subdirectories)
is supported.