### PR TITLE
[analyzer][cmd] Adapt to new clang-tidy checker options format.

### DIFF
--- a/analyzer/tests/unit/test_checker_option_parsing.py
+++ b/analyzer/tests/unit/test_checker_option_parsing.py
@@ -11,7 +11,6 @@ Test the parsing of checker options reported by the analyzers
 """
 
 import unittest
-from argparse import Namespace
 from codechecker_analyzer.analyzers.clangtidy.analyzer \
     import parse_checker_config as clangtidy_parse_checker_config
 

--- a/analyzer/tests/unit/test_checker_option_parsing.py
+++ b/analyzer/tests/unit/test_checker_option_parsing.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Test the parsing of checker options reported by the analyzers
+"""
+
+import unittest
+from argparse import Namespace
+from codechecker_analyzer.analyzers.clangtidy.analyzer \
+    import parse_checker_config as clangtidy_parse_checker_config
+
+
+class ClangTidyParseCheckerConfigTest(unittest.TestCase):
+    """
+    Test that the checker config options for clang-tidy are parsed correctly.
+    """
+
+    def test_old_format(self):
+        """
+        Test parsing of the output of 'clang-tidy -dump-config -checks=*' for
+        clang-tidy up to LLVM 14.
+        """
+        OLD_FORMAT_EXAMPLE = """
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,clang-diagnostic-*,\
+clang-analyzer-*,bugprone-*,-bugprone-easily-swappable-parameters,\
+concurrency-*,boost-*,concurrency-*,cppcoreguidelines-init-variables,\
+cppcoreguidelines-special-member-functions,misc-*,\
+-misc-definitions-in-headers,-misc-non-private-member-variables-in-classes,\
+performance-*,-misc-const-correctness,*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             readability-suspicious-call-argument.PrefixSimilarAbove
+    value:           '30'
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             llvmlibc-restrict-system-libc-headers.Includes
+    value:           '-*'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             bugprone-reserved-identifier.Invert
+    value:           'false'
+"""
+        result = clangtidy_parse_checker_config(OLD_FORMAT_EXAMPLE)
+        # The result can be an arbitrary iterable of pair-likes. To make
+        # assertions about it easer, we first convert it to a list-of-lists.
+        result = [[k, v] for (k, v) in result]
+        self.assertEqual(len(result), 6)
+        self.assertIn(
+            ["readability-suspicious-call-argument.PrefixSimilarAbove",
+             "'30'"], result)
+
+    def test_new_format(self):
+        """
+        Test parsing of the output of 'clang-tidy -dump-config -checks=*' for
+        clang-tidy starting with LLVM 15.
+        """
+        NEW_FORMAT_EXAMPLE = """
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  performance-unnecessary-value-param.IncludeStyle: llvm
+  readability-suspicious-call-argument.PrefixSimilarAbove: '30'
+  cppcoreguidelines-no-malloc.Reallocations: '::realloc'
+  llvmlibc-restrict-system-libc-headers.Includes: '-*'
+  bugprone-reserved-identifier.Invert: 'false'
+  cert-dcl16-c.IgnoreMacros: 'true'
+"""
+        result = clangtidy_parse_checker_config(NEW_FORMAT_EXAMPLE)
+        # The result can be an arbitrary iterable of pair-likes. To make
+        # assertions about it easer, we first convert it to a list-of-lists.
+        result = [[k, v] for (k, v) in result]
+        self.assertEqual(len(result), 6)
+        self.assertIn(
+            ["readability-suspicious-call-argument.PrefixSimilarAbove", "30"],
+            result)


### PR DESCRIPTION
Starting with LLVM15 / clang-tidy-15, the output of `--dump-config` has changed, and the old parser failed to parse the options in the new format. We need full YAML parsing now, the format looks like this:

```
---
Checks:          'clang-diagnostic-*,clang-analyzer-*,*'
AnalyzeTemporaryDtors: false
FormatStyle:     none
[…]
CheckOptions:
  performance-unnecessary-value-param.IncludeStyle: llvm
  readability-suspicious-call-argument.PrefixSimilarAbove: '30'
[…]
```

This solution implements a simple trial-and-error approach: It first tries the old parsing version, and if that fails, it tries the new one. This seems a lot simpler than first trying to figure out the clang-tidy version by e.g. parsing the output of `clang-tidy --version`.