### PR TITLE
[report-converter] Enable multiple input for report-converter

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/plist.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/plist.py
@@ -80,10 +80,11 @@ class _LXMLPlistParser(_PlistParser):
         # complain that too many arguments are used to invoke __init__, but
         # with newer interpreters, this is deadcode.
         if len(params) == 3 and "use_builtin_types" in params:
+            # Before 3.9 interpreter.
             # pylint: disable=E1121
             _PlistParser.__init__(self, True, dict_type)
-        # After 3.9 interpreter.
         else:
+            # After 3.9 interpreter.
             _PlistParser.__init__(self, dict_type)  # pylint: disable=E1120
 
         self.event_handler = _LXMLPlistEventHandler()

--- a/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/simple1.out
+++ b/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/simple1.out
@@ -1,0 +1,1 @@
+./files/simple.go:3:6: exported type T should have comment or be unexported

--- a/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/subdir/simple2.out
+++ b/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/subdir/simple2.out
@@ -1,0 +1,2 @@
+./files/simple.go:5:5: exported var Z should have its own declaration
+./files/b/simple.go:3:6: exported type T2 should have comment or be unexported

--- a/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/subdir/simple3.out
+++ b/tools/report-converter/tests/functional/cmdline/test_files/test_outputs/subdir/simple3.out
@@ -1,0 +1,1 @@
+./files/b/simple.go:5:5: exported var Z2 should have its own declaration

--- a/tools/report-converter/tests/unit/analyzers/test_asan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_asan_parser.py
@@ -52,7 +52,7 @@ class ASANAnalyzerResultTestCase(unittest.TestCase):
     def test_asan(self):
         """ Test for the asan.plist file. """
         self.analyzer_result.transform(
-            'asan.out', self.cc_result_dir, plist.EXTENSION,
+            ['asan.out'], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         with open('asan.plist', mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
@@ -54,7 +54,7 @@ class ClangTidyAnalyzerResultTestCase(unittest.TestCase):
                                 source_files, expected_plist):
         """ Check the result of the analyzer transformation. """
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir, analyzer_result_plist)
@@ -75,13 +75,13 @@ class ClangTidyAnalyzerResultTestCase(unittest.TestCase):
     def test_empty1(self):
         """ Test for empty Messages. """
         ret = self.analyzer_result.transform(
-            'empty1.out', self.cc_result_dir, plist.EXTENSION)
+            ['empty1.out'], self.cc_result_dir, plist.EXTENSION)
         self.assertFalse(ret)
 
     def test_empty2(self):
         """ Test for empty Messages with multiple line. """
         ret = self.analyzer_result.transform(
-            'empty2.out', self.cc_result_dir, plist.EXTENSION)
+            ['empty2.out'], self.cc_result_dir, plist.EXTENSION)
         self.assertFalse(ret)
 
     def test_tidy1(self):

--- a/tools/report-converter/tests/unit/analyzers/test_coccinelle_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_coccinelle_parser.py
@@ -43,7 +43,7 @@ class CoccinelleAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -52,7 +52,7 @@ class CoccinelleAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -60,7 +60,7 @@ class CoccinelleAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_cppcheck_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_cppcheck_parser.py
@@ -59,7 +59,7 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
                                        'divide_zero.cpp')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -68,7 +68,7 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'non_existing')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -77,7 +77,7 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(
             self.test_files, 'out', 'divide_zero.plist')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,
@@ -102,7 +102,7 @@ class CppcheckAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming a directory of plist files. """
         analyzer_result = os.path.join(self.test_files, 'out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_cpplint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_cpplint_parser.py
@@ -42,7 +42,7 @@ class CpplintAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.cpp')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class CpplintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class CpplintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_eslint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_eslint_parser.py
@@ -42,7 +42,7 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
                                        'index.js')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class ESLintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'reports.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_golint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_golint_parser.py
@@ -42,7 +42,7 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.go')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class GolintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'simple.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_infer_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_infer_parser.py
@@ -57,7 +57,7 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'infer-out-dead_store')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
@@ -86,7 +86,7 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'report.json')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
@@ -114,7 +114,7 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'infer-out-null_dereference')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 
@@ -144,7 +144,7 @@ class InferAnalyzerResultTestCase(unittest.TestCase):
                                        'report.json')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertTrue(ret)
 

--- a/tools/report-converter/tests/unit/analyzers/test_kerneldoc_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_kerneldoc_parser.py
@@ -43,7 +43,7 @@ class KernelDocAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -52,7 +52,7 @@ class KernelDocAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -60,7 +60,7 @@ class KernelDocAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_lsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_lsan_parser.py
@@ -55,7 +55,7 @@ class LSANPListConverterTestCase(unittest.TestCase):
     def test_san(self):
         """ Test for the lsan.plist file. """
         self.analyzer_result.transform(
-            'lsan.out', self.cc_result_dir, plist.EXTENSION,
+            ['lsan.out'], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         with open('lsan.plist', mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/analyzers/test_mdl_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_mdl_parser.py
@@ -42,7 +42,7 @@ class MarkdownlintAnalyzerResultTestCase(unittest.TestCase):
                                        'readme.md')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class MarkdownlintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class MarkdownlintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'readme.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_msan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_msan_parser.py
@@ -54,7 +54,7 @@ class MSANPListConverterTestCase(unittest.TestCase):
     def test_msan(self):
         """ Test for the msan.plist file. """
         self.analyzer_result.transform(
-            'msan.out', self.cc_result_dir, plist.EXTENSION,
+            ['msan.out'], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         with open('msan.plist', mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/analyzers/test_pyflakes_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_pyflakes_parser.py
@@ -42,7 +42,7 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.py')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class PyflakesAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'simple.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_pylint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_pylint_parser.py
@@ -42,7 +42,7 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
                                        'simple.py')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class PylintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single json file. """
         analyzer_result = os.path.join(self.test_files, 'simple.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_roslynator_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_roslynator_parser.py
@@ -41,7 +41,7 @@ class RoslynatorAnalyzerResultTestCase(unittest.TestCase):
                                        'Sample.cs')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -50,7 +50,7 @@ class RoslynatorAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -58,7 +58,7 @@ class RoslynatorAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'out.xml')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_smatch_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_smatch_parser.py
@@ -41,7 +41,7 @@ class SmatchAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -50,7 +50,7 @@ class SmatchAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -58,7 +58,7 @@ class SmatchAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_sparse_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_sparse_parser.py
@@ -41,7 +41,7 @@ class SparseAnalyzerResultTestCase(unittest.TestCase):
                                        'sample.c')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -50,7 +50,7 @@ class SparseAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -58,7 +58,7 @@ class SparseAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         for test_file in ['sample.c', 'sample.h']:

--- a/tools/report-converter/tests/unit/analyzers/test_sphinx_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_sphinx_parser.py
@@ -42,7 +42,7 @@ class SphinxResultTestCase(unittest.TestCase):
                                        'sample.rst')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class SphinxResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class SphinxResultTestCase(unittest.TestCase):
         """ Test transforming single output file. """
         analyzer_result = os.path.join(self.test_files, 'sample.out')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_spotbugs_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_spotbugs_parser.py
@@ -58,7 +58,7 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
                                        'Assign.java')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -67,7 +67,7 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files, 'files')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -75,7 +75,7 @@ class SpotBugsAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single plist file. """
         analyzer_result = os.path.join(self.test_files, 'assign.xml')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_tsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_tsan_parser.py
@@ -54,7 +54,7 @@ class TSANAnalyzerResultTestCase(unittest.TestCase):
     def test_tsan(self):
         """ Test for the tsan.plist file. """
         self.analyzer_result.transform(
-            'tsan.out', self.cc_result_dir, plist.EXTENSION,
+            ['tsan.out'], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         with open('tsan.plist', mode='rb') as pfile:

--- a/tools/report-converter/tests/unit/analyzers/test_tslint_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_tslint_parser.py
@@ -42,7 +42,7 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
                                        'index.ts')
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -51,7 +51,7 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
         analyzer_result = os.path.join(self.test_files)
 
         ret = self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
         self.assertFalse(ret)
 
@@ -59,7 +59,7 @@ class TSLintAnalyzerResultTestCase(unittest.TestCase):
         """ Test transforming single json file. """
         analyzer_result = os.path.join(self.test_files, 'reports.json')
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir,

--- a/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
@@ -55,7 +55,7 @@ class UBSANPListConverterTestCase(unittest.TestCase):
                                 source_files, expected_plist):
         """ Check the result of the analyzer transformation. """
         self.analyzer_result.transform(
-            analyzer_result, self.cc_result_dir, plist.EXTENSION,
+            [analyzer_result], self.cc_result_dir, plist.EXTENSION,
             file_name="{source_file}_{analyzer}")
 
         plist_file = os.path.join(self.cc_result_dir, analyzer_result_plist)
@@ -76,13 +76,13 @@ class UBSANPListConverterTestCase(unittest.TestCase):
     def test_empty1(self):
         """ Test for empty Messages. """
         ret = self.analyzer_result.transform(
-            'empty1.out', self.cc_result_dir, plist.EXTENSION)
+            ['empty1.out'], self.cc_result_dir, plist.EXTENSION)
         self.assertFalse(ret)
 
     def test_empty2(self):
         """ Test for empty Messages with multiple line. """
         ret = self.analyzer_result.transform(
-            'empty2.out', self.cc_result_dir, plist.EXTENSION)
+            ['empty2.out'], self.cc_result_dir, plist.EXTENSION)
         self.assertFalse(ret)
 
     def test_ubsan1(self):


### PR DESCRIPTION
Sometimes dynamic analysis is executed for the code base several times with different parameters. The output of these analyses may go to different log files which are given to report-converter one-by-one. If there are reports for the same source file in different log output files then the resulting .plist files will be overwritten at a subsequent execution of report-converter.

In this patch we make it possible to give multiple log files or directories containing log files to the report-converter. The reports in these files and directories will be collected all and will be converted to .plist without overriding the ones coming from a different log file.