### PR TITLE
[cmd] Warning message on no run delete.

### DIFF
--- a/web/api/report_server.thrift
+++ b/web/api/report_server.thrift
@@ -764,7 +764,7 @@ service codeCheckerDBAccess {
                         3: CompareData  cmpData)
                         throws (1: codechecker_api_shared.RequestFailed requestError),
 
-  // Remove run from the database.
+  // Remove run from the database. Return true if at least one report removed with the given criteria.
   // PERMISSION: PRODUCT_STORE
   bool removeRun(1: i64 runId,
                  2: optional RunFilter runFilter)

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1477,7 +1477,9 @@ def handle_remove_run_results(args):
     if client.removeRun(None, run_filter):
         LOG.info("Done.")
     else:
-        LOG.error("Failed to remove runs!")
+        LOG.warning(
+            "No runs were removed, check if the given criteria match existing "
+            "run names.")
 
 
 def handle_update_run(args):

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -3387,7 +3387,7 @@ class ThriftRequestHandler:
         db_cleanup.remove_unused_comments(self._Session)
         db_cleanup.remove_unused_analysis_info(self._Session)
 
-        return True
+        return bool(runs)
 
     @exc_to_thrift_reqfail
     @timeit

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -103,3 +103,12 @@ class RemoveRunResults(unittest.TestCase):
         # Check that we removed all results from the run.
         res = self._cc_client.getRunResultCount([run_id], ReportFilter(), None)
         self.assertEqual(res, 0)
+
+    def test_remove_nonexisting_run(self):
+        """
+        Test if False is returned on the removal of a non-existing run's
+        removal.
+        """
+        run_filter = RunFilter(names=['non_existing'], exactMatch=True)
+        res = self._cc_client.removeRun(None, run_filter)
+        self.assertFalse(res)


### PR DESCRIPTION
"CodeChecker cmd del ..." command gives no feedback if no run was deleted based on the given parameters, however, this would be an important feedback for the users.