### PR TITLE
test(gui): Add front-end test for checked status in AnalysisInfo dialog

### DIFF
--- a/web/server/vue-cli/e2e/pages/runs.js
+++ b/web/server/vue-cli/e2e/pages/runs.js
@@ -34,7 +34,7 @@ module.exports = {
     showDescriptionBtn: "button.description",
     showHistoryBtn: "a.show-history",
     showStatisticsBtn: "a.show-statistics",
-    showCheckCommandBtn: "button.show-analysis-info",
+    showAnalysisInfoBtn: "button.show-analysis-info",
     openDetectionStatus: "a.detection-status-count",
     descriptionMenu:
       ".menuable__content__active.run-description-menu .v-card__text",
@@ -61,10 +61,12 @@ module.exports = {
         storedBefore: ".stored-before",
       }
     },
-    checkCommandDialog: {
+    analysisInfoDialog: {
       selector: ".v-dialog__content--active .analysis-info",
       elements: {
-        content: ".container",
+        command: ".analyze-command",
+        checkerStatuses: ".checker-statuses",
+        checkerStatusError: ".checker-status-unavailable",
         closeBtn: ".v-card__title button"
       }
     },
@@ -89,7 +91,7 @@ module.exports = {
           elements: {
             date: ".date",
             showStatisticsBtn: "a.show-statistics",
-            showCheckCommandBtn: "button.show-analysis-info",
+            showAnalysisInfoBtn: "button.show-analysis-info",
             historyEvent: ".v-timeline-item.run-history",
             baseline: ".compare-events .v-input--checkbox:nth-child(1)",
             compareTo: ".compare-events .v-input--checkbox:nth-child(2)"

--- a/web/server/vue-cli/src/components/AnalysisInfo/Checker.vue
+++ b/web/server/vue-cli/src/components/AnalysisInfo/Checker.vue
@@ -2,6 +2,8 @@
   <v-row
     no-gutters
     align="center"
+    class="analysis-info-checker"
+    :data-checker-name="name"
   >
     <v-col
       cols="auto"

--- a/web/server/vue-cli/src/components/AnalysisInfo/CheckerGroup.vue
+++ b/web/server/vue-cli/src/components/AnalysisInfo/CheckerGroup.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-expansion-panel>
+  <v-expansion-panel
+    class="analyzer-checker-group-panel"
+    :data-group-name="group"
+  >
     <v-expansion-panel-header
       class="pa-0 px-1"
     >
@@ -76,7 +79,7 @@
 <script>
 import CountChips from "@/components/CountChips";
 import CheckerRows from "./CheckerRows";
-import { CountKeys } from "@/mixins/analysis-info-handling.mixin";
+import { CountKeys } from "@/mixins/api/analysis-info-handling.mixin";
 
 export default {
   name: "CheckerGroup",

--- a/web/server/vue-cli/src/components/AnalysisInfoDialog.vue
+++ b/web/server/vue-cli/src/components/AnalysisInfoDialog.vue
@@ -25,7 +25,7 @@
           <div
             v-for="cmd in highlightedCmds"
             :key="cmd"
-            class="analysis-info mb-2"
+            class="analyze-command mb-2"
             v-html="cmd"
           />
         </v-container>
@@ -37,7 +37,7 @@
             v-if="analysisInfo.checkerInfoAvailability ===
               CheckerInfoAvailability.Available"
           >
-            <v-container class="pa-0 pt-1">
+            <v-container class="checker-statuses pa-0 pt-1">
               <v-expansion-panels
                 multiple
                 hover
@@ -45,6 +45,8 @@
                 <v-expansion-panel
                   v-for="analyzer in analysisInfo.analyzers"
                   :key="analyzer"
+                  class="analyzer-checkers-panel"
+                  :data-analyzer-name="analyzer"
                 >
                   <v-expansion-panel-header
                     class="pa-0 px-1"
@@ -115,7 +117,7 @@
           >
             <v-alert
               icon="mdi-alert"
-              class="mt-2"
+              class="checker-status-unavailable mt-2"
               color="deep-orange"
               outlined
             >
@@ -148,8 +150,8 @@
                 <span class="version">{{
                   analysisInfo.codeCheckerVersion
                 }}</span>
-                client, and it was also <span class="font-italic">likely</span>
-                stored when the server ran this older version.
+                client, and it was also likely stored when the server ran this
+                older version.
               </span>
               <span
                 v-else-if="analysisInfo.checkerInfoAvailability ===
@@ -175,11 +177,11 @@ import {
 } from "@/components/AnalysisInfo";
 import CountChips from "@/components/CountChips";
 import {
-  default as AnalysisInfoHandlingMixin,
+  default as AnalysisInfoHandlingAPIMixin,
   CheckerInfoAvailability,
   CountKeys,
   GroupKeys
-} from "@/mixins/analysis-info-handling.mixin";
+} from "@/mixins/api/analysis-info-handling.mixin";
 
 export default {
   name: "AnalysisInfoDialog",
@@ -188,7 +190,7 @@ export default {
     CheckerRows,
     CountChips
   },
-  mixins: [ AnalysisInfoHandlingMixin ],
+  mixins: [ AnalysisInfoHandlingAPIMixin ],
   props: {
     value: { type: Boolean, default: false },
     runId: { type: Object, default: () => null },
@@ -283,26 +285,28 @@ export default {
 
 <style lang="scss" scoped>
 ::v-deep .analysis-info {
-  border: 1px solid grey;
-  padding: 4px;
+  .analyze-command {
+    border: 1px solid grey;
+    padding: 4px;
 
-  .param {
-    background-color: rgba(0, 0, 0, 0.15);
-    font-weight: bold;
-    padding-left: 2px;
-    padding-right: 2px;
-  }
+    .param {
+      background-color: rgba(0, 0, 0, 0.15);
+      font-weight: bold;
+      padding-left: 2px;
+      padding-right: 2px;
+    }
 
-  .enabled-checkers {
-    background-color: rgba(0, 142, 0, 0.15);
-  }
+    .enabled-checkers {
+      background-color: rgba(0, 142, 0, 0.15);
+    }
 
-  .disabled-checkers {
-    background-color: rgba(142, 0, 0, 0.15);
-  }
+    .disabled-checkers {
+      background-color: rgba(142, 0, 0, 0.15);
+    }
 
-  .ctu, .statistics {
-    background-color: rgba(0, 0, 142, 0.15);
+    .ctu, .statistics {
+      background-color: rgba(0, 0, 142, 0.15);
+    }
   }
 
   .analyzer-name {

--- a/web/server/vue-cli/src/mixins/api/analysis-info-handling.mixin.js
+++ b/web/server/vue-cli/src/mixins/api/analysis-info-handling.mixin.js
@@ -4,7 +4,7 @@ import {
   RunFilter,
   RunHistoryFilter
 } from "@cc/report-server-types";
-import VersionMixin from "./version.mixin";
+import VersionMixin from "../version.mixin";
 
 const GroupKeys = Object.freeze({
   NoGroup: "__N",
@@ -129,6 +129,10 @@ function mergeReduceCheckerStatuses(accumulator, inCheckerDict) {
 }
 
 class AnalysisInfo {
+  GroupKeys() { return GroupKeys; }
+  CountKeys() { return CountKeys; }
+  CheckerInfoAvailability() { return CheckerInfoAvailability; }
+
   constructor() {
     this.cmds = [];
     this.checkers = {};
@@ -217,7 +221,7 @@ class AnalysisInfo {
   }
 }
 
-const AnalysisInfoHandlingMixin = {
+const AnalysisInfoHandlingAPIMixin = {
   methods: {
     loadAnalysisInfo(runId, runHistoryId, reportId) {
       const analysisInfoFilter = new AnalysisInfoFilter({
@@ -260,7 +264,7 @@ const AnalysisInfoHandlingMixin = {
 
 export {
   AnalysisInfo,
-  AnalysisInfoHandlingMixin as default,
+  AnalysisInfoHandlingAPIMixin as default,
   CheckerInfoAvailability,
   CountKeys,
   GroupKeys,

--- a/web/server/vue-cli/src/mixins/api/index.js
+++ b/web/server/vue-cli/src/mixins/api/index.js
@@ -1,0 +1,5 @@
+import AnalysisInfoHandlingAPIMixin from "./analysis-info-handling.mixin";
+
+export {
+  AnalysisInfoHandlingAPIMixin,
+};

--- a/web/server/vue-cli/src/mixins/index.js
+++ b/web/server/vue-cli/src/mixins/index.js
@@ -1,4 +1,3 @@
-import AnalysisInfoHandlingMixin from "./analysis-info-handling.mixin";
 import BugPathLengthColorMixin from "./bug-path-length-color.mixin";
 import ConfidentialityMixin from "./confidentiality.mixin";
 import DateMixin from "./date.mixin";
@@ -10,7 +9,6 @@ import ToCSV from "./to-csv.mixin";
 import VersionMixin from "./version.mixin";
 
 export {
-  AnalysisInfoHandlingMixin,
   BugPathLengthColorMixin,
   ConfidentialityMixin,
   DateMixin,
@@ -19,5 +17,5 @@ export {
   SeverityMixin,
   StrToColorMixin,
   ToCSV,
-  VersionMixin
+  VersionMixin,
 };


### PR DESCRIPTION
> Follows up #4156.

Test that for a newly analysed project, the checker status GUI elements appear. Check that, for a few well-defined cases, the status is indeed what we are expecting.