### PR TITLE
[test] Get rid of mockldap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,7 @@ jobs:
           export PGPASSFILE=$HOME/.pgpass
 
           make pip_dev_deps
+          pip3 install -r web/requirements_py/auth/requirements.txt
           BUILD_UI_DIST=NO make package
 
           make -C web test_matrix_${{ matrix.database }}

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -8,7 +8,6 @@ psutil==5.8.0
 portalocker==2.2.1
 pylint==2.8.2
 nose==1.3.7
-mockldap==0.3.0
 mkdocs==1.2.3
 mypy_extensions==0.4.3
 coverage==5.5.0


### PR DESCRIPTION
Mockldap dependency is not supported for a long time. It can't be
installed to the latest Ubuntu versions, due to some of its old version
implicit dependencies (funcparserlib). For this reason the usage of
mockldap module has been eliminated and a simplified mock class has been
introduced instead with hardcoded return values.

This error could be reproduced by "make venv_dev" command which emitted
this error message:
"error in funcparserlib setup command: use_2to3 is invalid."

Fixes https://github.com/Ericsson/codechecker/issues/3892