### PR TITLE
Allow specifiying relative paths in the `--file` option without `*`

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -20,6 +20,7 @@ import traceback
 import zipfile
 
 from threading import Timer
+from pathlib import Path
 
 import multiprocess
 import psutil
@@ -712,8 +713,10 @@ def skip_cpp(compile_actions, skip_handlers):
     analyze = []
     skip = []
     for compile_action in compile_actions:
-
-        if skip_handlers and skip_handlers.should_skip(compile_action.source):
+        if skip_handlers and \
+                skip_handlers.should_skip(
+                    str(Path(Path(compile_action.directory).resolve(),
+                             compile_action.source))):
             skip.append(compile_action)
         else:
             analyze.append(compile_action)

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 # pylint: disable=no-name-in-module
 from distutils.spawn import find_executable
 from enum import Enum
+from pathlib import Path
 
 import glob
 import json
@@ -1290,7 +1291,9 @@ def parse_unique_log(compilation_database,
             # Skipping of the compile commands is done differently if no
             # CTU or statistics related feature was enabled.
             if analysis_skip_handlers \
-                and analysis_skip_handlers.should_skip(entry['file']) \
+                and analysis_skip_handlers.should_skip(
+                        str(Path(Path(entry["directory"]).resolve(),
+                                 entry["file"]))) \
                 and (not ctu_or_stats_enabled or pre_analysis_skip_handlers
                      and pre_analysis_skip_handlers.should_skip(
                          entry['file'])):

--- a/analyzer/tests/functional/skip/test_files/multidir/Makefile
+++ b/analyzer/tests/functional/skip/test_files/multidir/Makefile
@@ -1,0 +1,13 @@
+default: src/a.o src/b.o
+
+src/b.o: src/b.cpp
+	$(CXX) -c src/b.cpp -o /dev/null
+
+src/a.o: src/a.cpp lib/lib.o
+	$(CXX) -c src/a.cpp -o /dev/null
+
+lib/lib.o: lib/lib.cpp
+	$(CXX) -c lib/lib.cpp -o /dev/null
+
+clean:
+	rm -rf src/*.o lib/*.o

--- a/analyzer/tests/functional/skip/test_files/multidir/b.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/b.cpp
@@ -1,0 +1,3 @@
+int root(){
+  return 1/0;
+}

--- a/analyzer/tests/functional/skip/test_files/multidir/compile_commnands.json
+++ b/analyzer/tests/functional/skip/test_files/multidir/compile_commnands.json
@@ -1,0 +1,25 @@
+[
+  {
+	"directory": ".",
+		"command": "/usr/bin/g++ -c b.cpp -o /dev/null",
+		"file": "b.cpp"
+	}
+	,
+	{
+		"directory": ".",
+		"command": "/usr/bin/g++ -c lib/lib.cpp -o /dev/null",
+		"file": "lib/lib.cpp"
+	}
+	,
+	{
+		"directory": ".",
+		"command": "/usr/bin/g++ -c src/a.cpp -o /dev/null",
+		"file": "src/a.cpp"
+	}
+	,
+	{
+		"directory": ".",
+		"command": "/usr/bin/g++ -c src/b.cpp -o /dev/null",
+		"file": "src/b.cpp"
+	}
+]

--- a/analyzer/tests/functional/skip/test_files/multidir/include/lib.h
+++ b/analyzer/tests/functional/skip/test_files/multidir/include/lib.h
@@ -1,0 +1,6 @@
+#ifndef LIB_H
+#define LIB_H
+
+int myDiv(int x);
+
+#endif

--- a/analyzer/tests/functional/skip/test_files/multidir/lib/lib.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/lib/lib.cpp
@@ -1,4 +1,8 @@
 #include "../include/lib.h"
+/*
+ * The error in this file should only be reported in
+ * CTU mode, through a.cpp.
+ */
 
 int myDiv(int x)
 {

--- a/analyzer/tests/functional/skip/test_files/multidir/lib/lib.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/lib/lib.cpp
@@ -1,0 +1,6 @@
+#include "../include/lib.h"
+
+int myDiv(int x)
+{
+  return 1 / x;
+}

--- a/analyzer/tests/functional/skip/test_files/multidir/src/a.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/src/a.cpp
@@ -1,0 +1,5 @@
+#include "../include/lib.h"
+
+void foo() {
+  myDiv(0);
+}

--- a/analyzer/tests/functional/skip/test_files/multidir/src/a.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/src/a.cpp
@@ -1,5 +1,8 @@
 #include "../include/lib.h"
 
 void foo() {
+  int* p = new int(0);
+  delete p;
+  delete p;
   myDiv(0);
 }

--- a/analyzer/tests/functional/skip/test_files/multidir/src/b.cpp
+++ b/analyzer/tests/functional/skip/test_files/multidir/src/b.cpp
@@ -1,0 +1,3 @@
+int main() {
+  int i = 1 / 0;
+}

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -55,7 +55,7 @@ class SkipListHandler:
         for skip_line in skip_lines:
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
             rexpr = re.compile(
-                fnmatch.translate(norm_skip_path + '*'))
+                fnmatch.translate('*' + norm_skip_path + '*'))
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):
@@ -94,6 +94,7 @@ class SkipListHandler:
         Check if the given source should be skipped.
         Should the analyzer skip the given source file?
         """
+
         if not self.__skip:
             return False
 

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -94,7 +94,6 @@ class SkipListHandler:
         Check if the given source should be skipped.
         Should the analyzer skip the given source file?
         """
-
         if not self.__skip:
             return False
 


### PR DESCRIPTION
With this modification, the `--file` option would allow passing paths with folder prefixes.

Consider a compilation json that contains a `.` in the directory fields, with the following example directory layout:
```
.                            
├── compile_commnands.json
├── include                                
│   └── lib.h                    
├── lib                                                                               
│   └── lib.cpp                                                                       
├── Makefile                                                                          
└── src                                                                               
    ├── a.cpp            
    └── b.cpp  
```
Before this patch, you could only specify path to source files with the `--file` option, that were not absolute is to add a `*` before the directory name.  
`CodeChecker analyze ./compile_commnands.json -o ./reports --file "*src/b.cpp"`

After this patch the following two methods will also work:
`CodeChecker analyze ./compile_commnands.json -o ./reports --file "./src/b.cpp"`
`CodeChecker analyze ./compile_commnands.json -o ./reports --file "src/b.cpp"`

TBD.:
* Documentation changes