### PR TITLE
[enhancement] Add option to control clangsa header analysis and macro…

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -329,9 +329,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                                      "-Xclang", plugin])
 
             analyzer_mode = 'plist-multi-file'
+            if config.analyze_headers:
+                analyzer_cmd.extend(['-Xclang',
+                                     '-analyzer-opt-analyze-headers'])
+
             analyzer_cmd.extend(['-Xclang',
-                                 '-analyzer-opt-analyze-headers',
-                                 '-Xclang',
                                  '-analyzer-output=' + analyzer_mode,
                                  '-o', analyzer_output_file])
 
@@ -339,7 +341,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.extend(['-Xclang',
                                  '-analyzer-config',
                                  '-Xclang',
-                                 'expand-macros=true'])
+                                 'expand-macros=' +
+                                 ('true' if config.expand_macros
+                                  else 'false')])
 
             # Checker configuration arguments needs to be set before
             # the checkers.
@@ -576,6 +580,12 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
         handler.enable_z3_refutation = 'enable_z3_refutation' in args and \
             args.enable_z3_refutation == 'on'
+
+        handler.analyze_headers = 'analyze_headers' in args and \
+                                  args.analyze_headers == 'on'
+
+        handler.expand_macros = 'expand_macros' in args and \
+                                args.expand_macros == 'on'
 
         if 'ctu_phases' in args:
             handler.ctu_dir = os.path.join(args.output_path,

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/config_handler.py
@@ -27,3 +27,5 @@ class ClangSAConfigHandler(config_handler.AnalyzerConfigHandler):
         self.enable_z3 = False
         self.enable_z3_refutation = False
         self.environ = environ
+        self.analyze_headers = False
+        self.expand_macros = False

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -486,6 +486,19 @@ def add_arguments_to_parser(parser):
                                         "SMT solver. This should not cause "
                                         "that much of a slowdown compared to "
                                         "using only the Z3 solver.")
+    analyzer_opts.add_argument('--analyze-headers',
+                               dest='analyze_headers',
+                               choices=['on', 'off'],
+                               default='on',
+                               help="Force the static analyzer to analyze "
+                                    "functions defined in header files.")
+
+    analyzer_opts.add_argument('--expand-macros',
+                               dest='expand_macros',
+                               choices=['on', 'off'],
+                               default='on',
+                               help="Whether macros should be expanded and "
+                                    "included in the plist output.")
 
     if analyzer_types.is_ctu_capable():
         ctu_opts = parser.add_argument_group(


### PR DESCRIPTION
… expansion

Added two options
    '--analyze-headers [on|off] default=on' to enable/disable clang SA analysis of headers
    '--expand-macros [on|off] default=on' to enable/disable macro expansion in generated plist