### PR TITLE
[GUI] Update report sidebar structure and add review status reactivity

### DIFF
--- a/web/server/vue-cli/e2e/pages/reportDetail.js
+++ b/web/server/vue-cli/e2e/pages/reportDetail.js
@@ -33,16 +33,20 @@ const bugTreeCommands = {
     return `${this.elements.node.selector}:nth-child(${index})`;
   },
 
-  getTreeNodeSelector(severityIndex, bugIndex, stepIndex) {
-    let selectors = [ this.selector, ">", this.node(severityIndex) ];
-
-    if (bugIndex !== undefined) {
+  getTreeNodeSelector(outstandingStateIndex, severityIndex, bugIndex, stepIndex) {
+    let selectors = [ this.selector, ">", this.node(outstandingStateIndex) ];
+    if (severityIndex !== undefined) {
       selectors.push(
-        ...[ ">", this.elements.childNode.selector, this.node(bugIndex)]);
+        ...[ ">", this.elements.childNode.selector, this.node(severityIndex)]);
 
-      if (stepIndex !== undefined) {
+      if (bugIndex !== undefined) {
         selectors.push(
-          ...[">", this.elements.childNode.selector, this.node(stepIndex)]);
+          ...[ ">", this.elements.childNode.selector, this.node(bugIndex)]);
+
+        if (stepIndex !== undefined) {
+          selectors.push(
+            ...[">", this.elements.childNode.selector, this.node(stepIndex)]);
+        }
       }
     }
 

--- a/web/server/vue-cli/e2e/specs/reportDetail.js
+++ b/web/server/vue-cli/e2e/specs/reportDetail.js
@@ -232,14 +232,46 @@ module.exports = {
     const reportDetailPage = browser.page.reportDetail();
     const bugTree = reportDetailPage.section.bugTree;
 
+    const oldOutstandingStateIndex = 2;
+    const outstandingStateIndex = 1;
+    const oldSeverityIndex = 1;
+    const oldBugIndex = 1;
     const severityIndex = 2;
     const bugIndex = 1;
     const stepIndex = 1;
 
-    bugTree.click(bugTree.getTreeNodeSelector(severityIndex));
-    bugTree.click(bugTree.getTreeNodeSelector(severityIndex, bugIndex));
-    bugTree.click(
-      bugTree.getTreeNodeSelector(severityIndex, bugIndex, stepIndex));
+    bugTree.click(bugTree.getTreeNodeSelector(
+      oldOutstandingStateIndex,
+      oldSeverityIndex,
+      oldBugIndex
+    ));
+
+    bugTree.click(bugTree.getTreeNodeSelector(
+      oldOutstandingStateIndex,
+      oldSeverityIndex
+    ));
+
+    bugTree.click(bugTree.getTreeNodeSelector(oldOutstandingStateIndex));
+
+    bugTree.click(bugTree.getTreeNodeSelector(outstandingStateIndex));
+
+    bugTree.click(bugTree.getTreeNodeSelector(
+      outstandingStateIndex,
+      severityIndex
+    ));
+
+    bugTree.click(bugTree.getTreeNodeSelector(
+      outstandingStateIndex,
+      severityIndex,
+      bugIndex
+    ));
+
+    bugTree.click(bugTree.getTreeNodeSelector(
+      outstandingStateIndex,
+      severityIndex,
+      bugIndex,
+      stepIndex
+    ));
 
     reportDetailPage.waitForProgressBarNotPresent();
   }

--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -339,6 +339,9 @@ export default {
   props: {
     treeItem: { type: Object, default: null }
   },
+
+  emits: [ "update-review-data" ],
+
   data() {
     const enableBlameView =
       this.$router.currentRoute.query["view"] === "blame";
@@ -886,6 +889,11 @@ export default {
           this.reviewData.status = status;
           this.reviewData.author = author;
           this.reviewData.date = format(new Date(), "yyyy-MM-dd HH:mm:ss");
+          this.$emit(
+            "update-review-data",
+            this.reviewData,
+            this.report.reportId
+          );
         }));
     },
 

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
@@ -57,6 +57,24 @@
     mdi-note-outline
   </v-icon>
 
+  <v-icon
+    v-else-if="item.isOutstanding"
+    title="Outstanding reports (review status is unreviewed or confirmed 
+    and detection status is not resolved)"
+    color="primary"
+  >
+    mdi-folder-lock-open
+  </v-icon>
+
+  <v-icon
+    v-else-if="!item.isOutstanding"
+    title="Closed reports (review status is false positive or intentional 
+    or detection status is resolved)"
+    color="primary"
+  >
+    mdi-folder-lock
+  </v-icon>
+
   <v-icon v-else>
     {{ item.open ? "mdi-folder-open" : "mdi-folder" }}
   </v-icon>

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeLabel.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeLabel.vue
@@ -20,7 +20,12 @@
     <span v-else-if="isExtendedReportDataItem">
       L{{ item.data.startLine }} &ndash; {{ item.name }}
     </span>
-
+    <span v-else-if="item.kind === ReportTreeKind.SEVERITY_LEVEL">
+      {{ item.name }} 
+      <span v-if="newReportCount" style="color: #ec7672;">
+        {{ newReportCountLabel }}
+      </span>
+    </span>
     <span v-else>
       {{ item.name }}
     </span>
@@ -29,6 +34,7 @@
 
 <script>
 import ReportTreeKind from "./ReportTreeKind";
+import { DetectionStatus } from "@cc/report-server-types";
 
 export default {
   name: "ReportTreeLabel",
@@ -40,7 +46,8 @@ export default {
   },
   data() {
     return {
-      ReportTreeKind
+      ReportTreeKind,
+      DetectionStatus
     };
   },
   computed: {
@@ -55,6 +62,19 @@ export default {
     isExtendedReportDataItem() {
       return this.item.kind === ReportTreeKind.MACRO_EXPANSION_ITEM ||
              this.item.kind === ReportTreeKind.NOTE_ITEM;
+    },
+
+    newReportCount() {
+      if (this.item && this.item.kind === ReportTreeKind.SEVERITY_LEVEL) {
+        return this.item.children.filter(element => {
+          return element.report.detectionStatus == DetectionStatus.NEW;
+        }).length;
+      }
+      return 0;
+    },
+
+    newReportCountLabel() {
+      return ` [${this.newReportCount} new]`;
     }
   }
 };

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeRootItem.js
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeRootItem.js
@@ -1,56 +1,115 @@
-import { DetectionStatus, Severity } from "@cc/report-server-types";
+import { 
+  DetectionStatus, 
+  Severity
+} from "@cc/report-server-types";
 
 import ReportTreeKind from "./ReportTreeKind";
 
 const rootItems = [
   {
-    id: "critical",
-    name: "Critical",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.CRITICAL,
-    children: []
+    id: "outstanding",
+    name: "Outstanding",
+    isOutstanding: true,
+    children: [
+      {
+        id: "critical",
+        name: "Critical",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.CRITICAL,
+        children: []
+      },
+      {
+        id: "high",
+        name: "High",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.HIGH,
+        children: []
+      },
+      {
+        id: "medium",
+        name: "Medium",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.MEDIUM,
+        children: []
+      },
+      {
+        id: "low",
+        name: "Low",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.LOW,
+        children: []
+      },
+      {
+        id: "style",
+        name: "Style",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.STYLE,
+        children: []
+      },
+      {
+        id: "unspecified",
+        name: "Unspecified",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.UNSPECIFIED,
+        children: []
+      }
+    ]
   },
   {
-    id: "high",
-    name: "High",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.HIGH,
-    children: []
-  },
-  {
-    id: "medium",
-    name: "Medium",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.MEDIUM,
-    children: []
-  },
-  {
-    id: "low",
-    name: "Low",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.LOW,
-    children: []
-  },
-  {
-    id: "style",
-    name: "Style",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.STYLE,
-    children: []
-  },
-  {
-    id: "unspecified",
-    name: "Unspecified",
-    kind: ReportTreeKind.SEVERITY_LEVEL,
-    severity: Severity.UNSPECIFIED,
-    children: []
-  },
-  {
-    id: "resolved",
-    name: "Resolved",
-    kind: ReportTreeKind.DETECTION_STATUS,
-    detectionStatus: DetectionStatus.RESOLVED,
-    children: []
+    id: "closed",
+    name: "Closed",
+    isOutstanding: false,
+    children: [
+      {
+        id: "critical",
+        name: "Critical",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.CRITICAL,
+        children: []
+      },
+      {
+        id: "high",
+        name: "High",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.HIGH,
+        children: []
+      },
+      {
+        id: "medium",
+        name: "Medium",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.MEDIUM,
+        children: []
+      },
+      {
+        id: "low",
+        name: "Low",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.LOW,
+        children: []
+      },
+      {
+        id: "style",
+        name: "Style",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.STYLE,
+        children: []
+      },
+      {
+        id: "unspecified",
+        name: "Unspecified",
+        kind: ReportTreeKind.SEVERITY_LEVEL,
+        severity: Severity.UNSPECIFIED,
+        children: []
+      },
+      {
+        id: "resolved",
+        name: "Resolved",
+        kind: ReportTreeKind.DETECTION_STATUS,
+        detectionStatus: DetectionStatus.RESOLVED,
+        children: []
+      }
+    ]
   }
 ];
 

--- a/web/server/vue-cli/src/views/ReportDetail.vue
+++ b/web/server/vue-cli/src/views/ReportDetail.vue
@@ -77,6 +77,7 @@
             <report-tree
               v-fill-height
               :report="report"
+              :review-status="reviewStatus"
               @click="onReportTreeClick"
             />
           </v-col>
@@ -89,6 +90,7 @@
         :tree-item="treeItem"
         @toggle:comments="showComments = !showComments"
         @update:report="loadReport"
+        @update-review-data="updateReviewData"
       />
     </pane>
   </splitpanes>
@@ -125,7 +127,8 @@ export default {
       report: null,
       treeItem: null,
       showComments: true,
-      reportNotFound: false
+      reportNotFound: false,
+      reviewStatus: null
     };
   },
   computed: {
@@ -222,6 +225,11 @@ export default {
       }
 
       this.treeItem = item;
+    },
+
+    updateReviewData(newReviewData, reportId) {
+      this.reviewStatus = newReviewData.status;
+      this.loadReport(reportId);
     }
   }
 };


### PR DESCRIPTION
This PR gives a new report sidebar structure on the report-detail page. There are two main types in the report tree. One of them is the Outstanding category that contains outstanding reports classified into severity groups. The another category is the Closed that contains resolved, and not resolved but closed reports such as false positive, intentional.

Opening the a report-detail page, the report sidebar automatically opens a specific tree where the current report is located. If we changed the review status, the sidebar would react immediately.