### PR TITLE
[req] Upgrade PyYAML to 6.0.1

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -1,5 +1,5 @@
 lxml==4.9.2
 portalocker==2.2.1
 psutil==5.8.0
-PyYAML==6.0
+PyYAML==6.0.1
 mypy_extensions==0.4.3

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -5,6 +5,6 @@ psutil==5.8.0
 portalocker==2.2.1
 pylint==2.8.2
 mkdocs==1.2.3
-PyYAML==6.0
+PyYAML==6.0.1
 mypy_extensions==0.4.3
 coverage==5.5.0

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -2,5 +2,5 @@ lxml==4.9.2
 portalocker==2.2.1
 psutil==5.8.0
 scan-build==2.0.19
-PyYAML==6.0
+PyYAML==6.0.1
 mypy_extensions==0.4.3

--- a/codechecker_common/requirements_py/dev/requirements.txt
+++ b/codechecker_common/requirements_py/dev/requirements.txt
@@ -2,4 +2,4 @@ portalocker==2.2.1
 coverage==5.5.0
 mypy==0.812
 mypy_extensions==0.4.3
-PyYAML==6.0
+PyYAML==6.0.1

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -6,7 +6,7 @@ psutil==5.8.0
 mypy_extensions==0.4.3
 thrift==0.13.0
 gitpython==3.1.30
-PyYAML==6.0
+PyYAML==6.0.1
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz
 ./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz


### PR DESCRIPTION
PyYAML 6.0 is broken with the new Cython 3.0 release. See yaml/pyyaml#601.

As a side note: it would be helpful if `install_requires` in `setup.py` didn't contain `==` requirements. These prevent downstream projects from upgrading versions of things like PyYAML until codechecker makes a new release.