### PR TITLE
[gcc] Add severities to checkers

### DIFF
--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -4,227 +4,227 @@
     "gcc-allocation-size": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-allocation-size",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-deref-before-check": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-deref-before-check",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-double-fclose": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-fclose",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-double-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-free",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-exposure-through-output-file": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-exposure-through-output-file",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-exposure-through-uninit-copy": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-exposure-through-uninit-copy",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-fd-access-mode-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-access-mode-mismatch",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-double-close": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-double-close",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-leak",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-phase-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-phase-mismatch",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-type-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-type-mismatch",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-use-after-close": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-after-close",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-fd-use-without-check": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-without-check",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-file-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-file-leak",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-free-of-non-heap": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-free-of-non-heap",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-imprecise-fp-arithmetic": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-imprecise-fp-arithmetic",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:LOW"
     ],
     "gcc-infinite-recursion": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-infinite-recursion",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-jump-through-null": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-jump-through-null",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-malloc-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-malloc-leak",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-mismatching-deallocation": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-mismatching-deallocation",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-null-argument": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-argument",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-dereference",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-out-of-bounds": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-out-of-bounds",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-possible-null-argument": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-argument",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:LOW"
     ],
     "gcc-possible-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-dereference",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:LOW"
     ],
     "gcc-putenv-of-auto-var": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-putenv-of-auto-var",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-shift-count-negative": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-negative",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-shift-count-overflow": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-overflow",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-stale-setjmp-buffer": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-stale-setjmp-buffer",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-tainted-allocation-size": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-allocation-size",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-tainted-array-index": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-array-index",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-tainted-assertion": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-assertion",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-tainted-divisor": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-divisor",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-tainted-offset": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-offset",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-tainted-size": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-tainted-size",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-unsafe-call-within-signal-handler": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-unsafe-call-within-signal-handler",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-use-after-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-after-free",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-use-of-pointer-in-stale-stack-frame": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-of-pointer-in-stale-stack-frame",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-use-of-uninitialized-value": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-of-uninitialized-value",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-va-arg-type-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-arg-type-mismatch",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:MEDIUM"
     ],
     "gcc-va-list-exhausted": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-exhausted",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-va-list-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-leak",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-va-list-use-after-va-end": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-use-after-va-end",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-write-to-const": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-write-to-const",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ],
     "gcc-write-to-string-literal": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-write-to-string-literal",
       "profile:extreme",
-      "severity:UNSPECIFIED"
+      "severity:HIGH"
     ]
   }
 }   


### PR DESCRIPTION
I went ahead and added the missing severities. No checkers (as of now) are style checkers, so nothing got assigned to LOW. Here is some extra context:
* Pretty much every checker that warns about undefined behaviour was assigned HIGH. This seems consistent with our labels for other checkers.
* Leaks are not fatal errors, but leak checkers in other analyzers were categorized into HIGH, so I assigned HIGh to leak gcc checkers as well.
* The taint checker in ClangSA has HIGH severity, which I disagree with. Its an error to fix, but its not immediately breaking. Taint and other security checkers were assigned MEDIUM.

THIS PATCH ONLY ADDS SEVERITIES, NO PROFILES! I intend to fix those in a followup patch.

Here is the link to the GCC docs (they are rather sparse): https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html

Fixes #4091.