### PR TITLE
[gui] Update run filter when setting the filter options

### DIFF
--- a/web/server/vue-cli/src/components/Run/RunFilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Run/RunFilterToolbar.vue
@@ -220,6 +220,7 @@ export default {
         ? this.dateTimeToStr(this.storedAfter) : undefined;
       this.updateUrl({ "stored-after": date });
 
+      this.$emit("on-run-filter-changed");
       this.$emit("on-run-history-filter-changed");
     }, 500));
 
@@ -228,6 +229,7 @@ export default {
         ? this.dateTimeToStr(this.storedBefore) : undefined;
       this.updateUrl({ "stored-before": date });
 
+      this.$emit("on-run-filter-changed");
       this.$emit("on-run-history-filter-changed");
     }, 500));
   },

--- a/web/server/vue-cli/src/store/modules/run.js
+++ b/web/server/vue-cli/src/store/modules/run.js
@@ -36,10 +36,24 @@ const getters = {
     return state.storedAfter;
   },
   runFilter(state) {
-    if (!state.runName)
+    if (!state.runName && !state.storedAfter && !state.storedBefore)
       return null;
 
-    return new RunFilter({ names: [ `*${state.runName}*` ] });
+    let names = null;
+    if (state.runName)
+      names = [ `*${state.runName}*` ];
+    let after = null;
+    if (state.storedAfter)
+      after = getUnixTime(state.storedAfter);
+    let before = null;
+    if (state.storedBefore)
+      before = getUnixTime(state.storedBefore);
+
+    return new RunFilter({
+      names: names,
+      afterTime: after,
+      beforeTime: before
+    });
   },
   runHistoryFilter(state) {
     if (!state.runTag && !state.storedAfter && !state.storedBefore)


### PR DESCRIPTION
Previously only the run history was affected, when the analyzed before/after options were set. This resulted in a confusing view when the displayed run entries last analyzed date would show outside of the specified date.
This patch fixes this issue as it will hide those runs where the before/after criteria is not met.

fixes #3962 