### PR TITLE
[fix] Refine when a report is regarded as outstanding for tags

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -588,9 +588,11 @@ def get_open_reports_date_filter_query_old(tbl=Report, date=RunHistory.time):
 def get_diff_bug_id_query(session, run_ids, tag_ids, open_reports_date):
     """ Get bug id query for diff. """
     q = session.query(Report.bug_id.distinct())
-    q = q.filter(Report.fixed_at.is_(None))
+
     if run_ids:
         q = q.filter(Report.run_id.in_(run_ids))
+        if not tag_ids and not open_reports_date:
+            q = q.filter(Report.fixed_at.is_(None))
 
     if tag_ids:
         q = q.outerjoin(RunHistory,

--- a/web/tests/functional/diff_cmdline/test_diff_cmdline.py
+++ b/web/tests/functional/diff_cmdline/test_diff_cmdline.py
@@ -755,10 +755,8 @@ void a() {
                     ["run1:tag1"], ["run1:tag2"])
             return len(reports)
 
-        # FIXME: The FP suppression appeared from one tag to the next, so it
-        # should be in the RESOLVED set.
         self.assertEqual(get_run_diff_count(DiffType.NEW), 0)
-        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 0)
+        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 1)
         self.assertEqual(get_run_diff_count(DiffType.UNRESOLVED), 0)
 
         def get_run_diff_count_reverse(diff_type: DiffType):
@@ -767,9 +765,7 @@ void a() {
                     ["run1:tag2"], ["run1:tag1"])
             return len(reports)
 
-        # FIXME: The FP suppression appeared from one tag to the next, so it
-        # should be in the NEW set when the diff sets are reversed.
-        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 0)
+        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 1)
         self.assertEqual(get_run_diff_count_reverse(DiffType.RESOLVED), 0)
         self.assertEqual(get_run_diff_count_reverse(DiffType.UNRESOLVED), 0)
 
@@ -809,7 +805,7 @@ void a() {
             return len(reports)
 
         self.assertEqual(get_run_diff_count(DiffType.NEW), 0)
-        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 0)
+        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 1)
         self.assertEqual(get_run_diff_count(DiffType.UNRESOLVED), 0)
 
         def get_run_diff_count_reverse(diff_type: DiffType):
@@ -818,7 +814,7 @@ void a() {
                     ["run1:tag2"], ["run1:tag1"])
             return len(reports)
 
-        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 0)
+        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 1)
         self.assertEqual(get_run_diff_count_reverse(DiffType.RESOLVED), 0)
         self.assertEqual(get_run_diff_count_reverse(DiffType.UNRESOLVED), 0)
 


### PR DESCRIPTION
Despite only two lines of code, this patch is many things all in once:
* We fix a bug where diffing tags returned unexpected (and percieved to
  be incorrect) results,
* We redefine what we expect from diffing tags,
* We redefine the expected heaviour around review status rules.

Previously, we regarded review status rules are a timeless property, but
what is even more true, we didn't really know what we expect from them
when it came to diffing tags. This lead to confusion on the developer
side and on the user side as well, and lead to whack-a-mole issues and
patches like https://github.com/Ericsson/codechecker/issues/3675, that was more driven by what users expected from
this feature than a comprehensive plan.

This is okay -- the review status feature and the tag feature grew in
their own world, and nobody can be faulted for being on top of these
features having a very solid specifications right out of the gate. This
patch solved this issue.

From this point on, our stance is the following: when we diff runs, we
always check whether a report is outstanding _at the time of the query_,
and for diffing tags or timestamps, we check whether a report is
outstanding _at the time of the tag/timestamp_.

A user-facing documentation is written in https://github.com/Ericsson/codechecker/pull/4006, and can be previewed
here:
https://github.com/Szelethus/codechecker/blob/diff_docs_rewrite/docs/web/diff.md