### PR TITLE
fix(migration): Do not emit log output for `checker_id` normalisation

### DIFF
--- a/web/server/codechecker_server/migrations/report/versions/c3dad71f8e6b_store_information_about_enabled_and_disabled_checkers_for_a_run.py
+++ b/web/server/codechecker_server/migrations/report/versions/c3dad71f8e6b_store_information_about_enabled_and_disabled_checkers_for_a_run.py
@@ -47,9 +47,6 @@ def upgrade():
         # These values are normalised such that in the following, when the
         # foreign key-based look-up is added to the schema, their new
         # 'checker_id' will all point to the single "UNKNOWN/NOT FOUND" case.
-        LOG.info("Normalising unknowns in 'reports'.'analyzer_name' and "
-                 "'reports'.'checker_id'...")
-
         analyzer_name_affected = conn.execute(f"""
             UPDATE reports
             SET analyzer_name = '{UnknownChecker[0]}'
@@ -92,8 +89,6 @@ def upgrade():
             # lost, only the representation slightly changed.
             conn.execute("COMMIT;")
             conn.execute("START TRANSACTION;")
-
-        LOG.info("Done normalising 'reports'.")
 
     def create_new_tables():
         op.create_table(


### PR DESCRIPTION
> Follows up #4089, #4191.

In case a new product is added to an empty server, what happens in the background is a full "migration" from the "empty" state to the newest schema, which results in the log output that is removed by this patch on the standard output of the server.

These lines are not directly needed, but there is no good reason to hide them behind an `if len(...):` check either. In case actual rows are migrated (which never happens when a new product is added to the server), the appropriate output showing the row count of the `UPDATE` statement will be printed to the output normally.