### PR TITLE
[fix] Pass arch flag correctly

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -285,7 +285,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             if not has_flag('-arch', analyzer_cmd) and \
                     self.buildaction.arch != "":
-                analyzer_cmd.extend(["-arch ", self.buildaction.arch])
+                analyzer_cmd.extend(["-arch", self.buildaction.arch])
 
             if not has_flag('-std', analyzer_cmd) and \
                     self.buildaction.compiler_standard != "":


### PR DESCRIPTION
The `-arch` flag was passed to the clangsa analyze command with a trailing space. This resulted in a wrong invocation, where the command inculded this flag like this: `'arch ' arm64`.

Fixes #3847