### PR TITLE
[gcc][fix] Change gcc's output from file to stderr

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -72,7 +72,7 @@ class Gcc(analyzer_base.SourceAnalyzer):
 
         analyzer_cmd.extend(self.buildaction.analyzer_options)
 
-        analyzer_cmd.append('-fdiagnostics-format=sarif-file')
+        analyzer_cmd.append('-fdiagnostics-format=sarif-stderr')
 
         for checker_name, value in config.checks().items():
             if value[0] == CheckerState.disabled:

--- a/analyzer/codechecker_analyzer/analyzers/gcc/result_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/result_handler.py
@@ -59,13 +59,17 @@ class GccResultHandler(ResultHandler):
         into the database.
         """
         LOG.debug_analyzer(self.analyzer_stdout)
-        gcc_output_file = self.analyzed_source_file + ".sarif"
 
-        # Gcc doesn't create any files when there are no diagnostics.
-        # Unfortunately, we can't tell whethet the file missing was because of
-        # that or some other error, we need to bail out here.
-        if not os.path.exists(gcc_output_file):
-            return
+        # GCC places sarif files to the "directory" entry found in the
+        # compilation database. As of writing this comment, there is no way to
+        # tell GCC to place is elsewhere, so we need to find it, move it and
+        # rename it.
+        file_name = os.path.basename(self.analyzed_source_file)
+        gcc_output_file = \
+                str(Path(self.buildaction.directory, file_name)) + ".sarif"
+
+        assert os.path.exists(gcc_output_file), \
+                "Faile to find the sarif file for GCC analysis!"
 
         reports = report_file.get_reports(
             gcc_output_file, self.checker_labels,


### PR DESCRIPTION
The wording in the [GCC
docs](https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/Diagnostic-Message-Formatting-Options.html) is a little confusing, it says

"The ‘sarif-stderr’ and ‘sarif-file’ formats both emit diagnostics in SARIF Version 2.1.0 format, either to stderr, or to a file named source.sarif, respectively."

I thought this will create a sarif file right next to the source file, but in reality, the file is created in the `directory` field of the compilation database file. This patch fixed this by using the stderr output instead of the file output.