### PR TITLE
[fix] fix venv_dev and multiprocess lib usage

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -724,6 +724,7 @@ def start_workers(actions_map, actions, analyzer_config_map,
     Start the workers in the process pool.
     For every build action there is worker which makes the analysis.
     """
+    # pylint: disable=no-member multiprocess module members.
 
     # Handle SIGINT to stop this script running.
     def signal_handler(signum, frame):

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -136,6 +136,7 @@ def perform_analysis(args, skip_handlers, actions, metadata_tool,
     in the given analysis context for the supplied build actions.
     Additionally, insert statistical information into the metadata dict.
     """
+    # pylint: disable=no-member multiprocess module members.
 
     context = analyzer_context.get_context()
 

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -169,6 +169,7 @@ def add_arguments_to_parser(parser):
                         type=int,
                         dest="jobs",
                         required=False,
+                        # pylint: disable=no-member
                         default=multiprocess.cpu_count(),
                         help="Number of threads to use in analysis. More "
                              "threads mean faster analysis at the cost of "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -183,6 +183,7 @@ used to generate a log file on the fly.""")
                                type=int,
                                dest="jobs",
                                required=False,
+                               # pylint: disable=no-member
                                default=multiprocess.cpu_count(),
                                help="Number of threads to use in analysis. "
                                     "More threads mean faster analysis at "

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -150,6 +150,7 @@ def run_pre_analysis(actions, clangsa_config,
     """
     Run multiple pre analysis jobs before the actual analysis.
     """
+    # pylint: disable=no-member multiprocess module members.
     LOG.info('Pre-analysis started.')
     if ctu_data:
         LOG.info("Collecting data for ctu analysis.")

--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -2,6 +2,6 @@ lxml==4.9.3
 portalocker==2.2.1
 psutil==5.8.0
 PyYAML==6.0.1
+types-PyYAML==6.0.12.12
 sarif-tools==1.0.0
-mypy_extensions==0.4.3
 multiprocess==0.70.15

--- a/analyzer/requirements_py/dev/requirements.txt
+++ b/analyzer/requirements_py/dev/requirements.txt
@@ -1,11 +1,7 @@
-lxml==4.9.3
 pytest==7.3.1
 pycodestyle==2.7.0
-psutil==5.8.0
-portalocker==2.2.1
 pylint==2.8.2
 mkdocs==1.5.3
-PyYAML==6.0.1
-mypy_extensions==0.4.3
 coverage==5.5.0
-sarif-tools==1.0.0
+
+-r ../../requirements.txt

--- a/analyzer/requirements_py/osx/requirements.txt
+++ b/analyzer/requirements_py/osx/requirements.txt
@@ -1,6 +1,3 @@
-lxml==4.9.3
-portalocker==2.2.1
-psutil==5.8.0
 scan-build==2.0.19
-PyYAML==6.0.1
-mypy_extensions==0.4.3
+
+-r ../../requirements.txt

--- a/codechecker_common/requirements_py/dev/requirements.txt
+++ b/codechecker_common/requirements_py/dev/requirements.txt
@@ -1,5 +1,5 @@
 portalocker==2.2.1
 coverage==5.5.0
-mypy==0.812
-mypy_extensions==0.4.3
+mypy==1.7.1
 PyYAML==6.0.1
+types-PyYAML==6.0.12.12

--- a/tools/bazel/requirements_py/dev/requirements.txt
+++ b/tools/bazel/requirements_py/dev/requirements.txt
@@ -1,5 +1,4 @@
 pytest==7.3.1
 pycodestyle==2.7.0
 pylint==2.8.2
-mypy==0.812
-mypy_extensions==0.4.3
+mypy==1.7.1

--- a/tools/report-converter/codechecker_report_converter/report/checker_labels.py
+++ b/tools/report-converter/codechecker_report_converter/report/checker_labels.py
@@ -6,10 +6,10 @@
 #
 # -------------------------------------------------------------------------
 
-from typing import Any, Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 
 class CheckerLabels:
-    severity: Callable[[Any, str], str]
+    severity: Callable[[str], str]
     label_of_checker: Callable[
-        [Any, str, str, Optional[str]], Union[str, List[str]]]
+        [str, str, Optional[str]], Union[str, List[str]]]

--- a/tools/report-converter/codechecker_report_converter/report/reports.py
+++ b/tools/report-converter/codechecker_report_converter/report/reports.py
@@ -8,7 +8,7 @@
 
 import logging
 
-from typing import Any, Callable, Iterable, List, Optional, Set
+from typing import Callable, Iterable, List, Optional, Set
 
 from codechecker_report_converter.report import Report, SkipListHandlers
 from codechecker_report_converter.report.hash import get_report_path_hash
@@ -17,8 +17,8 @@ LOG = logging.getLogger('report-converter')
 
 
 class GenericSuppressHandler:
-    get_suppressed: Callable[[Any, Report], bool]
-    store_suppress_bug_id: Callable[[Any, str, str, str, str], bool]
+    get_suppressed: Callable[[Report], bool]
+    store_suppress_bug_id: Callable[[str, str, str, str], bool]
 
 
 def get_mentioned_original_files(reports: List[Report]) -> Set[str]:

--- a/tools/report-converter/requirements_py/dev/requirements.txt
+++ b/tools/report-converter/requirements_py/dev/requirements.txt
@@ -3,5 +3,4 @@ sarif-tools==1.0.0
 pycodestyle==2.7.0
 pylint==2.8.2
 portalocker==2.2.1
-mypy==0.812
-mypy_extensions==0.4.3
+mypy==1.7.1

--- a/tools/tu_collector/requirements_py/dev/requirements.txt
+++ b/tools/tu_collector/requirements_py/dev/requirements.txt
@@ -1,5 +1,4 @@
 pytest==7.3.1
 pycodestyle==2.7.0
 pylint==2.8.2
-mypy==0.812
-mypy_extensions==0.4.3
+mypy==1.7.1

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,11 +3,11 @@ sqlalchemy==1.3.23
 alembic==1.5.5
 portalocker==2.2.1
 psutil==5.8.0
-mypy_extensions==0.4.3
 multiprocess==0.70.15
 thrift==0.13.0
 gitpython==3.1.37
 PyYAML==6.0.1
+types-PyYAML==6.0.12.12
 sarif-tools==1.0.0
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz

--- a/web/requirements_py/dev/requirements.txt
+++ b/web/requirements_py/dev/requirements.txt
@@ -1,22 +1,12 @@
-lxml==4.9.3
-sqlalchemy==1.3.23
 pycodestyle==2.7.0
-alembic==1.5.5
 psycopg2-binary==2.8.6
 pg8000==1.15.2
-psutil==5.8.0
-portalocker==2.2.1
 pylint==2.8.2
 pytest==7.3.1
 mkdocs==1.5.3
-mypy_extensions==0.4.3
 coverage==5.5.0
-thrift==0.13.0
-gitpython==3.1.37
-sarif-tools==1.0.0
 
-./api/py/codechecker_api/dist/codechecker_api.tar.gz
-./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz
+-r ../../requirements.txt
 
 # publish packages to pypi
 twine

--- a/web/requirements_py/osx/requirements.txt
+++ b/web/requirements_py/osx/requirements.txt
@@ -1,10 +1,1 @@
-lxml==4.9.3
-alembic==1.5.5
-portalocker==2.2.1
-psutil==5.8.0
-sqlalchemy==1.3.23
-mypy_extensions==0.4.3
-thrift==0.13.0
-
-./api/py/codechecker_api/dist/codechecker_api.tar.gz
-./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz
+-r ../../requirements.txt

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -27,7 +27,7 @@ import urllib
 
 from http.server import HTTPServer, BaseHTTPRequestHandler, \
     SimpleHTTPRequestHandler
-from multiprocess import Process
+import multiprocess
 
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import func
@@ -1116,7 +1116,8 @@ def start_server(config_directory, package_data, port, config_sql_server,
     atexit.register(unregister_handler, os.getpid())
 
     for _ in range(manager.worker_processes - 1):
-        p = Process(target=http_server.serve_forever)
+        # pylint: disable=no-member multiprocess module members.
+        p = multiprocess.Process(target=http_server.serve_forever)
         processes.append(p)
         p.start()
 

--- a/web/tests/functional/authentication/__init__.py
+++ b/web/tests/functional/authentication/__init__.py
@@ -17,6 +17,7 @@ from libtest import codechecker
 from libtest import env
 import multiprocess
 
+# pylint: disable=no-member multiprocess module members.
 # Stopping event for CodeChecker server.
 __STOP_SERVER = multiprocess.Event()
 

--- a/web/tests/functional/cli_config/test_server_config.py
+++ b/web/tests/functional/cli_config/test_server_config.py
@@ -24,6 +24,7 @@ from . import setup_class_common, teardown_class_common
 
 
 class TestServerConfig(unittest.TestCase):
+    # pylint: disable=no-member multiprocess module members.
     _ccClient = None
 
     def setup_class(self):

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -187,6 +187,7 @@ int f(int x) { return 1 / x; }
                              severity_id)
 
     def test_garbage_file_collection(self):
+        # pylint: disable=no-member multiprocess module members.
         event = multiprocess.Event()
         event.clear()
 

--- a/web/tests/functional/instance_manager/test_instances.py
+++ b/web/tests/functional/instance_manager/test_instances.py
@@ -23,6 +23,7 @@ from libtest import env
 from libtest.codechecker import start_server
 import multiprocess
 
+# pylint: disable=no-member multiprocess module members.
 # Stopping events for CodeChecker servers.
 EVENT_1 = multiprocess.Event()
 EVENT_2 = multiprocess.Event()

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -31,6 +31,7 @@ from libtest import codechecker
 from libtest import env
 import multiprocess
 
+# pylint: disable=no-member multiprocess module members.
 # Stopping events for CodeChecker server.
 EVENT = multiprocess.Event()
 

--- a/web/tests/functional/ssl/test_ssl.py
+++ b/web/tests/functional/ssl/test_ssl.py
@@ -32,6 +32,7 @@ class TestSSL(unittest.TestCase):
 
         # Stopping event for CodeChecker server.
         global __STOP_SERVER
+        # pylint: disable=no-member multiprocess module members.
         __STOP_SERVER = multiprocess.Event()
 
         global TEST_WORKSPACE

--- a/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
+++ b/web/tests/functional/storage_of_analysis_statistics/test_storage_of_analysis_statistics.py
@@ -48,6 +48,7 @@ class TestStorageOfAnalysisStatistics(unittest.TestCase):
 
         # Stopping event for CodeChecker server.
         global EVENT_1
+        # pylint: disable=no-member multiprocess module members.
         EVENT_1 = multiprocess.Event()
 
         global TEST_WORKSPACE

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -700,6 +700,7 @@ def start_server(codechecker_cfg, event, server_args=None, pg_config=None):
                           pg_config,
                           server_args or [])
 
+    # pylint: disable=no-member multiprocess module members.
     server_proc = multiprocess.Process(
         name='server',
         target=start_server_proc,


### PR DESCRIPTION
Many functions and members of `multiprocess` lib are exposed dynamically. For this reason pylint is not able to tell what members this lib has (e.g. `multiprocess.Value()`. So these pylint reports have been suppressed.

Another purpose of this commit is to make "superset" relationship for venv_dev: if a CodeChecker developer installs venv_dev, then the content of venv should always be installed. venv_dev just extends them. `multiprocess` was a counterexample for this relationship: it was installed only by `venv` and not `venv_dev`. Such a mistake in the organization of requirements.txt files results missing libraries for developers.