### PR TITLE
[report-converter] Support Clang 17.0+ FixIt in Clang-Tidy

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/parser.py
@@ -55,7 +55,7 @@ class Parser(BaseParser):
             # Checker message.
             r'(?P<message>.*)')
 
-        # Matches pre clang 17 fix-its
+        # Matches pre Clang 17 fix-its:
         # "       fixit-text"
         self.fixit_old_re = re.compile(
             r'^\s+(?P<message>\S.*)')

--- a/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/parser.py
@@ -148,21 +148,18 @@ class Parser(BaseParser):
         while self.message_line_re.match(line) is None and \
                 self.note_line_re.match(line) is None:
             match = self.fixit_new_re.match(line)
-            old_format = False
             if not match:
                 match = self.fixit_old_re.match(line)
-                old_format = True
-            message_text = match.group("message")
-            if message_text != '':
-                if old_format:
-                    # Until clang-tidy 16 the fixit
-                    # line starts with white spaces
-                    col = line.find(message_text) + 1
-                else:
-                    # In later versions we have white spaces the
-                    # optionally a line number and then a | character
-                    col = line.find(message_text) - line.find("|") - 1
-                report.bug_path_events.append(BugPathEvent(
+                message_text = match.group("message")
+                # Until Clang 16, the FixIt line starts with whitespace.
+                col = line.find(message_text) + 1
+            else:
+                message_text = match.group("message")
+                # In newer versions, we have whitespace then, optionally
+                # a line number, and then a | character.
+                col = line.find(message_text) - line.find("|") - 1
+
+            report.bug_path_events.append(BugPathEvent(
                     f"{message_text} (fixit)",
                     report.file,
                     report.line,

--- a/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_clang_tidy_parser.py
@@ -103,3 +103,8 @@ class ClangTidyAnalyzerResultTestCase(unittest.TestCase):
         self.__check_analyzer_result('tidy3.out', 'test3.hh_clang-tidy.plist',
                                      ['files/test3.cpp', 'files/test3.hh'],
                                      'tidy3_hh.plist')
+
+        self.__check_analyzer_result('tidy3-clang17.out',
+                                     'test3.hh_clang-tidy.plist',
+                                     ['files/test3.cpp', 'files/test3.hh'],
+                                     'tidy3_hh.plist')

--- a/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy3-clang17.out
+++ b/tools/report-converter/tests/unit/analyzers/tidy_output_test_files/tidy3-clang17.out
@@ -1,0 +1,25 @@
+files/test3.hh:6:6: warning: Dereference of null pointer (loaded from variable 'x') [clang-analyzer-core.NullDereference]
+    6 |   *x = 42;
+      |      ^
+files/test3.cpp:4:3: note: 'x' initialized to a null pointer value
+    4 |   int* x = 0;
+      |   ^~~~~~
+files/test3.cpp:6:11: note: Assuming 'argc' is > 3
+    6 |   if (foo(argc > 3)) {
+      |           ^~~~~~~~
+files/test3.cpp:6:3: note: Taking true branch
+    6 |   if (foo(argc > 3)) {
+      |   ^
+files/test3.cpp:7:9: note: Passing null pointer value via 1st parameter 'x'
+    7 |     bar(x);
+      |         ^
+files/test3.cpp:7:5: note: Calling 'bar'
+    7 |     bar(x);
+      |     ^~~~~~
+files/test3.hh:6:6: note: Dereference of null pointer (loaded from variable 'x')
+    6 |   *x = 42;
+      |    ~ ^
+files/test3.cpp:4:12: warning: use nullptr [modernize-use-nullptr]
+    4 |   int* x = 0;
+      |            ^
+      |            nullptr


### PR DESCRIPTION
clang-tidy version 17 introduced a new fixit diagnostic formatting. The report converter is now prepared to parse this new format. It also still supports the old format.

Fixes #4047