### PR TITLE
[fix] Eliminate unnecessary error logging

### DIFF
--- a/codechecker_common/review_status_handler.py
+++ b/codechecker_common/review_status_handler.py
@@ -330,9 +330,6 @@ class ReviewStatusHandler:
         if source_file_name in report.changed_files:
             return None
 
-        if not os.path.exists(source_file_name):
-            LOG.error(f"Source file '{source_file_name}' does not exist.")
-
         if os.path.isfile(source_file_name):
             src_comment_data = self.__parse_codechecker_review_comment(
                 source_file_name, report.line, report.checker_name)


### PR DESCRIPTION
During "CodeChecker store" the server checks the review status of reports. Review status may come from source code comments (e.g. // codechecker_suppress [core.DivideZero] This is false positive). The server needs to read the content of source files in order to find these comment sections. However, source code files are not uploaded to the server when both the following conditions hold:

1. They were uploaded earlier with the same content by a previous "CodeChecker store" action.
2. The client realizes that there is no source comment in the source file.

In these cases the server is emitting an error which tells that the source file was not uploaded. This error message is definitely not necessary, since there is no review status comment that could be read by the server or it had been read in a previous storage.

Since in practice there is a lot of such files, and the immense number of error logs results log files in gigabytes. This commit eliminates these error logs.