### PR TITLE
Making an analyze and parse testcase checker set independent

### DIFF
--- a/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/multi_error_skipped_in_cmd.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make tidy_check multi_error_skipped_in_cmd" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy --file "*/multi_error_skipped_in_cmd.cpp" -d clang-diagnostic-unused-value -d misc-definitions-in-headers
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy --file "*/multi_error_skipped_in_cmd.cpp" -d default -e bugprone-sizeof-expression
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make tidy_check multi_error_skipped_in_cmd" --output $OUTPUT$ --analyzers clang-tidy --quiet --file "*/multi_error_skipped_in_cmd.cpp" -d clang-diagnostic-unused-value -d misc-definitions-in-headers
+CHECK#CodeChecker check --build "make tidy_check multi_error_skipped_in_cmd" --output $OUTPUT$ --analyzers clang-tidy --quiet --file "*/multi_error_skipped_in_cmd.cpp" -d default -e bugprone-sizeof-expression
 -----------------------------------------------
 [] - Starting build...
 [] - Using CodeChecker ld-logger.


### PR DESCRIPTION
The testcase was failing on new clang version which brought in a new checker. This patch makes the test case resilient to clang version changes.