### PR TITLE
[analyzer][clang] Remove mention of Clang plugin from debug script

### DIFF
--- a/scripts/debug_tools/README.md
+++ b/scripts/debug_tools/README.md
@@ -21,18 +21,31 @@ Example session for debugging a clang crash:
 ```sh
 $ export WS=/your_own_path
 $ cd reports/failed
+$
+$ # unzip the failzip of the crash you are interested in
 $ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
-$ $WS/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$
+$ # generate the analyzer-command
+$ $WS/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang $WS/llvm/build/debug/bin/clang
+$
+$ # run the debugging analyzer-command
 $ bash analyzer-command_DEBUG
 ```
 
 Example session for debuggin a CTU clang crash:
 ```sh
 $ export WS=/your_own_path
+$
+$ # put CodeChecker in PATH
 $ export PATH=$WS/CodeChecker/build/CodeChecker/bin:$PATH
-$ source $WS/CodeChecker/venv_dev/bin/activate
+$ # ensure CodeChecker is runnable in this env
+$ source $WS/CodeChecker/venv/bin/activate
+$
 $ cd reports/failed
+$ # unzip the failzip of the crash you are interested in
 $ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
-$ $WS/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$
+$ # generate the analyzer-command
+$ $WS/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang $WS/llvm/build/debug/bin/clang
 $ bash analyzer-command_DEBUG
 ```

--- a/scripts/debug_tools/prepare_all_cmd_for_ctu.py
+++ b/scripts/debug_tools/prepare_all_cmd_for_ctu.py
@@ -73,12 +73,6 @@ if __name__ == '__main__':
         '--clang',
         required=True,
         help="Path to the clang binary.")
-    parser.add_argument(
-        '--clang_plugin_name', default=None,
-        help="Name of the used clang plugin.")
-    parser.add_argument(
-        '--clang_plugin_path', default=None,
-        help="Path to the used clang plugin.")
     args = parser.parse_args()
 
     # CodeChecker log outputs 'compile_cmd.json' by default.
@@ -129,8 +123,6 @@ if __name__ == '__main__':
                 prepare_analyzer_cmd.PathOptions(
                     args.sources_root,
                     args.clang,
-                    args.clang_plugin_name,
-                    args.clang_plugin_path,
                     "./report_debug/ctu-dir/" + target)))
 
     print(

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -42,14 +42,6 @@ class AnalyzerCommandPathModifier:
                         self.opts.ctu_dir.rstrip(os.path.sep))),
                 os.path.basename(path))
 
-        if self.opts.clang_plugin_name is not None and\
-                re.search(self.opts.clang_plugin_name, path):
-            if self.opts.clang_plugin_path is None:
-                print("clang_plugin_name is in a path, "
-                      "but clang_plugin_path is not given in the options")
-                sys.exit(-1)
-            return self.opts.clang_plugin_path
-
         if re.search('ctu-dir', path):
             if self.opts.ctu_dir is None:
                 print('ctu-dir is in a path, but not in the options!')
@@ -68,13 +60,9 @@ class PathOptions:
             self,
             sources_root,
             clang,
-            clang_plugin_name,
-            clang_plugin_path,
             ctu_dir):
         self.sources_root = sources_root
         self.clang = clang
-        self.clang_plugin_name = clang_plugin_name
-        self.clang_plugin_path = clang_plugin_path
         self.ctu_dir = ctu_dir
 
 
@@ -121,12 +109,6 @@ if __name__ == '__main__':
         '--clang',
         required=True,
         help="Path to the clang binary.")
-    parser.add_argument(
-        '--clang_plugin_name', default=None,
-        help="Name of the used clang plugin.")
-    parser.add_argument(
-        '--clang_plugin_path', default=None,
-        help="Path to the used clang plugin.")
     args = parser.parse_args()
 
     print(
@@ -135,6 +117,4 @@ if __name__ == '__main__':
             PathOptions(
                 args.sources_root,
                 args.clang,
-                args.clang_plugin_name,
-                args.clang_plugin_path,
                 args.ctu_dir)))

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -90,6 +90,10 @@ def prepare(analyzer_command_file, pathOptions):
     return res.replace('-nobuiltininc',
                        '-nobuiltininc -isystem ' + clang_include_path)
 
+def write_analyzer_command_file(fname, content):
+    with open(fname, mode="wt", encoding="utf-8", errors="ignore") as f:
+        return f.write(content)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Prepare analyzer-command '
@@ -111,10 +115,11 @@ if __name__ == '__main__':
         help="Path to the clang binary.")
     args = parser.parse_args()
 
-    print(
-        prepare(
+    prepared_command = prepare(
             args.analyzer_command_file,
             PathOptions(
                 args.sources_root,
                 args.clang,
-                args.ctu_dir)))
+                args.ctu_dir))
+
+    write_analyzer_command_file("analyzer-command_DEBUG", prepared_command)


### PR DESCRIPTION
Clangsa internal checkers used to be shipped as a dynamic library. This is not the case any more, so the support for those is removed.