### PR TITLE
[cmd] Remove some deprecated flags.

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -169,10 +169,6 @@ def perform_analysis(args, skip_handlers, context, actions, metadata_tool,
 
     ctu_reanalyze_on_failure = 'ctu_reanalyze_on_failure' in args and \
         args.ctu_reanalyze_on_failure
-    if ctu_reanalyze_on_failure:
-        LOG.warning("Usage of a DEPRECATED FLAG!\n"
-                    "The --ctu-reanalyze-on-failure flag will be removed "
-                    "in the upcoming releases!")
 
     analyzers = args.analyzers if 'analyzers' in args \
         else analyzer_types.supported_analyzers

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -530,8 +530,7 @@ Cross-TU analysis. By default, no CTU analysis is run when
                               action='store_true',
                               dest='ctu_reanalyze_on_failure',
                               default=argparse.SUPPRESS,
-                              help="DEPRECATED. The flag will be removed. "
-                                   "If Cross-TU analysis is enabled and fails "
+                              help="If Cross-TU analysis is enabled and fails "
                                    "for some reason, try to re analyze the "
                                    "same translation unit without "
                                    "Cross-TU enabled.")

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -478,8 +478,7 @@ is called.""")
                               action='store_true',
                               dest='ctu_reanalyze_on_failure',
                               default=argparse.SUPPRESS,
-                              help="DEPRECATED. The flag will be removed. "
-                                   "If Cross-TU analysis is enabled and "
+                              help="If Cross-TU analysis is enabled and "
                                    "fails for some reason, try to re analyze "
                                    "the same translation unit without "
                                    "Cross-TU enabled.")

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -229,28 +229,6 @@ def add_arguments_to_parser(parser):
                              "These can be given to 'CodeChecker analyze "
                              "--checker-config'.")
 
-    filters = parser.add_mutually_exclusive_group(required=False)
-
-    # --only-enabled and --only-disabled flags are deprecated because they're
-    # not used anymore. Earlier we listed all checkers that would be enabled
-    # during analysis with the given filter set (--label, --profile,
-    # --guideline) and that list contained default checkers among others which
-    # were not explicitly enabled. (These could have been eliminated by
-    # --only-enabled). Now we list only those checkers which fulfill the
-    # conjunction of the provided labels, or we list all checkers if no filter
-    # is given.
-    filters.add_argument('--only-enabled',
-                         dest='only_enabled',
-                         default=argparse.SUPPRESS,
-                         action='store_true',
-                         help="DEPRECATED. Show only the enabled checkers.")
-
-    filters.add_argument('--only-disabled',
-                         dest='only_disabled',
-                         default=argparse.SUPPRESS,
-                         action='store_true',
-                         help="DEPRECATED. Show only the disabled checkers.")
-
     parser.add_argument('-o', '--output',
                         dest='output_format',
                         required=False,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -2148,7 +2148,6 @@ providing a quick overview on which checkers are available in the analyzers.
 usage: CodeChecker checkers [-h] [--analyzers ANALYZER [ANALYZER ...]]
                             [--details] [--label LABEL [LABEL ...]]
                             [--profile {PROFILE/list}]
-                            [--only-enabled | --only-disabled]
                             [-o {rows,table,csv,json}]
                             [--verbose {info,debug,debug_analyzer}]
 
@@ -2186,8 +2185,6 @@ optional arguments:
                         existing checkers supported by the analyzer.
                         These can be given to 'CodeChecker analyze
                         --checker-config'.
-  --only-enabled        DEPRECATED. Show only the enabled checkers.
-  --only-disabled       DEPRECATED. Show only the disabled checkers.
   -o {rows,table,csv,json}, --output {rows,table,csv,json}
                         The format to list the applicable checkers as.
                         (default: rows)
@@ -2225,10 +2222,6 @@ List labels and their available values:
     CodeChecker checkers --label severity
 ```
 </details>
-
-The list provided by default is formatted for easy machine and human
-reading. Use the `--only-` options (`--only-enabled` and `--only-disabled`) to
-filter the list if you wish to see just the enabled/disabled checkers.
 
 A detailed view of the available checkers is available via `--details`. In the
 *detailed view*, checker status, severity and description (if available) is

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -774,17 +774,6 @@ filter arguments:
                         'year:month:day:hour:minute:second' (the "time" part
                         can be omitted, in which case midnight (00:00:00) is
                         used).
-  -s, --suppressed      DEPRECATED. Use the '--filter' option to get false
-                        positive (suppressed) results. Show only suppressed
-                        results instead of only unsuppressed ones.
-  --filter FILTER       DEPRECATED. Filter results. Use separated filter
-                        options to filter the results. The filter string has
-                        the following format: [<SEVERITIES>]:[<CHECKER_NAMES>]
-                        :[<FILE_PATHS>]:[<DETECTION_STATUSES>]:[<REVIEW_STATUS
-                        ES>] where severites, checker_names, file_paths,
-                        detection_statuses, review_statuses should be a comma
-                        separated list, e.g.: "high,medium:unix,core:*.cpp,*.h
-                        :new,unresolved:false_positive,intentional"
 ```
 
 #### Source components (`components`)
@@ -1042,7 +1031,7 @@ usage: CodeChecker cmd results [-h] [--details] [--uniqueing {on,off}]
                                [--detected-after TIMESTAMP]
                                [--fixed-before TIMESTAMP]
                                [--fixed-after TIMESTAMP] [-s]
-                               [--filter FILTER] [--url PRODUCT_URL]
+                               [--url PRODUCT_URL]
                                [-o {plaintext,rows,table,csv,json}]
                                [--verbose {info,debug,debug_analyzer}]
                                RUN_NAMES [RUN_NAMES ...]
@@ -1115,7 +1104,7 @@ usage: CodeChecker cmd diff [-h] [-b BASE_RUNS [BASE_RUNS ...]]
                             [--detected-before TIMESTAMP]
                             [--detected-after TIMESTAMP]
                             [--fixed-before TIMESTAMP]
-                            [--fixed-after TIMESTAMP] [-s] [--filter FILTER]
+                            [--fixed-after TIMESTAMP] [-s]
                             (--new | --resolved | --unresolved)
                             [--url PRODUCT_URL]
                             [-o {plaintext,rows,table,csv,json,html,gerrit,codeclimate} [{plaintext,rows,table,csv,json,html,gerrit,codeclimate} ...]]
@@ -1306,17 +1295,6 @@ filter arguments:
                         'year:month:day:hour:minute:second' (the "time" part
                         can be omitted, in which case midnight (00:00:00) is
                         used).
-  -s, --suppressed      DEPRECATED. Use the '--filter' option to get false
-                        positive (suppressed) results. Show only suppressed
-                        results instead of only unsuppressed ones.
-  --filter FILTER       DEPRECATED. Filter results. Use separated filter
-                        options to filter the results. The filter string has
-                        the following format: [<SEVERITIES>]:[<CHECKER_NAMES>]
-                        :[<FILE_PATHS>]:[<DETECTION_STATUSES>]:[<REVIEW_STATUS
-                        ES>] where severites, checker_names, file_paths,
-                        detection_statuses, review_statuses should be a comma
-                        separated list, e.g.: "high,medium:unix,core:*.cpp,*.h
-                        :new,unresolved:false_positive,intentional"
 
 comparison modes:
   List reports that can be found only in baseline or new runs or in both. False
@@ -1496,7 +1474,7 @@ to the results stored on a remote CodeChecker server previously
 
 ```
 usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a)
-                           [--disable-unique] [--uniqueing {on,off}]
+                           [--uniqueing {on,off}]
                            [--report-hash [REPORT_HASH [REPORT_HASH ...]]]
                            [--review-status [REVIEW_STATUS [REVIEW_STATUS ...]]]
                            [--detection-status [DETECTION_STATUS [DETECTION_STATUS ...]]]
@@ -1513,7 +1491,7 @@ usage: CodeChecker cmd sum [-h] (-n RUN_NAME [RUN_NAME ...] | -a)
                            [--detected-before TIMESTAMP]
                            [--detected-after TIMESTAMP]
                            [--fixed-before TIMESTAMP]
-                           [--fixed-after TIMESTAMP] [-s] [--filter FILTER]
+                           [--fixed-after TIMESTAMP] [-s]
                            [--url PRODUCT_URL]
                            [-o {plaintext,rows,table,csv,json}]
                            [--verbose {info,debug,debug_analyzer}]
@@ -1533,12 +1511,6 @@ optional arguments:
                         runs. Use 'CodeChecker cmd runs' to get the available
                         runs.
   -a, --all             Show breakdown for all analysis runs.
-  --disable-unique      DEPRECATED. Use the '--uniqueing' option to get
-                        uniqueing results. List all bugs even if these end up
-                        in the same bug location, but reached through
-                        different paths. By uniqueing the bugs a report will
-                        be appeared only once even if it is found on several
-                        paths.
 ```
 </details>
 
@@ -1682,7 +1654,7 @@ report_hash||source_file_name||suppress_comment||type_of_suppression
 
 * `report_hash` is the hash identifier of the report to be suppressed
 * `source_file_name` is the name of the source file wher the report is located
-* `suppress_commant` why you think the issue should be suppressed
+* `suppress_comment` why you think the issue should be suppressed
 * `type_of_suppression` one of the following `false_positive`, `intentional`,
   `confirmed`
 

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -424,30 +424,6 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                               "\"time\" part can be omitted, in which case "
                               "midnight (00:00:00) is used).")
 
-    f_group.add_argument('-s', '--suppressed',
-                         default=argparse.SUPPRESS,
-                         dest="suppressed",
-                         action='store_true',
-                         help="DEPRECATED. Use the '--filter' option to get "
-                              "false positive (suppressed) results. Show only "
-                              "suppressed results instead of only "
-                              "unsuppressed ones.")
-
-    f_group.add_argument('--filter',
-                         type=str,
-                         dest='filter',
-                         default=argparse.SUPPRESS,
-                         help="DEPRECATED. Filter results. Use separated "
-                              "filter options to filter the results. The "
-                              "filter string has the following format: "
-                              "[<SEVERITIES>]:[<CHECKER_NAMES>]:"
-                              "[<FILE_PATHS>]:[<DETECTION_STATUSES>]:"
-                              "[<REVIEW_STATUSES>] where severites, "
-                              "checker_names, file_paths, detection_statuses, "
-                              "review_statuses should be a comma separated "
-                              "list, e.g.: \"high,medium:unix,core:*.cpp,*.h:"
-                              "new,unresolved:false_positive,intentional\"")
-
 
 def __register_results(parser):
     """
@@ -619,17 +595,6 @@ def __register_sum(parser):
                             action='store_true',
                             default=argparse.SUPPRESS,
                             help="Show breakdown for all analysis runs.")
-
-    parser.add_argument('--disable-unique',
-                        dest="disable_unique",
-                        action='store_true',
-                        default=argparse.SUPPRESS,
-                        help="DEPRECATED. Use the '--uniqueing' option to "
-                             "get uniqueing results. List all bugs even if "
-                             "these end up in the same bug location, but "
-                             "reached through different paths. By uniqueing "
-                             "the bugs a report will be appeared only once "
-                             "even if it is found on several paths.")
 
     default_filter_values = DEFAULT_FILTER_VALUES
     default_filter_values['uniqueing'] = 'on'

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -325,16 +325,6 @@ def check_run_names(client, check_names):
 
 
 def check_deprecated_arg_usage(args):
-    if 'suppressed' in args:
-        LOG.warning('"--suppressed" option has been deprecated. Use '
-                    '"--review-status" option to get false positive '
-                    '(suppressed) results.')
-
-    if 'filter' in args:
-        LOG.warning('"--filter" option has been deprecated. Use '
-                    'separate filter options of this command to filter the '
-                    'results. For more information see the help.')
-
     if 'detected_at' in args:
         LOG.warning('"--detected-at" option has been deprecated. Use '
                     '--detected-before/--detected-after options to filter the '
@@ -426,22 +416,6 @@ def check_filter_values(args):
     """
     severities = checkers = file_path = dt_statuses = rw_statuses = None
     bug_path_length = None
-
-    filter_str = args.filter if 'filter' in args else None
-    if filter_str:
-        if filter_str.count(':') != 4:
-            LOG.warning("Filter string has to contain four colons (e.g. "
-                        "\"high,medium:unix,core:*.cpp:new,unresolved:"
-                        "false_positive,intentional\").")
-        else:
-            filter_values = []
-            for x in filter_str.strip().split(':'):
-                values = [y.strip() for y in x.strip().split(',') if y.strip()]
-                filter_values.append(values if values else None)
-
-            # pylint: disable=unbalanced-tuple-unpacking
-            severities, checkers, file_path, dt_statuses, rw_statuses = \
-                filter_values
 
     if 'severity' in args:
         severities = args.severity
@@ -1335,11 +1309,6 @@ def handle_list_result_types(args):
 
     init_logger(args.verbose if 'verbose' in args else None, stream)
     check_deprecated_arg_usage(args)
-
-    if 'disable_unique' in args:
-        LOG.warning("--disable-unique option is deprecated. Please use the "
-                    "'--uniqueing on' option to get uniqueing results.")
-        args.uniqueing = 'off'
 
     def get_statistics(client, run_ids, field, values):
         report_filter = ttypes.ReportFilter()


### PR DESCRIPTION
Some flags are removed from the code base that are deprecated for a while.
Also, the deprecation of --ctu-reanalyze-on-failure is undone, because it will not be deprecated in the near future, probably.