### PR TITLE
[feat] Display dynamic columns in static HTML 

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/output/html/html.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/html.py
@@ -74,6 +74,8 @@ class HTMLReport(TypedDict):
     notes: HTMLBugPathEvents
     reviewStatus: Optional[str]
     severity: Optional[str]
+    testcase: Optional[str]
+    timestamp: Optional[str]
 
 
 HTMLReports = List[HTMLReport]
@@ -251,7 +253,11 @@ class HtmlBuilder:
                 'notes': to_bug_path_events(report.notes),
                 'reviewStatus': report.review_status.formatted_status()
                 if report.review_status else '',
-                'severity': self.get_severity(report.checker_name)
+                'severity': self.get_severity(report.checker_name),
+                'testcase': report.annotations.get('testcase')
+                if report.annotations else None,
+                'timestamp': report.annotations.get('timestamp')
+                if report.annotations else None
             })
 
         return html_reports, files
@@ -312,7 +318,9 @@ class HtmlBuilder:
             'message': data['report']['message'],
             'review-status': data['report']['reviewStatus'],
             'severity': data['report']['severity'],
-            'bug-path-length': len(data['report']['events'])
+            'bug-path-length': len(data['report']['events']),
+            'testcase': data['report']['testcase'],
+            'timestamp': data['report']['timestamp']
         }, html_report_links)
 
         self._tag_contents['table_reports'] = json.dumps(list(table_reports))

--- a/tools/report-converter/codechecker_report_converter/report/output/html/static/index.html
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/static/index.html
@@ -40,6 +40,8 @@
           <th id="message">Message</th>
           <th id="bug-path-length">Bug path length</th>
           <th id="review-status">Review status</th>
+          <th id="testcase" class="dynamic">Testcase</th>
+          <th id="timestamp" class="dynamic">Timestamp</th>
         </tr>
       </thead>
       <tbody id="report-list">

--- a/tools/report-converter/codechecker_report_converter/report/output/html/static/js/buglist.js
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/static/js/buglist.js
@@ -16,7 +16,12 @@ var BugList = {
   },
 
   _cmp3 : function (a, b) {
-    return a < b ? -1 : a > b ? 1 : 0;
+    if (a === null)
+      return -1;
+    else if (b === null)
+      return 1;
+    else
+      return a < b ? -1 : a > b ? 1 : 0;
   },
 
   initTableSort : function () {
@@ -73,17 +78,24 @@ var BugList = {
     function compare(a, b) {
       var result;
 
-      if (columnId == 'file-path')
-        result = that._cmp3(
-          [a['file-path'], a['line']],
-          [b['file-path'], b['line']]);
+      switch (columnId)
+      {
+        case 'file-path':
+          result = that._cmp3(
+            [a['file-path'], a['line']],
+            [b['file-path'], b['line']]);
+          break;
 
-      if (columnId == 'severity')
-        result = that._cmp3(
-          severities.indexOf(a['severity']),
-          severities.indexOf(b['severity']));
+        case 'severity':
+          result = that._cmp3(
+            severities.indexOf(a['severity']),
+            severities.indexOf(b['severity']));
+          break;
 
-      result = that._cmp3(a[columnId], b[columnId]);
+        default:
+          result = that._cmp3(a[columnId], b[columnId]);
+          break;
+      }
 
       return asc ? result : -result;
     }
@@ -138,6 +150,18 @@ var BugList = {
     review_col.appendChild(document.createTextNode(data['review-status']));
     row.appendChild(review_col);
 
+    let testcase_col = document.createElement('td');
+    testcase_col.setAttribute('class', 'dynamic');
+    testcase_col.appendChild(
+      document.createTextNode(data['testcase'] || ''));
+    row.appendChild(testcase_col);
+
+    let timestamp_col = document.createElement('td');
+    timestamp_col.setAttribute('class', 'dynamic');
+    timestamp_col.appendChild(
+      document.createTextNode(data['timestamp'] || ''));
+    row.appendChild(timestamp_col);
+
     return row;
   },
 
@@ -148,8 +172,20 @@ var BugList = {
     var report_list = document.getElementById('report-list');
     report_list.innerHTML = '';
 
-    for (var i = startIdx; i < endIdx; ++i)
+    var dynamic_cols_needed = false;
+
+    for (var i = startIdx; i < endIdx; ++i) {
       report_list.appendChild(this.buildRow(reports[i], i + 1));
+
+      if (reports[i]['testcase'] || reports[i]['timestamp'])
+        dynamic_cols_needed = true;
+    }
+
+    for (var tag of document.getElementsByClassName('dynamic'))
+      if (dynamic_cols_needed)
+        tag.style.removeProperty('display');
+      else
+        tag.style.display = 'none';
 
     this.initBugPathLength();
   },


### PR DESCRIPTION
"CodeChecker parse -e html" command produces a static HTML that displays
the reports. However, the dynamic analysis related columns were missing
from this table: testcase and timestamp are now displayed too, if any.

Note: this PR consists of 2 commits. The first one is deployed in another PR (#4168). After that's merged, this one can be rebased.