### PR TITLE
[enhancement] --cppcheckargs flag was missing

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -379,6 +379,13 @@ def add_arguments_to_parser(parser):
 
     cmd_config.add_option(analyzer_opts)
 
+    analyzer_opts.add_argument('--cppcheckargs',
+                               dest="cppcheck_args_cfg_file",
+                               required=False,
+                               default=argparse.SUPPRESS,
+                               help="File containing argument which will be "
+                                    "forwarded verbatim for Cppcheck.")
+
     analyzer_opts.add_argument('--saargs',
                                dest="clangsa_args_cfg_file",
                                required=False,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -917,7 +917,7 @@ usage: CodeChecker analyze [-h] [-j JOBS]
                            [-n NAME] [--analyzers ANALYZER [ANALYZER ...]]
                            [--capture-analysis-output] [--generate-reproducer]
                            [--config CONFIG_FILE]
-                           [--cppcheck-args CPPCHECK_ARGS_CFG_FILE]
+                           [--cppcheckargs CPPCHECK_ARGS_CFG_FILE]
                            [--saargs CLANGSA_ARGS_CFG_FILE]
                            [--tidyargs TIDY_ARGS_CFG_FILE]
                            [--timeout TIMEOUT]
@@ -1122,9 +1122,9 @@ analyzer arguments:
                         For more information see the docs: https://github.com/
                         Ericsson/codechecker/tree/master/docs/config_file.md
                         (default: None)
-  --cppcheck-args CPPCHECK_ARGS_CFG_FILE
-                        Configuration file to pass cppcheck command line
-                        arguments.
+  --cppcheckargs CPPCHECK_ARGS_CFG_FILE
+                        File containing argument which will be forwarded
+                        verbatim for Cppcheck.
   --saargs CLANGSA_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang Static Analyzer.


### PR DESCRIPTION
Analyzer config options can be forwarded to the analyzers by --saargs and --tidyargs flags. This was missing for Cppcheck, so --cppcheckargs flag has now been introduced.

Fixes #3936