### PR TITLE
[NFC] Factor args out of the diff logic for unit tests

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -721,26 +721,31 @@ def handle_list_results(args):
 
 
 def handle_diff_results(args):
+    handle_diff_results_impl(args)
+
+
+def handle_diff_results_impl(args):
     # If the given output format is not 'table', redirect logger's output to
     # the stderr.
     stream = None
-    if 'output_format' in args and args.output_format != 'table':
+    output_formats = args.output_formats
+    if output_formats != 'table':
         stream = 'stderr'
 
     init_logger(args.verbose if 'verbose' in args else None, stream)
 
     output_dir = args.export_dir if 'export_dir' in args else None
-    if len(args.output_format) > 1 and ('export_dir' not in args):
+    if len(output_formats) > 1 and ('export_dir' not in args):
         LOG.error("Export directory is required if multiple output formats "
                   "are selected!")
         sys.exit(1)
 
-    if 'html' in args.output_format and not output_dir:
+    if 'html' in output_formats and not output_dir:
         LOG.error("Argument --export not allowed without argument --output "
                   "when exporting to HTML.")
         sys.exit(1)
 
-    if 'gerrit' in args.output_format and \
+    if 'gerrit' in output_formats and \
             not gerrit.mandatory_env_var_is_set():
         sys.exit(1)
 
@@ -781,7 +786,7 @@ def handle_diff_results(args):
         if file_id not in file_cache:
             file_cache[file_id] = File(file_path, file_id)
 
-            if 'html' in args.output_format:
+            if 'html' in output_formats:
                 source = client.getSourceFileData(
                     file_id, True, ttypes.Encoding.BASE64)
                 file_cache[file_id].content = convert.from_b64(
@@ -824,7 +829,7 @@ def handle_diff_results(args):
             return reports
 
         source_line_contents = {}
-        if 'html' not in args.output_format:
+        if 'html' not in output_formats:
             source_line_contents = get_source_line_contents(reports_data)
 
         # Convert reports data to reports.
@@ -1257,7 +1262,7 @@ def handle_diff_results(args):
             basename_local_dirs, basename_baseline_files,
             newname_local_dirs, newname_baseline_files)
 
-        print_reports(reports, report_hashes, args.output_format)
+        print_reports(reports, report_hashes, output_formats)
         LOG.info("Compared the following local files / directories: %s and %s",
                  ', '.join([*basename_local_dirs, *basename_baseline_files]),
                  ', '.join([*newname_local_dirs, *newname_baseline_files]))
@@ -1267,7 +1272,7 @@ def handle_diff_results(args):
                 client, basename_run_names,
                 newname_local_dirs, newname_baseline_files)
 
-        print_reports(reports, report_hashes, args.output_format)
+        print_reports(reports, report_hashes, output_formats)
         LOG.info("Compared remote run(s) %s (matching: %s) and local files / "
                  "report directory(s) %s",
                  ', '.join(basename_run_names),
@@ -1279,7 +1284,7 @@ def handle_diff_results(args):
                 client, basename_local_dirs, basename_baseline_files,
                 newname_run_names)
 
-        print_reports(reports, report_hashes, args.output_format)
+        print_reports(reports, report_hashes, output_formats)
         LOG.info("Compared local files / report directory(s) %s and remote "
                  "run(s) %s (matching: %s).",
                  ', '.join([*basename_local_dirs, *basename_baseline_files]),
@@ -1288,7 +1293,7 @@ def handle_diff_results(args):
     else:
         reports, matching_base_run_names, matching_new_run_names = \
             get_diff_remote_runs(client, basename_run_names, newname_run_names)
-        print_reports(reports, None, args.output_format)
+        print_reports(reports, None, output_formats)
         LOG.info("Compared multiple remote runs %s (matching: %s) and %s "
                  "(matching: %s)",
                  ', '.join(basename_run_names),

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -415,6 +415,11 @@ def validate_filter_values(converted_values: List[int], valid_values,
 
 
 def parse_report_filter(client, args):
+    """
+    Parse and check attributes of the given report filter based on
+    the arguments which is provided in the command line.
+    Also, check if filter values are valid values.
+    """
     report_filter = parse_report_filter_offline(args)
 
     if 'tag' in args:
@@ -429,10 +434,9 @@ def parse_report_filter(client, args):
 
 def parse_report_filter_offline(args):
     """
-    This function fills some attributes of the given report filter based on
-    the arguments which is provided in the command line.
-    Check if filter values are valid values. Returns values which are checked
-    or exit from the interpreter.
+    Same as parse_report_filter, but will not make calls to the server.
+    As of writing this comment, this means that the 'tag' argument will be
+    ignored (as that would require a getRunHistory API call).
     """
     report_filter = ttypes.ReportFilter()
 
@@ -796,7 +800,7 @@ def get_diff_local_dir_remote_run(
     client,
     report_filter: ttypes.ReportFilter,
     diff_type: ttypes.DiffType,
-    output_formats,
+    output_formats: List[str],
     report_dirs: List[str],
     baseline_files: List[str],
     remote_run_names: List[str]
@@ -894,7 +898,7 @@ def get_diff_remote_run_local_dir(
     client,
     report_filter: ttypes.ReportFilter,
     diff_type: ttypes.DiffType,
-    output_formats,
+    output_formats: List[str],
     remote_run_names: List[str],
     report_dirs: List[str],
     baseline_files: List[str]
@@ -965,7 +969,7 @@ def get_diff_remote_runs(
     client,
     report_filter: ttypes.ReportFilter,
     diff_type: ttypes.DiffType,
-    output_formats,
+    output_formats: List[str],
     remote_base_run_names: Iterable[str],
     remote_new_run_names: Iterable[str]
 ) -> Tuple[List[Report], List[str], List[str]]:
@@ -1007,6 +1011,8 @@ def get_diff_remote_runs(
 def get_diff_local_dirs(
     report_filter: ttypes.ReportFilter,
     diff_type: ttypes.DiffType,
+    # TODO: No output_format argument? How come? Maybe the other functions
+    # don't need it either?
     report_dirs: List[str],
     baseline_files: List[str],
     new_report_dirs: List[str],
@@ -1065,7 +1071,7 @@ def print_reports(
     print_steps: bool,
     reports: List[Report],
     report_hashes: Iterable[str],
-    output_dir,
+    output_dir: str,
     output_formats: List[str]
 ):
     if report_hashes:

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -138,7 +138,6 @@ class DiffLocal(unittest.TestCase):
         high_severity_res, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', 'json',
             ['--severity', 'high'])
-        print(high_severity_res)
         self.assertEqual(len(high_severity_res), 4)
 
     def test_filter_severity_high_text(self):

--- a/web/tests/functional/diff_local/test_diff_local.py
+++ b/web/tests/functional/diff_local/test_diff_local.py
@@ -138,6 +138,7 @@ class DiffLocal(unittest.TestCase):
         high_severity_res, _, _ = get_diff_results(
             [self.base_reports], [self.new_reports], '--new', 'json',
             ['--severity', 'high'])
+        print(high_severity_res)
         self.assertEqual(len(high_severity_res), 4)
 
     def test_filter_severity_high_text(self):


### PR DESCRIPTION
CodeChecker cmd diff is a little out of whack right now, which is discussed in length here: #3884

One of the reasons why it was possible for this problem to fester into this state is that our testing methodology for diffs (really, the entirety of CodeChecker) is really-really poor. Cmdline diff in particular (though not unique in this manner) were done by literally calling CodeChecker, and reparsing its stdout and stderr by string matching whether we see what we want. 

That is weak even for a python project.

Part of the problem is that key functions/classes in CodeChecker take the ominous "args" argument, which contains the set of user arguments, as well as our defaults. We parse a tiny bit of "args" (possibly redundantly), and then pass it onto another function, that does the same. This is dumb -- we should parse args, and simply get on with our lives. Major function should have very concrete arguments that are, in an ideal scenario, contsructible in a unit test environment.

This multi-commit patch does just that: It gradually threads args out of all major functions and does some minimal refactoring with whats left.