### PR TITLE
[fix] --cppcheckargs should be present in "CodeChecker check"

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -327,6 +327,13 @@ used to generate a log file on the fly.""")
     cmd_config.add_option(analyzer_opts)
 
     # TODO: One day, get rid of these. See Issue #36, #427.
+    analyzer_opts.add_argument('--cppcheckargs',
+                               dest="cppcheck_args_cfg_file",
+                               required=False,
+                               default=argparse.SUPPRESS,
+                               help="File containing argument which will be "
+                                    "forwarded verbatim for Cppcheck.")
+
     analyzer_opts.add_argument('--saargs',
                                dest="clangsa_args_cfg_file",
                                required=False,
@@ -866,6 +873,7 @@ def main(args):
                           'files',
                           'analyzers',
                           'add_compiler_defaults',
+                          'cppcheck_args_cfg_file',
                           'clangsa_args_cfg_file',
                           'tidy_args_cfg_file',
                           'analyzer_config',


### PR DESCRIPTION
The --cppcheckargs flag is missing from under "CodeChecker check". This flag has now been added in order to be consistent with "CodeChecker analyze".

Fixes #4177