### PR TITLE
[cfg] Using multiprocess lib instead of multiprocessing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ rules while writing your code:
 Order your `import` commands according to as follows:
 
   1. **System-wide** imports come first and foremost, e.g.
-    `import multiprocessing`.
+    `import subprocess`.
   2. _(Empty line for readability)_
   3. External module/library imports that are not system-wide but related to
      CodeChecker's **dependencies**, e.g. `from thrift import Thrift`.
@@ -62,7 +62,7 @@ Documentation about the module.
 
 # -- 1. System specific imports
 import atexit
-from multiprocessing import Pool
+from collections import defaultdict
 import os
 import tempfile
 

--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -10,7 +10,6 @@
 
 
 import glob
-import multiprocessing
 import os
 import shlex
 import shutil
@@ -22,6 +21,7 @@ import zipfile
 
 from threading import Timer
 
+import multiprocess
 import psutil
 
 from codechecker_common.logger import get_logger
@@ -740,12 +740,11 @@ def start_workers(actions_map, actions, analyzer_config_map,
 
     actions, skipped_actions = skip_cpp(actions, skip_handlers)
     # Start checking parallel.
-    checked_var = multiprocessing.Value('i', 1)
-    actions_num = multiprocessing.Value('i', len(actions))
-    pool = multiprocessing.Pool(jobs,
-                                initializer=init_worker,
-                                initargs=(checked_var,
-                                          actions_num))
+    checked_var = multiprocess.Value('i', 1)
+    actions_num = multiprocess.Value('i', len(actions))
+    pool = multiprocess.Pool(jobs,
+                             initializer=init_worker,
+                             initargs=(checked_var, actions_num))
     signal.signal(signal.SIGINT, signal_handler)
 
     # If the analysis has failed, we help debugging.

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -11,12 +11,13 @@ Prepare and start different analysis types
 
 
 from collections import defaultdict
-from multiprocessing.managers import SyncManager
 import os
 import shutil
 import signal
 import sys
 import time
+
+from multiprocess.managers import SyncManager
 
 from codechecker_common.logger import get_logger
 

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -13,11 +13,11 @@ Execute analysis over an already existing build.json compilation database.
 import argparse
 import collections
 import json
-import multiprocessing
 import os
 import shutil
 import sys
 
+import multiprocess
 from typing import List
 
 from tu_collector import tu_collector
@@ -169,7 +169,7 @@ def add_arguments_to_parser(parser):
                         type=int,
                         dest="jobs",
                         required=False,
-                        default=multiprocessing.cpu_count(),
+                        default=multiprocess.cpu_count(),
                         help="Number of threads to use in analysis. More "
                              "threads mean faster analysis at the cost of "
                              "using more memory.")

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -12,11 +12,12 @@ stdout.
 """
 
 import argparse
-import multiprocessing
 import os
 import shutil
 import sys
 import tempfile
+
+import multiprocess
 
 from codechecker_analyzer.analyzers import analyzer_types
 from codechecker_analyzer.arg import \
@@ -182,7 +183,7 @@ used to generate a log file on the fly.""")
                                type=int,
                                dest="jobs",
                                required=False,
-                               default=multiprocessing.cpu_count(),
+                               default=multiprocess.cpu_count(),
                                help="Number of threads to use in analysis. "
                                     "More threads mean faster analysis at "
                                     "the cost of using more memory.")

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -9,7 +9,6 @@
 Run pre analysis, collect statistics or CTU data.
 """
 
-import multiprocessing
 import os
 import shlex
 import shutil
@@ -17,6 +16,8 @@ import signal
 import sys
 import traceback
 import uuid
+
+import multiprocess
 
 from codechecker_common.logger import get_logger
 
@@ -164,13 +165,12 @@ def run_pre_analysis(actions, clangsa_config,
 
     signal.signal(signal.SIGINT, signal_handler)
 
-    processed_var = multiprocessing.Value('i', 0)
-    actions_num = multiprocessing.Value('i', len(actions))
+    processed_var = multiprocess.Value('i', 0)
+    actions_num = multiprocess.Value('i', len(actions))
 
-    pool = multiprocessing.Pool(jobs,
-                                initializer=init_worker,
-                                initargs=(processed_var,
-                                          actions_num))
+    pool = multiprocess.Pool(jobs,
+                             initializer=init_worker,
+                             initargs=(processed_var, actions_num))
 
     if statistics_data:
         # Statistics collection is enabled setup temporary

--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -4,3 +4,4 @@ psutil==5.8.0
 PyYAML==6.0.1
 sarif-tools==1.0.0
 mypy_extensions==0.4.3
+multiprocess==0.70.15

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -4,6 +4,7 @@ alembic==1.5.5
 portalocker==2.2.1
 psutil==5.8.0
 mypy_extensions==0.4.3
+multiprocess==0.70.15
 thrift==0.13.0
 gitpython==3.1.35
 PyYAML==6.0.1

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -14,7 +14,6 @@ and browser requests.
 import atexit
 import datetime
 from hashlib import sha256
-from multiprocessing import Process
 import os
 import posixpath
 from random import sample
@@ -28,6 +27,7 @@ import urllib
 
 from http.server import HTTPServer, BaseHTTPRequestHandler, \
     SimpleHTTPRequestHandler
+from multiprocess import Process
 
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import func

--- a/web/tests/functional/authentication/__init__.py
+++ b/web/tests/functional/authentication/__init__.py
@@ -10,15 +10,15 @@
 """Setup for the package tests."""
 
 
-import multiprocessing
 import os
 import shutil
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 # Stopping event for CodeChecker server.
-__STOP_SERVER = multiprocessing.Event()
+__STOP_SERVER = multiprocess.Event()
 
 # Test workspace initialized at setup for authentication tests.
 TEST_WORKSPACE = None

--- a/web/tests/functional/cli_config/test_server_config.py
+++ b/web/tests/functional/cli_config/test_server_config.py
@@ -13,12 +13,12 @@ Test server configuration file.
 
 
 import json
-import multiprocessing
 import os
 import unittest
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 from . import setup_class_common, teardown_class_common
 
@@ -56,7 +56,7 @@ class TestServerConfig(unittest.TestCase):
             json.dump({
                 'server': ['--skip-db-cleanup']}, config_f)
 
-        event = multiprocessing.Event()
+        event = multiprocess.Event()
         event.clear()
 
         self.codechecker_cfg['viewer_port'] = env.get_free_port()
@@ -80,7 +80,7 @@ class TestServerConfig(unittest.TestCase):
 server:
   - --skip-db-cleanup""")
 
-        event = multiprocessing.Event()
+        event = multiprocess.Event()
         event.clear()
 
         self.codechecker_cfg['viewer_port'] = env.get_free_port()
@@ -102,7 +102,7 @@ server:
             json.dump({
                 'server': ['--dummy-option']}, config_f)
 
-        event = multiprocessing.Event()
+        event = multiprocess.Event()
         event.clear()
 
         self.codechecker_cfg['viewer_port'] = env.get_free_port()
@@ -123,7 +123,7 @@ server:
                   encoding="utf-8", errors="ignore") as config_f:
             config_f.write("")
 
-        event = multiprocessing.Event()
+        event = multiprocess.Event()
         event.clear()
 
         self.codechecker_cfg['viewer_port'] = env.get_free_port()

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -12,7 +12,6 @@ Test database cleanup.
 
 
 import json
-import multiprocessing
 import os
 import shutil
 import unittest
@@ -24,6 +23,7 @@ from codechecker_common.checker_labels import CheckerLabels
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 
 class TestDbCleanup(unittest.TestCase):
@@ -187,7 +187,7 @@ int f(int x) { return 1 / x; }
                              severity_id)
 
     def test_garbage_file_collection(self):
-        event = multiprocessing.Event()
+        event = multiprocess.Event()
         event.clear()
 
         self.codechecker_cfg['viewer_port'] = env.get_free_port()

--- a/web/tests/functional/instance_manager/test_instances.py
+++ b/web/tests/functional/instance_manager/test_instances.py
@@ -11,7 +11,6 @@ Instance manager tests.
 """
 
 
-import multiprocessing
 import os
 import shutil
 import subprocess
@@ -22,10 +21,11 @@ from codechecker_server import instance_manager
 
 from libtest import env
 from libtest.codechecker import start_server
+import multiprocess
 
 # Stopping events for CodeChecker servers.
-EVENT_1 = multiprocessing.Event()
-EVENT_2 = multiprocessing.Event()
+EVENT_1 = multiprocess.Event()
+EVENT_2 = multiprocess.Event()
 
 
 class TestInstances(unittest.TestCase):

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -16,7 +16,6 @@ environment.
 from . import setup_class_common, teardown_class_common
 
 from copy import deepcopy
-import multiprocessing
 import os
 import shutil
 import unittest
@@ -30,9 +29,10 @@ from codechecker_web.shared import convert
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 # Stopping events for CodeChecker server.
-EVENT = multiprocessing.Event()
+EVENT = multiprocess.Event()
 
 
 class TestProductConfigShare(unittest.TestCase):

--- a/web/tests/functional/ssl/test_ssl.py
+++ b/web/tests/functional/ssl/test_ssl.py
@@ -10,7 +10,6 @@
 SSL test.
 """
 
-import multiprocessing
 import os
 import shutil
 import subprocess
@@ -20,6 +19,7 @@ from codechecker_api_shared.ttypes import RequestFailed
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 
 class TestSSL(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestSSL(unittest.TestCase):
 
         # Stopping event for CodeChecker server.
         global __STOP_SERVER
-        __STOP_SERVER = multiprocessing.Event()
+        __STOP_SERVER = multiprocess.Event()
 
         global TEST_WORKSPACE
         TEST_WORKSPACE = env.get_workspace('ssl')

--- a/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
+++ b/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
@@ -11,7 +11,6 @@ Test storage of analysis statistics.
 """
 
 
-import multiprocessing
 import json
 import os
 import shutil
@@ -25,6 +24,7 @@ from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter
 
 from libtest import codechecker
 from libtest import env
+import multiprocess
 
 
 def extract(zip_file, output_dir):
@@ -48,7 +48,7 @@ class TestStorageOfAnalysisStatistics(unittest.TestCase):
 
         # Stopping event for CodeChecker server.
         global EVENT_1
-        EVENT_1 = multiprocessing.Event()
+        EVENT_1 = multiprocess.Event()
 
         global TEST_WORKSPACE
         TEST_WORKSPACE = env.get_workspace('storage_of_analysis_statistics')

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -11,13 +11,14 @@ Helper commands to run CodeChecker in the tests easier.
 
 
 import json
-import multiprocessing
 import os
 import shlex
 import stat
 import subprocess
 from subprocess import CalledProcessError
 import time
+
+import multiprocess
 
 from codechecker_api_shared.ttypes import Permission
 
@@ -699,7 +700,7 @@ def start_server(codechecker_cfg, event, server_args=None, pg_config=None):
                           pg_config,
                           server_args or [])
 
-    server_proc = multiprocessing.Process(
+    server_proc = multiprocess.Process(
         name='server',
         target=start_server_proc,
         args=(event, server_cmd, codechecker_cfg['check_env']))


### PR DESCRIPTION
The standard `multiprocessing` lib has some issues mainly in Mac environment. Also, in Linux environment, too small system resources cause CodeChecker analyzer processes hang:
If the maximum number of processes (`ulimit -u`) is too small, then allocating a process pool with the standard `multiprocessing` lib raises a RuntimeError that can't be handled. With `multiprocess` lib another kind of exception is thrown, but the process itself doesn't hang.