### PR TITLE
[fix] Recognize -pthread for gcc compile commands

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -219,7 +219,8 @@ COMPILE_OPTIONS = [
     '-Wno-',
     '--sysroot=',
     '-sdkroot',
-    '--gcc-toolchain='
+    '--gcc-toolchain=',
+    '-pthread'
 ]
 
 COMPILE_OPTIONS = re.compile('|'.join(COMPILE_OPTIONS))


### PR DESCRIPTION
We used to not recognize `-pthread` when the compiler was gcc. This patch fixes that.