### PR TITLE
[report-converter][fix] Don't crash when we can't find the checker name for ubsan

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/parser.py
@@ -188,6 +188,7 @@ class Parser(SANParser):
         stack_traces, events, line = self.parse_stack_trace(it, line)
 
         message = match.group('message').strip()
+        checker_name = None
         for check, patterns in self.checks.items():
             if any(pattern.search(message) for pattern in patterns):
                 checker_name = f"{self.checker_name}.{check}"

--- a/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
+++ b/tools/report-converter/tests/unit/analyzers/test_ubsan_parser.py
@@ -90,6 +90,16 @@ class UBSANPListConverterTestCase(unittest.TestCase):
         self.__check_analyzer_result('ubsan1.out', 'ubsan1.cpp_ubsan.plist',
                                      ['files/ubsan1.cpp'], 'ubsan1.plist')
 
+    def test_ubsan1_nonmatching_msg(self):
+        """
+        Test for the test_ubsan1_nonmatching_msg.plist file, where the reported
+        error message doesn't match any of the checkers we recognize.
+        """
+        self.maxDiff = None
+        self.__check_analyzer_result(
+            'ubsan1_nonmatching_msg.out', 'ubsan1.cpp_ubsan.plist',
+            ['files/ubsan1.cpp'], 'ubsan1_nonmatching_msg.plist')
+
     def test_ubsan2(self):
         """ Test for the ubsan2.plist file. """
         self.__check_analyzer_result('ubsan2.out', 'ubsan2.cpp_ubsan.plist',

--- a/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1_nonmatching_msg.out
+++ b/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1_nonmatching_msg.out
@@ -1,0 +1,1 @@
+files/ubsan1.cpp:4:5: runtime error: This is not an actual error message, just tests whether we crash on a msg we don't associate with a checker.

--- a/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1_nonmatching_msg.plist
+++ b/tools/report-converter/tests/unit/analyzers/ubsan_output_test_files/ubsan1_nonmatching_msg.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>diagnostics</key>
+	<array>
+		<dict>
+			<key>category</key>
+			<string>unknown</string>
+			<key>check_name</key>
+			<string>UndefinedBehaviorSanitizer</string>
+			<key>description</key>
+			<string>This is not an actual error message, just tests whether we crash on a msg we don't associate with a checker.</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>253cc81796d3eccc4c6fa0c4ade5bb53</string>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>5</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>4</integer>
+			</dict>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>5</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>4</integer>
+					</dict>
+					<key>message</key>
+					<string>This is not an actual error message, just tests whether we crash on a msg we don't associate with a checker.</string>
+				</dict>
+			</array>
+			<key>type</key>
+			<string>ubsan</string>
+		</dict>
+	</array>
+	<key>files</key>
+	<array>
+		<string>files/ubsan1.cpp</string>
+	</array>
+	<key>metadata</key>
+	<dict>
+		<key>analyzer</key>
+		<dict>
+			<key>name</key>
+			<string>ubsan</string>
+		</dict>
+		<key>generated_by</key>
+		<dict>
+			<key>name</key>
+			<string>report-converter</string>
+			<key>version</key>
+			<string>x.y.z</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
We forgot to inizialize `checker_name` to its default value, which lead to a read-before-assignment crash.