### PR TITLE
[analyzer][clang] Remove external plugin support

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -340,14 +340,6 @@ class Context(metaclass=Singleton):
         return self._data_files_dir_path
 
     @property
-    def checker_plugin(self):
-        # Do not load the plugin because it might be incompatible.
-        if env.is_analyzer_from_path():
-            return None
-
-        return os.path.join(self._data_files_dir_path, 'plugin')
-
-    @property
     def checker_labels(self):
         return self._checker_labels
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics.py
@@ -34,12 +34,6 @@ def build_stat_coll_cmd(action, config, source):
            '-Qunused-arguments',
            '--analyzer-output', 'text']
 
-    for plugin in ClangSA.analyzer_plugins():
-        cmd.extend(["-Xclang", "-plugin",
-                    "-Xclang", "checkercfg",
-                    "-Xclang", "-load",
-                    "-Xclang", plugin])
-
     cmd.extend(['-Xclang',
                 '-analyzer-opt-analyze-headers'])
 

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -49,10 +49,6 @@ epilog_env_var = f"""
                            binary.
                            Format: CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;
                                                     <analyzer2>:/path/to/bin2'
-  CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
-                           is set you can configure the plugin directory of the
-                           Clang Static Analyzer by using this environment
-                           variable.
 """
 
 epilog_issue_hashes = """

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -147,8 +147,3 @@ def is_analyzer_from_path():
     if analyzers_from_path in ['yes', '1']:
         return True
     return False
-
-
-def get_clangsa_plugin_dir():
-    """ Return the value of the CC_CLANGSA_PLUGIN_DIR environment variable. """
-    return os.environ.get('CC_CLANGSA_PLUGIN_DIR')

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -506,10 +506,6 @@ Environment variables for 'CodeChecker analyze' command:
                            binary.
                            Format: CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;
                                                     <analyzer2>:/path/to/bin2'
-  CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
-                           is set you can configure the plugin directory of the
-                           Clang Static Analyzer by using this environment
-                           variable.
 
 Environment variables for 'CodeChecker parse' command:
 
@@ -1043,10 +1039,6 @@ Environment variables
                            binary.
                            Format: CC_ANALYZER_BIN='<analyzer1>:/path/to/bin1;
                                                     <analyzer2>:/path/to/bin2'
-  CC_CLANGSA_PLUGIN_DIR    If the CC_ANALYZERS_FROM_PATH environment variable
-                           is set you can configure the plugin directory of the
-                           Clang Static Analyzer by using this environment
-                           variable.
 ```
 </details>
 
@@ -2421,9 +2413,7 @@ binaries you intend to use.
 
 You can set the `CC_ANALYZERS_FROM_PATH` environment variable before running a
 CodeChecker command to `yes` or `1` to enforce taking the analyzers from the
-`PATH` instead of the given binaries. If this option is set you can also
-configure the plugin directory of the Clang Static Analyzer by using the
-`CC_CLANGSA_PLUGIN_DIR` environment variable.
+`PATH` instead of the given binaries.
 
 Make sure that the required include paths are at the right place!
 Clang based tools search by default for

--- a/docs/package_layout.md
+++ b/docs/package_layout.md
@@ -4,10 +4,6 @@ Short description for the package layout of the generic CodeChecker package.
 Package creation is based on the package layout config file.
 It has two main parts a static and a runtime part.
 
-### External checker libraries
-External checker libraries can be used in the package. The shared object files
-should be in the plugin directory and will be automatically loaded at runtime.
-
 ## Runtime section
 The runtime part contains information which will be used only at runtime
 to find files during the checking process.
@@ -26,9 +22,7 @@ paths.
 
 You can set the `CC_ANALYZERS_FROM_PATH` environment variable before running a
 CodeChecker command to `yes` or `1` to enforce taking the analyzers from the
-`PATH` instead of the given binaries. If this option is set you can also
-configure the plugin directory of the Clang Static Analyzer by using the
-`CC_CLANGSA_PLUGIN_DIR` environment variable.
+`PATH` instead of the given binaries.
 
 ### Replacer section
 This section is a key-value component. The key is `clang-apply-replacements`

--- a/scripts/debug_tools/README.md
+++ b/scripts/debug_tools/README.md
@@ -22,7 +22,7 @@ Example session for debugging a clang crash:
 $ export WS=/your_own_path
 $ cd reports/failed
 $ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
-$ $WS/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$ $WS/CodeChecker/debug_tools/prepare_analyzer_cmd.py --clang $WS/llvm/build/debug/bin/clang
 $ bash analyzer-command_DEBUG
 ```
 
@@ -33,6 +33,6 @@ $ export PATH=$WS/CodeChecker/build/CodeChecker/bin:$PATH
 $ source $WS/CodeChecker/venv_dev/bin/activate
 $ cd reports/failed
 $ unzip main.c_4c7feffae4c2b887abcdc37a3c88b2e5.plist.zip
-$ $WS/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang $WS/llvm/build/debug/bin/clang --clang_plugin_name libericsson --clang_plugin_path $WS/codechecker_core_ws/build/debug/libericsson-checkers.so
+$ $WS/CodeChecker/debug_tools/prepare_all_cmd_for_ctu.py --clang $WS/llvm/build/debug/bin/clang
 $ bash analyzer-command_DEBUG
 ```

--- a/scripts/debug_tools/prepare_all_cmd_for_ctu.py
+++ b/scripts/debug_tools/prepare_all_cmd_for_ctu.py
@@ -73,12 +73,6 @@ if __name__ == '__main__':
         '--clang',
         required=True,
         help="Path to the clang binary.")
-    parser.add_argument(
-        '--clang_plugin_name', default=None,
-        help="Name of the used clang plugin.")
-    parser.add_argument(
-        '--clang_plugin_path', default=None,
-        help="Path to the used clang plugin.")
     args = parser.parse_args()
 
     # CodeChecker log outputs 'compile_cmd.json' by default.
@@ -129,8 +123,6 @@ if __name__ == '__main__':
                 prepare_analyzer_cmd.PathOptions(
                     args.sources_root,
                     args.clang,
-                    args.clang_plugin_name,
-                    args.clang_plugin_path,
                     "./report_debug/ctu-dir/" + target)))
 
     print(

--- a/scripts/debug_tools/prepare_analyzer_cmd.py
+++ b/scripts/debug_tools/prepare_analyzer_cmd.py
@@ -42,14 +42,6 @@ class AnalyzerCommandPathModifier:
                         self.opts.ctu_dir.rstrip(os.path.sep))),
                 os.path.basename(path))
 
-        if self.opts.clang_plugin_name is not None and\
-                re.search(self.opts.clang_plugin_name, path):
-            if self.opts.clang_plugin_path is None:
-                print("clang_plugin_name is in a path, "
-                      "but clang_plugin_path is not given in the options")
-                sys.exit(-1)
-            return self.opts.clang_plugin_path
-
         if re.search('ctu-dir', path):
             if self.opts.ctu_dir is None:
                 print('ctu-dir is in a path, but not in the options!')
@@ -68,13 +60,9 @@ class PathOptions:
             self,
             sources_root,
             clang,
-            clang_plugin_name,
-            clang_plugin_path,
             ctu_dir):
         self.sources_root = sources_root
         self.clang = clang
-        self.clang_plugin_name = clang_plugin_name
-        self.clang_plugin_path = clang_plugin_path
         self.ctu_dir = ctu_dir
 
 
@@ -125,12 +113,6 @@ if __name__ == '__main__':
         '--clang',
         required=True,
         help="Path to the clang binary.")
-    parser.add_argument(
-        '--clang_plugin_name', default=None,
-        help="Name of the used clang plugin.")
-    parser.add_argument(
-        '--clang_plugin_path', default=None,
-        help="Path to the used clang plugin.")
     args = parser.parse_args()
 
     prepared_command = prepare(
@@ -138,8 +120,6 @@ if __name__ == '__main__':
             PathOptions(
                 args.sources_root,
                 args.clang,
-                args.clang_plugin_name,
-                args.clang_plugin_path,
                 args.ctu_dir))
 
     with open(args.output, mode="w", encoding="utf-8", errors="ignore") as f:


### PR DESCRIPTION
Shipping plugins as external dynamic libraries for Clang Static Analyzer is generally frowned upon, and not supported. This patch removes the existing support for using external ClangSA analyzer plugins.