### PR TITLE
[analyzer] Fix crash when an assembler command is analyzed

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1068,10 +1068,11 @@ def parse_options(compilation_db_entry,
         gcc_toolchain.toolchain_in_args(details['analyzer_options'])
 
     # Store the compiler built in include paths and defines.
-    # If clang compiler is used for compilation and analysis,
-    # do not collect the implicit include paths.
-    if (not toolchain and not using_same_clang_to_compile_and_analyze) or \
-            (compiler_info_file and os.path.exists(compiler_info_file)):
+    # If clang compiler is used for compilation and analysis, or language is
+    # not recognized, do not collect the implicit include paths.
+    if ((not toolchain and not using_same_clang_to_compile_and_analyze) or
+            (compiler_info_file and os.path.exists(compiler_info_file))) and \
+            details['lang']:
         ImplicitCompilerInfo.set(details, compiler_info_file)
 
     if not keep_gcc_include_fixed:

--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -79,6 +79,21 @@ class OptionParserTest(unittest.TestCase):
         self.assertTrue('main.cpp' == res.source)
         self.assertEqual(BuildAction.COMPILE, res.action_type)
 
+    def test_nasm_action(self):
+        """
+        Test if an assembler is logged and analyzed.
+        """
+        action = {
+            'file': 'main.asm',
+            'command': "nasm -f elf64 main.asm",
+            'directory': ''}
+
+        res = log_parser.parse_options(action)
+        print(res)
+        self.assertIsNone(res.lang)
+        self.assertEqual(res.source, 'main.asm')
+        self.assertEqual(res.analyzer_type, -1)
+
     def test_preprocess_onefile(self):
         """
         Test the preprocess command of one file.


### PR DESCRIPTION
If an assember command is analyzed then the recognized language remains None which can't be provided after -x flag in a subprocess.Popen call. So -x is added to the command if the recognized language is not None.

Fixes #3670
Fixes #3730