### PR TITLE
[analyzers] Deprecate --all and --details for analyzers

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -226,8 +226,7 @@ def perform_analysis(args, skip_handlers, actions, metadata_tool,
 
         # TODO: cppcheck may require a different environment than clang.
         version = analyzer_types.supported_analyzers[analyzer] \
-            .get_binary_version(context.analyzer_binaries[analyzer],
-                                context.analyzer_env)
+            .get_binary_version(context.analyzer_env)
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -226,7 +226,8 @@ def perform_analysis(args, skip_handlers, actions, metadata_tool,
 
         # TODO: cppcheck may require a different environment than clang.
         version = analyzer_types.supported_analyzers[analyzer] \
-            .get_version(context.analyzer_env)
+            .get_binary_version(context.analyzer_binaries[analyzer],
+                                context.analyzer_env)
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
@@ -56,6 +56,17 @@ class SourceAnalyzer(metaclass=ABCMeta):
         """
         raise NotImplementedError("Subclasses should implement this!")
 
+    @abstractmethod
+    def get_binary_version(self, configured_binary, environ, details=False) \
+            -> str:
+        """
+        Return the version number of the binary that CodeChecker found, even
+        if its incompatible. If details is true, additional version information
+        is provided. If details is false, the return value should be
+        convertible to a distutils.version.StrictVersion type.
+        """
+        raise NotImplementedError("Subclasses should implement this!")
+
     @classmethod
     def is_binary_version_incompatible(cls, configured_binary, environ) \
             -> Optional[str]:

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
@@ -57,8 +57,7 @@ class SourceAnalyzer(metaclass=ABCMeta):
         raise NotImplementedError("Subclasses should implement this!")
 
     @abstractmethod
-    def get_binary_version(self, configured_binary, environ, details=False) \
-            -> str:
+    def get_binary_version(self, environ, details=False) -> str:
         """
         Return the version number of the binary that CodeChecker found, even
         if its incompatible. If details is true, additional version information
@@ -68,8 +67,7 @@ class SourceAnalyzer(metaclass=ABCMeta):
         raise NotImplementedError("Subclasses should implement this!")
 
     @classmethod
-    def is_binary_version_incompatible(cls, configured_binary, environ) \
-            -> Optional[str]:
+    def is_binary_version_incompatible(cls, environ) -> Optional[str]:
         """
         CodeChecker can only execute certain versions of analyzers.
         Returns a error object (an optional string). If the return value is

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -221,8 +221,7 @@ def construct_analyzer(buildaction,
             LOG.error('Unsupported analyzer type: %s', analyzer_type)
         return analyzer
 
-    except Exception as ex:
-        LOG.debug_analyzer(ex)
+    except Exception:
         # We should've detected well before this point that something is off
         # with the analyzer. We can't recover here.
         raise

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -186,8 +186,7 @@ def check_supported_analyzers(analyzers):
         # Check version compatibility of the analyzer binary.
         if analyzer_bin:
             analyzer = supported_analyzers[analyzer_name]
-            error = analyzer.is_binary_version_incompatible(analyzer_bin,
-                                                            check_env)
+            error = analyzer.is_binary_version_incompatible(check_env)
             if error:
                 failed_analyzers.add((analyzer_name,
                                       f"Incompatible version: {error}"))

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -171,16 +171,19 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.extend(["-load", plugin])
 
     @classmethod
-    def get_version(cls, env=None):
-        """ Get analyzer version information. """
-        version = [cls.analyzer_binary(), '--version']
+    def get_binary_version(self, configured_binary, environ, details=False) \
+            -> str:
+        if details:
+            version = [configured_binary, '--version']
+        else:
+            version = [configured_binary, '-dumpversion']
         try:
             output = subprocess.check_output(version,
-                                             env=env,
+                                             env=environ,
                                              universal_newlines=True,
                                              encoding="utf-8",
                                              errors="ignore")
-            return output
+            return output.strip()
         except (subprocess.CalledProcessError, OSError) as oerr:
             LOG.warning("Failed to get analyzer version: %s",
                         ' '.join(version))

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -171,12 +171,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.extend(["-load", plugin])
 
     @classmethod
-    def get_binary_version(self, configured_binary, environ, details=False) \
-            -> str:
+    def get_binary_version(self, environ, details=False) -> str:
         if details:
-            version = [configured_binary, '--version']
+            version = [self.analyzer_binary(), '--version']
         else:
-            version = [configured_binary, '-dumpversion']
+            version = [self.analyzer_binary(), '-dumpversion']
         try:
             output = subprocess.check_output(version,
                                              env=environ,
@@ -581,7 +580,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         return clang
 
     @classmethod
-    def is_binary_version_incompatible(cls, configured_binary, environ):
+    def is_binary_version_incompatible(cls, environ):
         """
         We support pretty much every ClangSA version.
         """

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -230,9 +230,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             .analyzer_binaries[cls.ANALYZER_NAME]
 
     @classmethod
-    def get_binary_version(self, configured_binary, environ, details=False) \
-            -> str:
-        version = [configured_binary, '--version']
+    def get_binary_version(self, environ, details=False) -> str:
+        version = [self.analyzer_binary(), '--version']
         try:
             output = subprocess.check_output(version,
                                              env=environ,
@@ -545,7 +544,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         return clangtidy
 
     @classmethod
-    def is_binary_version_incompatible(cls, configured_binary, environ):
+    def is_binary_version_incompatible(cls, environ):
         """
         We support pretty much every Clang-Tidy version.
         """

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -67,7 +67,7 @@ def parse_version(cppcheck_output):
     version_re = re.compile(r'^Cppcheck (?P<version>[\d\.]+)')
     match = version_re.match(cppcheck_output)
     if match:
-        return StrictVersion(match.group('version'))
+        return match.group('version')
 
 
 class Cppcheck(analyzer_base.SourceAnalyzer):
@@ -83,16 +83,19 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             .analyzer_binaries[cls.ANALYZER_NAME]
 
     @classmethod
-    def get_version(cls, env=None):
+    def get_binary_version(self, configured_binary, environ, details=False) \
+            -> str:
         """ Get analyzer version information. """
-        version = [cls.analyzer_binary(), '--version']
+        version = [configured_binary, '--version']
         try:
             output = subprocess.check_output(version,
-                                             env=env,
+                                             env=environ,
                                              universal_newlines=True,
                                              encoding="utf-8",
                                              errors="ignore")
-            return output
+            if details:
+                return output.strip()
+            return parse_version(output)
         except (subprocess.CalledProcessError, OSError) as oerr:
             LOG.warning("Failed to get analyzer version: %s",
                         ' '.join(version))
@@ -334,33 +337,16 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         return cppcheck
 
     @classmethod
-    def __get_analyzer_version(cls, analyzer_binary, env):
-        """
-        Return the analyzer version.
-        """
-        command = [analyzer_binary, "--version"]
-
-        try:
-            result = subprocess.check_output(
-                    command,
-                    env=env,
-                    encoding="utf-8",
-                    errors="ignore")
-            return parse_version(result)
-        except (subprocess.CalledProcessError, OSError):
-            return []
-
-    @classmethod
     def is_binary_version_incompatible(cls, configured_binary, environ):
         """
         Check the version compatibility of the given analyzer binary.
         """
         analyzer_version = \
-            cls.__get_analyzer_version(configured_binary, environ)
+            cls.get_binary_version(configured_binary, environ)
 
         # The analyzer version should be above 1.80 because '--plist-output'
         # argument was introduced in this release.
-        if analyzer_version >= StrictVersion("1.80"):
+        if StrictVersion(analyzer_version) >= StrictVersion("1.80"):
             return None
 
         return "CppCheck binary found is too old at " \

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -83,10 +83,9 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             .analyzer_binaries[cls.ANALYZER_NAME]
 
     @classmethod
-    def get_binary_version(self, configured_binary, environ, details=False) \
-            -> str:
+    def get_binary_version(self, environ, details=False) -> str:
         """ Get analyzer version information. """
-        version = [configured_binary, '--version']
+        version = [self.analyzer_binary(), '--version']
         try:
             output = subprocess.check_output(version,
                                              env=environ,
@@ -337,12 +336,11 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         return cppcheck
 
     @classmethod
-    def is_binary_version_incompatible(cls, configured_binary, environ):
+    def is_binary_version_incompatible(cls, environ):
         """
         Check the version compatibility of the given analyzer binary.
         """
-        analyzer_version = \
-            cls.get_binary_version(configured_binary, environ)
+        analyzer_version = cls.get_binary_version(environ)
 
         # The analyzer version should be above 1.80 because '--plist-output'
         # argument was introduced in this release.

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -42,11 +42,6 @@ class Gcc(analyzer_base.SourceAnalyzer):
         return analyzer_context.get_context() \
             .analyzer_binaries[cls.ANALYZER_NAME]
 
-    @classmethod
-    def get_version(cls, env=None):
-        """ Get analyzer version information. """
-        return cls.__get_analyzer_version(cls.analyzer_binary(), env)
-
     def add_checker_config(self, checker_cfg):
         # TODO
         pass
@@ -174,19 +169,21 @@ class Gcc(analyzer_base.SourceAnalyzer):
         pass
 
     @classmethod
-    def __get_analyzer_version(cls, analyzer_binary, env):
+    def get_binary_version(self, configured_binary, env, details=False) \
+            -> str:
         """
         Return the analyzer version.
         """
-        # --version outputs a lot of garbage as well (like copyright info),
-        # this only contains the version info.
-        version = [analyzer_binary, '-dumpfullversion']
+        if details:
+            version = [configured_binary, '--version']
+        else:
+            version = [configured_binary, '-dumpfullversion']
         try:
             output = subprocess.check_output(version,
                                              env=env,
                                              encoding="utf-8",
                                              errors="ignore")
-            return output
+            return output.strip()
         except (subprocess.CalledProcessError, OSError) as oerr:
             LOG.warning("Failed to get analyzer version: %s",
                         ' '.join(version))
@@ -200,7 +197,7 @@ class Gcc(analyzer_base.SourceAnalyzer):
         Check the version compatibility of the given analyzer binary.
         """
         analyzer_version = \
-            cls.__get_analyzer_version(configured_binary, environ)
+            cls.get_binary_version(configured_binary, environ)
 
         # The analyzer version should be above 13.0.0 because the
         # '-fdiagnostics-format=sarif-file' argument was introduced in this

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -169,18 +169,17 @@ class Gcc(analyzer_base.SourceAnalyzer):
         pass
 
     @classmethod
-    def get_binary_version(self, configured_binary, env, details=False) \
-            -> str:
+    def get_binary_version(self, environ, details=False) -> str:
         """
         Return the analyzer version.
         """
         if details:
-            version = [configured_binary, '--version']
+            version = [self.analyzer_binary(), '--version']
         else:
-            version = [configured_binary, '-dumpfullversion']
+            version = [self.analyzer_binary(), '-dumpfullversion']
         try:
             output = subprocess.check_output(version,
-                                             env=env,
+                                             env=environ,
                                              encoding="utf-8",
                                              errors="ignore")
             return output.strip()
@@ -192,12 +191,11 @@ class Gcc(analyzer_base.SourceAnalyzer):
         return None
 
     @classmethod
-    def is_binary_version_incompatible(cls, configured_binary, environ):
+    def is_binary_version_incompatible(cls, environ):
         """
         Check the version compatibility of the given analyzer binary.
         """
-        analyzer_version = \
-            cls.get_binary_version(configured_binary, environ)
+        analyzer_version = cls.get_binary_version(environ)
 
         # The analyzer version should be above 13.0.0 because the
         # '-fdiagnostics-format=sarif-file' argument was introduced in this

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -186,12 +186,12 @@ def main(args):
     rows = []
     for analyzer_name in analyzer_types.supported_analyzers:
         analyzer_class = analyzer_types.supported_analyzers[analyzer_name]
-        binary = context.analyzer_binaries.get(analyzer_name)
         check_env = context.analyzer_env
-        version = analyzer_class.get_binary_version(binary, check_env)
+        version = analyzer_class.get_binary_version(check_env)
         if not version:
             version = 'ERROR'
 
+        binary = context.analyzer_binaries.get(analyzer_name)
         rows.append([analyzer_name, binary, version])
 
     assert rows


### PR DESCRIPTION
* Deprecate both `--all` and `--details`, because they were more confusing than useful
* We list all supported (not available) analyzers by default, but print a warning message when its not available.
* We used to query the version of each analyzer binary in a uniform way, but clang, cppcheck, gcc prints their version using different flags, and in different formats. I changed this to call the analyzer plugins' get_binary_version method (which I also implemented in this patch).