### PR TITLE
[clang-tidy] Fix Clang tidy checker option output

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -66,7 +66,10 @@ def parse_checker_config_old(config_dump):
     config_dump -- clang-tidy config options YAML dump in pre-LLVM15 format.
     """
     reg = re.compile(r'key:\s+(\S+)\s+value:\s+([^\n]+)')
-    return re.findall(reg, config_dump)
+    all = re.findall(reg, config_dump)
+    # tidy emits the checker option with a "." prefix, but we need a ":"
+    all = [(option[0].replace(".", ":"), option[1]) for option in all]
+    return all
 
 
 def parse_checker_config_new(config_dump):
@@ -82,7 +85,7 @@ def parse_checker_config_new(config_dump):
         if 'CheckOptions' not in data:
             return None
 
-        return [[key, value]
+        return [[key.replace(".", ":"), value]
                 for (key, value) in data['CheckOptions'].items()]
     except ImportError:
         return None

--- a/analyzer/tests/unit/test_checker_option_parsing.py
+++ b/analyzer/tests/unit/test_checker_option_parsing.py
@@ -57,7 +57,7 @@ CheckOptions:
         result = [[k, v] for (k, v) in result]
         self.assertEqual(len(result), 6)
         self.assertIn(
-            ["readability-suspicious-call-argument.PrefixSimilarAbove",
+            ["readability-suspicious-call-argument:PrefixSimilarAbove",
              "'30'"], result)
 
     def test_new_format(self):
@@ -86,5 +86,5 @@ CheckOptions:
         result = [[k, v] for (k, v) in result]
         self.assertEqual(len(result), 6)
         self.assertIn(
-            ["readability-suspicious-call-argument.PrefixSimilarAbove", "30"],
+            ["readability-suspicious-call-argument:PrefixSimilarAbove", "30"],
             result)


### PR DESCRIPTION
The `CodeChecker checkers --checker-config` command did not output the clang-tidy checker options correcly because it left a "." before the actual option.

This patch replaces the dot with a colon.