### PR TITLE
[fix] Analysis shouldn't fail on non-existing directory

### DIFF
--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -127,9 +127,8 @@ def pre_analyze(params):
                                       ctu_temp_fnmap_folder)
 
     except Exception as ex:
-        LOG.debug_analyzer(str(ex))
+        LOG.error("Pre-analysis failed for %s: %s", action.source, str(ex))
         traceback.print_exc(file=sys.stdout)
-        raise
 
     try:
         if statistics_data:


### PR DESCRIPTION
When the compilation command database contains the build information of a file in a non-existing directory then the pre-analysis phase of CTU shouldn't fail.