### PR TITLE
Dynamic results annotation filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/TestcaseFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/TestcaseFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <select-option
     :id="id"
-    title="Testsuite"
+    title="Testcase"
     :bus="bus"
     :fetch-items="fetchItems"
     :selected-items="selectedItems"
@@ -29,7 +29,7 @@ import SelectOption from "./SelectOption/SelectOption";
 import BaseSelectOptionFilterMixin from "./BaseSelectOptionFilter.mixin";
 
 export default {
-  name: "TestsuiteFilter",
+  name: "TestcaseFilter",
   components: {
     SelectOption
   },
@@ -37,9 +37,9 @@ export default {
 
   data() {
     return {
-      id: "testsuite",
+      id: "testcase",
       search: {
-        placeHolder: "Search for testsuite names...",
+        placeHolder: "Search for testcase names...",
         regexLabel: "Filter by wildcard pattern",
         filterItems: this.filterItems
       }
@@ -51,14 +51,14 @@ export default {
       this.setReportFilter({
         annotations: this.selectedItems.length == 0
           ? null : this.selectedItems.map(item => new Pair({
-            first: "testsuite",
+            first: "testcase",
             second: item.id
           }))
       });
     },
 
     onReportFilterChange(key) {
-      if (key === "testsuiteName") return;
+      if (key === "testcaseName") return;
       this.update();
     },
 
@@ -66,7 +66,7 @@ export default {
       this.loading = true;
 
       return new Promise(resolve => {
-        ccService.getClient().getReportAnnotations("testsuite",
+        ccService.getClient().getReportAnnotations("testcase",
           handleThriftError(res => {
             resolve(res.map(annotation => {
               return {

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/index.js
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/index.js
@@ -19,7 +19,7 @@ import CheckerNameFilter from "./CheckerNameFilter";
 import CheckerMessageFilter from "./CheckerMessageFilter";
 import BaseFilterMixin from "./BaseFilter.mixin";
 import BugPathLengthFilter from "./BugPathLengthFilter";
-import TestsuiteFilter from "./TestsuiteFilter";
+import TestcaseFilter from "./TestcaseFilter";
 
 export {
   AnalyzerNameFilter,
@@ -42,5 +42,5 @@ export {
   CheckerMessageFilter,
   BaseFilterMixin,
   BugPathLengthFilter,
-  TestsuiteFilter
+  TestcaseFilter
 };

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -287,7 +287,7 @@
 
       <v-list-item class="pl-1">
         <v-list-item-content class="pa-0">
-          <testsuite-filter
+          <testcase-filter
             ref="filters"
             :namespace="namespace"
             @update:url="updateUrl"
@@ -335,7 +335,7 @@ import {
   ReviewStatusFilter,
   SeverityFilter,
   SourceComponentFilter,
-  TestsuiteFilter,
+  TestcaseFilter,
   UniqueFilter
 } from "./Filters";
 
@@ -368,7 +368,7 @@ export default {
     CheckerMessageFilter,
     RemoveFilteredReports,
     BugPathLengthFilter,
-    TestsuiteFilter
+    TestcaseFilter
   },
   props: {
     namespace: { type: String, required: true },

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -277,8 +277,8 @@ export default {
           sortable: true
         },
         {
-          text: "Testsuite",
-          value: "testsuite",
+          text: "Testcase",
+          value: "testcase",
           align: "center",
           sortable: false
         }
@@ -360,7 +360,7 @@ export default {
           "$id": id,
           "sameReports": report.sameReports,
           "timestamp": report.annotations["timestamp"],
-          "testsuite": report.annotations["testsuite"]
+          "testcase": report.annotations["testcase"]
         };
       });
     }

--- a/web/tests/functional/component/test_component.py
+++ b/web/tests/functional/component/test_component.py
@@ -147,8 +147,8 @@ class TestComponent(unittest.TestCase):
         Other component doesn't contain reports which are covered by rest of
         the component.
         """
-        all_results = self._cc_client.getRunResults(None, 500, 0, None, None,
-                                                    None, False)
+        all_results = self._cc_client.getRunResults(
+            None, 500, 0, None, ReportFilter(), None, False)
 
         r_filter = ReportFilter(componentNames=[c['name'] for c in components])
         component_results = self._cc_client.getRunResults(None, 500, 0, None,
@@ -385,8 +385,8 @@ class TestComponent(unittest.TestCase):
         components = self.__get_user_defined_source_components()
         self.assertEqual(len(components), 0)
 
-        all_results = self._cc_client.getRunResults(None, 500, 0, None, None,
-                                                    None, False)
+        all_results = self._cc_client.getRunResults(
+            None, 500, 0, None, ReportFilter(), None, False)
         self.assertIsNotNone(all_results)
 
         r_filter = ReportFilter(componentNames=[GEN_OTHER_COMPONENT_NAME])

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -112,9 +112,8 @@ int f(int x) { return 1 / x; }
 
         run_id = self.__get_run_id([run_name])
 
-        reports \
-            = self._cc_client.getRunResults([run_id], 10, 0, [], None, None,
-                                            False)
+        reports = self._cc_client.getRunResults(
+            [run_id], 10, 0, [], ReportFilter(), None, False)
 
         details = self._cc_client.getReportDetails(reports[0].reportId)
 
@@ -142,9 +141,8 @@ int f(int x) { return 1 / x; }
         runs = self._cc_client.getRunData(run_filter, None, 0, None)
         run_id = runs[0].runId
 
-        reports \
-            = self._cc_client.getRunResults([run_id], 10, 0, [], None, None,
-                                            False)
+        reports = self._cc_client.getRunResults(
+            [run_id], 10, 0, [], ReportFilter(), None, False)
 
         checker_labels = CheckerLabels(self.workspace_labels_dir)
         for report in reports:
@@ -189,8 +187,8 @@ int f(int x) { return 1 / x; }
                                     self.test_dir)
 
         run_id1 = self.__get_run_id([run_name1])
-        report = self._cc_client.getRunResults(None, 1, 0, [], None,
-                                               None, False)[0]
+        report = self._cc_client.getRunResults(
+            None, 1, 0, [], ReportFilter(), None, False)[0]
 
         report_hash = report.bugHash
         report_id = report.reportId

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -15,7 +15,7 @@ import shutil
 import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import DetectionStatus, \
-    Encoding
+    Encoding, ReportFilter
 
 from libtest import codechecker
 from libtest import env
@@ -157,7 +157,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
 
@@ -172,7 +172,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
         for report in reports:
@@ -194,7 +194,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
         for report in reports:
@@ -242,7 +242,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
         for report in reports:
@@ -265,7 +265,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
         for report in reports:
@@ -316,7 +316,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
 
@@ -338,7 +338,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
         offed_reports = [r for r in reports
@@ -358,7 +358,7 @@ int main()
                                                 100,
                                                 0,
                                                 [],
-                                                None,
+                                                ReportFilter(),
                                                 None,
                                                 False)
 
@@ -384,8 +384,8 @@ int main()
         self._create_clang_tidy_cfg_file(['-*', 'hicpp-*', 'modernize-*'])
         return_code = self._check_source_file(cfg)
         self.assertEqual(return_code, 0)
-        reports = self._cc_client.getRunResults(None, 100, 0, [], None, None,
-                                                False)
+        reports = self._cc_client.getRunResults(
+            None, 100, 0, [], ReportFilter(), None, False)
 
         hicpp_results = [r for r in reports
                          if r.checkerId.startswith('hicpp')]
@@ -403,8 +403,8 @@ int main()
         # OFF (every report marked as Unresolved).
         self._check_source_file(cfg)
 
-        reports = self._cc_client.getRunResults(None, 100, 0, [], None, None,
-                                                False)
+        reports = self._cc_client.getRunResults(
+            None, 100, 0, [], ReportFilter(), None, False)
         self.assertTrue([r for r in reports
                          if r.detectionStatus == DetectionStatus.UNRESOLVED])
 
@@ -453,8 +453,8 @@ int main()
         codechecker.store(cfg, 'hello')
 
         # Check that no reports are marked as OFF.
-        reports = self._cc_client.getRunResults(None, 100, 0, [], None, None,
-                                                False)
+        reports = self._cc_client.getRunResults(
+            None, 100, 0, [], ReportFilter(), None, False)
 
         offed_reports = [r for r in reports
                          if r.detectionStatus == DetectionStatus.OFF]

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -106,7 +106,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.NEW)
 
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data,
                                                     None,
                                                     0)
@@ -148,7 +148,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.NEW)
 
         diff_res = self._cc_client.getRunResultCount([],
-                                                     None,
+                                                     ReportFilter(),
                                                      cmp_data)
         # No differences.
         self.assertEqual(diff_res, 0)
@@ -167,7 +167,7 @@ class DiffRemote(unittest.TestCase):
                                                  500,
                                                  0,
                                                  [],
-                                                 None,
+                                                 ReportFilter(),
                                                  cmp_data,
                                                  False)
         # 4 new core.NullDereference issues.
@@ -187,7 +187,7 @@ class DiffRemote(unittest.TestCase):
                                                  500,
                                                  0,
                                                  [],
-                                                 None,
+                                                 ReportFilter(),
                                                  cmp_data,
                                                  False)
         # 4 resolved core.CallAndMessage
@@ -228,7 +228,7 @@ class DiffRemote(unittest.TestCase):
                                                  500,
                                                  0,
                                                  [],
-                                                 None,
+                                                 ReportFilter(),
                                                  cmp_data,
                                                  False)
         self.assertEqual(len(diff_res), 25)
@@ -262,7 +262,7 @@ class DiffRemote(unittest.TestCase):
         new_run_id = self._new_runid
 
         base_count = self._cc_client.getRunResultCount([base_run_id],
-                                                       None,
+                                                       ReportFilter(),
                                                        None)
         print("Base run id: %d", base_run_id)
         print("Base count: %d", base_count)
@@ -272,7 +272,7 @@ class DiffRemote(unittest.TestCase):
         print_run_results(base_run_res)
 
         new_count = self._cc_client.getRunResultCount([new_run_id],
-                                                      None,
+                                                      ReportFilter(),
                                                       None)
         print("New run id: %d", new_run_id)
         print("New count: %d", new_count)
@@ -285,7 +285,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.UNRESOLVED)
 
         diff_res = self._cc_client.getRunResultCount([base_run_id],
-                                                     None,
+                                                     ReportFilter(),
                                                      cmp_data)
 
         self.assertEqual(diff_res, 25)
@@ -322,7 +322,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.UNRESOLVED)
 
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data,
                                                     None,
                                                     0)
@@ -347,7 +347,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.UNRESOLVED)
 
         sev_res = self._cc_client.getSeverityCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data)
         test_res = {Severity.HIGH: 18,
                     Severity.LOW: 6,
@@ -365,7 +365,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.NEW)
 
         sev_res = self._cc_client.getSeverityCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data)
         test_res = {Severity.HIGH: 4}
         self.assertDictEqual(sev_res, test_res)
@@ -381,7 +381,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.NEW)
 
         res = self._cc_client.getReviewStatusCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data)
 
         test_res = {ReviewStatus.UNREVIEWED: 4}
@@ -398,7 +398,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.UNRESOLVED)
 
         res = self._cc_client.getReviewStatusCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data)
 
         test_res = {ReviewStatus.UNREVIEWED: 25}
@@ -415,7 +415,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.RESOLVED)
 
         res = self._cc_client.getReviewStatusCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data)
 
         print(res)
@@ -433,7 +433,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.RESOLVED)
 
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
-                                                    None,
+                                                    ReportFilter(),
                                                     cmp_data,
                                                     None,
                                                     0)
@@ -455,7 +455,7 @@ class DiffRemote(unittest.TestCase):
 
         diff_res = \
             self._cc_client.getCheckerCounts([base_run_id],
-                                             None,
+                                             ReportFilter(),
                                              cmp_data,
                                              None,
                                              0)

--- a/web/tests/functional/dynamic_results/test_dynamic_results.py
+++ b/web/tests/functional/dynamic_results/test_dynamic_results.py
@@ -38,14 +38,14 @@ class DiffRemote(unittest.TestCase):
         Test if the reports can be sorted by their "timestamp" attribute.
         """
         results = self._cc_client.getRunResults(
-            None, 500, 0, None, None, None, False)
+            None, 500, 0, None, ReportFilter(), None, False)
 
         self.assertEqual(len(results), 4)
 
         sort_timestamp = SortMode(SortType.TIMESTAMP, Order.ASC)
 
         results = self._cc_client.getRunResults(
-            None, 500, 0, [sort_timestamp], None, None, False)
+            None, 500, 0, [sort_timestamp], ReportFilter(), None, False)
 
         # At least one report has a timestamp.
         # Needed for the next sorting test.
@@ -77,3 +77,21 @@ class DiffRemote(unittest.TestCase):
         self.assertTrue(all(map(
             lambda report: report.annotations['testcase'] == 'TC-1',
             results)))
+
+    def test_count_by_attribute(self):
+        """
+        Test the report count functions with the usage of report annotations.
+        """
+        num = self._cc_client.getRunResultCount(
+            None, ReportFilter(), None)
+
+        self.assertEqual(num, 4)
+
+        testcase_filter = ReportFilter(annotations=[Pair(
+            first='testcase',
+            second='TC-1')])
+
+        num = self._cc_client.getRunResultCount(
+            None, testcase_filter, None)
+
+        self.assertEqual(num, 3)

--- a/web/tests/functional/dynamic_results/test_dynamic_results.py
+++ b/web/tests/functional/dynamic_results/test_dynamic_results.py
@@ -16,7 +16,7 @@ import os
 import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import \
-    Order, SortMode, SortType
+    Order, Pair, ReportFilter, SortMode, SortType
 
 from libtest import env
 
@@ -60,3 +60,20 @@ class DiffRemote(unittest.TestCase):
             self.assertLess(
                 results[i].annotations['timestamp'],
                 results[i + 1].annotations['timestamp'])
+
+    def test_filter_by_attribute(self):
+        """
+        Test if the reports can be filtered by their attributes.
+        """
+        testcase_filter = ReportFilter(annotations=[Pair(
+            first='testcase',
+            second='TC-1')])
+
+        results = self._cc_client.getRunResults(
+            None, 500, 0, None, testcase_filter, None, False)
+
+        self.assertEqual(len(results), 3)
+
+        self.assertTrue(all(map(
+            lambda report: report.annotations['testcase'] == 'TC-1',
+            results)))

--- a/web/tests/functional/extended_report_data/test_extended_report_data.py
+++ b/web/tests/functional/extended_report_data/test_extended_report_data.py
@@ -16,8 +16,8 @@ import unittest
 
 from libtest import env
 
-from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter, \
-    ExtendedReportDataType
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportFilter, \
+    RunFilter, ExtendedReportDataType
 
 
 class TestExtendedReportData(unittest.TestCase):
@@ -52,8 +52,8 @@ class TestExtendedReportData(unittest.TestCase):
         runs = self._cc_client.getRunData(run_filter, None, 0, None)
         run_id = runs[0].runId
 
-        return self._cc_client.getRunResults([run_id], None, 0, [], None, None,
-                                             False)
+        return self._cc_client.getRunResults(
+            [run_id], None, 0, [], ReportFilter(), None, False)
 
     def test_notes(self):
         """

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -83,7 +83,7 @@ class RunResults(unittest.TestCase):
                       str(runid))
 
         run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
         self.assertTrue(run_result_count)
 
@@ -102,7 +102,7 @@ class RunResults(unittest.TestCase):
                       str(runid))
 
         run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
         self.assertTrue(run_result_count)
 
@@ -239,14 +239,13 @@ class RunResults(unittest.TestCase):
         sort_types = [sort_mode1, sort_mode2]
 
         run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
         self.assertTrue(run_result_count)
 
         run_results = get_all_run_results(self._cc_client,
                                           runid,
-                                          sort_types,
-                                          None)
+                                          sort_types)
         self.assertIsNotNone(run_results)
 
         for i in range(run_result_count - 1):
@@ -271,14 +270,13 @@ class RunResults(unittest.TestCase):
         sort_types = [sortMode1, sortMode2]
 
         run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
         self.assertTrue(run_result_count)
 
         run_results = get_all_run_results(self._cc_client,
                                           runid,
-                                          sort_types,
-                                          None)
+                                          sort_types)
         self.assertIsNotNone(run_results)
 
         print_run_results(run_results)

--- a/web/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/web/tests/functional/report_viewer_api/test_hash_clash.py
@@ -23,7 +23,8 @@ from uuid import uuid4
 from libtest import env
 from libtest import codechecker
 
-from codechecker_api.codeCheckerDBAccess_v6.ttypes import Encoding, RunFilter
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import Encoding, \
+    RunFilter, ReportFilter
 
 
 def _generate_content(cols, lines):
@@ -100,7 +101,7 @@ class HashClash(unittest.TestCase):
                                           100,
                                           0,
                                           [],
-                                          None,
+                                          ReportFilter(),
                                           None,
                                           False)
 

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -79,7 +79,7 @@ class RemoveRunResults(unittest.TestCase):
         run_id = runs[0].runId
 
         orig_results_count = \
-            self._cc_client.getRunResultCount([run_id], None, None)
+            self._cc_client.getRunResultCount([run_id], ReportFilter(), None)
         self.assertNotEqual(orig_results_count, 0)
 
         checker_filter = ReportFilter(checkerName=["core.CallAndMessage"])
@@ -101,5 +101,5 @@ class RemoveRunResults(unittest.TestCase):
         self._cc_client.removeRun(run_id, None)
 
         # Check that we removed all results from the run.
-        res = self._cc_client.getRunResultCount([run_id], None, None)
+        res = self._cc_client.getRunResultCount([run_id], ReportFilter(), None)
         self.assertEqual(res, 0)

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -63,20 +63,16 @@ class TestReportFilter(unittest.TestCase):
 
     def test_filter_none(self):
         """ Filter value is None should return all results."""
-        runid = self._runids[0]
-        sort_types = None
-        simple_filters = None
-
-        run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             simple_filters,
+        run_result_count = self._cc_client.getRunResultCount([self._runids[0]],
+                                                             ReportFilter(),
                                                              None)
         self.assertIsNotNone(run_result_count)
 
-        run_results = self._cc_client.getRunResults([runid],
+        run_results = self._cc_client.getRunResults([self._runids[0]],
                                                     run_result_count,
                                                     0,
-                                                    sort_types,
-                                                    simple_filters,
+                                                    None,
+                                                    ReportFilter(),
                                                     None,
                                                     False)
         self.assertIsNotNone(run_results)
@@ -213,7 +209,7 @@ class TestReportFilter(unittest.TestCase):
         """
 
         run_result_count = self._cc_client.getRunResultCount(self._runids,
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
 
         self.assertEqual(run_result_count, 75)
@@ -222,7 +218,7 @@ class TestReportFilter(unittest.TestCase):
                                                     run_result_count,
                                                     0,
                                                     [],
-                                                    None,
+                                                    ReportFilter(),
                                                     None,
                                                     False)
 
@@ -237,13 +233,13 @@ class TestReportFilter(unittest.TestCase):
             'filter_review_status']
 
         run_result_count = self._cc_client.getRunResultCount([runid],
-                                                             None,
+                                                             ReportFilter(),
                                                              None)
         run_results = self._cc_client.getRunResults([runid],
                                                     run_result_count,
                                                     0,
                                                     [],
-                                                    None,
+                                                    ReportFilter(),
                                                     None,
                                                     False)
 
@@ -357,8 +353,8 @@ class TestReportFilter(unittest.TestCase):
 
     def test_detection_date_filters(self):
         """ Filter by detection dates. """
-        run_results = self._cc_client.getRunResults([self._runids[0]], 1, 0,
-                                                    None, None, None, False)
+        run_results = self._cc_client.getRunResults(
+            [self._runids[0]], 1, 0, None, ReportFilter(), None, False)
         self.assertEqual(len(run_results), 1)
 
         detected_after = datetime.strptime(run_results[0].detectedAt,

--- a/web/tests/functional/run_tag/test_run_tag.py
+++ b/web/tests/functional/run_tag/test_run_tag.py
@@ -98,9 +98,8 @@ int main()
         """
         Get run history tag for the given run.
         """
-        test_run_tags = \
-            self._cc_client.getRunHistoryTagCounts([run_id], None, None,
-                                                   limit, offset)
+        test_run_tags = self._cc_client.getRunHistoryTagCounts(
+            [run_id], ReportFilter(), None, limit, offset)
 
         self.assertGreater(len(test_run_tags), 0)
 

--- a/web/tests/libtest/thrift_client_to_db.py
+++ b/web/tests/libtest/thrift_client_to_db.py
@@ -23,6 +23,8 @@ import codechecker_api_shared
 from codechecker_client.product import create_product_url
 from codechecker_web.shared.version import CLIENT_API as VERSION
 
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportFilter
+
 
 class ThriftAPIHelper:
 
@@ -239,7 +241,12 @@ class CCConfigHelper(ThriftAPIHelper):
         return partial(self._thrift_client_call, attr)
 
 
-def get_all_run_results(client, run_id=None, sort_mode=None, filters=None):
+def get_all_run_results(
+    client,
+    run_id=None,
+    sort_mode=None,
+    filters=ReportFilter()
+):
     """
     Get all the results for a run.
     Query limit limits the number of results can be got from the

--- a/web/tests/projects/dynamic/main.c_clang-tidy_0212cbc2c7194b7a5d431a18ff51bb1c.plist
+++ b/web/tests/projects/dynamic/main.c_clang-tidy_0212cbc2c7194b7a5d431a18ff51bb1c.plist
@@ -17,7 +17,7 @@
 			<dict>
 				<key>timestamp</key>
 				<string>2000-01-01 09:01</string>
-				<key>testsuite</key>
+				<key>testcase</key>
 				<string>TS-1</string>
 				<key>testcase</key>
 				<string>TC-1</string>

--- a/web/tests/projects/dynamic/main.c_clangsa_0212cbc2c7194b7a5d431a18ff51bb1c.plist
+++ b/web/tests/projects/dynamic/main.c_clangsa_0212cbc2c7194b7a5d431a18ff51bb1c.plist
@@ -17,7 +17,7 @@
 			<dict>
 				<key>timestamp</key>
 				<string>2000-01-01 09:00</string>
-				<key>testsuite</key>
+				<key>testcase</key>
 				<string>TS-1</string>
 				<key>testcase</key>
 				<string>TC-1</string>

--- a/web/tests/projects/dynamic/main.c_cppcheck_0212cbc2c7194b7a5d431a18ff51bb1c.plist
+++ b/web/tests/projects/dynamic/main.c_cppcheck_0212cbc2c7194b7a5d431a18ff51bb1c.plist
@@ -17,7 +17,7 @@
 			<dict>
 				<key>timestamp</key>
 				<string>2000-01-01 09:02</string>
-				<key>testsuite</key>
+				<key>testcase</key>
 				<string>TS-1</string>
 				<key>testcase</key>
 				<string>TC-1</string>


### PR DESCRIPTION
Dynamic analyzers may produce .plist files which contain the timestamps
when the report was emitted, The timestamps of independent test
executions can overlap. They can be separated by choosing a testcase
during which they were emitted. This patch introduces a testcase filter.