### PR TITLE
[check actions] setting GITHUB_TOKEN permissions to read

### DIFF
--- a/.github/workflows/config_coverage.yml
+++ b/.github/workflows/config_coverage.yml
@@ -21,6 +21,8 @@ on:
   # Allow running this job manually from either API or GitHub UI.
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   checker-config-coverage:
     name: "Config coverage of checkers"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,8 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,6 +6,8 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   build:
     name: Build pypi package

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -5,6 +5,8 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   build:
     name: Build snap package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: codechecker-tests
 # Triggers the workflow on push or pull request events.
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   # Note: UI related linter tests will run in the gui job.
   lint:


### PR DESCRIPTION
This change limits the scope of GITHUB_TOKENs to "read-only" for all contexts for the checker actions.

This is one part of adopting security best practices of the OpenSSF based on the ScoreCard tool [1] as outlined in issue #3977.

Moreover, this PR only updates one workflow. For the other workflows, we need to determine if read-only is feasible or if some actions must be run with write permissions.

[1] https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions