### PR TITLE
[GUI] Change the selected bubble's brightness

### DIFF
--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -954,5 +954,12 @@ export default {
 
 ::v-deep .report-step-msg.current {
   border: 2px dashed var(--v-primary-base) !important;
+  opacity: 1;
+  font-weight: bold;
+}
+
+::v-deep .report-step-msg {
+  opacity: 0.7;
+  font-weight: lighter;
 }
 </style>


### PR DESCRIPTION
To highlight selected bubble on the report page currently we use only a 2px dashed border. It is hard to detect the active chip section when there are many bubbles in one report file. The active bubble is more highlighted when its opacity is 100 and 70% for the others. The font-weight is bold for active and lighter for non actives. The current modifications emphasize the selected bubble more then the dashed border.