### PR TITLE
[analyzer] Disable cppcheck-preprocessorErrorDirective explicitly

### DIFF
--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -695,7 +695,6 @@
       "severity:LOW"
     ],
     "cppcheck-preprocessorErrorDirective": [
-      "profile:default",
       "severity:HIGH"
     ],
     "cppcheck-publicAllocationError": [


### PR DESCRIPTION
This checker gives a lot of false positive reports mainly because cppcheck doesn't support the analysis on different target architectures.