### PR TITLE
[feat] Exclude dynamic parts of checker message in hash generation

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
@@ -119,10 +119,17 @@ class SANParser(BaseParser):
         if stack_traces:
             notes = [BugPathEvent(''.join(stack_traces), file, line, column)]
 
+        # Dynamic analyzers usually generate checker messages containing
+        # memory addresses. Since checker messages are included in the report
+        # hash, the subsequent executions of the analysis produces different
+        # reports even if they refer the same problem. For this reason the
+        # memory addresses are cut out from "static_message" for sake of
+        # stabile hash generation.
         return Report(
             file, line, column, message, self.checker_name,
             bug_path_events=events,
-            notes=notes)
+            notes=notes,
+            static_message=re.sub(r'0x[0-9a-fA-F]+', '', message))
 
     def parse_stack_trace(
         self,

--- a/tools/report-converter/codechecker_report_converter/report/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/report/__init__.py
@@ -292,8 +292,21 @@ class Report:
         bug_path_positions: Optional[List[BugPathPosition]] = None,
         notes: Optional[List[BugPathEvent]] = None,
         macro_expansions: Optional[List[MacroExpansion]] = None,
-        annotations: Optional[Dict[str, str]] = None
+        annotations: Optional[Dict[str, str]] = None,
+        static_message: Optional[str] = None
     ):
+        """
+        This constructor populates the members of the Report object.
+
+        static_message: hash.get_report_hash() function generates a hash value
+            based on this report object. The checker message is usually the
+            part of this hash. However, sometimes a checker message may contain
+            dynamically generated parts (e.g. sanitizers include some memory
+            addresses). This results changing hashes at every analysis
+            execution. In this case the report converter of that analyzer may
+            provide a more stable message which is used only for hash
+            generation.
+        """
         self.analyzer_result_file_path = analyzer_result_file_path
         self.file = file
         self.line = line
@@ -306,6 +319,9 @@ class Report:
         self.category = category
         self.type = type
         self.annotations = annotations
+
+        self.static_message = \
+            message if static_message is None else static_message
 
         self.bug_path_events = bug_path_events \
             if bug_path_events is not None else \

--- a/tools/report-converter/codechecker_report_converter/report/hash.py
+++ b/tools/report-converter/codechecker_report_converter/report/hash.py
@@ -65,7 +65,9 @@ def __get_report_hash_path_sensitive(report: Report) -> List[str]:
     High level overview of the hash content:
      * 'file_name' from the main diag section.
      * 'checker name'
-     * 'checker message'
+     * 'checker message' (Some analyzers may generate dynamic content to
+         messages, line memory addresses in case of sanitizers. The report
+         converter of these analyzers may exclude these dynamic parts.)
      * 'line content' from the source file if can be read up
      * 'column numbers' from the main diag section
      * 'range column numbers' from bug_path_positions.
@@ -87,7 +89,7 @@ def __get_report_hash_path_sensitive(report: Report) -> List[str]:
 
         hash_content = [report.file.name,
                         report.checker_name,
-                        event.message,
+                        report.static_message,
                         line_content,
                         str(from_col),
                         str(until_col)]
@@ -140,7 +142,7 @@ def __get_report_hash_context_free(report: Report) -> List[str]:
 
         return [
             report.file.name,
-            report.message,
+            report.static_message,
             line_content,
             str(from_col),
             str(until_col)]

--- a/tools/report-converter/tests/unit/analyzers/asan_output_test_files/asan.plist
+++ b/tools/report-converter/tests/unit/analyzers/asan_output_test_files/asan.plist
@@ -12,7 +12,7 @@
 			<key>description</key>
 			<string>heap-use-after-free on address 0x614000000044 at pc 0x0000004f4b45 bp 0x7ffd40559120 sp 0x7ffd40559118</string>
 			<key>issue_hash_content_of_line_in_context</key>
-			<string>8cdbdf52c8542acf9393deee98235edb</string>
+			<string>ff912898a35de2f0f14a384e42c78bc7</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>

--- a/tools/report-converter/tests/unit/analyzers/tsan_output_test_files/tsan.plist
+++ b/tools/report-converter/tests/unit/analyzers/tsan_output_test_files/tsan.plist
@@ -12,7 +12,7 @@
 			<key>description</key>
 			<string>SEGV on unknown address 0x000000000000 (pc 0x0000004b525c bp 0x7fff93b54920 sp 0x7fff93b548b0 T23755)</string>
 			<key>issue_hash_content_of_line_in_context</key>
-			<string>4c95a99bdc3a7ca6f49bfac68164842c</string>
+			<string>31af200dd5f348df293f187088337ccd</string>
 			<key>location</key>
 			<dict>
 				<key>col</key>


### PR DESCRIPTION
Some dynamic analyzers, like sanitizers generate dynamic parts in the checker message (e.g. memory addresses). These are changing in every execution of the analyer. Since the checker message is part of the report hash, the hash changes too. This is bad, because the report itself is supposed to be the same.

The report converter can provide a static_message field for the report which is a stable version of the checker message. If this field is given then it will be used for hash generation.