### PR TITLE
[docs] Leave a better TODO for gcc docs

### DIFF
--- a/docs/analyzer/checker_and_analyzer_configuration.md
+++ b/docs/analyzer/checker_and_analyzer_configuration.md
@@ -274,13 +274,14 @@ As of CodeChecker 6.23, Codechecker can now execute the GCC Static Analyzer.
 
 ## Analyzer Configuration
 
+TODO: Currently, we don't support GCC Static analyzer options. This will likely
+be fixed in between the 6.23 release candidates and the actual release.
+
 TODO: gcc-too-complex
 
 ## Limitations
 
-TODO
-
-Gcc doesn't well with C++. Prefer only running on C.
+TODO: Gcc doesn't well with C++. Prefer only running on C.
 
 ## Example invocation
 


### PR DESCRIPTION
This is especially important because we link from the rc1 release page to this doc -- which is currently just a big fat TODO.