### PR TITLE
[fix] Bugfix at --enable-all and disable warning

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -392,6 +392,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                     if state == CheckerState.enabled:
                         compiler_warnings.add('-W' + warning_name)
                         enabled_checkers.add(checker_name)
+                    else:
+                        compiler_warnings.add('-Wno-' + warning_name)
 
                 continue
 
@@ -490,6 +492,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             if config.enable_all:
                 analyzer_cmd.append("-Weverything")
+                analyzer_cmd.extend(
+                    filter(lambda x: x.startswith('-Wno-'), compiler_warnings))
             else:
                 analyzer_cmd.extend(compiler_warnings)
 


### PR DESCRIPTION
**[fix] Bugfix at --enable-all and disable warning**

There was a bug in CodeChecker:

CodeChecker analyze --enable-all --disable clang-diagnostic-unused-variable

This command didn't disable that warning. The problem is that we represent --enable-all with -Weverything in the clang-tidy analyzer command, but -Wno-unused-variable has to be appended too. It was a false assumption that
"clang-tidy -checks='-clang-diagnostic-unused-variable' main.c -- -Weverything" does the job.

**[fix] Fix non-determinism of clang-diagnostic checker appearances**

Earlier we collected the enabled/disabled checkers in a set which
results non-determinism in the appearance of clang-tidy checkers.
Instead of sets we're using lists now.