### PR TITLE
[GUI] Pop the call stack when the message starts with "Returning;"

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportDetailFormatter.js
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportDetailFormatter.js
@@ -51,7 +51,8 @@ function getHighlightData(stack, step) {
         + " while the last function " + "was "
         + stack.funcStack[stack.funcStack.length - 1]);
     }
-  } else if (msg === "Returned allocated memory") {
+  } else if (msg === "Returned allocated memory" ||
+             msg.startsWith("Returning;")) {
     stack.funcStack.pop();
     stack.bgColor = highlightColours[
       stack.funcStack.length % highlightColours];


### PR DESCRIPTION
Previous to this commit, CodeChecker GUI didn't recognize that when a message starts with "Returning;", it may also signal that we are exiting a function.
# Test file
```cpp
#include <iostream>

void f(int *ptr) {
  delete ptr;
}

void g() {
  int *ptr = new int;
  f(ptr);
  *ptr = 5;
}
```
# Before
![image](https://github.com/Ericsson/codechecker/assets/23276031/e88bf6ad-ff61-4c43-b4a8-9dde4c5caba4)
# After
![image](https://github.com/Ericsson/codechecker/assets/23276031/b5d8ddf4-88a8-4bc1-b25c-b6635fe617a8)
