### PR TITLE
[fix] Wait for run_lock when freeing it

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -421,9 +421,15 @@ class MassStoreRun:
         """ Remove the lock from the database for the given run name. """
         # Using with_for_update() here so the database (in case it supports
         # this operation) locks the lock record's row from any other access.
+        # The "nowait" option is turned off, because it results a 'could not
+        # obtain lock on row in relation "run_locks"' error message in case
+        # this query happens simultaneously with a concurrent locking of
+        # another parallel store event. With "nowait" option the query will be
+        # blocked until the lock is undone. In the worst case when
+        # statement_timeout is reached, the exception will be thrown anyway.
         run_lock = session.query(RunLock) \
             .filter(RunLock.name == self.__name) \
-            .with_for_update(nowait=True).one()
+            .with_for_update(nowait=False).one()
         session.delete(run_lock)
         session.commit()
 


### PR DESCRIPTION
A store event inserts a line to the run_lock table in order to prevent concurrent storage to the same run. The run_lock record is removed at the end of storage. The insertion and deletion of the run_lock record are locked operations on the database level. In CodeChecker we used "nowait" lock which means that these insert and delete operations fail and throw an exception if they can't happen immediately.

This is too strict in case of removing the run_lock object, because the thrown exception is forwarded to the user who can't handle it anyway. For this reason the run_lock removal is waiting for the database lock to be free. In the worst case the exception will still be thrown after the configured statement_timeout, but ideally that should be an unlikely event.