### PR TITLE
[gcc][GUI] Fix indentations for gcc fn calls bug reports

### DIFF
--- a/web/server/vue-cli/e2e/specs/reports.js
+++ b/web/server/vue-cli/e2e/specs/reports.js
@@ -185,7 +185,9 @@ module.exports = {
     reportPage.expect.element("@overlay").to.be.visible.before(5000);
 
     dateDialog
+      .pause(100)
       .click("@date")
+      .pause(100)
       .click("@ok");
 
     reportPage.expect.element("@overlay").to.not.be.present.before(5000);


### PR DESCRIPTION
Previously, all notes of GCC were uncategorized, which lead to function calls not being indented properly. This patch fixes that (though I admit, this JS code isn't my proudest work):

## Before:
![image](https://github.com/Ericsson/codechecker/assets/23276031/fda615db-c431-4feb-8c91-1be7b75597ff)

## After:
![image](https://github.com/Ericsson/codechecker/assets/23276031/53639831-7e71-41ad-9ac2-bdad65fcb860)

With Clang, its easy to identify loops, but for gcc, not so much, so I skipped it:
![image](https://github.com/Ericsson/codechecker/assets/23276031/ec222788-45b7-46d2-a69c-02dc0ccb5473)
