### PR TITLE
Revert "Add config folder contents to the dev_package target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,28 +79,14 @@ dev_package: package
 	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_web && \
 	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_server && \
 	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_report_converter && \
-	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_client && \
-	rm -rf $(CC_BUILD_DIR)/config && \
-	mkdir -p $(CC_BUILD_DIR)/config
+	rm -rf $(CC_BUILD_LIB_DIR)/codechecker_client
 
 	ln -fsv $(ROOT)/codechecker_common $(CC_BUILD_LIB_DIR) && \
 	ln -fsv $(CC_ANALYZER)/codechecker_analyzer $(CC_BUILD_LIB_DIR) && \
 	ln -fsv $(CC_WEB)/codechecker_web $(CC_BUILD_LIB_DIR) && \
 	ln -fsv $(CC_SERVER)/codechecker_server $(CC_BUILD_LIB_DIR) && \
 	ln -fsv $(CC_TOOLS)/report-converter/codechecker_report_converter $(CC_BUILD_LIB_DIR) && \
-	ln -fsv $(CC_CLIENT)/codechecker_client $(CC_BUILD_LIB_DIR) && \
-	ln -fsv $(ROOT)/config/* $(CC_BUILD_DIR)/config && \
-	ln -fsv $(CC_ANALYZER)/config/* $(CC_BUILD_DIR)/config && \
-	ln -fsv $(CC_WEB)/config/* $(CC_BUILD_DIR)/config && \
-	ln -fsv $(CC_SERVER)/config/* $(CC_BUILD_DIR)/config
-
-	${PYTHON_BIN} ./scripts/build/create_commands.py -b $(BUILD_DIR) \
-	  --cmd-dir $(ROOT)/codechecker_common/cmd \
-	    $(CC_WEB)/codechecker_web/cmd \
-	    $(CC_SERVER)/codechecker_server/cmd \
-	    $(CC_CLIENT)/codechecker_client/cmd \
-	    $(CC_ANALYZER)/codechecker_analyzer/cmd \
-	  --bin-file $(ROOT)/bin/CodeChecker
+	ln -fsv $(CC_CLIENT)/codechecker_client $(CC_BUILD_LIB_DIR)
 
 package_api:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) package_api


### PR DESCRIPTION
This reverts commit 1ae30cd8c222f43bec1af774779527677e7bbca2.

The reason of this revert is that the original "make package" executed
this scrip too:

${PYTHON_BIN} ./scripts/build/extend_version_file.py -r $(ROOT) \
	$(CC_BUILD_DIR)/config/analyzer_version.json \
	$(CC_BUILD_DIR)/config/web_version.json

This command modifies the version json files, without this the CodeChecker
commands raise an error during usage.. However, if this modification is
done through the symlinks, then the original json files are modified too,
and shown as changed files in "git status".