### PR TITLE
Fix Broken Links In Documentation

### DIFF
--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -643,7 +643,7 @@ Runs the given build command and records the executed compilation steps. These
 steps are written to the output file in a JSON format. Available build logger
 tool that will be used is '...'. ld-logger can be fine-tuned with some
 environment variables. For details see the following documentation:
-https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/build-
+https://github.com/Ericsson/codechecker/tree/master/analyzer/tools/build-logger
 logger/README.md#usage
 
 optional arguments:

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1792,8 +1792,7 @@ export arguments:
                         Specify extra output format type.
                         'codeclimate' format can be used for Code Climate and
                         for GitLab integration. For more information see:
-                        https://github.com/codeclimate/platform/blob/master/sp
-                        ec/analyzers/SPEC.md#data-types
+                        https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
                         'baseline' output can be used to integrate CodeChecker
                         into your local workflow without using a CodeChecker
                         server. For more information see our usage guide.

--- a/tools/report-converter/tests/unit/parser/sarif/sarif_test_files/3-Beyond-basics/standard-taxonomy.sarif
+++ b/tools/report-converter/tests/unit/parser/sarif/sarif_test_files/3-Beyond-basics/standard-taxonomy.sarif
@@ -8,7 +8,7 @@
           "version": "3.2",
           "releaseDateUtc": "2019-01-03",
           "guid": "A9282C88-F1FE-4A01-8137-E8D2A037AB82",
-          "informationUri": "https://cwe.mitre.org/data/published/cwe_v3.2.pdf/",
+          "informationUri": "https://cwe.mitre.org/data/published/cwe_v3.2.pdf",
           "downloadUri": "https://cwe.mitre.org/data/xml/cwec_v3.2.xml.zip",
           "organization": "MITRE",
           "shortDescription": {

--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -2232,7 +2232,7 @@ analyzer:
                   </li>
                 </ul>
                 For more information
-                <a href="https://github.com/Ericsson/codechecker/blob/master/docs/user_guide.md#source-components">
+                <a href="https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#source-components-components">
                   see
                 </a>.
               </v-col>

--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -2343,7 +2343,7 @@ analyzer:
               </li>
             </ul>
             For more information
-            <a href="https://github.com/Ericsson/codechecker/blob/master/docs/authentication.md#personal-access-token">
+            <a href="https://github.com/Ericsson/codechecker/blob/master/docs/web/authentication.md#personal-access-token">
               see
             </a>.
           </new-feature-item>

--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -2315,7 +2315,7 @@ analyzer:
               </li>
             </ul>
             For more information
-            <a href="https://github.com/Ericsson/codechecker/blob/master/docs/user_guide.md#cmd">
+            <a href="https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#cmd">
               see
             </a>.
           </new-feature-item>


### PR DESCRIPTION
There are multiple broken links in the documentation of this project. Here is what I have fixed:

https://github.com/Ericsson/codechecker/blob/master/docs/user_guide.md#source-components --> https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#source-components-components

https://cwe.mitre.org/data/published/cwe_v3.2.pdf/ --> https://cwe.mitre.org/data/published/cwe_v3.2.pdf

https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/build- --> https://github.com/Ericsson/codechecker/tree/master/analyzer/tools/build-logger

https://github.com/Ericsson/codechecker/blob/master/docs/user_guide.md#cmd --> https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#cmd

https://github.com/Ericsson/codechecker/blob/master/docs/authentication.md#personal-access-token --> https://github.com/Ericsson/codechecker/blob/master/docs/web/authentication.md#personal-access-token

https://github.com/codeclimate/platform/blob/master/sp --> https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types

I found this links using a tool I created called [link-inspector](https://github.com/justindhillon/link-inspector) . If you find this PR useful, give the repo a ⭐

I have also applied to the [Software Developer Co-op (EIP) - Summer 2024](https://jobs.ericsson.com/careers?query=coop&pid=563121757429592&domain=ericsson.com&sort_by=relevance&utm_source=ericsson.com&utm_campaign=search_widget) position at your company. If you could put a word in for me, it would be greatly appreciated.