### PR TITLE
[cmd] Remove --tidy-config flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -133,8 +133,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         Return a list of checkers and warnings what needs to be enabled during
         analysis.
 
-        If the file specified by the '--tidy-config' option contains a 'Checks'
-        key or the 'Checks' option is specified through the '--analyzer-config'
+        If 'Checks' option is specified through '--analyzer-config'
         the return value will be a tuple of empty lists which means do not turn
         checkers explicitly. "clang-analyzer-*" is an exception, because we
         want to disable these even if analyzer config is given. If we wouldn't

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -394,7 +394,8 @@ def add_arguments_to_parser(parser):
                                dest='tidy_config',
                                required=False,
                                default=argparse.SUPPRESS,
-                               help="A file in YAML format containing the "
+                               help="DEPRECATED. "
+                                    "A file in YAML format containing the "
                                     "configuration of clang-tidy checkers. "
                                     "The file can be dumped by "
                                     "'CodeChecker analyzers --dump-config "
@@ -877,6 +878,11 @@ def main(args):
     readable format.
     """
     logger.setup_logger(args.verbose if 'verbose' in args else None)
+
+    if 'tidy_config' in args:
+        LOG.warning(
+            "--tidy-config is deprecated and will be removed in the next "
+            "release. Use --analyzer-config or --checker-config instead.")
 
     # CTU loading mode is only meaningful if CTU itself is enabled.
     if 'ctu_ast_mode' in args and 'ctu_phases' not in args:

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -341,7 +341,8 @@ used to generate a log file on the fly.""")
                                dest='tidy_config',
                                required=False,
                                default=argparse.SUPPRESS,
-                               help="A file in YAML format containing the "
+                               help="DEPRECATED. "
+                                    "A file in YAML format containing the "
                                     "configuration of clang-tidy checkers. "
                                     "The file can be dumped by "
                                     "'CodeChecker analyzers --dump-config "
@@ -819,7 +820,6 @@ def main(args):
                           'add_compiler_defaults',
                           'clangsa_args_cfg_file',
                           'tidy_args_cfg_file',
-                          'tidy_config',
                           'analyzer_config',
                           'checker_config',
                           'capture_analysis_output',

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -137,7 +137,6 @@ usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q]
                          [--config CONFIG_FILE]
                          [--saargs CLANGSA_ARGS_CFG_FILE]
                          [--tidyargs TIDY_ARGS_CFG_FILE]
-                         [--tidy-config TIDY_CONFIG]
                          [--analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]]
                          [--checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]]
                          [--timeout TIMEOUT]
@@ -277,11 +276,6 @@ analyzer arguments:
   --tidyargs TIDY_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang-Tidy analyzer.
-  --tidy-config TIDY_CONFIG
-                        A file in YAML format containing the configuration of
-                        clang-tidy checkers. The file can be dumped by
-                        'CodeChecker analyzers --dump-config clang-tidy'
-                        command.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the
@@ -898,7 +892,7 @@ usage: CodeChecker analyze [-h] [-j JOBS]
                            [--cppcheck-args CPPCHECK_ARGS_CFG_FILE]
                            [--saargs CLANGSA_ARGS_CFG_FILE]
                            [--tidyargs TIDY_ARGS_CFG_FILE]
-                           [--tidy-config TIDY_CONFIG] [--timeout TIMEOUT]
+                           [--timeout TIMEOUT]
                            [--ctu | --ctu-collect | --ctu-analyze]
                            [--ctu-ast-mode {load-from-pch, parse-on-demand}]
                            [--ctu-reanalyze-on-failure]
@@ -1107,11 +1101,6 @@ analyzer arguments:
   --tidyargs TIDY_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for Clang-Tidy.
-  --tidy-config TIDY_CONFIG
-                        A file in YAML format containing the configuration of
-                        clang-tidy checkers. The file can be dumped by
-                        'CodeChecker analyzers --dump-config clang-tidy'
-                        command.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the


### PR DESCRIPTION
CodeChecker analyze --tidy-config is a rarely used and redundant flag. ClangTidy options can be given through .clang-tidy file, --analyzer-config, --checker-config and --tidyargs flags.