### PR TITLE
[fix] Cppcheck premium version check

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -64,7 +64,7 @@ def parse_version(cppcheck_output):
     """
     Parse cppcheck version output and return the version number.
     """
-    version_re = re.compile(r'^Cppcheck (?P<version>[\d\.]+)')
+    version_re = re.compile(r'^Cppcheck(.*?)(?P<version>[\d\.]+)')
     match = version_re.match(cppcheck_output)
     if match:
         return match.group('version')

--- a/analyzer/tests/unit/test_cppcheck_version_parsing.py
+++ b/analyzer/tests/unit/test_cppcheck_version_parsing.py
@@ -1,0 +1,25 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+""" Test Cppcheck version parsing. """
+
+
+import unittest
+
+from codechecker_analyzer.analyzers.cppcheck.analyzer import parse_version
+
+
+class CppcheckVersionTest(unittest.TestCase):
+    """
+    Test the parsing of various possible version strings, which cppcheck
+    binaries can produce.
+    """
+
+    def test_cppcheck_version(self):
+        self.assertEqual(parse_version('Cppcheck 1.2.3'), '1.2.3')
+        self.assertEqual(parse_version('Cppcheck Premium 1.2.3'), '1.2.3')


### PR DESCRIPTION
Cppcheck Premium version dumps the version number in the following format:

Cppcheck Premium 1.2.3

CodeChecker couldn't handle the "Premium" word in the middle.

Fixes #4133