### PR TITLE
[test] Allow additional pytest args to be given through make targets

### DIFF
--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -7,7 +7,7 @@ PYTHON_BIN ?= python3
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test_in_env: pycodestyle_in_env pylint_in_env test_unit_in_env test_functional_in_env test_build_logger test_tu_collector_in_env
 
@@ -31,11 +31,25 @@ pylint:
 pylint_in_env: venv_dev
 	$(ACTIVATE_DEV_VENV) && $(PYLINT_TEST_CMD)
 
-run_test:
+is_TEST_set:
+	@if [ -z ${TEST} ]; then \
+		echo "!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!"; \
+		echo "Environmental variable 'TEST' is not set!"; \
+		echo "'TEST' should be set to a test file/directory."; \
+		echo "Example: 'TEST=tests/functional/suppress make test_analyzer_feature'."; \
+		echo "Note: You may provide additional pytest argument by setting "\
+		     "'EXTRA_PYTEST_ARGS', which allows you to select a specific test "\
+				 "inside a test file (via the -k option)."; \
+		echo "Example: EXTRA_PYTEST_ARGS='-k test_source_suppress_export'  TEST=tests/functional/suppress make test_analyzer_feature"; \
+		echo "!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!"; \
+		exit 1; \
+	fi
+
+run_test: is_TEST_set
 	$(REPO_ROOT) $(TEST_PROJECT) \
 		pytest $(PYTESTCFG) ${TEST} || exit 1
 
-run_test_in_env: venv_dev
+run_test_in_env: venv_dev is_TEST_set
 	$(ACTIVATE_DEV_VENV) && $(REPO_ROOT) $(TEST_PROJECT) \
 		pytest $(PYTESTCFG) ${TEST} || exit 1
 

--- a/analyzer/tools/build-logger/tests/Makefile
+++ b/analyzer/tools/build-logger/tests/Makefile
@@ -3,7 +3,7 @@
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: pycodestyle pylint test_unit
 

--- a/analyzer/tools/merge_clang_extdef_mappings/tests/Makefile
+++ b/analyzer/tools/merge_clang_extdef_mappings/tests/Makefile
@@ -3,7 +3,7 @@
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: pycodestyle pylint test_unit
 

--- a/analyzer/tools/statistics_collector/tests/Makefile
+++ b/analyzer/tools/statistics_collector/tests/Makefile
@@ -3,7 +3,7 @@
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: pycodestyle pylint test_unit
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -49,6 +49,15 @@ PostgreSQL database backend.
 Further configuration options can be found here
 [Pytest configuration](https://docs.pytest.org/en/7.1.x/reference/customize.html).
 
+You can specify additional pytest arguments to the make targets by using the
+environmental variable `EXTRA_PYTEST_ARGS`:
+```sh
+EXTRA_PYTEST_ARGS='-k test_source_suppress_export'  TEST=tests/functional/suppress make test_analyzer_feature
+```
+The above example displays how you can select a specific testcase via the `-k`
+option passed through `EXTRA_PYTEST_ARGS`, within a specific testfile via
+`TEST`, in the analyzer library via `test_analyzer_feature`.
+
 ## Virtual environment to run tests
 Test running virtual environment is automatically created and sourced by the
 `make test*` commands.

--- a/tools/bazel/tests/Makefile
+++ b/tools/bazel/tests/Makefile
@@ -6,7 +6,7 @@ TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: pycodestyle pylint test_unit
 

--- a/tools/report-converter/tests/Makefile
+++ b/tools/report-converter/tests/Makefile
@@ -8,7 +8,7 @@ TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 LAYOUT_DIR ?= LAYOUT_DIR=$(STATIC_DIR)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: mypy pycodestyle pylint test_unit test_functional
 

--- a/tools/tu_collector/tests/Makefile
+++ b/tools/tu_collector/tests/Makefile
@@ -6,7 +6,7 @@ TEST_PROJECT ?= TEST_PROJ=$(CURRENT_DIR)/tests/projects
 REPO_ROOT ?= REPO_ROOT=$(ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: mypy pycodestyle pylint test_unit
 

--- a/web/tests/Makefile
+++ b/web/tests/Makefile
@@ -21,7 +21,7 @@ WOKSPACE_GLOBAL_SIMPLE_SERVER = $(CC_TEST_WORKSPACE_ROOT)/global_simple_server
 CLEAR_WORKSPACE_CMD = rm -rf $(CC_TEST_WORKSPACE_ROOT)
 
 # pytest test runner configuration options.
-PYTESTCFG = -c pytest.ini
+PYTESTCFG = -c pytest.ini ${EXTRA_PYTEST_ARGS}
 
 test: pycodestyle pylint test_unit test_functional
 
@@ -91,10 +91,24 @@ RUN_TEST_CMD = $(CLEAR_WORKSPACE_CMD) && \
   pytest $(PYTESTCFG) $(ROOT)/web/${TEST} \
   && { ${SHUTDOWN_GLOBAL_SERVERS_CMD}; } || ${EXIT_ERROR}
 
-run_test:
+is_TEST_set:
+	@if [ -z ${TEST} ]; then \
+		echo "!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!"; \
+		echo "Environmental variable 'TEST' is not set!"; \
+		echo "'TEST' should be set to a test file/directory inside the 'web/' directory."; \
+		echo "Example: 'TEST=tests/functional/skip make test_web_feature'."; \
+		echo "Note: You may provide additional pytest argument by setting "\
+		     "'EXTRA_PYTEST_ARGS', which allows you to select a specific test "\
+				 "inside a test file (via the -k option)."; \
+		echo "Example: EXTRA_PYTEST_ARGS='-k test_skip_plist_without_diag' TEST=tests/functional/skip make test_web_feature"; \
+		echo "!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!"; \
+		exit 1; \
+	fi
+
+run_test: is_TEST_set
 	$(RUN_TEST_CMD)
 
-run_test_in_env: venv_dev
+run_test_in_env: venv_dev is_TEST_set
 	$(ACTIVATE_DEV_VENV) && $(RUN_TEST_CMD)
 
 test_unit: test_unit_server test_unit_client


### PR DESCRIPTION
Previously, unless you wanted to directly invoke pytest (and even before
that, nosetests), you had to edit the corresponding config file in order
to provide additional args to pytest.
Invoking pytest directly is possible, but cumbersome -- you need to
remove the workspace directory, set environmental variables `REPO_ROOT`,
`BUILD_DIR`, `TEST_PROJ` and `TEST_CLANG_VERSION`.

I am not saying this is ideal, maybe we should make direct invocation a
little less painful, but until we do that, I added support for another
environmental variable, `EXTRA_PYTEST_ARGS`. For instance the following
invocation selects only the test matching 'test_source_suppress_export':

```
EXTRA_PYTEST_ARGS="-k test_source_suppress_export" TEST=tests/functional/suppress make test_analyzer_feature
```