### PR TITLE
[fix] Extra arguments added twice to cppcheck

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -231,8 +231,6 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
 
             analyzer_cmd.append('--plist-output=' + str(output_dir))
 
-            analyzer_cmd.extend(config.analyzer_extra_arguments)
-
             analyzer_cmd.append(self.source_file)
 
             return analyzer_cmd


### PR DESCRIPTION
The removed line is duplicated: the extra arguments had been added a few lines above.