### PR TITLE
Fix debug logging in store

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -918,7 +918,7 @@ class MassStoreRun:
                     fixed_at = run_history_time
 
             self.__check_report_count()
-            report_id = self.__add_report(
+            self.__add_report(
                 session, run_id, report, file_path_to_id,
                 review_status, detection_status, detected_at,
                 run_history_time, analysis_info, analyzer_name, fixed_at)
@@ -927,7 +927,8 @@ class MassStoreRun:
                 review_status.status
             self.__already_added_report_hashes.add(report_path_hash)
 
-            LOG.debug("Storing report done. ID=%d", report_id)
+            LOG.debug(f"Storing report done. bug_hash:{report.report_hash}, " +
+                      f"source_file:{report_file_path}")
 
         return True
 


### PR DESCRIPTION
The id was a primary key, that was only assigned after the flush was done. The format string being used was not a flexible one, it was changed to the newer kind of format string, and the printed debug message was changed to a more meaningful one, stating the report hash, and the source file path.