### PR TITLE
[gui] Retain filter configuration between reports and statistics views

### DIFF
--- a/web/server/vue-cli/src/components/Layout/TheHeader.vue
+++ b/web/server/vue-cli/src/components/Layout/TheHeader.vue
@@ -62,9 +62,9 @@
         :key="item.name"
         :to="{
           name: item.route,
-          query: queries[item.route] === undefined
+          query: queries[item.query_namespace] === undefined
             ? item.query || {}
-            : queries[item.route]
+            : queries[item.query_namespace]
         }"
         :class="item.active.includes($route.name) &&
           'v-btn--active router-link-active'"
@@ -165,6 +165,7 @@ export default {
       menuButtons: [
         {
           name: "Products",
+          query_namespace: "products",
           icon: "mdi-briefcase-outline",
           route: "products",
           active: [ "products" ],
@@ -173,6 +174,7 @@ export default {
         },
         {
           name: "Runs",
+          query_namespace: "runs",
           icon: "mdi-run-fast",
           route: "runs",
           active: [ "runs", "main_runs" ],
@@ -181,6 +183,7 @@ export default {
         },
         {
           name: "Reports",
+          query_namespace: "report_filter",
           icon: "mdi-bug",
           route: "reports",
           active: [ "reports" ],
@@ -190,6 +193,7 @@ export default {
         },
         {
           name: "Statistics",
+          query_namespace: "report_filter",
           icon: "mdi-chart-line",
           route: "statistics",
           active: [ "statistics" ],

--- a/web/server/vue-cli/src/main.js
+++ b/web/server/vue-cli/src/main.js
@@ -91,7 +91,16 @@ router.afterEach(to => {
   if (to.name === "products")
     store.commit(CLEAR_QUERIES, { except: [ "products" ] });
 
-  store.commit(SET_QUERIES, { location: to.name, query: to.query });
+  let query_namespace = to.name;
+  if (to.name === "reports"
+    || to.name === "product-overview"
+    || to.name === "checker-statistics"
+    || to.name === "severity-statistics"
+    || to.name === "component-statistics"
+  )
+    query_namespace = "report_filter";
+
+  store.commit(SET_QUERIES, { location: query_namespace, query: to.query });
 });
 
 new Vue({


### PR DESCRIPTION
Previously when changing between the reports and statistics views the report filter configuration wasn't retained.

This patch implements the feature of retaining the filter configuration between the reports view and the different statistics sub pages.

Fixes #3828