### PR TITLE
Fix exception when SourceLine has no source_path attribute

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
@@ -105,8 +105,7 @@ class AnalyzerResult(AnalyzerResultBase):
         long_message = bug.find('LongMessage').text
 
         source_line = bug.find('SourceLine')
-        source_path = source_line.attrib.get('sourcepath')
-        source_path = self.__get_abs_path(source_path)
+        source_path = self.__get_source_path(source_line)
         if not source_path:
             return
 
@@ -148,11 +147,7 @@ class AnalyzerResult(AnalyzerResultBase):
         message = element.find('Message').text
 
         source_line = element.find('SourceLine')
-        if source_line is None:
-            return None
-
-        source_path = source_line.attrib.get('sourcepath')
-        source_path = self.__get_abs_path(source_path)
+        source_path = self.__get_source_path(source_line)
         if not source_path:
             return None
 
@@ -170,11 +165,7 @@ class AnalyzerResult(AnalyzerResultBase):
         message = element.find('Message').text
 
         source_line = element.find('SourceLine')
-        if source_line is None:
-            return None
-
-        source_path = source_line.attrib.get('sourcepath')
-        source_path = self.__get_abs_path(source_path)
+        source_path = self.__get_source_path(source_line)
         if not source_path:
             return None
 
@@ -186,3 +177,15 @@ class AnalyzerResult(AnalyzerResultBase):
             get_or_create_file(source_path, self.__file_cache),
             line,
             col)
+
+    def __get_source_path(self, source_line):
+        """ Get source path from the source line. """
+        if source_line is None:
+            return None
+
+        source_path_attrib = source_line.attrib.get('sourcepath')
+        if source_path_attrib is None:
+            LOG.warning("No source path attribute found for class: %s", source_line.attrib.get('classname'))
+            return None
+
+        return self.__get_abs_path(source_path_attrib)

--- a/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
@@ -50,12 +50,21 @@ class AnalyzerResult(AnalyzerResultBase):
 
         return reports
 
-    def __get_abs_path(self, source_path: str):
-        """ Returns full path of the given source path.
+    def __get_abs_path(self, source_line):
+        """ Returns full source path of the given source line.
 
         It will try to find the given source path in the project paths and
         returns full path if it founds.
         """
+        if source_line is None:
+            return None
+
+        source_path = source_line.attrib.get('sourcepath')
+        if source_path is None:
+            LOG.warning("No source path attribute found for class: %s",
+                        source_line.attrib.get('classname'))
+            return None
+
         if os.path.exists(source_path):
             return source_path
 
@@ -105,7 +114,7 @@ class AnalyzerResult(AnalyzerResultBase):
         long_message = bug.find('LongMessage').text
 
         source_line = bug.find('SourceLine')
-        source_path = self.__get_source_path(source_line)
+        source_path = self.__get_abs_path(source_line)
         if not source_path:
             return
 
@@ -147,7 +156,7 @@ class AnalyzerResult(AnalyzerResultBase):
         message = element.find('Message').text
 
         source_line = element.find('SourceLine')
-        source_path = self.__get_source_path(source_line)
+        source_path = self.__get_abs_path(source_line)
         if not source_path:
             return None
 
@@ -165,7 +174,7 @@ class AnalyzerResult(AnalyzerResultBase):
         message = element.find('Message').text
 
         source_line = element.find('SourceLine')
-        source_path = self.__get_source_path(source_line)
+        source_path = self.__get_abs_path(source_line)
         if not source_path:
             return None
 
@@ -177,15 +186,3 @@ class AnalyzerResult(AnalyzerResultBase):
             get_or_create_file(source_path, self.__file_cache),
             line,
             col)
-
-    def __get_source_path(self, source_line):
-        """ Get source path from the source line. """
-        if source_line is None:
-            return None
-
-        source_path_attrib = source_line.attrib.get('sourcepath')
-        if source_path_attrib is None:
-            LOG.warning("No source path attribute found for class: %s", source_line.attrib.get('classname'))
-            return None
-
-        return self.__get_abs_path(source_path_attrib)


### PR DESCRIPTION
The `report-converter` fail with an exception when a SpotBugs input has a `<SourceLine>` element without a `source_path` attribute.

---

Example for an element like above explained from a SpotBugs run:

```xml
<Method classname="org.w3c.dom.Element" name="getAttribute" signature="(Ljava/lang/String;)Ljava/lang/String;" isStatic="false" role="METHOD_RETURN_VALUE_OF">
  <SourceLine classname="org.w3c.dom.Element"/>
  <Message>Return value of org.w3c.dom.Element.getAttribute(String) of type String</Message>
</Method>
```

In this case the `report-converter` failed with the following exception:

```text
Traceback (most recent call last):
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\cli.py", line 243, in <module>
    main()
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\cli.py", line 237, in main
    return transform_output(
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\cli.py", line 100, in transform_output
    parser.transform(
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\analyzers\analyzer_result.py", line 57, in transform
    reports = self.get_reports(analyzer_result_file_path)
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\analyzers\spotbugs\analyzer_result.py", line 47, in get_reports
    report = self.__parse_bug(bug)
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\analyzers\spotbugs\analyzer_result.py", line 122, in __parse_bug
    event = self.__event_from_method(element)
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\analyzers\spotbugs\analyzer_result.py", line 177, in __event_from_method
    source_path = self.__get_abs_path(source_path)
  File "<personal path>\codechecker\tools\report-converter\codechecker_report_converter\analyzers\spotbugs\analyzer_result.py", line 59, in __get_abs_path
    if os.path.exists(source_path):
  File "<personal path>\miniconda3\lib\genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

With this modification the converter won't be interrupted by an exception, but gives a warning message:

```text
[WARNING] - No source path attribute found for class: org.w3c.dom.Element
```