### PR TITLE
[cmd] Fix a crash with CodeChecker cmd diff --unique on

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1788,7 +1788,9 @@ class ThriftRequestHandler:
                                   Report.review_status_date,
                                   Report.review_status_is_in_source,
                                   File.filename, File.filepath,
-                                  Report.path_length, Report.analyzer_name) \
+                                  Report.path_length, Report.analyzer_name,
+                                  Report.file_id, Report.run_id, Report.line,
+                                  Report.column, Report.detection_status) \
                     .outerjoin(File, Report.file_id == File.id) \
                     .outerjoin(sorted_reports,
                                sorted_reports.c.id == Report.id) \
@@ -1814,7 +1816,8 @@ class ThriftRequestHandler:
                     review_status_author, review_status_message, \
                     review_status_date, review_status_is_in_source, \
                     filename, _, bug_path_len, \
-                        analyzer_name in query_result:
+                        analyzer_name, file_id, run_id, line, column, \
+                        d_status in query_result:
 
                     review_data = create_review_data(
                         review_status,
@@ -1824,18 +1827,25 @@ class ThriftRequestHandler:
                         review_status_is_in_source)
 
                     results.append(
-                        ReportData(bugHash=bug_id,
+                        ReportData(runId=run_id,
+                                   bugHash=bug_id,
                                    checkedFile=filename,
                                    checkerMsg=checker_msg,
+                                   reportId=report_id,
+                                   fileId=file_id,
+                                   line=line,
+                                   column=column,
                                    checkerId=checker,
                                    severity=severity,
                                    reviewData=review_data,
+                                   detectionStatus=detection_status_enum(
+                                       d_status),
                                    detectedAt=str(detected_at),
                                    fixedAt=str(fixed_at),
                                    bugPathLength=bug_path_len,
                                    details=report_details.get(report_id),
                                    analyzerName=analyzer_name))
-            else:
+            else:  # not is_unique
                 sort_types, sort_type_map, order_type_map = \
                     get_sort_map(sort_types)
 

--- a/web/tests/functional/diff_local_remote/test_diff_local_remote.py
+++ b/web/tests/functional/diff_local_remote/test_diff_local_remote.py
@@ -91,6 +91,16 @@ class LocalRemote(unittest.TestCase):
         count = len(re.findall(r'\[core\.NullDereference\]', out))
         self.assertEqual(count, 4)
 
+    def test_local_to_remote_unique_diff(self):
+        """Check whether CodeChecker cmd diff crashes when --unique is on."""
+        _, _, code = get_diff_results([self._local_reports],
+                                      [self._run_names[0]],
+                                      '--new', None,
+                                      ["--url", self._url,
+                                       "--uniqueing", "on"])
+
+        self.assertEqual(code, 2)
+
     def test_remote_to_local_compare_count_new(self):
         """Count the new results with no filter."""
         out, _, _ = get_diff_results([self._run_names[0]],


### PR DESCRIPTION
Suppose we have a server with two non-empty, non-identical runs, Example1 and Example2. The following invocation:

CodeChecker cmd diff -o rows --url localhost/Default -n "Example2" -b "Example1" --new --uniqueing on

would have crashed at a thrift call level. If uniqueing wasn't on, the crash was abscent as well.

The root of the problem wasn't on the thrift level, however, but rather that a thrift function was invoked with None values, when said parameters mustn't have been None.

Specifically, these values were the file ID's of some reports. The file ID, column and row numbers of a report are None in the ReportData with uniqueing, but are proper values otherwise.

This makes some sense -- if 10 reports have the same report hash, by uniquing we obtain a report that describes 10 reports, so "some sense of identity being lost" would be an understandable approach to uniquing, but we can do better.

We can just take the arguably easier solution of picking a random report out of the 10 equivalent one, and say that this report stands in the place of the other 9.

On the implementation level, I simply querried the rest of the fields of the table, which in effect does just this.