### PR TITLE
[fix] Fix commentCount related error in gui

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2450,13 +2450,11 @@ class ThriftRequestHandler:
         self.__require_view()
         with DBSession(self._Session) as session:
             report = session.query(Report).get(report_id)
+            commentCount = 0
             if report:
                 commentCount = session.query(Comment) \
                     .filter(Comment.bug_hash == report.bug_id) \
                     .count()
-
-            if commentCount is None:
-                commentCount = 0
 
             return commentCount
 


### PR DESCRIPTION
If the query could not return a report, commentCount would be referenced before assignemt.
The more interesting question is, how could one obtain a reportId on the gui that is nonexistant.