### PR TITLE
[GUI] Update reviewData when switching between reports

### DIFF
--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -348,7 +348,6 @@ export default {
       step: null,
       editor: null,
       sourceFile: null,
-      reviewData: new ReviewData(),
       jsPlumbInstance: null,
       lineMarks: [],
       lineWidgets: [],
@@ -386,6 +385,12 @@ export default {
       return this.showComments
         ? maxCols - this.commentCols
         : maxCols;
+    },
+
+    reviewData() {
+      return this.report && this.report.reviewData
+        ? this.report.reviewData
+        : new ReviewData();
     }
   },
 
@@ -530,8 +535,6 @@ export default {
       }
 
       this.report = report;
-
-      this.reviewData = report.reviewData;
 
       await this.setSourceFileData(report.fileId);
       await this.drawBugPath();


### PR DESCRIPTION
There was a bug when the report was loaded. The value of the review status dropdown menu did not change when switching to a report with a different status. 
Now, everytime when the report changes, the reviewData is updated as a computed property.