### PR TITLE
replace os.uname() with platform.uname() for Windows support

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -14,6 +14,7 @@ Context to store package related information.
 from distutils.spawn import find_executable
 
 import os
+import platform
 import sys
 
 from pathlib import Path
@@ -65,7 +66,7 @@ class Context(metaclass=Singleton):
         self.__analyzers = {}
         self.__analyzer_env = None
 
-        machine = os.uname().machine
+        machine = platform.uname().machine
 
         self.logger_lib_dir_path = os.path.join(
             self._data_files_dir_path, 'ld_logger', 'lib', machine)

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -11,6 +11,7 @@
 
 import json
 import os
+import platform
 import shutil
 import tempfile
 import unittest
@@ -684,5 +685,5 @@ class LogParserTest(unittest.TestCase):
 
         # Make sure that the test running machine architecture is in the
         # LD_PRELOAD path.
-        machine = os.uname().machine
+        machine = platform.uname().machine
         self.assertTrue(env["LD_PRELOAD"].endswith(machine + "/ldlogger.so"))

--- a/analyzer/tools/build-logger/tests/unit/__init__.py
+++ b/analyzer/tools/build-logger/tests/unit/__init__.py
@@ -10,6 +10,7 @@
 
 import json
 import os
+import platform
 import shlex
 import subprocess
 import tempfile
@@ -106,7 +107,7 @@ class BasicLoggerTest(unittest.TestCase):
             return fd.read()
 
     def get_envvars(self) -> Mapping[str, str]:
-        machine = os.uname().machine
+        machine = platform.uname().machine
         return {
             "PATH": os.getenv("PATH"),
             "LD_PRELOAD": os.path.join(LOGGER_DIR,


### PR DESCRIPTION
fix for #3968 