### PR TITLE
Eliminate should skip

### DIFF
--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -103,12 +103,6 @@ class SkipListHandler:
                 return sign == '-'
         return False
 
-    def __call__(self, source_file_path: str) -> bool:
-        """
-        Check if the given source should be skipped.
-        """
-        return self.should_skip(source_file_path)
-
 
 class SkipListHandlers(list):
     def should_skip(self, file_path: str):
@@ -117,11 +111,3 @@ class SkipListHandlers(list):
         handler.
         """
         return any(handler.should_skip(file_path) for handler in self)
-
-    # FIXME: eliminate this function and use should_skip instead of this.
-    # Do the same in the SkipListHandler class above.
-    def __call__(self, file_path: str) -> bool:
-        """
-        Check if the given source should be skipped.
-        """
-        return self.should_skip(file_path)

--- a/tools/report-converter/codechecker_report_converter/report/__init__.py
+++ b/tools/report-converter/codechecker_report_converter/report/__init__.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Protocol, Set
 
 from .. import util
 
@@ -22,7 +22,8 @@ from .. import util
 LOG = logging.getLogger('report-converter')
 
 
-SkipListHandlers = Callable[[str], bool]
+class SkipListHandlers(Protocol):
+    should_skip: Callable[[str], bool]
 
 
 InvalidFileContentMsg: str = \
@@ -473,7 +474,7 @@ class Report:
         if not skip_handlers:
             return False
 
-        return skip_handlers(self.file.original_path)
+        return skip_handlers.should_skip(self.file.original_path)
 
     def to_json(self) -> Dict:
         """ Creates a JSON dictionary. """


### PR DESCRIPTION
SkiplistHandler class had a __call__() function which forwarded to
should_skip(), so it didn't really had a real purpose. There was
also a "TODO" in the code to eliminate this function.