### PR TITLE
Removing some noisy checkers from the default profile

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -5296,7 +5296,6 @@
     ],
     "cppcoreguidelines-special-member-functions": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/special-member-functions.html",
-      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:LOW"
@@ -5375,7 +5374,6 @@
     ],
     "google-global-names-in-headers": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html",
-      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:STYLE"
@@ -6001,7 +5999,6 @@
     ],
     "misc-use-anonymous-namespace": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html",
-      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:LOW"


### PR DESCRIPTION
- cppcoreguidelines-special-member-functions Many findings on legacy C++ code bases for missing move constructors
- misc-use-anonymous-namespace : this is a style checker to use anonymous namespace instead of global scope. Switched off from the default profile this checker is very noisy on projects not following this convention.
- google-global-names-in-headers: google specific styleguide for not polluting the global namespace. Switched off from the default profile this checker is very noisy on projects not following this convention.