### PR TITLE
Makefile: package_gerrit_skiplist should depend on package_dir_structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ package_dir_structure:
 mkdocs_build:
 	mkdocs build
 
-package_gerrit_skiplist:
+package_gerrit_skiplist: package_dir_structure
 	cp -p scripts/gerrit_changed_files_to_skipfile.py $(CC_BUILD_BIN_DIR)
 
 package: package_dir_structure set_git_commit_template package_gerrit_skiplist


### PR DESCRIPTION
In the Makefile, the `package_gerrit_skiplist` target copies a script to a directory created in the `package_dir_structure` target. However, `package_gerrit_skiplist` does not have a dependency on `package_dir_structure`, and it is possible that `package_gerrit_skiplist` is run before the directory created in `package_dir_structure` actually exists. This can be reproduced by running `make` with multiple jobs (e.g `make -j16`)