### PR TITLE
[diff] Fix a CLI remote-remote bug where we checked the detection status 

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -991,13 +991,6 @@ def get_diff_remote_runs(
     cmp_data.runIds = new_ids
     cmp_data.runTag = new_run_tags
 
-    # Do not show resolved bugs in compare mode new.
-    if cmp_data.diffType == ttypes.DiffType.NEW:
-        report_filter.detectionStatus = [
-            ttypes.DetectionStatus.NEW,
-            ttypes.DetectionStatus.UNRESOLVED,
-            ttypes.DetectionStatus.REOPENED]
-
     sort_mode = [(ttypes.SortMode(
         ttypes.SortType.FILENAME,
         ttypes.Order.ASC))]

--- a/web/tests/functional/diff_cmdline/test_diff_cmdline.py
+++ b/web/tests/functional/diff_cmdline/test_diff_cmdline.py
@@ -645,9 +645,7 @@ void b() {
             return len(reports)
 
         self.assertEqual(get_run_diff_count(DiffType.NEW), 1)
-        # FIXME: The division by zero disappeared from tag1 to tag2, so the
-        # RESOLVED set should have a report.
-        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 0)
+        self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 1)
         self.assertEqual(get_run_diff_count(DiffType.UNRESOLVED), 0)
 
         def get_run_diff_count_reverse(diff_type: DiffType):
@@ -656,9 +654,7 @@ void b() {
                     ["run1:tag2"], ["run1:tag1"])
             return len(reports)
 
-        # FIXME: The division by zero disappeared from tag1 to tag2, so the
-        # NEW set should have a report when we reverse the diff.
-        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 0)
+        self.assertEqual(get_run_diff_count_reverse(DiffType.NEW), 1)
         self.assertEqual(get_run_diff_count_reverse(DiffType.RESOLVED), 1)
         self.assertEqual(get_run_diff_count_reverse(DiffType.UNRESOLVED), 0)
 
@@ -866,7 +862,6 @@ void b() {
         # tag1 and tag2 shouldn't change.
         self.__analyze_and_store(dir1, "run1", src_no_warnings, "tag3")
 
-        # FIXME: This report should not have disappeared!
-        self.assertEqual(get_run_diff_count(DiffType.NEW), 0)
+        self.assertEqual(get_run_diff_count(DiffType.NEW), 1)
         self.assertEqual(get_run_diff_count(DiffType.RESOLVED), 0)
         self.assertEqual(get_run_diff_count(DiffType.UNRESOLVED), 0)


### PR DESCRIPTION
Ideally, when we use CodeChecker cmd diff, we should return exactly what
the server API calls return. We obviously can't do that when either the
baseline or the newline result contains a local directory, since they
are not on the server. In that case, we need to parse the results, check
for review status rules on the server, etc.

However, when both operands _are_ on the server, there is no need to do
additional filtering, lets just trust that the server returns correct
results. If not, we should fix it the server.

Depends on #3995.