### PR TITLE
[bugfix] Required format for --checker-config

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -9,7 +9,6 @@
 Clang Static Analyzer related functions.
 """
 
-
 import os
 import re
 import shlex
@@ -482,17 +481,15 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             'enable_all' in args and args.enable_all)
 
         handler.checker_config = []
-        r = re.compile(r'(?P<analyzer>.+?):(?P<key>.+?)=(?P<value>.+)')
 
         # TODO: This extra "isinstance" check is needed for
         # CodeChecker checkers --checker-config. This command also runs
         # this function in order to construct a config handler.
         if 'checker_config' in args and isinstance(args.checker_config, list):
             for cfg in args.checker_config:
-                m = re.search(r, cfg)
-                if m.group('analyzer') == cls.ANALYZER_NAME:
+                if cfg.analyzer == cls.ANALYZER_NAME:
                     handler.checker_config.append(
-                        m.group('key') + '=' + m.group('value'))
+                        f"{cfg.checker}:{cfg.option}={cfg.value}")
 
         # TODO: This extra "isinstance" check is needed for
         # CodeChecker analyzers --analyzer-config. This command also runs
@@ -500,9 +497,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         if 'analyzer_config' in args and \
                 isinstance(args.analyzer_config, list):
             for cfg in args.analyzer_config:
-                m = re.search(r, cfg)
-                if m.group('analyzer') == cls.ANALYZER_NAME:
-                    handler.checker_config.append(
-                        m.group('key') + '=' + m.group('value'))
+                if cfg.analyzer == cls.ANALYZER_NAME:
+                    handler.checker_config.append(f"{cfg.option}={cfg.value}")
 
         return handler

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -6,7 +6,10 @@
 #
 # -------------------------------------------------------------------------
 """
+Cppcheck related functions.
 """
+
+from collections import defaultdict
 # TODO distutils will be removed in python3.12
 from distutils.version import StrictVersion
 from pathlib import Path
@@ -355,18 +358,13 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         handler.analyzer_binary = context.analyzer_binaries.get(
             cls.ANALYZER_NAME)
 
-        analyzer_config = {}
+        analyzer_config = defaultdict(list)
 
         if 'analyzer_config' in args and \
                 isinstance(args.analyzer_config, list):
-            r = re.compile(r'(?P<analyzer>.+?):(?P<key>.+?)=(?P<value>.+)')
             for cfg in args.analyzer_config:
-                m = re.search(r, cfg)
-                if m.group('analyzer') == cls.ANALYZER_NAME:
-                    key = m.group('key')
-                    if key not in analyzer_config:
-                        analyzer_config[key] = []
-                    analyzer_config[m.group('key')].append(m.group('value'))
+                if cfg.analyzer == cls.ANALYZER_NAME:
+                    analyzer_config[cfg.option].append(cfg.value)
 
         handler.analyzer_config = analyzer_config
 

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -9,7 +9,15 @@
 
 
 import argparse
+import collections
 import os
+import re
+
+
+AnalyzerConfig = collections.namedtuple(
+    'AnalyzerConfig', ["analyzer", "option", "value"])
+CheckerConfig = collections.namedtuple(
+    "CheckerConfig", ["analyzer", "checker", "option", "value"])
 
 
 class OrderedCheckersAction(argparse.Action):
@@ -87,3 +95,41 @@ def existing_abspath(path: str) -> str:
         raise argparse.ArgumentTypeError(f"File doesn't exist: {path}")
 
     return path
+
+
+def analyzer_config(arg: str) -> AnalyzerConfig:
+    """
+    This function can be used at "type" argument of argparse.add_argument().
+    It checks the format of --analyzer-config flag:
+    <analyzer>:<option>=<value>
+    These three things return as a tuple.
+    """
+    m = re.match(r"(?P<analyzer>.+):(?P<option>.+)=(?P<value>.+)", arg)
+
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"Analyzer option in wrong format: {arg}, should be "
+            "<analyzer>:<option>=<value>")
+
+    return AnalyzerConfig(
+        m.group("analyzer"), m.group("option"), m.group("value"))
+
+
+def checker_config(arg: str) -> CheckerConfig:
+    """
+    This function can be used at "type" argument of argparse.add_argument().
+    It checks the format of --checker-config flag:
+    <analyzer>:<checker>:<option>=<value>
+    These four things return as a tuple.
+    """
+    m = re.match(
+        r"(?P<analyzer>.+):(?P<checker>.+):(?P<option>.+)=(?P<value>.+)", arg)
+
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"Checker option in wrong format: {arg}, should be"
+            "<analyzer>:<checker>:<option>=<value>")
+
+    return CheckerConfig(
+        m.group("analyzer"), m.group("checker"),
+        m.group("option"), m.group("value"))

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -20,7 +20,8 @@ import tempfile
 
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.arg import \
-        OrderedCheckersAction, OrderedConfigAction
+    OrderedCheckersAction, OrderedConfigAction, \
+    analyzer_config, checker_config
 
 from codechecker_common import arg, cmd_config, logger
 from codechecker_report_converter.source_code_comment_handler import \
@@ -348,10 +349,11 @@ used to generate a log file on the fly.""")
                                     "clang-tidy' command.")
 
     analyzer_opts.add_argument('--analyzer-config',
+                               type=analyzer_config,
                                dest='analyzer_config',
                                nargs='*',
                                action=OrderedConfigAction,
-                               default=["clang-tidy:HeaderFilterRegex=.*"],
+                               default=argparse.SUPPRESS,
                                help="Analyzer configuration options in the "
                                     "following format: analyzer:key=value. "
                                     "The collection of the options can be "
@@ -360,9 +362,8 @@ used to generate a log file on the fly.""")
                                     "--analyzer-config'.\n"
                                     "If the file at --tidyargs "
                                     "contains a -config flag then those "
-                                    "options extend these and override "
-                                    "\"HeaderFilterRegex\" if any.\n"
-                                    "To use analyzer configuration file "
+                                    "options extend these.\n"
+                                    "To use an analyzer configuration file "
                                     "in case of Clang Tidy (.clang-tidy) use "
                                     "the "
                                     "'clang-tidy:take-config-from-directory="
@@ -371,6 +372,7 @@ used to generate a log file on the fly.""")
                                     "binary.")
 
     analyzer_opts.add_argument('--checker-config',
+                               type=checker_config,
                                dest='checker_config',
                                nargs='*',
                                action=OrderedConfigAction,

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -1080,7 +1080,7 @@ class TestAnalyze(unittest.TestCase):
                        "--analyzer-config",
                        "clang-tidy:Checks=hicpp-use-nullptr",
                        "--checker-config",
-                       "clang-tidy:hicpp-use-nullptr.NullMacros=MY_NULL"]
+                       "clang-tidy:hicpp-use-nullptr:NullMacros=MY_NULL"]
 
         print(analyze_cmd)
         process = subprocess.Popen(

--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -230,3 +230,29 @@ class TestCmdline(unittest.TestCase):
             desc = cfg['description']
             self.assertTrue(desc)
             self.assertFalse(desc[0].islower())
+
+    def test_checker_config_format(self):
+        """
+        Test if checker config option is meeting the reqired format.
+        """
+        test_file = os.path.join(self.test_workspace, 'main.cpp')
+
+        with open(test_file, 'w', encoding="utf-8", errors="ignore") as f:
+            f.write("int main() {}")
+
+        cmd = [env.codechecker_cmd(), 'check',
+               '--checker-config', 'clangsa:checker.option=value',
+               '-b', f'g++ {test_file}']
+
+        return_code, _, err = run_cmd(cmd)
+
+        self.assertEqual(return_code, 1)
+        self.assertIn("Checker option in wrong format", err)
+
+        cmd = [env.codechecker_cmd(), 'check',
+               '--checker-config', 'clangsa:checker:option=value',
+               '-b', f'g++ {test_file}']
+
+        _, _, err = run_cmd(cmd)
+
+        self.assertNotIn("Checker option in wrong format", err)

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -281,13 +281,12 @@ analyzer arguments:
                         format: analyzer:key=value. The collection of the
                         options can be printed with 'CodeChecker analyzers
                         --analyzer-config'. If the file at --tidyargs contains
-                        a -config flag then those options extend these and
-                        override "HeaderFilterRegex" if any. To use analyzer
-                        configuration file in case of Clang Tidy (.clang-tidy)
-                        use the 'clang-tidy:take-config-from-directory=true'
-                        option. It will skip setting the '-checks' parameter
-                        of the clang-tidy binary. (default: ['clang-
-                        tidy:HeaderFilterRegex=.*'])
+                        a -config flag then those options extend these. To use
+                        an analyzer configuration file in case of Clang Tidy
+                        (.clang-tidy) use the
+                        'clang-tidy:take-config-from-directory=true' option.
+                        It will skip setting the '-checks' parameter of the
+                        clang-tidy binary.
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:
                         analyzer:key=value. The collection of the options can
@@ -1113,13 +1112,12 @@ analyzer arguments:
                         format: analyzer:key=value. The collection of the
                         options can be printed with 'CodeChecker analyzers
                         --analyzer-config'. If the file at --tidyargs contains
-                        a -config flag then those options extend these and
-                        override "HeaderFilterRegex" if any. To use analyzer
-                        configuration file in case of Clang Tidy (.clang-tidy)
-                        use the 'clang-tidy:take-config-from-directory=true'
-                        option. It will skip setting the '-checks' parameter
-                        of the clang-tidy binary. (default: ['clang-
-                        tidy:HeaderFilterRegex=.*'])
+                        a -config flag then those options extend these. To use
+                        an analyzer configuration file in case of Clang Tidy
+                        (.clang-tidy) use the
+                        'clang-tidy:take-config-from-directory=true' option.
+                        It will skip setting the '-checks' parameter of the
+                        clang-tidy binary.
   --checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]
                         Checker configuration options in the following format:
                         analyzer:key=value. The collection of the options can


### PR DESCRIPTION
"CodeChecker analyze" command has a --checker-config flag. The parameter
of this flag should be in the following format:
`<analyzer>:<checker>:<option>=<value>`

clang-tidy tool requires a "." character between the checker and the
option, so CodeChecker should convert it from : to .

The format of --checker-config (and --analyzer-config) is now checked
at the command line parsing phase, so it is done with a common algorithm
for all analyzer tools.

Earlier the default value of --analyzer-config was
"clang-tidy:HeaderFilterRegex='.*'", so clang-tidy analysis of header
files is also done. This is not a default value for the flag anymore,
but it is handled under clang-tidy module.