### PR TITLE
[report-converter] Check whether input paths exist

### DIFF
--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -151,12 +151,19 @@ class CollectFiles(argparse.Action):
 
         all_files = []
 
+        had_nonexistent_path = False
         for path in values:
-            if os.path.isfile(path):
+            if not os.path.exists(path):
+                LOG.error(f"File or directory '{path}' does not exist!")
+                had_nonexistent_path = True
+            elif os.path.isfile(path):
                 all_files.append(path)
             else:
                 for root, _, files in os.walk(path):
                     all_files.extend(os.path.join(root, f) for f in files)
+        if had_nonexistent_path:
+            sys.exit(1)
+        assert all_files
 
         setattr(namespace, 'input', all_files)
 

--- a/tools/report-converter/tests/functional/cmdline/test_cmdline.py
+++ b/tools/report-converter/tests/functional/cmdline/test_cmdline.py
@@ -28,6 +28,18 @@ class TestCmdline(unittest.TestCase):
                               stderr=subprocess.PIPE)
         self.assertEqual(0, ret)
 
+    def test_nonexistent_file(self):
+        """ Get help for report-converter tool. """
+        process = subprocess.Popen(['report-converter', '-t', 'gcc',
+                                    '-o', 'reports/', 'non_existent.sarif'],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE,
+                                   encoding="utf-8",
+                                   universal_newlines=True)
+        out, _ = process.communicate()
+        self.assertIn("'non_existent.sarif' does not exist", out)
+        self.assertEqual(1, process.returncode)
+
     def test_metadata(self):
         """ Generate metadata for CodeChecker server. """
         analyzer_version = "x.y.z"


### PR DESCRIPTION
We check (via `nargs`) whether any input paths were given, but we don't actually emit any errors if those paths point nowhere. This can be quite frustrating when the user erronously believes that the input file name was correct, is not given any errors, and left wondering why report-converter is not working.

This patch checks whether those paths actually exist.