### PR TITLE
Introduce sanitizer checker names

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/address/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/address/parser.py
@@ -8,6 +8,9 @@
 
 import logging
 import re
+from typing import Iterator, Optional, Tuple
+
+from codechecker_report_converter.report import Report
 
 from ..parser import SANParser
 
@@ -25,3 +28,78 @@ class Parser(SANParser):
             r'==(?P<code>\d+)==(ERROR|WARNING): AddressSanitizer: '
             # Checker message.
             r'(?P<message>[\S \t]+)')
+
+    check_msg_pairs = {
+        "double-free": re.compile(
+            "attempting double-free on .+ in thread .+:"),
+        "new-delete-type-mismatch": re.compile(
+            "new-delete-type-mismatch on .+ in thread .+:"),
+        "bad-free": re.compile(
+            "attempting free on address which was not malloc()-ed: .+ in "
+            "thread .+"),
+        "alloc-dealloc-mismatch": re.compile(
+            "alloc-dealloc-mismatch (.+ vs .+) on .+"),
+        "bad-malloc_usable_size": re.compile(
+            "attempting to call malloc_usable_size() for pointer which is not "
+            "not owned: .+"),
+        "bad-__sanitizer_get_allocated_size": re.compile(
+            "attempting to call __sanitizer_get_allocated_size() for pointer "
+            "which is not owned: .+"),
+        "calloc-overflow": re.compile(
+            "calloc parameters overflow: count * size (.+ * .+) cannot be "
+            "represented in type size_t (thread .+)"),
+        "reallocarray-overflow": re.compile(
+            "reallocarray parameters overflow: count * size (.+ * .+) cannot "
+            "be represented in type size_t (thread .+)"),
+        "pvalloc-overflow": re.compile(
+            "pvalloc parameters overflow: size 0x.+ rounded up to system page "
+            "size 0x.+ cannot be represented in type size_t (thread .+)"),
+        "invalid-allocation-alignment": re.compile(
+            "invalid allocation alignment: .+, alignment must be a power of "
+            "two (thread .+)"),
+        "invalid-aligned-alloc-alignment": re.compile(
+            "invalid alignment requested in aligned_alloc: .+ the requested "
+            "size 0x.+ must be a multiple of alignment (thread .+)"),
+        "invalid-posix-memalign-alignment": re.compile(
+            "invalid alignment requested in posix_memalign: .+, alignment "
+            "must be a power of two and a multiple of sizeof(void*) == .+ "
+            "(thread .+)"),
+        "allocation-size-too-big": re.compile(
+            "requested allocation size 0x.+ (0x.+ after adjustments for "
+            "alignment, red zones etc.) exceeds maximum supported size of "
+            "0x.+ (thread .+)"),
+        "rss-limit-exceeded": re.compile(
+            "specified RSS limit exceeded, currently set to "
+            "soft_rss_limit_mb=.+"),
+        "out-of-memory": re.compile(
+            "allocator is trying to allocate 0x.+ bytes"),
+        "string-function-memory-ranges-overlap": re.compile(
+            ".+: memory ranges .+ and .+ overlap"),
+        "negative-size-param": re.compile(
+            "negative-size-param: (size=.+)"),
+        "bad-__sanitizer_annotate_contiguous_container": re.compile(
+            "bad parameters to __sanitizer_annotate_contiguous_container:"),
+        "bad-__sanitizer_annotate_double_ended_contiguous_container":
+        re.compile(
+            "bad parameters to "
+            "__sanitizer_annotate_double_ended_contiguous_container:"),
+        "odr-violation": re.compile("odr-violation (.+):"),
+        "invalid-pointer-pair": re.compile("invalid-pointer-pair: .+ .+")
+    }
+
+    def parse_sanitizer_message(
+        self,
+        it: Iterator[str],
+        line: str
+    ) -> Tuple[Optional[Report], str]:
+        report, line = super().parse_sanitizer_message(it, line)
+
+        if not report:
+            return report, line
+
+        for check, pattern in self.check_msg_pairs.items():
+            if pattern.search(report.message):
+                report.checker_name = f"{self.checker_name}.{check}"
+                break
+
+        return report, line

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
@@ -107,9 +107,13 @@ class SANParser(BaseParser):
         line: int,
         column: int,
         message: str,
-        stack_traces: List[str]
+        stack_traces: List[str],
+        checker_name: Optional[str] = None
     ) -> Report:
-        """ Create a report for the sanitizer output. """
+        """
+        Create a report for the sanitizer output with the given data.
+        checker_name: if None then the sanitizer name will be applied.
+        """
         # The original message should be the last part of the path. This is
         # displayed by quick check, and this is the main event displayed by
         # the web interface.
@@ -120,7 +124,7 @@ class SANParser(BaseParser):
             notes = [BugPathEvent(''.join(stack_traces), file, line, column)]
 
         return Report(
-            file, line, column, message, self.checker_name,
+            file, line, column, message, checker_name or self.checker_name,
             bug_path_events=events,
             notes=notes)
 

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
@@ -43,9 +43,9 @@ class Parser(SANParser):
 
     # This list of diagnostic messages is extracted from the LLVM project:
     #   https://github.com/llvm/llvm-project
-    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_handlers.cpp
-    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_handlers_cxx.cpp
-    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_checks.inc
+    # /blob/main/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+    # /blob/main/compiler-rt/lib/ubsan/ubsan_handlers_cxx.cpp
+    # /blob/main/compiler-rt/lib/ubsan/ubsan_checks.inc
     checks = {
         "alignment": [
             re.compile(

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
@@ -41,6 +41,117 @@ class Parser(SANParser):
         # Checker message.
         r'(?P<message>[\S \t]+)')
 
+    # This list of diagnostic messages is extracted from the LLVM project:
+    #   https://github.com/llvm/llvm-project
+    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_handlers_cxx.cpp
+    # /llvm/llvm-project/blob/main/compiler-rt/lib/ubsan/ubsan_checks.inc
+    checks = {
+        "alignment": [
+            re.compile(
+                ".+ misaligned address .+ for type .+, which requires .+ byte "
+                "alignment"),
+            re.compile(
+                "assumption of .+ byte alignment for pointer of type .+ "
+                "failed"),
+            re.compile(
+                "assumption of .+ byte alignment (with offset of .+ byte) for "
+                "pointer of type .+ failed")],
+        "bool": [
+            re.compile(
+                "load of value .+, which is not a valid value for type "
+                ".*bool.*")],
+        "builtin": [
+            re.compile("passing zero to .+, which is not a valid argument")],
+        "bounds": [
+            re.compile("index .+ out of bounds for type .+")],
+        "enum": [
+            re.compile(
+                "load of value .+, which is not a valid value for type .+")],
+        "float-cast-overflow": [
+            re.compile(
+                ".+ is outside the range of representable values of type .+")],
+        "integer-divide-by-zero-or-float-divide-by-zero": [
+            re.compile("division by zero")],
+        "implicit-signed-integer-truncation": [
+            re.compile(
+                "implicit conversion from type .+ of value .+ (.+-bit, "
+                "signed) to type .+ changed the value to .+ (.+-bit, "
+                "signed)")],
+        "implicit-unsigned-integer-truncation": [
+            re.compile(
+                "implicit conversion from type .+ of value .+ (.+-bit, "
+                "unsigned) to type .+ changed the value to .+ (.+-bit, "
+                "unsigned)")],
+        "implicit-integer-sign-change": [
+            re.compile(
+                "implicit conversion from type .+ of value .+ (.+-bit, "
+                ".*signed) to type .+ changed the value to .+ (.+-bit, "
+                ".*signed)")],
+        "nonnull-attribute-or-nullability-arg": [
+            re.compile(
+                "null pointer passed as argument .+, which is declared to "
+                "never be null")],
+        "null-or-nullability-assign": [
+            re.compile(".+ null pointer of type .+")],
+        "nullability-return-or-returns-nonnull-attribute": [
+            re.compile(
+                "null pointer returned from function declared to never return "
+                "null")],
+        "objc-cast": [
+            re.compile(
+                "invalid ObjC cast, object is a '.+', but expected a .+")],
+        "object-size": [
+            re.compile(
+                ".+ address .+ with insufficient space for an object of type "
+                ".+")],
+        "pointer-overflow": [
+            re.compile("applying zero offset to null pointer"),
+            re.compile("applying non-zero offset .+ to null pointer"),
+            re.compile(
+                "applying non-zero offset to non-null pointer .+ produced "
+                "null pointer"),
+            re.compile("addition of unsigned offset to .+ overflowed to .+"),
+            re.compile(
+                "subtraction of unsigned offset from .+ overflowed to .+"),
+            re.compile(
+                "pointer index expression with base .+ overflowed to .+")],
+        "return": [
+            re.compile(
+                "execution reached the end of a value-returning function "
+                "without returning a value")],
+        "shift": [
+            re.compile("shift exponent .+ is negative"),
+            re.compile("shift exponent .+ is too large for .+-bit type .+"),
+            re.compile("left shift of negative value .+")],
+        "signed-integer-overflow": [
+            re.compile(
+                "signed integer overflow: .+ .+ .+ cannot be represented in "
+                "type .+"),
+            re.compile(
+                "negation of .+ cannot be represented in type .+; cast to an "
+                "unsigned type to negate this value to itself"),
+            re.compile(
+                "division of .+ by -1 cannot be represented in type .+")],
+        "unreachable": [
+            re.compile("execution reached an unreachable program point")],
+        "unsigned-integer-overflow": [
+            re.compile(
+                "unsigned integer overflow: .+ .+ .+ cannot be represented "
+                "in type .+"),
+            re.compile("negation of .+ cannot be represented in type .+"),
+            re.compile(
+                "left shift of .+ by .+ places cannot be represented in type "
+                ".+")],
+        "vla-bound": [
+            re.compile(
+                "variable length array bound evaluates to non-positive value "
+                ".+")],
+        "vptr": [
+            re.compile(
+                ".+ address .+ which does not point to an object of type .+")]
+    }
+
     def parse_stack_trace(self, it, line):
         """ Iterate over lines and parse stack traces. """
         events = []
@@ -76,8 +187,14 @@ class Parser(SANParser):
         line = get_next(it)
         stack_traces, events, line = self.parse_stack_trace(it, line)
 
+        message = match.group('message').strip()
+        for check, patterns in self.checks.items():
+            if any(pattern.search(message) for pattern in patterns):
+                checker_name = f"{self.checker_name}.{check}"
+                break
+
         report = self.create_report(
             events, report_file, report_line, report_col,
-            match.group('message').strip(), stack_traces)
+            message, stack_traces, checker_name)
 
         return report, line

--- a/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1.plist
+++ b/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1.plist
@@ -8,7 +8,7 @@
 			<key>category</key>
 			<string>unknown</string>
 			<key>check_name</key>
-			<string>UndefinedBehaviorSanitizer</string>
+			<string>UndefinedBehaviorSanitizer.signed-integer-overflow</string>
 			<key>description</key>
 			<string>signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'</string>
 			<key>issue_hash_content_of_line_in_context</key>

--- a/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan2.plist
+++ b/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan2.plist
@@ -8,7 +8,7 @@
 			<key>category</key>
 			<string>unknown</string>
 			<key>check_name</key>
-			<string>UndefinedBehaviorSanitizer</string>
+			<string>UndefinedBehaviorSanitizer.enum</string>
 			<key>description</key>
 			<string>load of value 7, which is not a valid value for type 'enum E'</string>
 			<key>issue_hash_content_of_line_in_context</key>
@@ -49,7 +49,7 @@
 			<key>category</key>
 			<string>unknown</string>
 			<key>check_name</key>
-			<string>UndefinedBehaviorSanitizer</string>
+			<string>UndefinedBehaviorSanitizer.bool</string>
 			<key>description</key>
 			<string>load of value 2, which is not a valid value for type 'bool'</string>
 			<key>issue_hash_content_of_line_in_context</key>


### PR DESCRIPTION
When UBsan and Asan tools emit a report then the checker name is
UndefinedBehaviorSanitizer and AddressSanitizer respectively. This could
be more granular, because the checker message could determine which
"checker" emitted it. By "checker" we mean these:

-fsanitize=alignment
-fsanitize=bool
...