### PR TITLE
[analyzer] Add support the CC_ANALYZER_BIN env var 

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -12,6 +12,7 @@ Context to store package related information.
 
 # pylint: disable=no-name-in-module
 from distutils.spawn import find_executable
+from argparse import ArgumentTypeError
 
 import os
 import platform
@@ -91,7 +92,6 @@ class Context(metaclass=Singleton):
         self.__populate_analyzers()
         self.__populate_replacer()
 
-
     def __parse_CC_ANALYZER_BIN(self):
         env_var_bins = {}
         if 'CC_ANALYZER_BIN' in self.__analyzer_env:
@@ -99,7 +99,7 @@ class Context(metaclass=Singleton):
             for value in self.__analyzer_env['CC_ANALYZER_BIN'].split(';'):
                 try:
                     analyzer_name, path = analyzer_binary(value)
-                except argparse.ArgumentTypeError as e:
+                except ArgumentTypeError as e:
                     LOG.error(e)
                     had_error = True
                     continue

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 from codechecker_common import logger
+from codechecker_analyzer.arg import analyzer_binary
 from codechecker_common.checker_labels import CheckerLabels
 from codechecker_common.singleton import Singleton
 from codechecker_common.util import load_json
@@ -89,6 +90,38 @@ class Context(metaclass=Singleton):
         self.__set_version()
         self.__populate_analyzers()
         self.__populate_replacer()
+
+
+    def __parse_CC_ANALYZER_BIN(self):
+        env_var_bins = {}
+        if 'CC_ANALYZER_BIN' in self.__analyzer_env:
+            had_error = False
+            for value in self.__analyzer_env['CC_ANALYZER_BIN'].split(';'):
+                try:
+                    analyzer_name, path = analyzer_binary(value)
+                except argparse.ArgumentTypeError as e:
+                    LOG.error(e)
+                    had_error = True
+                    continue
+
+                if not os.path.isfile(path):
+                    LOG.error(f"'{path}' is not a path to an analyzer binary "
+                              "given to CC_ANALYZER_BIN!")
+                    had_error = True
+
+                if had_error:
+                    continue
+
+                LOG.info(f"Using '{path}' for analyzer '{analyzer_name}'")
+                env_var_bins[analyzer_name] = path
+
+            if had_error:
+                LOG.info("The value of CC_ANALYZER_BIN should be in the"
+                         "format of "
+                         "CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;"
+                         "<analyzer2>:/path/to/bin2'")
+                sys.exit(1)
+        return env_var_bins
 
     def __get_package_config(self):
         """ Get package configuration. """
@@ -166,8 +199,13 @@ class Context(metaclass=Singleton):
         if not analyzer_from_path:
             analyzer_env = self.analyzer_env
 
+        env_var_bin = self.__parse_CC_ANALYZER_BIN()
+
         compiler_binaries = self.pckg_layout.get('analyzers')
         for name, value in compiler_binaries.items():
+            if name in env_var_bin:
+                self.__analyzers[name] = env_var_bin[name]
+                continue
 
             if analyzer_from_path:
                 value = os.path.basename(value)

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -220,6 +220,7 @@ class Context(metaclass=Singleton):
                 if not compiler_binary:
                     LOG.debug("'%s' binary can not be found in your PATH!",
                               value)
+                    self.__analyzers[name] = None
                     continue
 
                 self.__analyzers[name] = os.path.realpath(compiler_binary)

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -189,7 +189,10 @@ def check_supported_analyzers(analyzers):
             error = analyzer.is_binary_version_incompatible(check_env)
             if error:
                 failed_analyzers.add((analyzer_name,
-                                      f"Incompatible version: {error}"))
+                                      f"Incompatible version: {error} "
+                                      "Maybe try setting an absolute path to "
+                                      "a different analyzer binary via the "
+                                      "env variable CC_ANALYZER_BIN?"))
                 available_analyzer = False
 
         if not analyzer_bin or \

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -172,6 +172,10 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def get_binary_version(self, environ, details=False) -> str:
+        # No need to LOG here, we will emit a warning later anyway.
+        if not self.analyzer_binary():
+            return None
+
         if details:
             version = [self.analyzer_binary(), '--version']
         else:

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -231,6 +231,10 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def get_binary_version(self, environ, details=False) -> str:
+        # No need to LOG here, we will emit a warning later anyway.
+        if not self.analyzer_binary():
+            return None
+
         version = [self.analyzer_binary(), '--version']
         try:
             output = subprocess.check_output(version,

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -85,6 +85,9 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
     @classmethod
     def get_binary_version(self, environ, details=False) -> str:
         """ Get analyzer version information. """
+        # No need to LOG here, we will emit a warning later anyway.
+        if not self.analyzer_binary():
+            return None
         version = [self.analyzer_binary(), '--version']
         try:
             output = subprocess.check_output(version,

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -173,6 +173,9 @@ class Gcc(analyzer_base.SourceAnalyzer):
         """
         Return the analyzer version.
         """
+        # No need to LOG here, we will emit a warning later anyway.
+        if not self.analyzer_binary():
+            return None
         if details:
             version = [self.analyzer_binary(), '--version']
         else:

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -18,6 +18,8 @@ AnalyzerConfig = collections.namedtuple(
     'AnalyzerConfig', ["analyzer", "option", "value"])
 CheckerConfig = collections.namedtuple(
     "CheckerConfig", ["analyzer", "checker", "option", "value"])
+AnalyzerBinary = collections.namedtuple(
+    "AnalyzerBinary", ["analyzer", "path"])
 
 
 class OrderedCheckersAction(argparse.Action):
@@ -133,3 +135,18 @@ def checker_config(arg: str) -> CheckerConfig:
     return CheckerConfig(
         m.group("analyzer"), m.group("checker"),
         m.group("option"), m.group("value"))
+
+
+def analyzer_binary(arg: str) -> AnalyzerBinary:
+    """
+    This function can be used at "type" argument of argparse.add_argument().
+    It checks the format of --analyzer_binary flag: <analyzer>:<path>
+    """
+    m = re.match(r"(?P<analyzer>.+):(?P<path>.+)", arg)
+
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"Analyzer binary in wrong format: {arg}, should be "
+            "<analyzer>:</path/to/bin/>")
+
+    return AnalyzerBinary(m.group("analyzer"), m.group("path"))

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -27,7 +27,7 @@ from codechecker_analyzer import analyzer, analyzer_context, \
 from codechecker_analyzer.analyzers import analyzer_types, clangsa
 from codechecker_analyzer.arg import \
     OrderedCheckersAction, OrderedConfigAction, existing_abspath, \
-    analyzer_config, checker_config, analyzer_binary
+    analyzer_config, checker_config
 from codechecker_analyzer.buildlog import log_parser
 
 from codechecker_common import arg, logger, cmd_config

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -904,40 +904,6 @@ def __get_result_source_files(metadata):
     return result_src_files
 
 
-def __parse_CC_ANALYZER_BIN():
-    context = analyzer_context.get_context()
-    if 'CC_ANALYZER_BIN' in context.analyzer_env:
-        had_error = False
-        for value in context.analyzer_env['CC_ANALYZER_BIN'].split(';'):
-            try:
-                analyzer_name, path = analyzer_binary(value)
-            except argparse.ArgumentTypeError as e:
-                LOG.error(e)
-                had_error = True
-                continue
-
-            if analyzer_name not in analyzer_types.supported_analyzers:
-                LOG.error(f"Unsupported analyzer_name name '{analyzer_name}' "
-                          "given to CC_ANALYZER_BIN!")
-                had_error = True
-            if not os.path.isfile(path):
-                LOG.error(f"'{path}' is not a path to an analyzer binary "
-                          "given to CC_ANALYZER_BIN!")
-                had_error = True
-
-            if had_error:
-                continue
-
-            LOG.info(f"Using '{path}' for analyzer '{analyzer_name}'")
-            context.analyzer_binaries[analyzer_name] = path
-
-        if had_error:
-            LOG.info("The value of CC_ANALYZER_BIN should be in the format of "
-                     "CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;"
-                     "<analyzer2>:/path/to/bin2'")
-            sys.exit(1)
-
-
 def main(args):
     """
     Perform analysis on the given inputs. Possible inputs are a compilation
@@ -1020,7 +986,6 @@ def main(args):
         ctu_or_stats_enabled = True
 
     context = analyzer_context.get_context()
-    __parse_CC_ANALYZER_BIN()
 
     # Number of all the compilation commands in the parsed log files,
     # logged by the logger.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -499,6 +499,11 @@ Environment variables for 'CodeChecker analyze' command:
 
   CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
                            from the `PATH` instead of the given binaries.
+  CC_ANALYZER_BIN          Set the absolute paths of an analyzer binaries.
+                           Overrides other means of CodeChecker getting hold of
+                           binary.
+                           Format: CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;
+                                                    <analyzer2>:/path/to/bin2'
   CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
                            is set you can configure the plugin directory of the
                            Clang Static Analyzer by using this environment
@@ -1031,6 +1036,11 @@ Environment variables
 
   CC_ANALYZERS_FROM_PATH   Set to `yes` or `1` to enforce taking the analyzers
                            from the `PATH` instead of the given binaries.
+  CC_ANALYZER_BIN          Set the absolute paths of an analyzer binaries.
+                           Overrides other means of CodeChecker getting hold of
+                           binary.
+                           Format: CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;
+                                                    <analyzer2>:/path/to/bin2'
   CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
                            is set you can configure the plugin directory of the
                            Clang Static Analyzer by using this environment


### PR DESCRIPTION
This environmental variable can be used the specify the absolute path of
an analyzer. Similar to https://github.com/Ericsson/codechecker/pull/4041, but this is the only solution we can
realistically get though the door.

Here is a glimpse of how the error messages look like:
```bash
$ CC_ANALYZER_BIN="gccldjkfg:/usr/bi++-13;clangsa;g++:g" CodeChecker check -b "gcc double-free.c -c" -o resultNative/ --analyzers=gcc -c -e extreme
[INFO 2023-10-24 15:22] - Starting build...
[INFO 2023-10-24 15:22] - Using CodeChecker ld-logger.
[INFO 2023-10-24 15:22] - Build finished successfully.
[ERROR 2023-10-24 15:22] - Unsupported analyzer_name name 'gccldjkfg' given to CC_ANALYZER_BIN!
[ERROR 2023-10-24 15:22] - '/usr/bi++-13' is not a path to an analyzer binary given to CC_ANALYZER_BIN!
[ERROR 2023-10-24 15:22] - Analyzer binary in wrong format: clangsa, should be <analyzer>:</path/to/bin/>
[ERROR 2023-10-24 15:22] - Unsupported analyzer_name name 'g++' given to CC_ANALYZER_BIN!
[ERROR 2023-10-24 15:22] - 'g' is not a path to an analyzer binary given to CC_ANALYZER_BIN!
[INFO 2023-10-24 15:22] - The value of CC_ANALYZER_BIN should be in the format of CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;<analyzer2>:/path/to/bin2'
```
```bash
$ CodeChecker analyzers -o table
---------------------------------------------------------------------------------------
Name       | Path                                                             | Version
---------------------------------------------------------------------------------------
clangsa    | /home/eumakri/Documents/llvm-project/releaseBuild/bin/clang-17   | 16.0.4 
clang-tidy | /home/eumakri/Documents/llvm-project/releaseBuild/bin/clang-tidy | 16.0.4 
cppcheck   | /usr/bin/cppcheck                                                | 2.7    
gcc        | /usr/lib/ccache/g++                                              | 11.4.0 
---------------------------------------------------------------------------------------
[WARNING 2023-10-24 15:24] - Can't analyze with 'gcc': Incompatible version: GCC binary found is too old at v11.4.0; minimum version is 13.0.0. Maybe try setting an absolute path to a different analyzer binary via the env variable CC_ANALYZER_BIN?
```

Depends on #4056.