### PR TITLE
[analyzer] Use absolute path to logger.so in LD_PRELOAD

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -16,6 +16,8 @@ from distutils.spawn import find_executable
 import os
 import sys
 
+from pathlib import Path
+
 from codechecker_common import logger
 from codechecker_common.checker_labels import CheckerLabels
 from codechecker_common.singleton import Singleton
@@ -63,12 +65,18 @@ class Context(metaclass=Singleton):
         self.__analyzers = {}
         self.__analyzer_env = None
 
+        machine = os.uname().machine
+
         self.logger_lib_dir_path = os.path.join(
-            self._data_files_dir_path, 'ld_logger', 'lib')
+            self._data_files_dir_path, 'ld_logger', 'lib', machine)
 
         if not os.path.exists(self.logger_lib_dir_path):
             self.logger_lib_dir_path = os.path.join(
-                self._lib_dir_path, 'codechecker_analyzer', 'ld_logger', 'lib')
+                self._lib_dir_path,
+                'codechecker_analyzer',
+                'ld_logger',
+                'lib',
+                machine)
 
         self.logger_bin = None
         self.logger_file = None
@@ -231,8 +239,12 @@ class Context(metaclass=Singleton):
         return os.path.join(self._bin_dir_path, 'ld_logger')
 
     @property
-    def path_logger_lib(self):
-        return self.logger_lib_dir_path
+    def logger_lib_path(self):
+        """
+        Returns the absolute path to the logger library.
+        """
+        return str(Path(self.logger_lib_dir_path,
+                        self.logger_lib_name).absolute())
 
     @property
     def logger_lib_name(self):

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -28,14 +28,7 @@ def get_log_env(logfile, original_env):
 
     new_env[context.env_var_cc_logger_bin] = context.path_logger_bin
 
-    new_env['LD_PRELOAD'] = context.logger_lib_name
-
-    try:
-        original_ld_library_path = new_env['LD_LIBRARY_PATH']
-        new_env['LD_LIBRARY_PATH'] = context.path_logger_lib + ':' + \
-            original_ld_library_path
-    except KeyError:
-        new_env['LD_LIBRARY_PATH'] = context.path_logger_lib
+    new_env['LD_PRELOAD'] = context.logger_lib_path
 
     # Set ld logger logfile.
     new_env[context.env_var_cc_logger_file] = logfile

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -16,6 +16,7 @@ import tempfile
 import unittest
 
 from codechecker_analyzer.buildlog import log_parser
+from codechecker_analyzer.env import get_log_env
 from codechecker_common.skiplist_handler import SkipListHandler, \
     SkipListHandlers
 from codechecker_common.util import load_json
@@ -664,3 +665,24 @@ class LogParserTest(unittest.TestCase):
 
         self.assertEqual(len(build_actions), 3)
         self.assertEqual(build_action.source, fileC_symdir)
+
+    def test_get_log_env(self):
+        """
+        Test if get_log_env returns the correct environment
+        with LD_PRELOAD set to pointing to the correct directory
+        of the ldlogger.so lib.
+        """
+        log_file = os.path.join(self.tmp_dir, "compile_commands.json")
+        original_env = os.environ.copy()
+        # If this asset fails, make sure that you don't have LD_PRELOAD set
+        # in your environment.
+        self.assertNotIn("LD_PRELOAD", original_env)
+        env = get_log_env(log_file, original_env)
+
+        # The new environment should contain the LD_PRELOAD variable.
+        self.assertIn("LD_PRELOAD", env)
+
+        # Make sure that the test running machine architecture is in the
+        # LD_PRELOAD path.
+        machine = os.uname().machine
+        self.assertTrue(env["LD_PRELOAD"].endswith(machine + "/ldlogger.so"))

--- a/analyzer/tools/build-logger/README.md
+++ b/analyzer/tools/build-logger/README.md
@@ -14,8 +14,7 @@ make all test
 
 Set the following environment variables:
 ~~~~~~~
-export LD_PRELOAD=ldlogger.so
-export LD_LIBRARY_PATH=`pwd`/build/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=`pwd`/build/lib/`uname -m`/ldlogger.so
 export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:cc:c++"
 # The output compilation JSON file.
 export CC_LOGGER_FILE=`pwd`/compilation.json

--- a/analyzer/tools/build-logger/tests/unit/__init__.py
+++ b/analyzer/tools/build-logger/tests/unit/__init__.py
@@ -106,10 +106,13 @@ class BasicLoggerTest(unittest.TestCase):
             return fd.read()
 
     def get_envvars(self) -> Mapping[str, str]:
+        machine = os.uname().machine
         return {
             "PATH": os.getenv("PATH"),
-            "LD_PRELOAD": "ldlogger.so",
-            "LD_LIBRARY_PATH": os.path.join(LOGGER_DIR, "lib"),
+            "LD_PRELOAD": os.path.join(LOGGER_DIR,
+                                       "lib",
+                                       machine,
+                                       "ldlogger.so"),
             "CC_LOGGER_GCC_LIKE": "gcc:g++:clang:clang++:cc:c++",
             "CC_LOGGER_FILE": self.logger_file,
             "CC_LOGGER_DEBUG_FILE": self.logger_debug_file,

--- a/analyzer/tools/build-logger/tests/unit/test_paths.py
+++ b/analyzer/tools/build-logger/tests/unit/test_paths.py
@@ -4,7 +4,6 @@ import glob
 import os
 import shutil
 import tempfile
-from typing import Mapping
 from . import BasicLoggerTest, empty_env, REPO_ROOT
 
 AVAILABLE_GNU_COMPILERS = [
@@ -12,13 +11,6 @@ AVAILABLE_GNU_COMPILERS = [
     for path in os.getenv("PATH").split(":")
     for compiler in glob.glob(f"{path}/g++-*")
 ]
-
-
-def append_host_LD_LIBRARY_PATH(env: Mapping[str, str]) -> Mapping[str, str]:
-    LD_LIBRARY_PATH = os.getenv("LD_LIBRARY_PATH")
-    if LD_LIBRARY_PATH:
-        env["LD_LIBRARY_PATH"] += ':' + LD_LIBRARY_PATH
-    return env
 
 
 class EscapingTests(BasicLoggerTest):
@@ -250,7 +242,6 @@ class EscapingTests(BasicLoggerTest):
         """Test clang-specific response files."""
         logger_env = self.get_envvars()
         # clang might need Z3
-        logger_env = append_host_LD_LIBRARY_PATH(logger_env)
         file = self.source_file
         binary = self.binary_file
         clang = shutil.which("clang")
@@ -286,7 +277,6 @@ class EscapingTests(BasicLoggerTest):
         """
         logger_env = self.get_envvars()
         # clang might need Z3
-        logger_env = append_host_LD_LIBRARY_PATH(logger_env)
         file = self.source_file
         binary = self.binary_file
         clang = shutil.which("clang")


### PR DESCRIPTION
It can happen that a build system overwrites the LD_LIBRARY_PATH environment variable, this could result in the following error:

```
“ERROR: ld.so: object 'ldlogger.so' from LD_PRELOAD cannot be preloaded: ignored”
```