### PR TITLE
[fix] Fixing OFF and UNAVAILABLE detectionStatus in the report sidebar

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
@@ -163,6 +163,8 @@ export default {
 
             const status = !(
               isResolved ||
+              report.detectionStatus === DetectionStatus.OFF ||
+              report.detectionStatus === DetectionStatus.UNAVAILABLE ||
               report.reviewData.status === ReviewStatus.FALSE_POSITIVE ||
               report.reviewData.status === ReviewStatus.INTENTIONAL
             ) ? this.items.find(item => item.isOutstanding)
@@ -231,6 +233,8 @@ export default {
 
       const status = !(
         isResolved ||
+        this.report.detectionStatus === DetectionStatus.OFF ||
+        this.report.detectionStatus === DetectionStatus.UNAVAILABLE ||
         this.report.reviewData.status === ReviewStatus.FALSE_POSITIVE ||
         this.report.reviewData.status === ReviewStatus.INTENTIONAL
       ) ? this.items.find(item => item.isOutstanding)

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
@@ -59,8 +59,9 @@
 
   <v-icon
     v-else-if="item.isOutstanding"
-    title="Outstanding reports (review status is unreviewed or confirmed 
-    and detection status is not resolved)"
+    title="Outstanding reports, that are potential bugs
+(review status is unreviewed or confirmed and
+detection status is new, unresolved or reopened)"
     color="primary"
   >
     mdi-folder-lock-open
@@ -68,8 +69,9 @@
 
   <v-icon
     v-else-if="!item.isOutstanding"
-    title="Closed reports (review status is false positive or intentional 
-    or detection status is resolved)"
+    title="Closed reports, that are fixed bugs, suppressed reports
+(false positive, intentional) or whose detection status is resolved,
+off or unavailable."
     color="primary"
   >
     mdi-folder-lock


### PR DESCRIPTION
It is a bug fix to locate correctly both OFF and UNAVAILABLE reports in the sidebar. These kind of reports are not outstanding, so they should be classified as closed.