### PR TITLE
[cfg] Add a config file to change review statuses

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -722,7 +722,8 @@ def skip_cpp(compile_actions, skip_handlers):
 
 
 def start_workers(actions_map, actions, analyzer_config_map,
-                  jobs, output_path, skip_handlers, rs_handler, metadata_tool,
+                  jobs, output_path, skip_handlers,
+                  rs_handler: ReviewStatusHandler, metadata_tool,
                   quiet_analyze, capture_analysis_output, generate_reproducer,
                   timeout, ctu_reanalyze_on_failure, statistics_data, manager,
                   compile_cmd_count):

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -129,7 +129,7 @@ def __has_enabled_checker(ch: AnalyzerConfigHandler):
                for _, (state, _) in ch.checks().items())
 
 
-def perform_analysis(args, skip_handlers, actions, metadata_tool,
+def perform_analysis(args, skip_handlers, rs_handler, actions, metadata_tool,
                      compile_cmd_count):
     """
     Perform static analysis via the given (or if not, all) analyzers,
@@ -313,6 +313,7 @@ def perform_analysis(args, skip_handlers, actions, metadata_tool,
                                        config_map, args.jobs,
                                        args.output_path,
                                        skip_handlers,
+                                       rs_handler,
                                        metadata_tool,
                                        'quiet' in args,
                                        'capture_analysis_output' in args,

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -20,6 +20,7 @@ import time
 from multiprocess.managers import SyncManager
 
 from codechecker_common.logger import get_logger
+from codechecker_common.review_status_handler import ReviewStatusHandler
 
 from . import analyzer_context, analysis_manager, pre_analysis_manager, \
     checkers
@@ -129,8 +130,8 @@ def __has_enabled_checker(ch: AnalyzerConfigHandler):
                for _, (state, _) in ch.checks().items())
 
 
-def perform_analysis(args, skip_handlers, rs_handler, actions, metadata_tool,
-                     compile_cmd_count):
+def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
+                     actions, metadata_tool, compile_cmd_count):
     """
     Perform static analysis via the given (or if not, all) analyzers,
     in the given analysis context for the supplied build actions.

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/result_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/result_handler.py
@@ -18,6 +18,7 @@ from codechecker_report_converter.report import report_file
 from codechecker_report_converter.report.hash import get_report_hash, HashType
 from codechecker_common.logger import get_logger
 from codechecker_common.skiplist_handler import SkipListHandlers
+from codechecker_common.review_status_handler import ReviewStatusHandler
 
 from ..result_handler_base import ResultHandler
 
@@ -34,7 +35,11 @@ class ClangSAResultHandler(ResultHandler):
 
         super(ClangSAResultHandler, self).__init__(*args, **kwargs)
 
-    def postprocess_result(self, skip_handlers: Optional[SkipListHandlers]):
+    def postprocess_result(
+        self,
+        skip_handlers: Optional[SkipListHandlers],
+        rs_handler: Optional[ReviewStatusHandler]
+    ):
         """
         Generate analyzer result output file which can be parsed and stored
         into the database.
@@ -54,6 +59,10 @@ class ClangSAResultHandler(ResultHandler):
             if hash_type is not None:
                 for report in reports:
                     report.report_hash = get_report_hash(report, hash_type)
+
+            if rs_handler:
+                reports = [r for r in reports
+                           if not rs_handler.should_ignore(r)]
 
             report_file.create(
                 self.analyzer_result_file, reports, self.checker_labels,

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/result_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/result_handler.py
@@ -20,6 +20,7 @@ from codechecker_report_converter.report.hash import get_report_hash, HashType
 
 from codechecker_common.logger import get_logger
 from codechecker_common.skiplist_handler import SkipListHandlers
+from codechecker_common.review_status_handler import ReviewStatusHandler
 
 from ..result_handler_base import ResultHandler
 
@@ -36,7 +37,11 @@ class ClangTidyResultHandler(ResultHandler):
 
         super(ClangTidyResultHandler, self).__init__(*args, **kwargs)
 
-    def postprocess_result(self, skip_handlers: Optional[SkipListHandlers]):
+    def postprocess_result(
+        self,
+        skip_handlers: Optional[SkipListHandlers],
+        rs_handler: Optional[ReviewStatusHandler]
+    ):
         """
         Generate analyzer result output file which can be parsed and stored
         into the database.
@@ -61,6 +66,9 @@ class ClangTidyResultHandler(ResultHandler):
 
         for report in reports:
             report.report_hash = get_report_hash(report, hash_type)
+
+        if rs_handler:
+            reports = [r for r in reports if not rs_handler.should_ignore(r)]
 
         report_file.create(
             self.analyzer_result_file, reports, self.checker_labels,

--- a/analyzer/codechecker_analyzer/analyzers/gcc/result_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/result_handler.py
@@ -21,6 +21,7 @@ from codechecker_report_converter.report.hash import get_report_hash, HashType
 
 from codechecker_common.logger import get_logger
 from codechecker_common.skiplist_handler import SkipListHandlers
+from codechecker_common.review_status_handler import ReviewStatusHandler
 
 from ..result_handler_base import ResultHandler
 
@@ -53,7 +54,11 @@ class GccResultHandler(ResultHandler):
 
         super(GccResultHandler, self).__init__(*args, **kwargs)
 
-    def postprocess_result(self, skip_handlers: Optional[SkipListHandlers]):
+    def postprocess_result(
+        self,
+        skip_handlers: Optional[SkipListHandlers],
+        rs_handler: Optional[ReviewStatusHandler]
+    ):
         """
         Generate analyzer result output file which can be parsed and stored
         into the database.
@@ -106,6 +111,9 @@ class GccResultHandler(ResultHandler):
 
         for report in reports:
             report.report_hash = get_report_hash(report, hash_type)
+
+        if rs_handler:
+            reports = [r for r in reports if not rs_handler.should_ignore(r)]
 
         report_file.create(
             self.analyzer_result_file, reports, self.checker_labels,

--- a/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/result_handler_base.py
@@ -19,6 +19,7 @@ from typing import Optional
 from codechecker_analyzer import analyzer_context
 from codechecker_common.logger import get_logger
 from codechecker_common.skiplist_handler import SkipListHandlers
+from codechecker_common.review_status_handler import ReviewStatusHandler
 
 
 LOG = get_logger('analyzer')
@@ -181,7 +182,13 @@ class ResultHandler(metaclass=ABCMeta):
                 # There might be no result file if analysis failed.
                 LOG.debug(oserr)
 
-    def postprocess_result(self, skip_handlers: Optional[SkipListHandlers]):
+    # TODO: If the parameters are not optional then we can get rid of some
+    #   extra checks.
+    def postprocess_result(
+        self,
+        skip_handlers: Optional[SkipListHandlers],
+        rs_handler: Optional[ReviewStatusHandler]
+    ):
         """
         Postprocess result if needed.
         Should be called after the analyses finished.

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -985,8 +985,13 @@ def main(args):
     # Process the skip list if present.
     skip_handlers = __get_skip_handlers(args, compile_commands)
     rs_handler = review_status_handler.ReviewStatusHandler(args.output_path)
-    if 'review_status_config' in args:
-        rs_handler.set_review_status_config(args.review_status_config)
+
+    try:
+        if 'review_status_config' in args:
+            rs_handler.set_review_status_config(args.review_status_config)
+    except ValueError as ex:
+        LOG.error(ex)
+        sys.exit(1)
 
     ctu_or_stats_enabled = False
     # Skip list is applied only in pre-analysis

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -30,7 +30,7 @@ from codechecker_analyzer.arg import \
     analyzer_config, checker_config
 from codechecker_analyzer.buildlog import log_parser
 
-from codechecker_common import arg, logger, cmd_config
+from codechecker_common import arg, logger, cmd_config, review_status_handler
 from codechecker_common.skiplist_handler import SkipListHandler, \
     SkipListHandlers
 from codechecker_common.util import load_json
@@ -877,7 +877,7 @@ def __update_review_status_config(args):
     if 'review_status_config' in args:
         LOG.debug("Copying review status config file %s to %s",
                   args.review_status_config, rs_config_to_send)
-        shutil.copyfile(args.review_status_config, rs_config_to_send)
+        os.symlink(args.review_status_config, rs_config_to_send)
 
 
 def __cleanup_metadata(metadata_prev, metadata):
@@ -984,6 +984,9 @@ def main(args):
 
     # Process the skip list if present.
     skip_handlers = __get_skip_handlers(args, compile_commands)
+    rs_handler = review_status_handler.ReviewStatusHandler(args.output_path)
+    if 'review_status_config' in args:
+        rs_handler.set_review_status_config(args.review_status_config)
 
     ctu_or_stats_enabled = False
     # Skip list is applied only in pre-analysis
@@ -1121,8 +1124,8 @@ def main(args):
     LOG.debug_analyzer("Compile commands forwarded for analysis: %d",
                        compile_cmd_count.analyze)
 
-    analyzer.perform_analysis(args, skip_handlers, actions, metadata_tool,
-                              compile_cmd_count)
+    analyzer.perform_analysis(args, skip_handlers, rs_handler, actions,
+                              metadata_tool, compile_cmd_count)
 
     __update_skip_file(args)
     __update_review_status_config(args)

--- a/analyzer/codechecker_analyzer/cmd/parse.py
+++ b/analyzer/codechecker_analyzer/cmd/parse.py
@@ -395,7 +395,7 @@ def main(args):
 
     for dir_path, file_paths in report_file.analyzer_result_files(args.input):
         review_status_cfg = os.path.join(dir_path, 'review_status.yaml')
-        if os.path.isfile(review_status_cfg):
+        if os.path.lexists(review_status_cfg):
             try:
                 review_status_handler.set_review_status_config(
                     review_status_cfg)

--- a/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/Makefile
@@ -12,6 +12,8 @@ nofail:
 	$(CXX) -w nofail.cpp -o /dev/null
 simple1:
 	$(CXX) -w simple1.cpp -o /dev/null
+dir_simple1:
+	$(CXX) -w test_dir/simple1.cpp -o /dev/null
 simple2:
 	$(CXX) -w simple2.cpp -o /dev/null
 tidy_check:

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1.yaml
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1.yaml
@@ -1,0 +1,7 @@
+$version: 1
+rules:
+  - filters:
+      checker_name: core.DivideZero
+    actions:
+      review_status: false_positive
+      reason: Division by zero in test files is automatically intentional.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1_glob.yaml
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1_glob.yaml
@@ -1,0 +1,7 @@
+$version: 1
+rules:
+  - filters:
+      filepath: "*/test_dir/*"
+    actions:
+      review_status: false_positive
+      reason: Division by zero in test files is automatically intentional.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1_hash.yaml
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status1_hash.yaml
@@ -1,0 +1,7 @@
+$version: 1
+rules:
+  - filters:
+      report_hash: 8459557f082fb0cc2d6150da71a7bcd3
+    actions:
+      review_status: false_positive
+      reason: Division by zero in test files is automatically intentional.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file.output
@@ -1,0 +1,69 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make simple1" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --review-status-config simple1_review_status1.yaml
+
+# The review status config file should've set the report to false_positive.
+# We expect to see the first parse to return with 'no defects', and the second
+# with one defect.
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=unreviewed
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=false_positive
+--------------------------------------------------------------------------------
+[] - Starting build...
+[] - Using CodeChecker ld-logger.
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+Found no defects in simple1.cpp
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 0
+---------------------------------------------
+----=================----
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero] [False positive]
+  return 2015 / x;
+              ^
+
+Found 1 defect(s) in simple1.cpp
+
+
+----==== Severity Statistics ====----
+----------------------------
+Severity | Number of reports
+----------------------------
+HIGH     |                 1
+----------------------------
+----=================----
+
+----==== Checker Statistics ====----
+----------------------------------------------
+Checker name    | Severity | Number of reports
+----------------------------------------------
+core.DivideZero | HIGH     |                 1
+----------------------------------------------
+----=================----
+
+----==== File Statistics ====----
+-------------------------------
+File name   | Number of reports
+-------------------------------
+simple1.cpp |                 1
+-------------------------------
+----=================----
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 1
+---------------------------------------------
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file_glob.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file_glob.output
@@ -1,0 +1,69 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make dir_simple1" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --review-status-config simple1_review_status1_glob.yaml
+
+# The review status config file should've set the report to false_positive.
+# We expect to see the first parse to return with 'no defects', and the second
+# with one defect.
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=unreviewed
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=false_positive
+--------------------------------------------------------------------------------
+[] - Starting build...
+[] - Using CodeChecker ld-logger.
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+Found no defects in simple1.cpp
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 0
+---------------------------------------------
+----=================----
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero] [False positive]
+  return 2015 / x;
+              ^
+
+Found 1 defect(s) in simple1.cpp
+
+
+----==== Severity Statistics ====----
+----------------------------
+Severity | Number of reports
+----------------------------
+HIGH     |                 1
+----------------------------
+----=================----
+
+----==== Checker Statistics ====----
+----------------------------------------------
+Checker name    | Severity | Number of reports
+----------------------------------------------
+core.DivideZero | HIGH     |                 1
+----------------------------------------------
+----=================----
+
+----==== File Statistics ====----
+-------------------------------
+File name   | Number of reports
+-------------------------------
+simple1.cpp |                 1
+-------------------------------
+----=================----
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 1
+---------------------------------------------
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file_hash.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple1_review_status_file_hash.output
@@ -1,0 +1,69 @@
+NORMAL#CodeChecker log --output $LOGFILE$ --build "make simple1" --quiet
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clangsa --review-status-config simple1_review_status1_hash.yaml
+
+# The review status config file should've set the report to false_positive.
+# We expect to see the first parse to return with 'no defects', and the second
+# with one defect.
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=unreviewed
+NORMAL#CodeChecker parse $OUTPUT$ --review-status=false_positive
+--------------------------------------------------------------------------------
+[] - Starting build...
+[] - Using CodeChecker ld-logger.
+[] - Build finished successfully.
+[] - Starting static analysis ...
+[] - [1/1] clangsa analyzed simple1.cpp successfully.
+[] - ----==== Summary ====----
+[] - Successfully analyzed
+[] -   clangsa: 1
+[] - Total analyzed compilation commands: 1
+[] - ----=================----
+[] - Analysis finished.
+[] - To view results in the terminal use the "CodeChecker parse" command.
+[] - To store results use the "CodeChecker store" command.
+[] - See --help and the user guide for further options about parsing and storing the reports.
+[] - ----=================----
+Found no defects in simple1.cpp
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 0
+---------------------------------------------
+----=================----
+[HIGH] simple1.cpp:18:15: Division by zero [core.DivideZero] [False positive]
+  return 2015 / x;
+              ^
+
+Found 1 defect(s) in simple1.cpp
+
+
+----==== Severity Statistics ====----
+----------------------------
+Severity | Number of reports
+----------------------------
+HIGH     |                 1
+----------------------------
+----=================----
+
+----==== Checker Statistics ====----
+----------------------------------------------
+Checker name    | Severity | Number of reports
+----------------------------------------------
+core.DivideZero | HIGH     |                 1
+----------------------------------------------
+----=================----
+
+----==== File Statistics ====----
+-------------------------------
+File name   | Number of reports
+-------------------------------
+simple1.cpp |                 1
+-------------------------------
+----=================----
+
+----======== Summary ========----
+---------------------------------------------
+Number of processed analyzer result files | 1
+Number of analyzer reports                | 1
+---------------------------------------------
+----=================----

--- a/analyzer/tests/functional/analyze_and_parse/test_files/test_dir/simple1.cpp
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/test_dir/simple1.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+
+int foo(int y) {
+  if (y <= 0) {
+    return 0;
+  }
+
+  return 42;
+}
+
+int main() {
+  int x, y;
+
+  std::cin >> y;
+
+  x = foo(y);
+
+  return 2015 / x;
+}

--- a/analyzer/tests/unit/review_status_config.py
+++ b/analyzer/tests/unit/review_status_config.py
@@ -1,0 +1,273 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""TODO"""
+
+
+import os
+import unittest
+
+from codechecker_common.review_status_handler import ReviewStatusHandler
+from libtest import env
+
+
+class ReviewStatusHandlerTest(unittest.TestCase):
+    """
+    Test the build command escaping and execution.
+    """
+
+    @classmethod
+    def setup_class(self):
+        global TEST_WORKSPACE
+        TEST_WORKSPACE = env.get_workspace('review_status_config')
+
+        os.environ['TEST_WORKSPACE'] = TEST_WORKSPACE
+        self._test_workspace = os.environ['TEST_WORKSPACE']
+
+    @classmethod
+    def teardown_class(self):
+        pass
+
+    def setup_method(self, method):
+        self.rshandler = ReviewStatusHandler(None)
+        pass
+
+    def teardown_method(self, method):
+        pass
+
+    def __put_in_review_status_cfg_file(self, file_contents: str) -> str:
+        rs_cfg = os.path.join(self._test_workspace, "review_status.yaml")
+        with open(rs_cfg, "w") as f:
+            f.write(file_contents)
+
+        return rs_cfg
+
+    def test_empty_file(self):
+        cfg = ""
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "$version"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_version(self):
+        cfg = """
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "$version"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_empty_action_list(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "TODO"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_empty_filter_list(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "TODO"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_empty_filter_and_action_list(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+    actions:
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "TODO"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_empty_rules_list(self):
+        cfg = """
+$version: 1
+rules:
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "'rules'"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_correct(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_invalid_review_status(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+      review_status: oopsie
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError,
+                                    "Invalid review status field: "):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_invalid_action(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+        bake: cake
+        reason: Birthday
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError,
+                                    "'bake' is not allowed"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_review_status(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+        reason: Birthday
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError,
+                                    "review_status' .* required"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_invalid_filter(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      favourite_color: green
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError,
+                                    "'favourite_color' is not allowed"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_actions(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "'filters' and 'actions'"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_filters(self):
+        cfg = """
+$version: 1
+rules:
+  - actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "'filters' and 'actions'"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_reason(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+      review_status: intentional
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "TODO"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_rules(self):
+        cfg = """
+$version: 1
+  - filters:
+      checker_name: core.NullDereference
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "Invalid YAML"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_no_rules2(self):
+        cfg = """
+$version: 1
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "'rules'"):
+            self.rshandler.set_review_status_config(rscfg_file)
+
+    def test_multiple_checker_keys(self):
+        cfg = """
+$version: 1
+rules:
+  - filters:
+      checker_name: core.NullDereference
+      checker_name: core.DivByZero
+    actions:
+      review_status: intentional
+      review_status: suppress
+      reason: Division by zero in test files is automatically intentional.
+        """
+
+        rscfg_file = self.__put_in_review_status_cfg_file(cfg)
+        with self.assertRaisesRegex(ValueError, "TODO"):
+            self.rshandler.set_review_status_config(rscfg_file)

--- a/codechecker_common/review_status_handler.py
+++ b/codechecker_common/review_status_handler.py
@@ -146,10 +146,15 @@ class ReviewStatusHandler:
         raises ValueError with the description of the error if the format is
         invalid.
         """
-        if not isinstance(self.__data, dict) or '$version' not in self.__data:
+        if not isinstance(self.__data, dict):
             raise ValueError(
-                f"{self.__review_status_yaml} should be a dictionary with "
-                "the key '$version'.")
+                f"{self.__review_status_yaml} should represent a dictionary.")
+
+        if '$version' not in self.__data:
+            raise ValueError(
+                f"{self.__review_status_yaml} must contain the key "
+                f"'$version'. Hint: Currently the latest version of this "
+                f"is 1. Consider adding '$version: 1' to the top of the file.")
 
         if not isinstance(self.__data['$version'], int):
             raise ValueError(

--- a/codechecker_common/review_status_handler.py
+++ b/codechecker_common/review_status_handler.py
@@ -49,10 +49,11 @@ class ReviewStatusHandler:
         'checker_name',
         'report_hash']
 
+    # TODO: Read the commit message where THIS current line was committed!
+    # That will tell you why "ignore" option is not found in this list.
     ALLOWED_ACTIONS = [
         'review_status',
-        'reason',
-        'ignore']
+        'reason']
 
     def __init__(self, source_root=''):
         """
@@ -121,7 +122,7 @@ class ReviewStatusHandler:
                     'ignore' not in rule['actions']:
                 raise ValueError(
                     f"Format error in {self.__review_status_yaml}. "
-                    f"'review_status' or 'ignore' is required in:\n"
+                    f"'review_status' is required in:\n"
                     f"{yaml.dump(rule)}.")
 
             if 'review_status' in rule['actions']:

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -2610,38 +2610,64 @@ Review status can be configured by a config file in YAML format. This config
 file has to represent a list of review status settings:
 
 ```yaml
-- filepath_filter: /path/to/project/test/*
-  checker_filter: core.DivideZero
-  message: Division by zero in test files is automatically intentional.
-  review_status: intentional
-- filepath_filter: /path/to/project/important/module/*
-  message: All reports in this module should be investigated.
-  review_status: confirmed
-- filepath_filter: "*/project/test/*"
-  message: If a filter starts with asterix, then it should be quoted due to YAML format.
-  review_status: suppress
-- report_hash_filter: b85851b34789e35c6acfa1a4aaf65382
-  message: This report is false positive.
-  review_status: false_positive
+$version: 1
+rules:
+  - filters:
+      filepath: /path/to/project/test/*
+      checker_name: core.DivideZero
+    actions:
+      review_status: intentional
+      reason: Division by zero in test files is automatically intentional.
+
+  - filters:
+      filepath: /path/to/project/important/module/*
+    actions:
+      review_status: confirmed
+      reason: All reports in this module should be investigated.
+
+  - filters:
+      filepath: "*/project/test/*"
+    actions:
+      review_status: suppress
+      reason: If a filter starts with asterix, then it should be quoted due to YAML format.
+
+  - filters:
+      report_hash: b85851b34789e35c6acfa1a4aaf65382
+    actions:
+      review_status: false_positive
+      reason: This report is false positive.
+
+  - filters:
+      filepath: /path/to/3pp/lib/*
+    actions:
+      ignore: true
+      reason: The reports of this lib are ignored completely.
 ```
 
-The fields of a review status settings are:
+The review settings rules have two componetes: `filters` and `actions`. A rule
+is applied for every report that match the filter fields. The following filter
+options are available:
 
-- `filepath_filter` (optional): A glob to a path where the given review status
-  is applied. A [https://docs.python.org/3/library/glob.html](glob) is a path
-  that may contain shell-style wildcards: `*` substitutes zero or more
-  characters, `?` substitutes exactly one character. This filter option is
-  applied on the full path of a source file, even if `--trim-path-prefix` flag
-  is used later.
-- `checker_filter` (optional): Set the review status for only these checkers'
+- `filepath` (optional): A glob to a path where the given review status is
+  applied. A [https://docs.python.org/3/library/glob.html](glob) is a path that
+  may contain shell-style wildcards: `*` substitutes zero or more characters,
+  `?` substitutes exactly one character. This filter option is applied on the
+  full path of a source file, even if `--trim-path-prefix` flag is used later.
+- `checker_name` (optional): Set the review status for only these checkers'
   reports.
-- `report_hash_filter` (optional): Set the review status for only the checkers
-  having this report hash. A prefix match is applied on report hashes, so it is
-  enough to provide the beginning of a hash. Make sure to use a quite long
-  prefix so it covers one specific report.
-- `message` (optional): A comment message that describes the reason of the
-  setting.
-- `review_status`: The review status to set.
+- `report_hash` (optional): Set the review status for only the reports having
+  this report hash. A prefix match is applied on report hashes, so it is enough
+  to provide the beginning of a hash. Make sure to use a quite long prefix so
+  it covers one specific report.
 
-If none of the `_filter` options is provided, then that setting is not applied
-on any report.
+The following actions are available:
+
+- `review_status`: The review status to set.
+- `ignore`: If set to `true` then the report is completely ignored. Such a
+  report is not even dumped to the .plist files, thus it's completely invisible
+  for other CodeChecker commands like "parse", "diff", "store", etc.
+- `reason` (optional): A comment message that describes the reason of the
+  setting.
+
+The `review_status` and `ignore` are mutually exclusive. If none of the filter
+options is provided, then that setting is not applied on any report.

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -2636,12 +2636,6 @@ rules:
     actions:
       review_status: false_positive
       reason: This report is false positive.
-
-  - filters:
-      filepath: /path/to/3pp/lib/*
-    actions:
-      ignore: true
-      reason: The reports of this lib are ignored completely.
 ```
 
 The review settings rules have two componetes: `filters` and `actions`. A rule
@@ -2663,11 +2657,8 @@ options are available:
 The following actions are available:
 
 - `review_status`: The review status to set.
-- `ignore`: If set to `true` then the report is completely ignored. Such a
-  report is not even dumped to the .plist files, thus it's completely invisible
-  for other CodeChecker commands like "parse", "diff", "store", etc.
 - `reason` (optional): A comment message that describes the reason of the
   setting.
 
-The `review_status` and `ignore` are mutually exclusive. If none of the filter
-options is provided, then that setting is not applied on any report.
+If none of the filter options is provided, then that setting is not applied on
+any report.


### PR DESCRIPTION
 [feat] Ignore reports in post-processing

Reports can be ignored on filepath or checker name basis. This means
that these reports will not only be considered as "closed" but totally
ignored from the .plist files. These reports are thus invisible for all
other CodeChecker commands like "diff", "parse", "store", etc.

 [feat] Change review status config YAML format

The format of the review status config is changed. A version number is
also included to identify the format in case further modifications are
needed in the future.