### PR TITLE
[test] Clang may need Z3 in logger tests

### DIFF
--- a/analyzer/tools/build-logger/tests/unit/test_paths.py
+++ b/analyzer/tools/build-logger/tests/unit/test_paths.py
@@ -4,6 +4,7 @@ import glob
 import os
 import shutil
 import tempfile
+from typing import Mapping
 from . import BasicLoggerTest, empty_env, REPO_ROOT
 
 AVAILABLE_GNU_COMPILERS = [
@@ -11,6 +12,15 @@ AVAILABLE_GNU_COMPILERS = [
     for path in os.getenv("PATH").split(":")
     for compiler in glob.glob(f"{path}/g++-*")
 ]
+
+
+def append_host_LD_LIBRARY_PATH(env: Mapping[str, str]) -> Mapping[str, str]:
+    LD_LIBRARY_PATH = os.getenv("LD_LIBRARY_PATH")
+    if LD_LIBRARY_PATH:
+        if "LD_LIBRARY_PATH" not in env:
+            env["LD_LIBRARY_PATH"] = ""
+        env["LD_LIBRARY_PATH"] += ':' + LD_LIBRARY_PATH
+    return env
 
 
 class EscapingTests(BasicLoggerTest):
@@ -242,6 +252,7 @@ class EscapingTests(BasicLoggerTest):
         """Test clang-specific response files."""
         logger_env = self.get_envvars()
         # clang might need Z3
+        logger_env = append_host_LD_LIBRARY_PATH(logger_env)
         file = self.source_file
         binary = self.binary_file
         clang = shutil.which("clang")
@@ -277,6 +288,7 @@ class EscapingTests(BasicLoggerTest):
         """
         logger_env = self.get_envvars()
         # clang might need Z3
+        logger_env = append_host_LD_LIBRARY_PATH(logger_env)
         file = self.source_file
         binary = self.binary_file
         clang = shutil.which("clang")


### PR DESCRIPTION
The build logger tests whether a build action using Clang compiler can be captured. In some environments Clang may be built with using Z3. The location of Z3 is provided in LD_LIBRARY_PATH in this case. So the value of this environment variable needs to be preserved.