### PR TITLE
[web] Fix stale permission caching

### DIFF
--- a/web/server/vue-cli/src/App.vue
+++ b/web/server/vue-cli/src/App.vue
@@ -3,7 +3,7 @@
     <the-header />
 
     <v-main>
-      <keep-alive include="Products">
+      <keep-alive :include="keepAliveList">
         <router-view />
       </keep-alive>
       <errors />
@@ -20,7 +20,27 @@ export default {
   components: {
     Errors,
     TheHeader
-  }
+  },
+  data() {
+    return {
+      keepAliveList: []
+    };
+  },
+  computed: {
+    isAuthenticated() {
+      return this.$store.getters.isAuthenticated;
+    }
+  },
+  watch: {
+    // eslint-disable-next-line no-unused-vars
+    isAuthenticated(newValue, _) {
+      if (newValue) {
+        this.keepAliveList.push("Products");
+      } else {
+        this.keepAliveList = [];
+      }
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
Due that the keep-alive component cache is used wrapping the router view, the products page was cached after logout.
Now the keep-alive inclusion list is dynamically adjusted according to the user authentication state.
The cache is only kept for one login session.