### PR TITLE
[fix][clang-tidy] Fix env var replace for extra args

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -564,7 +564,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             with open(args.tidy_args_cfg_file, 'r', encoding='utf-8',
                       errors='ignore') as tidy_cfg:
                 handler.analyzer_extra_arguments = \
-                    re.sub(r'\$\((.*?)\)', env.replace_env_var,
+                    re.sub(r'\$\((.*?)\)',
+                           env.replace_env_var(args.tidy_args_cfg_file),
                            tidy_cfg.read().strip())
                 handler.analyzer_extra_arguments = \
                     shlex.split(handler.analyzer_extra_arguments)


### PR DESCRIPTION
Running codechecker and giving extra arguments for clang-tidy containing environmental variables fails. This issue seems to stem from that `env.replace_env_var` is use without an argument in `analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py`. This should fix it.

**To reproduce the issue, run the following:**
With the file `main.c` containing:
```
#include <stdio.h>

int main(void){
  int i = BUILDVAR;
  printf("Hello world!\n\tBUILDVAR=%d\n", i  );
  return 0;
}
```
and the file `.clangtidy_extra_flags.txt containing:
```
--extra-arg="-DBUILDVAR=$(MY_ENV_VAR)"
```

1. Set the environmental varible `MY_ENV_VAR`
```
export MY_ENV_VAR=55
```

2. Run the following command
```
CodeChecker check -b "gcc main.c -DBUILDVAR=$MY_ENV_VAR" --tidyargs .clangtidy_extra_flags.txt
```
This should fail with `TypeError: sequence item 1: expected str instance, function found`