### PR TITLE
Remove a clang-tidy checker from default profile.

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -5747,9 +5747,7 @@
     ],
     "misc-include-cleaner": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html",
-      "profile:default",
       "profile:extreme",
-      "profile:sensitive",
       "severity:LOW"
     ],
     "misc-incorrect-roundings": [


### PR DESCRIPTION
misc-include-cleaner checker results too many reports and causes an undeterministic failure at storage.