### PR TITLE
[fix] Fix a condition about checkers being compiler warnings 

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
@@ -15,6 +15,11 @@ from codechecker_common.logger import get_logger
 from ..config_handler import AnalyzerConfigHandler, CheckerState, \
                              get_compiler_warning_name
 
+
+def is_compiler_warning(checker_name):
+    return (get_compiler_warning_name(checker_name) is not None)
+
+
 LOG = get_logger('analyzer.tidy')
 
 
@@ -34,7 +39,7 @@ class ClangTidyConfigHandler(AnalyzerConfigHandler):
         """
         if self.analyzer_config and \
            self.analyzer_config.get('take-config-from-directory') == 'true':
-            if get_compiler_warning_name(checker_name) is None:
+            if is_compiler_warning(checker_name):
                 return
 
         super(ClangTidyConfigHandler, self).add_checker(checker_name,

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -17,6 +17,8 @@ from argparse import Namespace
 from codechecker_analyzer.analyzers.clangsa.analyzer import ClangSA
 from codechecker_analyzer.analyzers.clangtidy.analyzer import ClangTidy
 from codechecker_analyzer.analyzers.config_handler import CheckerState
+from codechecker_analyzer.analyzers.clangtidy.config_handler \
+        import is_compiler_warning
 
 from codechecker_analyzer import analyzer_context
 from codechecker_analyzer.buildlog import log_parser
@@ -278,6 +280,9 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
         for arg in analyzer.construct_analyzer_cmd(result_handler):
             if arg.startswith('-checks='):
                 self.assertIn('-clang-analyzer-*', arg)
+
+        self.assertTrue(is_compiler_warning('Wreserved-id-macro'))
+        self.assertFalse(is_compiler_warning('hicpp'))
 
         args = Namespace()
         args.ordered_checkers = [('Wreserved-id-macro', True)]

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -134,7 +134,7 @@ int main()
             f.write(self.sources[version])
 
     def _check_source_file(self, cfg):
-        codechecker.check_and_store(cfg, self._run_name, self._test_dir)
+        return codechecker.check_and_store(cfg, self._run_name, self._test_dir)
 
     def _create_clang_tidy_cfg_file(self, checkers):
         """ This function will create a .clang-tidy config file. """
@@ -382,8 +382,8 @@ int main()
 
         self._create_source_file(1)
         self._create_clang_tidy_cfg_file(['-*', 'hicpp-*', 'modernize-*'])
-        self._check_source_file(cfg)
-
+        return_code = self._check_source_file(cfg)
+        self.assertEqual(return_code, 0)
         reports = self._cc_client.getRunResults(None, 100, 0, [], None, None,
                                                 False)
 

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -285,6 +285,7 @@ def check_and_store(codechecker_cfg, test_project_name, test_project_path,
             encoding="utf-8",
             errors="ignore")
         out, err = process.communicate()
+        # errcode = process.returncode
         print(out)
         print(err)
 


### PR DESCRIPTION
Seems like I never tested this well enough in
https://github.com/Ericsson/codechecker/pull/3698, because I could
negate a condition in config_handler.py and no tests broke. This broke
in https://github.com/Ericsson/codechecker/pull/3820, however, when
hicpp-* was mistakenly not understood to be a checker, which caused an
error (instead of a warning).