### PR TITLE
Clang-tidy arch parameter pass fix

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -478,7 +478,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             if not has_flag('-arch', analyzer_cmd) and \
                     self.buildaction.arch != "":
-                analyzer_cmd.extend(["-arch ", self.buildaction.arch])
+                analyzer_cmd.extend(["-arch", self.buildaction.arch])
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
 


### PR DESCRIPTION
When -arch is specified in the compilation commmand '-arch ' was passed to clang-tidy which causes a
parsing error for clang tidy version 17