### PR TITLE
[GUI] Unnecessary reports columns

### DIFF
--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -286,6 +286,7 @@ export default {
       reports: [],
       sameReports: {},
       hasTimeStamp: true,
+      hasTestCase : true,
       selected: [],
       namespace: namespace,
       pagination: {
@@ -332,6 +333,10 @@ export default {
           return this.hasTimeStamp;
         }
 
+        if (header.value === "testcase") {
+          return this.hasTestCase;
+        }
+
         return true;
       });
     },
@@ -375,6 +380,15 @@ export default {
         }
       },
       deep: true
+    },
+    formattedReports: {
+      handler() {
+        this.hasTimeStamp =
+          this.formattedReports.some(report => report.timestamp);
+
+        this.hasTestCase =
+          this.formattedReports.some(report => report.testcase);
+      }
     }
   },
 


### PR DESCRIPTION
The "timestamp" and "testcase" columns are only needed for a special test case, therefore, they can be removed if their content is completely empty. When the "formattedReports" prop is changed, the values are verified again. If a report had timestamp or testcase, the columns would be displayed again.