### PR TITLE
[fix][server] Fix webapp crash when using component filter

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1870,14 +1870,14 @@ class ThriftRequestHandler:
                                   File.filename,
                                   *annotation_cols.values()) \
                     .outerjoin(
+                        File,
+                        Report.file_id == File.id) \
+                    .outerjoin(
                         ReportAnnotations,
                         Report.id == ReportAnnotations.report_id) \
                     .outerjoin(sorted_reports,
                                sorted_reports.c.id == Report.id) \
                     .filter(sorted_reports.c.id.isnot(None))
-
-                if File not in join_tables:
-                    q = q.outerjoin(File, Report.file_id == File.id)
 
                 if report_filter.annotations is not None:
                     annotations = defaultdict(list)


### PR DESCRIPTION
This is the query produced by the modified logic:
```sql
SELECT
	reports.id AS reports_id, 
	reports.file_id AS reports_file_id, 
	reports.run_id AS reports_run_id, 
	reports.bug_id AS reports_bug_id, 
	reports.checker_id AS reports_checker_id, 
	reports.checker_cat AS reports_checker_cat, 
	reports.bug_type AS reports_bug_type, 
	reports.severity AS reports_severity, 
	reports.line AS reports_line, 
	reports."column" AS reports_column, 
	reports.path_length AS reports_path_length, 
	reports.analyzer_name AS reports_analyzer_name, 
	reports.checker_message AS reports_checker_message, 
	reports.detection_status AS reports_detection_status, 
	reports.review_status AS reports_review_status, 
	reports.review_status_author AS reports_review_status_author, 
	reports.review_status_message AS reports_review_status_message, 
	reports.review_status_date AS reports_review_status_date, 
	reports.review_status_is_in_source AS reports_review_status_is_in_source, 
	reports.detected_at AS reports_detected_at, 
	reports.fixed_at AS reports_fixed_at, 
	files.filename AS files_filename 
FROM reports LEFT OUTER JOIN report_annotations ON                        <- ...only FROM reports.... 
	reports.id = report_annotations.report_id LEFT OUTER JOIN 
(SELECT anon_2.id AS id FROM 
	(SELECT max(reports.id) AS id, max(reports.severity) AS severity 
FROM reports LEFT OUTER JOIN files ON 
	reports.file_id = files.id 
		WHERE files.filepath LIKE %(filepath_1)s GROUP BY reports.bug_id) AS anon_2 
			ORDER BY anon_2.severity ASC 
LIMIT %(param_1)s OFFSET %(param_2)s) AS anon_1 ON anon_1.id = reports.id 
	LEFT OUTER JOIN files ON reports.file_id = files.id                      <- new outer join
WHERE anon_1.id IS NOT NULL
````
It is correctly showing the proper number of reports.

This is the original one:

```sql
SELECT 
	reports.id AS reports_id, 
	reports.file_id AS reports_file_id, 
	reports.run_id AS reports_run_id, 
	reports.bug_id AS reports_bug_id, 
	reports.checker_id AS reports_checker_id, 
	reports.checker_cat AS reports_checker_cat, 
	reports.bug_type AS reports_bug_type, 
	reports.severity AS reports_severity, 
	reports.line AS reports_line, 
	reports."column" AS reports_column, 
	reports.path_length AS reports_path_length, 
	reports.analyzer_name AS reports_analyzer_name, 
	reports.checker_message AS reports_checker_message, 
	reports.detection_status AS reports_detection_status, 
	reports.review_status AS reports_review_status, 
	reports.review_status_author AS reports_review_status_author, 
	reports.review_status_message AS reports_review_status_message, 
	reports.review_status_date AS reports_review_status_date, 
	reports.review_status_is_in_source AS reports_review_status_is_in_source, 
	reports.detected_at AS reports_detected_at, 
	reports.fixed_at AS reports_fixed_at, 
	files.filename AS files_filename 
FROM files, reports LEFT OUTER JOIN report_annotations ON       <- ...FROM files.... 
	reports.id = report_annotations.report_id LEFT OUTER JOIN 
(SELECT anon_2.id AS id FROM 
	(SELECT max(reports.id) AS id, max(reports.severity) AS severity 
FROM reports LEFT OUTER JOIN files ON 
	reports.file_id = files.id 
		WHERE files.filepath LIKE %(filepath_1)s GROUP BY reports.bug_id) AS anon_2 
			ORDER BY anon_2.severity ASC 
LIMIT %(param_1)s OFFSET %(param_2)s) AS anon_1 ON anon_1.id = reports.id 
WHERE anon_1.id IS NOT NULL
```
Produces lots of bogus outputs, where the report hashes are the same, and freezes client browsers:
![image](https://user-images.githubusercontent.com/23135800/232884157-02425fb7-d26e-40c4-89be-3f15963524be.png)

The sane filter settings were used for both query printing which was: 
uniqueing + a source_component filter
It seems like we had a descartes product in one of the subqueries, which we still need to restrict with a join.
I would be lying if I said I understood it completely, so discuss it.

One extra thing to note is the `reports."column" AS reports_column, ` lines. I also don't know why these appear.
