### PR TITLE
[analyze] Removing long enabled checker list at info log level

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -256,8 +256,9 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info
-
-    LOG.info("Enabled checkers:\n%s", '\n'.join(
+    LOG.info("Enabled checker list can be found in " +
+             os.path.join(args.output_path, "metadata.json"))
+    LOG.debug("Enabled checkers:\n%s", '\n'.join(
         k + ': ' + ', '.join(v) for k, v in enabled_checkers.items()))
 
     if 'makefile' in args and args.makefile:

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -256,10 +256,10 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info
-    LOG.info("Enabled checker list can be found in " +
+    LOG.info("Enabled checker list can be found in %s",
              os.path.join(args.output_path, "metadata.json"))
     LOG.debug("Enabled checkers:\n%s", '\n'.join(
-        k + ': ' + ', '.join(v) for k, v in enabled_checkers.items()))
+              k + ': ' + ',\n '.join(v) for k, v in enabled_checkers.items()))
 
     if 'makefile' in args and args.makefile:
         statistics_data = __get_statistics_data(args)

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -1250,8 +1250,6 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
 
-        # It's printed as the member of enabled checkers at the beginning
-        # of the output, a found report and in the checker statistics.
         self.assertEqual(out.count('hicpp-use-nullptr'), 3)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
@@ -1270,9 +1268,7 @@ class TestAnalyze(unittest.TestCase):
             errors="ignore")
         out, _ = process.communicate()
         print(out)
-        # It's printed as the member of enabled checkers at the beginning
-        # of the output, a found report and in the checker statistics.
-        self.assertEqual(out.count('UninitializedObject'), 3)
+        self.assertEqual(out.count('UninitializedObject'), 2)
 
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clangsa", "-o", self.report_dir,
@@ -1293,9 +1289,7 @@ class TestAnalyze(unittest.TestCase):
         out, _ = process.communicate()
 
         print(out)
-        # It is printed as the member of enabled checkers, but it gives no
-        # report.
-        self.assertEqual(out.count('UninitializedObject'), 1)
+        self.assertEqual(out.count('UninitializedObject'), 0)
 
     def test_invalid_compilation_database(self):
         """ Warn in case of an invalid enabled checker. """

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -220,7 +220,7 @@ class AnalyzeParseTestCase(
                          "[] - Skipping input file",
                          # Enabled checkers are listed in the beginning of
                          # analysis.
-                         "[] - Enabled checkers:",
+                         "[] - Enabled checker",
                          "clang-tidy:",
                          "clangsa:",
                          "cppcheck:",


### PR DESCRIPTION
At every analysis at the defult log level there was a wall of text checker list. It is enough to print this list at the verbose log level and redirect the user to the metadat.json file at default log level.