### PR TITLE
chore(store): Give a name to the timeout watchdog thread

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -798,6 +798,7 @@ def _timeout_watchdog(timeout: timedelta, trap: int):
     pid = os.getpid()
     timer = Timer(timeout.total_seconds(),
                   lambda: os.kill(pid, trap))
+    timer.name = "StoreTimeoutWatcher"
     LOG.debug("Set up timer for %d seconds (%s) for PID %d",
               timeout.total_seconds(), str(timeout), pid)
     try:


### PR DESCRIPTION
In some cases, spurious exceptions may crop up in the outputs when something goes wrong, and in those cases, threads are usually just given an automatic name like `Thread-1` or so. This patch adds a unique name to the store watchdog so it's clear if that causes an exception (it shouldn't).