### PR TITLE
[logger] + add missing header fcntl.h

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-logger.c
+++ b/analyzer/tools/build-logger/src/ldlogger-logger.c
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Trying to compile the project in a docker alpine environment using GCC 13.1.1 and got the following error:

```
× Building wheel for codechecker (pyproject.toml) did not run successfully.
11.35   │ exit code: 1
11.35   ╰─> [29 lines of output]
11.35       running bdist_wheel
11.35       running build
11.35       running build_ext
11.35       building 'codechecker_analyzer.ld_logger.lib.ldlogger' extension
11.35       creating build
11.35       creating build/temp.linux-x86_64-cpython-311
11.35       creating build/temp.linux-x86_64-cpython-311/analyzer
11.35       creating build/temp.linux-x86_64-cpython-311/analyzer/tools
11.35       creating build/temp.linux-x86_64-cpython-311/analyzer/tools/build-logger
11.35       creating build/temp.linux-x86_64-cpython-311/analyzer/tools/build-logger/src
11.35       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -D__LOGGER_MAIN__ -D_GNU_SOURCE -I/usr/include/python3.11 -c analyzer/tools/build-logger/src/ldlogger-hooks.c -o build/temp.linux-x86_64-cpython-311/analyzer/tools/build-logger/src/ldlogger-hooks.o
11.35       analyzer/tools/build-logger/src/ldlogger-hooks.c: In function 'unsetLDPRELOAD':
11.35       analyzer/tools/build-logger/src/ldlogger-hooks.c:46:64: warning: the comparison will always evaluate as 'true' for the pointer operand in 'pos + -1' must not be NULL [-Waddress]
11.35          46 |     if ((prefix_length == pos_number) && ( pos_number == 0 || (pos-1 && *--pos == '/')))
11.35             |                                                                ^~~
11.35       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -D__LOGGER_MAIN__ -D_GNU_SOURCE -I/usr/include/python3.11 -c analyzer/tools/build-logger/src/ldlogger-logger.c -o build/temp.linux-x86_64-cpython-311/analyzer/tools/build-logger/src/ldlogger-logger.o
11.35       analyzer/tools/build-logger/src/ldlogger-logger.c: In function 'logExec':
11.35       analyzer/tools/build-logger/src/ldlogger-logger.c:214:11: warning: implicit declaration of function 'open'; did you mean 'popen'? [-Wimplicit-function-declaration]
11.35         214 |   logFd = open(logFileEnv, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
11.35             |           ^~~~
11.35             |           popen
11.35       analyzer/tools/build-logger/src/ldlogger-logger.c:214:28: error: 'O_CREAT' undeclared (first use in this function)
11.35         214 |   logFd = open(logFileEnv, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
11.35             |                            ^~~~~~~
11.35       analyzer/tools/build-logger/src/ldlogger-logger.c:214:28: note: each undeclared identifier is reported only once for each function it appears in
11.35       analyzer/tools/build-logger/src/ldlogger-logger.c:214:38: error: 'O_RDWR' undeclared (first use in this function)
11.35         214 |   logFd = open(logFileEnv, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
11.35             |                                      ^~~~~~
11.35       error: command '/usr/bin/gcc' failed with exit code 1
11.35       [end of output]
```

I do not know if the issue was the GCC 13.1.1 is now more restrictive on missing include or a alpine musl stuff but adding `<fcntl.h>` header fixed the issue.

It is required to use `open` function.