### PR TITLE
Fix typo 'vesion' in sarif conversion template

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
@@ -314,7 +314,7 @@ class Parser(BaseParser):
             results.append(self._create_result(report))
 
         return {
-            "vesion": "2.1.0",
+            "version": "2.1.0",
             "$schema": "https://raw.githubusercontent.com/oasis-tcs/"
                        "sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
             "runs": [{


### PR DESCRIPTION
The Sarif schema has a 'version' field but the template is mis-typed as 'vesion'. Adding the missing 'r' allows the code to be read as Sarif data (e.g. by the VSCode Sarif viewer plugin.