### PR TITLE
[fix] One more attempt to fix gui tests

### DIFF
--- a/web/server/vue-cli/e2e/commands/clearAndSetValue.js
+++ b/web/server/vue-cli/e2e/commands/clearAndSetValue.js
@@ -5,6 +5,9 @@ module.exports.command = function (selector, value, section) {
     section = this;
 
   return section
+    // This pause(100) is required to make sure the element
+    // is visible before clicking it.
+    .pause(100)
     .click(selector)
     .getValue(selector, function (result) {
       section.setValue(selector, [

--- a/web/server/vue-cli/e2e/pages/product.js
+++ b/web/server/vue-cli/e2e/pages/product.js
@@ -164,7 +164,7 @@ const commands = {
   },
 
   saveProduct() {
-    this.section.productDialog.click("@confirmBtn");
+    this.section.productDialog.pause(100).click("@confirmBtn");
 
     this.waitForElementNotPresent("@progressBar", 5000);
 
@@ -179,6 +179,7 @@ const commands = {
 
     this.section.removeProductDialog
       .waitForElementVisible("@confirmBtn")
+      .pause(100)
       .click("@confirmBtn");
 
     this.waitForElementNotPresent("@progressBar", 5000);

--- a/web/server/vue-cli/e2e/specs/reportDetail.js
+++ b/web/server/vue-cli/e2e/specs/reportDetail.js
@@ -34,7 +34,7 @@ module.exports = {
 
     dialog.expect.element("@content").text.to.not.equal(null);
 
-    dialog.click("@closeBtn");
+    dialog.pause(100).click("@closeBtn");
 
     reportDetailPage.expect.section(dialog).to.not.be.present.before(5000);
   },
@@ -47,6 +47,36 @@ module.exports = {
       .waitForElementVisible("@blameCommitInfo")
       .click("@toggleBlameViewBtn")
       .waitForElementNotPresent("@blameCommitInfo");
+  },
+
+  "change review status without message" (browser) {
+    const reportDetailPage = browser.page.reportDetail();
+    const selectReviewStatusMenu =
+      reportDetailPage.section.selectReviewStatusMenu;
+    const changeReviewStatusMessageDialog =
+      reportDetailPage.section.changeReviewStatusMessageDialog;
+
+    // Open the selector.
+    reportDetailPage.click("@selectReviewStatus");
+
+    reportDetailPage.expect.section(selectReviewStatusMenu)
+      .to.be.visible.before(5000);
+
+    // Select an item.
+    selectReviewStatusMenu.click({ selector: "@item", index: 1 });
+
+    reportDetailPage.expect.section(changeReviewStatusMessageDialog)
+      .to.be.visible.before(5000);
+
+    reportDetailPage.expect.element("@overlay").to.be.visible.before(5000);
+
+    // Clear the message.
+    changeReviewStatusMessageDialog
+      .clearAndSetValue("@message", "", changeReviewStatusMessageDialog)
+      .click("@save");
+
+    reportDetailPage.expect.element("@reviewStatusMessage")
+      .to.be.not.present.before(5000);
   },
 
   "change review status with a message" (browser) {
@@ -90,36 +120,6 @@ module.exports = {
     reportDetailPage.expect.section(reviewStatusMessageMenu)
       .to.be.not.present.before(5000);
     reportDetailPage.expect.element("@overlay").to.not.be.present.before(5000);
-  },
-
-  "change review status without message" (browser) {
-    const reportDetailPage = browser.page.reportDetail();
-    const selectReviewStatusMenu =
-      reportDetailPage.section.selectReviewStatusMenu;
-    const changeReviewStatusMessageDialog =
-      reportDetailPage.section.changeReviewStatusMessageDialog;
-
-    // Open the selector.
-    reportDetailPage.click("@selectReviewStatus");
-
-    reportDetailPage.expect.section(selectReviewStatusMenu)
-      .to.be.visible.before(5000);
-
-    // Select an item.
-    selectReviewStatusMenu.click({ selector: "@item", index: 1 });
-
-    reportDetailPage.expect.section(changeReviewStatusMessageDialog)
-      .to.be.visible.before(5000);
-
-    reportDetailPage.expect.element("@overlay").to.be.visible.before(5000);
-
-    // Clear the message.
-    changeReviewStatusMessageDialog
-      .clearAndSetValue("@message", "", changeReviewStatusMessageDialog)
-      .click("@save");
-
-    reportDetailPage.expect.element("@reviewStatusMessage")
-      .to.be.not.present.before(5000);
   },
 
   async "manage comments" (browser) {
@@ -172,7 +172,7 @@ module.exports = {
       .to.be.visible.before(5000);
     reportDetailPage.expect.element("@overlay").to.be.visible.before(5000);
 
-    removeCommentDialog.click("@removeBtn");
+    removeCommentDialog.pause(100).click("@removeBtn");
 
     reportDetailPage.expect.section(removeCommentDialog)
       .to.be.not.present.before(5000);

--- a/web/server/vue-cli/e2e/specs/reports.js
+++ b/web/server/vue-cli/e2e/specs/reports.js
@@ -507,13 +507,13 @@ module.exports = {
     dialogSection.pause(500);
 
     dialogSection.waitForElementVisible("@removeBtn");
-    dialogSection.click({ selector: "@removeBtn", index: 0 });
+    dialogSection.pause(100).click({ selector: "@removeBtn", index: 0 });
     reportPage.expect.section(removeComponentDialog)
       .to.be.visible.before(5000);
 
     reportPage.expect.element("@overlay").to.be.visible.before(5000);
 
-    removeComponentDialog.click("@confirmBtn");
+    removeComponentDialog.pause(100).click("@confirmBtn");
 
     dialogSection
       .waitForElementVisible("@emptyTable")

--- a/web/server/vue-cli/e2e/specs/reviewStatusRule.js
+++ b/web/server/vue-cli/e2e/specs/reviewStatusRule.js
@@ -112,7 +112,7 @@ module.exports = {
     reviewStatusRulePage.expect.element("@overlay").to.be.visible.before(5000);
     reviewStatusRulePage.expect.section(dialog).to.be.visible.before(5000);
 
-    reviewStatusRulePage.section.removeReviewStatusRuleDialog.click("@confirmBtn");
+    reviewStatusRulePage.section.removeReviewStatusRuleDialog.pause(100).click("@confirmBtn");
 
     reviewStatusRulePage.expect.section(dialog).to.not.be.present.before(5000);
     reviewStatusRulePage.expect.element("@overlay")

--- a/web/server/vue-cli/e2e/specs/runs.js
+++ b/web/server/vue-cli/e2e/specs/runs.js
@@ -92,7 +92,7 @@ module.exports = {
     dialogSection.assert.containsText("@content", checkCommand);
 
     // Close check command dialog.
-    dialogSection.click("@closeBtn");
+    dialogSection.pause(100).click("@closeBtn");
 
     runsPage.expect.section(dialogSection)
       .to.not.be.present.before(5000);
@@ -104,6 +104,7 @@ module.exports = {
 
     runsPage
       .click("@name")
+      .pause(100)
       .assert.urlContains(`run=${runName}`)
       .assert.urlContains("review-status=Unreviewed")
       .assert.urlContains("review-status=Confirmed%20bug")
@@ -362,7 +363,7 @@ module.exports = {
       .expect.section("@removeRunDialog").to.be.visible.before(5000);
 
     runsPage.expect.element("@overlay").to.be.visible.before(5000);
-    removeDialog.click("@confirmBtn");
+    removeDialog.pause(100).click("@confirmBtn");
 
     runsPage.expect.section("@removeRunDialog")
       .to.not.be.present.before(5000);


### PR DESCRIPTION
The order of two testcases was swapped, and some of the click() calls
got a 100 msec pause inserted before them.
I've yet to discover the reason why these momentary pauses fix the
shadowing, but it looks like it is working.