### PR TITLE
[analyzer] Add a new flag to demote missing checker errors to a warning

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -181,9 +181,17 @@ def perform_analysis(args, skip_handlers, actions, metadata_tool,
         missing_checkers = checkers.available(args.ordered_checkers,
                                               available_checkers)
         if missing_checkers:
-            LOG.error("No checker(s) with these names was found:\n%s",
-                      '\n'.join(missing_checkers))
-            sys.exit(1)
+            diag_msg = "No checker(s) with these names was found:\n{}".format(
+                '\n'.join(missing_checkers))
+            if 'no_missing_checker_error' in args:
+                LOG.warning(diag_msg)
+            else:
+                LOG.error(diag_msg)
+                LOG.info("Although it is not reccomended, if you want to "
+                         "suppress errors relating to unknown "
+                         "checker names, consider using the option "
+                         "'--no-missing-checker-error'")
+                sys.exit(1)
 
     if 'stats_enabled' in args:
         config_map[ClangSA.ANALYZER_NAME].set_checker_enabled(

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -748,6 +748,15 @@ LLVM/Clang community, and thus discouraged.
                                     "the analysis. USE WISELY AND AT YOUR "
                                     "OWN RISK!")
 
+    checkers_opts.add_argument('--no-missing-checker-error',
+                               dest="no_missing_checker_error",
+                               action='store_true',
+                               required=False,
+                               default=argparse.SUPPRESS,
+                               help="Emit a warning instead of an error when "
+                                    "an unknown checker name is given to "
+                                    "either --enable or --disable.")
+
     logger.add_verbose_arguments(parser)
     parser.set_defaults(
         func=main, func_process_config_file=cmd_config.process_config_file)

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -694,6 +694,15 @@ LLVM/Clang community, and thus discouraged.
                                     "the analysis. USE WISELY AND AT YOUR "
                                     "OWN RISK!")
 
+    checkers_opts.add_argument('--no-missing-checker-error',
+                               dest="no_missing_checker_error",
+                               action='store_true',
+                               required=False,
+                               default=argparse.SUPPRESS,
+                               help="Emit a warning instead of an error when "
+                                    "an unknown checker name is given to "
+                                    "either --enable or --disable.")
+
     output_opts = parser.add_argument_group("output arguments")
 
     output_opts.add_argument('--print-steps',


### PR DESCRIPTION
Altough discouraged, if someone really insists on having a soft warning when a checker is supplied to --enable or --disable, they can use the new flag '--no-missing-checker-error', which is disabled by default.