### PR TITLE
Adding OpenSSF Scorecard badge to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,10 @@
     <img src="https://readthedocs.org/projects/codechecker/badge/?version=latest"
          alt="Documentation Status">
   </a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/Ericsson/codechecker">
+    <img src="https://api.securityscorecards.dev/projects/github.com/Ericsson/codechecker/badge"
+         alt="OpenSSF Scorecard Score">
+  </a>
 </p>
 
 **CodeChecker** is a static analysis infrastructure built on the [LLVM/Clang


### PR DESCRIPTION
This adds the OpenSSF Scorecard badge to the README. We spent effort on adopting Scorecards best-practices, so we should be proudly showing this to the users of CodeChecker.