### PR TITLE
[analyzer] Yet another unknown gcc flag

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -93,6 +93,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-jump-table',
     '-fno-keep-inline-dllexport'
     '-fno-keep-static-consts',
+    '-fno-lifetime-dse',
     '-f(no-)?reorder-functions',
     '-fno-strength-reduce',
     '-fno-toplevel-reorder',


### PR DESCRIPTION
-fno-lifetime-dse is not known by clang.