### PR TITLE
[analyzer] Ignore `-fno-tree-dominator-opts`

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -102,6 +102,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-toplevel-reorder',
     '-fno-unit-at-a-time',
     '-fno-var-tracking-assignments',
+    '-fno-tree-dominator-opts',
     '-fobjc-link-runtime',
     '-fpartial-inlining',
     '-fpeephole2',


### PR DESCRIPTION
The `-fno-tree-dominator-opts` GCC option is not recognized by clang.