### PR TITLE
[context][fix] Use the property instead of the field for analyzer env

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -94,7 +94,7 @@ class Context(metaclass=Singleton):
 
     def __parse_CC_ANALYZER_BIN(self):
         env_var_bins = {}
-        if 'CC_ANALYZER_BIN' in self.__analyzer_env:
+        if 'CC_ANALYZER_BIN' in self.analyzer_env:
             had_error = False
             for value in self.__analyzer_env['CC_ANALYZER_BIN'].split(';'):
                 try:


### PR DESCRIPTION
AnalyzerContext.__analyzer_env is lazy initialized via AnalyzerContext.analyzer_env. __parse_CC_ANALYZER_BIN became the first to use it, but erronously accessed the field directly -- which wasn't initialized at that time.