### PR TITLE
feat(script): Verify the existence of checker config `doc_url` pages and find appropriate older releases for gone (removed, dealpha, etc.) checkers

### DIFF
--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -34,9 +34,7 @@ def arg_match(options, args):
 
 
 def clamp(min_: int, value: int, max_: int) -> int:
-    """
-    Clamps ``value`` to be between ``min_`` and ``max_``, inclusive.
-    """
+    """Clamps ``value`` such that ``min_ <= value <= max_``."""
     if min_ > max_:
         raise ValueError("min <= max required")
     return min(max(min_, value), max_)

--- a/scripts/labels/compiler_warnings.py
+++ b/scripts/labels/compiler_warnings.py
@@ -1,3 +1,4 @@
+# FIXME: Subsume into the newer label_tool package.
 import argparse
 import json
 import urllib3

--- a/scripts/labels/doc_url_generate.py
+++ b/scripts/labels/doc_url_generate.py
@@ -1,3 +1,4 @@
+# FIXME: Subsume into the newer label_tool/doc_url package!
 import argparse
 import json
 import sys

--- a/scripts/labels/label_tool/__init__.py
+++ b/scripts/labels/label_tool/__init__.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+This library ships reusable components and user-facing tools to verify,
+generate, and adapt the checker labels in the CodeChecker configuration
+structure.
+"""
+# Load the interpreter injection first.
+from . import codechecker
+
+from . import \
+    checker_labels, \
+    http_, \
+    output, \
+    transformer, \
+    util
+
+
+__all__ = [
+    "checker_labels",
+    "codechecker",
+    "http_",
+    "output",
+    "transformer",
+    "util",
+]

--- a/scripts/labels/label_tool/__main__.py
+++ b/scripts/labels/label_tool/__main__.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Dispatching to the top-level tools implemented in the package."""
+import argparse
+import sys
+
+
+try:
+    from .doc_url.verify_tool import __main__ as doc_url_verify
+except ModuleNotFoundError as e:
+    import traceback
+    traceback.print_exc()
+
+    print("\nFATAL: Failed to import some required modules! "
+          "Please make sure you also install the contents of the "
+          "'requirements.txt' of this tool into your virtualenv:\n"
+          "\tpip install -r scripts/requirements.txt",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def args() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=__package__,
+        description="""
+Tooling related to creating, managing, verifying, and updating the checker
+labels in a CodeChecker config directory.
+This main script is the union of several independent tools using a common
+internal library.
+""",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        description="Please select a subcommand to continue.",
+        dest="subcommand",
+        required=True)
+
+    def add_subparser(command: str, package):
+        subparser = subparsers.add_parser(
+            command,
+            prog=package.__package__,
+            help=package.short_help,
+            description=package.description,
+            epilog=package.epilogue,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        subparser = package.args(subparser)
+        subparser.set_defaults(__main=package.main)
+
+    add_subparser("doc_url_verify", doc_url_verify)
+
+    return parser
+
+
+if __name__ == "__main__":
+    def _main():
+        _args = args().parse_args()
+        del _args.__dict__["subcommand"]
+
+        main = _args.__dict__["__main"]
+        del _args.__dict__["__main"]
+
+        sys.exit(main(_args) or 0)
+    _main()

--- a/scripts/labels/label_tool/checker_labels.py
+++ b/scripts/labels/label_tool/checker_labels.py
@@ -1,0 +1,140 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Provides I/O with the configuration files that describe checker labels."""
+from collections import deque
+import json
+import pathlib
+from typing import Dict, List, Optional, cast
+
+from codechecker_common.checker_labels import split_label_kv
+
+from .output import Settings as OutputSettings, error, trace
+
+
+_ConfigFileLabels = Dict[str, List[str]]
+
+SingleLabels = Dict[str, Optional[str]]
+Labels = Dict[str, Dict[str, str]]
+
+
+def _load_json(path: pathlib.Path) -> Dict:
+    try:
+        with path.open("r") as file:
+            return json.load(file)
+    except OSError:
+        import traceback
+        traceback.print_exc()
+
+        error("Failed to open label config file '%s'", path)
+        raise
+    except json.JSONDecodeError:
+        import traceback
+        traceback.print_exc()
+
+        error("Failed to parse label config file '%s'", path)
+        raise
+
+
+def _save_json(path: pathlib.Path, data: Dict):
+    try:
+        with path.open("w") as file:
+            json.dump(data, file, indent=2)
+            file.write('\n')
+    except OSError:
+        import traceback
+        traceback.print_exc()
+
+        error("Failed to write label config file '%s'", path)
+        raise
+    except (TypeError, ValueError):
+        import traceback
+        traceback.print_exc()
+
+        error("Failed to encode label config file '%s'", path)
+        raise
+
+
+class MultipleLabelsError(Exception):
+    """
+    Raised by `get_checker_labels` if multiple labels exist for the same key.
+    """
+
+    def __init__(self, key):
+        super().__init__("Multiple labels with key: %s", key)
+        self.key = key
+
+
+def get_checker_labels(analyser: str, path: pathlib.Path, key: str) \
+        -> SingleLabels:
+    """
+    Loads and filters the checker config label file available at `path`
+    for the `key` label. Raises `MultipleLabelsError` if there is at least
+    two labels with the same `key`.
+    """
+    try:
+        label_cfg = cast(_ConfigFileLabels, _load_json(path)["labels"])
+    except KeyError:
+        error("'%s' is not a label config file", path)
+        raise
+
+    filtered_labels = {
+        checker: [label_v
+                  for label in labels
+                  for label_k, label_v in (split_label_kv(label),)
+                  if label_k == key]
+        for checker, labels in label_cfg.items()}
+    if OutputSettings.trace():
+        deque((trace("No '%s:' label found for '%s/%s'",
+                     key, analyser, checker)
+               for checker, labels in filtered_labels.items()
+               if not labels), maxlen=0)
+
+    if any(len(labels) > 1 for labels in filtered_labels.values()):
+        raise MultipleLabelsError(key)
+    return {checker: labels[0] if labels else None
+            for checker, labels in filtered_labels.items()}
+
+
+def update_checker_labels(analyser: str,
+                          path: pathlib.Path,
+                          key: str,
+                          updates: SingleLabels):
+    """
+    Loads a checker config label file available at `path` and updates the
+    `key` labels based on the `updates` structure, overwriting or adding the
+    existing label (or raising `MultipleLabelsError` if it is not unique which
+    one to overwrite), then writes the resulting data structure back to `path`.
+    """
+    try:
+        config = _load_json(path)
+        label_cfg = cast(_ConfigFileLabels, config["labels"])
+    except KeyError:
+        error("'%s's '%s' is not a label config file", analyser, path)
+        raise
+
+    label_indices = {
+        checker: [index for index, label in enumerate(labels)
+                  if split_label_kv(label)[0] == key]
+        for checker, labels in label_cfg.items()
+    }
+
+    if any(len(indices) > 1 for indices in label_indices.values()):
+        raise MultipleLabelsError(key)
+    label_indices = {checker: indices[0] if len(indices) == 1 else None
+                     for checker, indices in label_indices.items()}
+    for checker, new_label in updates.items():
+        checker_labels = label_cfg[checker]
+        idx = label_indices[checker]
+        e = f"{key}:{new_label}"
+        if idx is not None:
+            checker_labels[idx] = e
+        else:
+            checker_labels.insert(0, e)
+            label_cfg[checker] = sorted(checker_labels)
+
+    _save_json(path, config)

--- a/scripts/labels/label_tool/codechecker.py
+++ b/scripts/labels/label_tool/codechecker.py
@@ -1,0 +1,62 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Shim to inject a CodeChecker package into the current interpreter."""
+import os
+import pathlib
+import sys
+from typing import Optional
+
+from .util import find_if
+
+
+def codechecker_src_root() -> Optional[pathlib.Path]:
+    """
+    Returns the root directory for the CodeChecker source package parent to
+    the label tooling.
+    """
+    try:
+        this_file = pathlib.Path(__file__).resolve(strict=True)
+        labels_idx = find_if(this_file.parents,
+                             lambda p: p.stem == "labels")
+        if not labels_idx:
+            return None
+
+        if this_file.parents[labels_idx + 1].stem == "scripts":
+            return this_file.parents[labels_idx + 2]
+
+        return None
+    except Exception:
+        import traceback
+        traceback.print_exc()
+
+        return None
+
+
+def inject_codechecker_to_interpreter():
+    """
+    Adds the built CodeChecker package relative to the root of the working
+    copy to the current interpreter to be able to load code from the main
+    distribution.
+    """
+    src_root = codechecker_src_root()
+    if not src_root:
+        raise NotADirectoryError("Can not find CodeChecker source root!")
+
+    codechecker_package = src_root / "build" / "CodeChecker"
+    python_package_dir = codechecker_package / "lib" / "python3"
+    if python_package_dir not in sys.path:
+        # Leave position 0, the current directory of the interpreter, intact.
+        sys.path.insert(1, str(python_package_dir))
+
+    # Make sure the injected environment has access to CodeChecker's logging
+    # configuration. We do not use it directly in this tool, but packages
+    # imported from "over there" can end up having issues without this.
+    os.environ.update({"CC_DATA_FILES_DIR": str(codechecker_package)})
+
+
+inject_codechecker_to_interpreter()

--- a/scripts/labels/label_tool/doc_url/__init__.py
+++ b/scripts/labels/label_tool/doc_url/__init__.py
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Verifies and generates fixed ``doc_url`` labels for checkers in the
+configuration.
+"""
+from . import \
+    output, \
+    verifiers
+
+
+__all__ = [
+    "output",
+    "verifiers",
+]

--- a/scripts/labels/label_tool/doc_url/output.py
+++ b/scripts/labels/label_tool/doc_url/output.py
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Tool-level output settings."""
+from ..util import _Singleton
+
+
+class Settings(_Singleton):
+    """Tool-level output settings."""
+
+    def __init__(self):
+        """Returns the instance that was loaded as a `_Singleton`."""
+        if "_report_missing" not in self.__dict__:
+            self._report_missing: bool = False
+        if "_report_ok" not in self.__dict__:
+            self._report_ok: bool = False
+
+    @staticmethod
+    def factory():
+        """Initialises the `_Singleton`."""
+        o = Settings()
+        return o
+
+    @staticmethod
+    def report_missing() -> bool:
+        return Settings.factory()._report_missing  # type: ignore
+
+    @staticmethod
+    def set_report_missing(v: bool):
+        Settings.factory()._report_missing = v  # type: ignore
+
+    @staticmethod
+    def report_ok() -> bool:
+        return Settings.factory()._report_ok  # type: ignore
+
+    @staticmethod
+    def set_report_ok(v: bool):
+        Settings.factory()._report_ok = v  # type: ignore

--- a/scripts/labels/label_tool/doc_url/verifiers/__init__.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/__init__.py
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Implements the logic for generic and analyser-specific verification and
+translation of documentation URLs.
+"""
+from .analyser_selection import select_verifier
+from .generic import Outcome, \
+    HTTPStatusCodeVerifier, HTMLAnchorVerifier
+from .status import Status
+
+
+__all__ = [
+    "select_verifier",
+    "Outcome",
+    "HTTPStatusCodeVerifier",
+    "HTMLAnchorVerifier",
+    "Status",
+]

--- a/scripts/labels/label_tool/doc_url/verifiers/analyser_selection.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/analyser_selection.py
@@ -1,0 +1,61 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Selects the appropriate verification engine for the analyser configuration.
+"""
+from collections import defaultdict
+from typing import Dict, Iterable, Tuple, Type, Union
+
+from ...checker_labels import SingleLabels
+
+from .generic import HTMLAnchorVerifier, HTTPStatusCodeVerifier
+
+from .clang_diagnostic import ClangDiagnosticVerifier
+from .clang_tidy import ClangTidyVerifier
+from .clangsa import ClangSAVerifier
+
+
+class _Generic:
+    """
+    Tag type that decides between the raw `HTTPStatusCodeVerifier` for direct
+    links and the `HTMLAnchorVerifier` for single-page multi-section links.
+    """
+
+    @staticmethod
+    def select(labels: SingleLabels) -> Type:
+        return HTMLAnchorVerifier if any('#' in label
+                                         for label in labels.values()
+                                         if label) \
+            else HTTPStatusCodeVerifier
+
+
+AnalyserVerifiers: Dict[str, Union[Type, Tuple[Type, ...]]] = defaultdict(
+    lambda: _Generic,
+    {
+        "clangsa": ClangSAVerifier,
+        "clang-tidy": (ClangTidyVerifier, ClangDiagnosticVerifier,),
+    }
+)
+
+
+def select_verifier(analyser: str, labels: SingleLabels) -> Iterable[Type]:
+    """
+    Dispatches the `analyser` to one of the verifier classes and returns
+    which class(es) should be used for the verification.
+    """
+    verifiers = AnalyserVerifiers[analyser]
+    if not verifiers:
+        return iter(())
+    if not isinstance(verifiers, tuple):
+        verifiers = (verifiers,)
+
+    if verifiers[0] is _Generic:
+        verifiers = (_Generic.select(labels),)
+        AnalyserVerifiers[analyser] = verifiers[0]
+
+    return iter(verifiers)

--- a/scripts/labels/label_tool/doc_url/verifiers/clang_diagnostic.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/clang_diagnostic.py
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Clang compiler diagnostics (implemented through CodeChecker as Clang-Tidy
+checks).
+"""
+from typing import Collection, Optional, Tuple
+import urllib.parse
+
+from ... import http_ as http, transformer
+from ...transformer import Version
+from .generic import HTMLAnchorVerifier
+from .llvm import fetch_llvm_release_versions
+from .status import Status
+
+
+class ClangDiagnosticVerifier(HTMLAnchorVerifier):
+    """
+    Verifies the documentation for Clang warnings (diagnostics).
+    """
+
+    kind = "clang-diagnostic"
+
+    def __init__(self, analyser: str,
+                 cache_size: int = http.CachingHTMLAcquirer.DefaultCacheSize):
+        super().__init__(analyser=analyser, cache_size=cache_size)
+
+        self._release_fixer = transformer.PerReleaseRules(
+            releases=fetch_llvm_release_versions)
+        # Clang Diagnostic reference in the Sphinx-based structure was
+        # introduced in
+        # llvm/llvm-project b6a3b4ba61383774dae692efb5767ffdb23ac36e
+        # which was first present in version 4.0.0-rc1.
+        self._release_fixer.add_rule(
+            "https://releases.llvm.org/<VERSION>/tools/clang/docs/"
+            "DiagnosticsReference.html#<ANCHOR>",
+            Version("4.0.0"))
+
+        self._reset_pattern = transformer.ReplacePatternApplicator(
+            "https://clang.llvm.org/docs/DiagnosticsReference.html#<ANCHOR>")
+
+    def skip(self, checker: str, url: str) -> Status:
+        if not checker.startswith("clang-diagnostic"):
+            # This class only verifies the clang-diagnostic- "Tidy" "checkers".
+            return Status.SKIP
+        if checker == "clang-diagnostic-error":
+            # This is a special case of "-Werror" as parsed by CodeChecker and
+            # it is not a real diagnostic that exists in the reference.
+            return Status.SKIP
+        if not url:
+            return Status.MISSING
+        return Status.OK
+
+    def _normalise_checker_name(self, checker: str) -> Tuple[str, str]:
+        """
+        Returns a ``(checker_name, checker_anchor)`` after applying the usual
+        naming pattern, normalising from ``clang-diagnostic-foo`` to ``-Wfoo``.
+        """
+        name = checker \
+            .replace("clang-diagnostic-", '')
+        anchor = checker \
+            .replace("clang-diagnostic-", '') \
+            .replace('#', '-') \
+            .replace('=', '-') \
+            .replace("++", '-') \
+            .lower()
+        return name, anchor
+
+    def reset(self, checker: str, url: str) -> Optional[str]:
+        _, anchor = self._http.split_anchor(url)
+        if not anchor:
+            _, anchor = self._normalise_checker_name(checker)
+        return self._reset_pattern(anchor=anchor)
+
+    anchor_prefixes = (
+        # Warnings.
+        ("-W", "w"),
+        # Remarks.
+        ("-R", "r")
+    )
+
+    def try_fix(self, checker: str, url: str) -> Optional[str]:
+        _, anchor = self._http.split_anchor(url)
+        normal_name, normal_anchor = self._normalise_checker_name(checker)
+
+        def _try_anchor(prefixes: Collection[Tuple[str, str]],
+                        url: str) -> Optional[str]:
+            for prefix in prefixes:
+                other_anchor = next(
+                    (a for a
+                     in self.find_anchors_for_text(
+                         url, prefix[0] + normal_name)
+                     if a.startswith(prefix[1] + normal_anchor)),
+                    None)
+                if other_anchor:
+                    return urllib.parse.urlparse(url). \
+                            _replace(fragment=other_anchor). \
+                            geturl()
+
+        attempt = _try_anchor(self.anchor_prefixes, url)
+        if attempt:
+            return attempt
+
+        for release_url in self._release_fixer.generate_urls(anchor=anchor):
+            if self.verify(checker, release_url)[0] == Status.OK:
+                return release_url
+            attempt = _try_anchor(self.anchor_prefixes, release_url)
+            if attempt:
+                return attempt

--- a/scripts/labels/label_tool/doc_url/verifiers/clang_tidy.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/clang_tidy.py
@@ -1,0 +1,73 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Clang-Tidy."""
+from typing import Optional
+
+from ... import transformer
+from ...transformer import Version
+from .generic import HTTPStatusCodeVerifier
+from .llvm import fetch_llvm_release_versions
+from .status import Status
+
+
+class ClangTidyVerifier(HTTPStatusCodeVerifier):
+    """
+    Verifies and allows downgrading the documentation for Clang-Tidy checks.
+    """
+
+    kind = "clang-tidy"
+
+    def __init__(self, analyser: str):
+        super().__init__(analyser=analyser)
+
+        self._release_fixer = transformer.PerReleaseRules(
+            releases=fetch_llvm_release_versions)
+        # Clang-Tidy documentation pages in the Sphinx-based structure were
+        # introduced in
+        # llvm/llvm-project aabfadef84cdcc6aef529348a287e0130f7aee6d
+        # which was first present in version 3.8.0-rc1.
+        # Manually checking the deployment, however, shows that the links only
+        # work 3.9 onwards.
+        self._release_fixer.add_rule(
+            "https://releases.llvm.org/<VERSION>/tools/clang/tools/extra/"
+            "docs/clang-tidy/checks/<GROUP>-<NAME>.html",
+            Version("3.9.0"))
+        # llvm/llvm-project 6e566bc5523f743bc34a7e26f050f1f2b4d699a8
+        # changed the directory structure and introduced an explicit parent
+        # directory for the check's "group".
+        self._release_fixer.add_rule(
+            "https://releases.llvm.org/<VERSION>/tools/clang/tools/extra/"
+            "docs/clang-tidy/checks/<GROUP>/<NAME>.html",
+            Version("15.0.0"))
+
+        self._reset_pattern = transformer.ReplacePatternApplicator(
+            "https://clang.llvm.org/extra/clang-tidy/checks/"
+            "<GROUP>/<NAME>.html")
+
+    def skip(self, checker: str, url: str) -> Status:
+        if checker.startswith("clang-diagnostic"):
+            # Clang diagnostics are special, as they appear as-if they were
+            # Clang-Tidy checks, but their documentation is in a completely
+            # different structure.
+            return Status.SKIP
+        if not url:
+            return Status.MISSING
+        return Status.OK
+
+    def reset(self, checker: str, url: str) -> Optional[str]:
+        group, check = checker.split("-", 1)
+        return self._reset_pattern(group=group, name=check)
+
+    def try_fix(self, checker: str, url: str) -> Optional[str]:
+        group, check = checker.split("-", 1)
+        older_release_url = self._release_fixer(
+            lambda url_: self.verify(checker, url_)[0] == Status.OK,
+            group=group,
+            name=check)
+        if older_release_url:
+            return older_release_url

--- a/scripts/labels/label_tool/doc_url/verifiers/clangsa.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/clangsa.py
@@ -1,0 +1,87 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Clang Static Analyzer."""
+from typing import Optional
+import urllib.parse
+
+from ... import http_ as http, transformer
+from ...transformer import Version
+from .generic import HTMLAnchorVerifier
+from .llvm import fetch_llvm_release_versions
+from .status import Status
+
+
+class ClangSAVerifier(HTMLAnchorVerifier):
+    """
+    Verifies and allows downgrading the documentation for Clang Static Analyzer
+    checkers.
+    """
+
+    kind = "clangsa"
+
+    def __init__(self, analyser: str,
+                 cache_size: int = http.CachingHTMLAcquirer.DefaultCacheSize):
+        super().__init__(analyser=analyser, cache_size=cache_size)
+
+        self._release_fixer = transformer.PerReleaseRules(
+            releases=fetch_llvm_release_versions)
+        # Analysis information in the Sphinx-based structure was introduced in
+        # llvm/llvm-project 1a17032b788016299ea4e3c4b53670c6dcd94b4f
+        # which was first present in version 9.0.0-rc1.
+        self._release_fixer.add_rule(
+            "https://releases.llvm.org/<VERSION>/tools/clang/docs/analyzer/"
+            "checkers.html#<ANCHOR>",
+            Version("9.0.0"))
+
+        self._reset_pattern = transformer.ReplacePatternApplicator(
+            "https://clang.llvm.org/docs/analyzer/checkers.html#<ANCHOR>")
+
+    def _fake_anchor(self, checker: str) -> str:
+        """
+        Returns a normalised version of the checker's name which can be used
+        as a fake anchor to initiate an anchor search.
+
+        This anchor is most often never the real one, because there is not a
+        one-to-one mapping from checker names to anchors, as the actual
+        anchors, e.g., ``core-dividezero-c-c-objc`` (for the HTML text
+        "core.DivideZero (C, C++, ObjC)") can not be generated automatically
+        from the actual checker name.
+        Luckily, at least as of last change to this logic, the anchors
+        generated here are at least substrings of the actual anchors.
+        """
+        return checker.replace('.', '-').lower()
+
+    def reset(self, checker: str, url: str) -> Optional[str]:
+        _, anchor = self._http.split_anchor(url)
+        if not anchor:
+            anchor = self._fake_anchor(checker)
+        return self._reset_pattern(anchor=anchor)
+
+    def try_fix(self, checker: str, url: str) -> Optional[str]:
+        _, anchor = self._http.split_anchor(url)
+        checker_name_in_anchor = self._fake_anchor(checker)
+
+        def _try_anchor(url: str) -> Optional[str]:
+            other_anchor = next(
+                (a for a in self.find_anchors_for_text(url, checker)
+                 if a.startswith(checker_name_in_anchor)), None)
+            if other_anchor:
+                return urllib.parse.urlparse(url). \
+                        _replace(fragment=other_anchor). \
+                        geturl()
+
+        attempt = _try_anchor(url)
+        if attempt:
+            return attempt
+
+        for release_url in self._release_fixer.generate_urls(anchor=anchor):
+            if self.verify(checker, release_url)[0] == Status.OK:
+                return release_url
+            attempt = _try_anchor(release_url)
+            if attempt:
+                return attempt

--- a/scripts/labels/label_tool/doc_url/verifiers/generic.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/generic.py
@@ -1,0 +1,279 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Implements the logic for generic verification of documentation URLs.
+"""
+from typing import Iterable, Optional, Tuple, cast
+
+from lxml import html
+import lxml.etree
+import urllib3
+
+from ... import http_ as http
+from ...output import error, trace
+from ...util import Ternary
+from .status import Status
+
+
+Outcome = Tuple[Status, Optional[http.Response]]
+
+
+class Base:
+    kind = "abstract"
+
+    def __init__(self, analyser: str):
+        self.analyser = analyser
+
+    def skip(self, checker: str, url: str) -> Status:
+        """
+        Returns `Status.OK` if the current verifier is capable of verifying the
+        `checker`. `Status.SKIP` is returned in case the `checker` is
+        unverifiable due to a pattern, and `Status.MISSING` is returned if
+        it is unverifiable due to its lack of `url`.
+        """
+        return Status.OK
+
+    def verify(self, checker: str, url: str) -> Outcome:
+        """
+        Verifies that the documentation page at `url` is available and relevant
+        for the `checker` checker.
+
+        Subclasses must override this method and provide an implementation.
+        """
+        return Status.UNKNOWN, None
+
+    def reset(self, checker: str, url: str) -> Optional[str]:
+        """
+        Attempts to reset a potentially fixed (e.g., downgraded) documentation
+        URL to its rawest upstream version.
+        There are no guarantees that the method here returns a valid,
+        user-accessible URL.
+        This method is used, when requested, to essentially "undo" the results
+        of `try_fix`.
+
+        This class does not implement any link-resetting capability.
+        Subclasses might override this method and provide an implementation.
+        """
+        return None
+
+    def try_fix(self, checker: str, url: str) -> Optional[str]:
+        """
+        Attempts to fix the documentation supposedly available, but in fact
+        missing from `url` for `checker` to some alternative version that is
+        still available to users.
+        A common reason for the disappearance of current `url`s is the
+        removal of checks, after which the previously up-to-date URLs would
+        cause errors if accessed.
+
+        This class does not implement any link-fixing capability.
+        Subclasses might override this method and provide an implementation.
+        """
+        return None
+
+
+class HTTPStatusCodeVerifier(Base):
+    """
+    Generic URL verifier that only checks whether the URL returns a valid
+    HTTP status that indicates the URL resolves to a documentation accessible
+    by the user.
+
+    This class does not allow downgrading the documentation URL to an earlier
+    version.
+    """
+
+    kind = "webpage"
+
+    """
+    HTTP Response status codes that indicate that the webpage is
+    deterministically available to the request.
+    """
+    Ok = {http.HTTPStatusCode.OK,
+          http.HTTPStatusCode.NON_AUTHORITATIVE_INFORMATION,
+          }
+    """
+    HTTP Response status codes that indicate that the webpage is not or
+    no longer available to requestors.
+    """
+    NotOk = {http.HTTPStatusCode.BAD_REQUEST,
+             http.HTTPStatusCode.UNAUTHORIZED,
+             http.HTTPStatusCode.FORBIDDEN,
+             http.HTTPStatusCode.NOT_FOUND,
+             http.HTTPStatusCode.GONE,
+             http.HTTPStatusCode.UNAVAILABLE_FOR_LEGAL_REASONS,
+             }
+    """
+    HTTP Response status codes that indicate an issue with the request that
+    prevents deterministically deciding whether the requested resource is
+    available.
+    """
+    Unknown = {http.HTTPStatusCode.INTERNAL_SERVER_ERROR,
+               http.HTTPStatusCode.BAD_GATEWAY,
+               http.HTTPStatusCode.SERVICE_UNAVAILABLE,
+               http.HTTPStatusCode.GATEWAY_TIMEOUT,
+               }
+
+    def __init__(self, analyser: str,
+                 http_acquirer: Optional[http.HTMLAcquirer] = None):
+        super().__init__(analyser=analyser)
+        self._http = http_acquirer or http.HTMLAcquirer()
+
+    def get_url(self, url: str) -> http.Response:
+        """
+        Downloads the contents of `url` and returns the raw HTTP response.
+        Appropriate HTTP Redirects, which would be respected by the user's
+        browser, are also transparently respected by this method.
+        """
+        return self._http.get_url(url)
+
+    def get_dom(self, url: str) -> Optional[html.HtmlElement]:
+        """
+        Downloads the content of `url`.
+        If the download is successful, parses the obtained HTML and returns the
+        parsed `ElementTree` corresponding to its DOM.
+        """
+        return self._http.get_dom(url)
+
+    def check_response(self, response: http.Response) -> Ternary:
+        """
+        Selects whether the HTTP status code in the `response` object is
+        indicating an "OK" (page is there), a "NOT OK" (page is
+        deterministically not there), or that it could not be determined.
+        """
+        status = response.status
+        if status in self.Ok:  # Deterministically clear.
+            return True
+        if status in self.NotOk:  # Deterministically failed.
+            return False
+        if status in self.Unknown:  # Unknown result, could not determine.
+            return None
+
+        error("Received unhandled HTTP status '%d %s'!",
+              status, response.reason)
+        return None
+
+    def skip(self, checker: str, url: str) -> Status:
+        return Status.MISSING if not url else Status.OK
+
+    ResponseToVerifyStatus = {True: Status.OK,
+                              False: Status.NOT_OK,
+                              None: Status.UNKNOWN
+                              }
+
+    def verify(self, checker: str, url: str) -> Outcome:
+        """
+        Verifies that the given URL is openable as an HTTP request and returns
+        a "truthy" HTTP response code.
+
+        Notes
+        -----
+        The contents of the page is not analysed.
+        """
+        try:
+            trace("%s/%s -> %s ...", self.analyser, checker, url)
+            response = self.get_url(url)
+        except urllib3.exceptions.HTTPError:
+            import traceback
+            traceback.print_exc()
+
+            return Status.UNKNOWN, None
+
+        http_status = self.check_response(response)
+        return self.ResponseToVerifyStatus[http_status], response
+
+
+class HTMLAnchorVerifier(HTTPStatusCodeVerifier):
+    """
+    Generic URL verifier that checks whether the URL returns a valid HTTP
+    status code that indicates the URL resolves to a documentation that is
+    accessible by the user, and that the anchor in the ``GET`` response's DOM
+    exists.
+    This is used for documentation pages where several entries are on the same
+    page.
+
+    Notes
+    -----
+    This class caches the response for the same base URL (excluding anchors)
+    to speed up queries.
+    """
+
+    kind = "webpage#anchor"
+
+    def __init__(self, analyser: str,
+                 cache_size=http.CachingHTMLAcquirer.DefaultCacheSize):
+        super().__init__(analyser=analyser,
+                         http_acquirer=http.CachingHTMLAcquirer(cache_size))
+
+    def verify(self, checker: str, url: str) -> Outcome:
+        """
+        Executes the verification for `checker` of the site of the given
+        `url`.
+        In addition to downloading the `url` contents and checking the HTTP
+        status code, check if the anchor, as specified by the `url`, exists
+        appropriately (a real browser would have found the anchor to jump to).
+        If the `url` does not contain an anchor, provides the same behaviour,
+        except for internal caching, as `HTTPStatusCodeVerifier.verify()`
+        would.
+        """
+        page, anchor = self._http.split_anchor(url)
+        try:
+            trace("%s/%s -> %s ...", self.analyser, checker, url)
+            response = self.get_url(page)
+        except lxml.etree.LxmlError:
+            import traceback
+            traceback.print_exc()
+
+            return Status.UNKNOWN, None
+        except urllib3.exceptions.HTTPError:
+            return Status.UNKNOWN, None
+
+        http_status = self.check_response(response)
+        if not anchor or not http_status:
+            return self.ResponseToVerifyStatus[http_status], response
+
+        dom = self.get_dom(page)
+        if not (dom is not None):
+            return Status.NOT_OK, response
+        dom = cast(html.HtmlElement, dom)  # mypy does not recognise the if.
+
+        if dom.find(f".//*[@id=\"{anchor}\"]") is not None:
+            return Status.OK, response
+        if "github.com" in url and ".md#" in url:
+            # GitHub is doing something nasty with how they render Markdown.
+            #
+            # If you have a ToC and a header, they will generate two
+            #     <a href="#my-header" ...>
+            # tags, from which the invisible "permalink button" one near the
+            # actual header will have the
+            #     id="user-content-my-header"
+            # attribute as well.
+            #
+            # Specifying "whatever.md#my-header" will scroll the viewport to
+            # the heading, even though the previous XPath query won't return
+            # a valid element.
+            # This is because they use a custom web frontend to render the
+            # code from an embedded JavaScript object, so the render itself
+            # is not part of the downloaded DOM unless executed by a browser.
+            if anchor in response.data.decode():
+                return Status.OK, response
+
+        return Status.NOT_OK, response
+
+    def find_anchors_for_text(self, url: str, text: str) -> Iterable[str]:
+        """
+        Find elements in the DOM for `url` that contain the text `text` and
+        return the closest ancestors that have an ``id`` attribute that the
+        user can jump to.
+        """
+        page, _ = self._http.split_anchor(url)
+        dom = self.get_dom(page)
+        if not (dom is not None):
+            return iter(())
+        dom = cast(html.HtmlElement, dom)
+
+        return map(lambda e: e.attrib["id"], dom.xpath(
+            f"//*[contains(text(), \"{text}\")]/ancestor::*[@id][1]"))

--- a/scripts/labels/label_tool/doc_url/verifiers/llvm/__init__.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/llvm/__init__.py
@@ -1,0 +1,12 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Helper package to hoist common logic specific to the LLVM Project."""
+from .releases import fetch_llvm_release_versions
+
+
+__all__ = ["fetch_llvm_release_versions"]

--- a/scripts/labels/label_tool/doc_url/verifiers/llvm/releases.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/llvm/releases.py
@@ -1,0 +1,55 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Fetch the list of official LLVM release versions."""
+import os
+
+from lxml import html
+from selenium import webdriver
+from selenium.webdriver.common.by import By as WebdriverBy
+
+from ....output import error
+from ....transformer import Version, Versions
+
+
+def fetch_llvm_release_versions() -> Versions:
+    """
+    Downloads and returns the list of release versions (tags) for the
+    LLVM Project from the official archive.
+    """
+    # Note: Schema for the page last checked for version 18.1.
+    url = "https://releases.llvm.org"
+    xpath = "*//table[@id=\"download\"]"
+
+    try:
+        os.environ["MOZ_HEADLESS"] = "1"
+
+        # Unfortunately, a pure HTTP GET is not enough here, because the
+        # download table is populated by an inline JavaScript which we can't
+        # execute directly from Python code.
+        with webdriver.Firefox() as wd:
+            wd.get(url)
+            table_src = wd.find_element(WebdriverBy.XPATH, xpath). \
+                get_attribute("outerHTML")
+            download_table = html.fromstring(table_src)
+    except Exception:
+        import traceback
+        traceback.print_exc()
+
+        error("Failed to download or parse page '%s'!", url)
+        return list()
+    finally:
+        try:
+            del os.environ["MOZ_HEADLESS"]
+        except KeyError:
+            pass
+
+    releases = [Version(r)
+                for r in [r.text_content()
+                          for r in download_table.findall(".//tr/td[2]")]
+                if r not in ("Version", "Git",)]
+    return releases

--- a/scripts/labels/label_tool/doc_url/verifiers/status.py
+++ b/scripts/labels/label_tool/doc_url/verifiers/status.py
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+from enum import Enum, auto as Enumerator
+
+
+class Status(Enum):
+    """The outcome of an attempt at verifying a checker's documentation."""
+
+    """The result could not be determined."""
+    UNKNOWN = Enumerator()
+
+    """
+    The verifier engine skipped verifying the checker.
+    This is an internal indicator used for "multi-pass" verifications, and it
+    is not normally reported to the user.
+    """
+    SKIP = Enumerator()
+
+    """
+    The verification could not execute because the documentation data is empty.
+    """
+    MISSING = Enumerator()
+
+    """Successful."""
+    OK = Enumerator()
+
+    """Not successful. (Deterministic result.)"""
+    NOT_OK = Enumerator()

--- a/scripts/labels/label_tool/doc_url/verify_tool/__init__.py
+++ b/scripts/labels/label_tool/doc_url/verify_tool/__init__.py
@@ -1,0 +1,22 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+This subpackage implements logic that is primarily user-facing, as opposed to
+reusable library-like components.
+"""
+from . import \
+    action, \
+    report, \
+    tool
+
+
+__all__ = [
+    "action",
+    "report",
+    "tool",
+]

--- a/scripts/labels/label_tool/doc_url/verify_tool/__main__.py
+++ b/scripts/labels/label_tool/doc_url/verify_tool/__main__.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Implementation of the user-facing entry point to the script."""
+import argparse
+import fnmatch
+import os
+import pathlib
+import sys
+from typing import List, Optional, Set
+
+from tabulate import tabulate
+
+from codechecker_common.compatibility.multiprocessing import cpu_count
+from codechecker_common.util import clamp
+
+from ...checker_labels import SingleLabels, get_checker_labels, \
+    update_checker_labels
+from ...codechecker import codechecker_src_root
+from ...output import Settings as GlobalOutputSettings, \
+    error, log, trace, coloured, emoji
+from ...util import plural
+from ..output import Settings as OutputSettings
+from ..verifiers import analyser_selection
+from . import tool
+
+
+short_help: str = """
+Verify that the 'doc_url's are accessible by users, and update them to a fixed
+version, if necessary.
+"""
+description: str = (
+    """
+Verify that the 'doc_url's are accessible by users, and update them to a fixed
+version, if necessary.
+This tool makes several HTTP requests to simulate a browser (a User-Agent)
+querying for checker documentations, as if a user was clicking the URLs present
+on the CodeChecker UI.
+Found analysers and checkers are verified, and if the verification fails,
+attempts to resolve to a working URL (often by fixing typos and finding an
+older release of the analysers where the requested page still exists).
+
+Following execution, the tool prints a statistics output automatically.
+The tool's output is primarily engineered to be human readable (with the added
+sprinkle of colours and emojis).
+If the output is not sent to an interactive terminal, the output switches to
+the creation of a machine-readable output.
+
+The return code of this tool is indicative of errors encountered during
+execution.
+'0' is returned for no errors (success), '1' indicate general
+errors, '2' indicate configuration errors.
+In every other case, the return value is the OR of a bitmask:
+"""
+    f"""
+Having found checkers without a 'doc_url' label will set the bit
+'{tool.ReturnFlags.HadMissing}'.
+Having found checkers that have a "Not OK" label will set the bit
+'{tool.ReturnFlags.HadNotOK}'.
+Having found checkers that were "Not OK" but managed to obtain a fixed,
+working URL will set the bit '{tool.ReturnFlags.HadFound}'.
+Having found checkers that were "Not OK" and failed the attempted
+automatic fixing routing will set the bit '{tool.ReturnFlags.HadGone}'.
+"""
+)
+epilogue: str = ""
+
+
+def args(parser: Optional[argparse.ArgumentParser]) -> argparse.ArgumentParser:
+    def default_checker_label_dir() -> Optional[pathlib.Path]:
+        codechecker_root = codechecker_src_root()
+        return codechecker_root / "config" / "labels" / "analyzers" \
+            if codechecker_root else None
+
+    if not parser:
+        parser = argparse.ArgumentParser(
+            prog=__package__,
+            description=description,
+            epilog=epilogue,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument(
+        "checker_label_dir",
+        metavar="LABEL_DIR",
+        nargs='?',
+        default=default_checker_label_dir(),
+        type=pathlib.PurePath,
+        help="""
+The configuration directory where the checker labels are available.
+""")
+
+    parser.add_argument(
+        "-j", "--jobs",
+        metavar="COUNT",
+        dest="jobs",
+        type=int,
+        default=cpu_count(),
+        help="""
+The number of parallel processes to use for querying the validity of the
+"documentation URLs.
+Defaults to all available logical cores.
+""")
+
+    behaviour = parser.add_argument_group("behaviour arguments", """
+These optional arguments allow fine-tuning the steps executed by the
+verification logic.
+Unlike filters, which change what inputs are considered for verification, the
+behavioural arguments change the executed logic for all considered inputs.
+""")
+
+    behaviour.add_argument(
+        "--reset-to-upstream",
+        dest="reset_to_upstream",
+        action="store_true",
+        help="""
+Where applicable to the analyser and known how to do so, reset every checker's
+documentation URL to what it would be if it pointed to the upstream version,
+even if it does not actually do so.
+This allows both the verification of the "URL fixing" logic, and to uncover
+potentially old or outdated documentation URLs.
+""")
+
+    fix = behaviour.add_mutually_exclusive_group(required=False)
+
+    fix.add_argument(
+        "-f", "--fix",
+        dest="apply_fixes",
+        action="store_true",
+        help="""
+Apply and update the fixed 'doc_url's for cases which were "Not OK" but the
+fixing heuristics managed to find a proper result back into the input
+configuration file.
+""")
+
+    fix.add_argument(
+        "--skip-fixes",
+        dest="skip_fixes",
+        action="store_true",
+        help="""
+Completely skip executing the "URL fixing" phase in which the tool would search
+for a version of the URL where the documentation is available to the user.
+Instead, stop and quit after gathering "OK" and "Not OK" status.
+""")
+
+    filters = parser.add_argument_group("filter arguments")
+
+    filters.add_argument(
+        "--analysers", "--analyzers",
+        metavar="ANALYSER",
+        nargs='*',
+        type=str,
+        help="""
+Filter for only the specified analysers before executing the verification.
+Each analyser's configuration is present in exactly one JSON file, named
+'<analyser-name>.json'.
+If 'None' is given, automatically run for every found configuration file.
+""")
+
+    filters.add_argument(
+        "--checkers",
+        metavar="CHECKER",
+        nargs='*',
+        type=str,
+        help="""
+Filter for only the specified checkers before executing the verification.
+This filter matches only for the checker's name (as present in the
+configuration file), and every checker of every candidate analyser is matched
+against.
+It is not an error to specify filters that do not match anything.
+It is possible to match entire patterns of names using the '?' and '*'
+wildcards, as understood by the 'fnmatch' library, see
+"https://docs.python.org/%d.%d/library/fnmatch.html#fnmatch.fnmatchcase"
+for details.
+Depending on your shell, you might have to specify wildcards in single quotes,
+e.g., 'alpha.*', to prevent the shell from globbing first!
+If 'None' is given, automatically run for every checker.
+""" % (sys.version_info[0], sys.version_info[1]))
+
+    output = parser.add_argument_group("output control arguments", """
+These optional arguments allow enabling additional verbosity for the output
+of the program.
+By default, the tool tries to be the most concise possible, and only report
+negative findings ("Not OK" results) and encountered errors.
+""")
+
+    output.add_argument(
+        "-v", "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="""
+Shortcut to enable all verbosity options in this group that increase the
+useful information presented on the output.
+Does not enable any trace or debug information.
+""")
+
+    output.add_argument(
+        "--report-missing",
+        dest="report_missing",
+        action="store_true",
+        help="""
+If set, the output will contain an additional list that details which checkers
+do not have any 'doc_url' label at all ("MISSING").
+""")
+
+    output.add_argument(
+        "--report-ok",
+        dest="report_ok",
+        action="store_true",
+        help="""
+If set, the output will contain the "OK" reports for checkers that successfully
+verified.
+""")
+
+    output.add_argument(
+        "-vd", "--verbose-debug",
+        dest="verbose_debug",
+        action="store_true",
+        help="Emit additional trace and debug output.")
+
+    output.add_argument(
+        "-vv", "--very-verbose",
+        dest="very_verbose",
+        action="store_true",
+        help="""
+Shortcut to enable all verbosity options, including trace and debug
+information.
+""")
+
+    return parser
+
+
+def _handle_package_args(args: argparse.Namespace):
+    if not args.checker_label_dir:
+        log("%sFATAL: Failed to find the checker label configuration "
+            "directory, and it was not specified. "
+            "Please specify!",
+            emoji(":no_entry:  "))
+        raise argparse.ArgumentError(None,
+                                     "positional argument 'checker_label_dir'")
+    if args.jobs < 0:
+        log("%sFATAL: There can not be a non-positive number of jobs.",
+            emoji(":no_entry:  "))
+        raise argparse.ArgumentError(None, "-j/--jobs")
+    OutputSettings.set_report_missing(args.report_missing or
+                                      args.verbose or
+                                      args.very_verbose)
+    OutputSettings.set_report_ok(args.report_ok or
+                                 args.verbose or
+                                 args.very_verbose)
+    GlobalOutputSettings.set_trace(args.verbose_debug or args.very_verbose)
+
+
+def main(args: argparse.Namespace) -> Optional[int]:
+    try:
+        _handle_package_args(args)
+    except argparse.ArgumentError:
+        # Simulate argparse's return code of parse_args().
+        raise SystemExit(2)
+
+    rc = 0
+    statistics: List[tool.Statistics] = list()
+    trace("Checking checker labels from '%s'", args.checker_label_dir)
+
+    args.checker_label_dir = pathlib.Path(args.checker_label_dir)
+    if not args.checker_label_dir.is_dir():
+        error("'%s' is not a directory!", args.checker_label_dir)
+        return 1
+
+    # FIXME: pathlib.Path.walk() is only available Python >= 3.12.
+    for root, _, files in os.walk(args.checker_label_dir):
+        root = pathlib.Path(root)
+
+        for file in sorted(files):
+            file = pathlib.Path(file)
+            if file.suffix != ".json":
+                continue
+            analyser = file.stem
+            if args.analysers and analyser not in args.analysers:
+                continue
+
+            path = root / file
+            log("%sLoading '%s'... ('%s')",
+                emoji(":magnifying_glass_tilted_left:  "),
+                analyser,
+                path)
+            try:
+                labels = get_checker_labels(analyser, path, "doc_url")
+            except Exception:
+                import traceback
+                traceback.print_exc()
+
+                error("Failed to obtain checker labels for '%s'!", analyser)
+                continue
+
+            if args.checkers:
+                labels = {checker: url
+                          for checker, url in labels.items()
+                          for filter_ in args.checkers
+                          if fnmatch.fnmatchcase(checker, filter_)}
+            if not labels:
+                log("%sNo checkers are configured%s.",
+                    emoji(":cup_with_straw:  "),
+                    " or match the \"--checkers\" %s"
+                    % plural(args.checkers, "filter", "filters")
+                    if args.checkers else "")
+                continue
+
+            process_count = clamp(1, args.jobs, len(labels)) \
+                if len(labels) > 2 * args.jobs else 1
+            fixes: SingleLabels = dict()
+            conflicts: Set[str] = set()
+            for verifier in analyser_selection.select_verifier(analyser,
+                                                               labels):
+                log("%sVerifying '%s' as '%s' (%s)...",
+                    emoji(":thought_balloon:  "),
+                    analyser,
+                    verifier.kind, verifier)
+                status, local_fixes, statistic = tool.execute(
+                    analyser,
+                    verifier,
+                    labels,
+                    process_count,
+                    args.skip_fixes,
+                    args.reset_to_upstream,
+                    )
+                statistics.append(statistic)
+                rc = int(tool.ReturnFlags(rc) | status)
+
+                for checker in local_fixes.keys() - conflicts:
+                    fix = local_fixes[checker]
+                    try:
+                        existing_fix = fixes[checker]
+                        if existing_fix != fix:
+                            error("%s%s/%s: %s [%s] =/= [%s]",
+                                  emoji(":collision:  "),
+                                  analyser, checker,
+                                  coloured("FIX COLLISION", "red"),
+                                  existing_fix, fix
+                                  )
+                            conflicts.add(checker)
+                            del fixes[checker]
+                    except KeyError:
+                        fixes[checker] = fix
+
+                if args.apply_fixes and fixes:
+                    log("%sUpdating %s %s for '%s'... ('%s')",
+                        emoji(":writing_hand:  "),
+                        coloured("%d" % len(fixes), "green"),
+                        plural(fixes, "checker", "checkers"),
+                        analyser,
+                        path)
+                    try:
+                        update_checker_labels(analyser, path, "doc_url", fixes)
+                    except Exception:
+                        error("Failed to write checker labels for '%s'!",
+                              analyser)
+                        continue
+
+    log(tabulate(tabular_data=statistics,
+                 headers=tuple(map(lambda s: s.replace('_', ' '),
+                                   tool.Statistics._fields)),
+                 tablefmt="fancy_outline" if sys.stderr.isatty()
+                 else "outline"),
+        file=sys.stderr)
+
+    log("%s", repr(tool.ReturnFlags(rc)))
+    return rc
+
+
+if __name__ == "__main__":
+    def _main():
+        _args = args(None).parse_args()
+        sys.exit(main(_args) or 0)
+    _main()

--- a/scripts/labels/label_tool/doc_url/verify_tool/action.py
+++ b/scripts/labels/label_tool/doc_url/verify_tool/action.py
@@ -1,0 +1,213 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Provides implementations for the high-level user-facing actions."""
+import sys
+from typing import List, Optional, Tuple, Type
+
+from codechecker_common.compatibility.multiprocessing import Pool
+
+from ...checker_labels import SingleLabels
+from ...output import Settings as GlobalOutputSettings, log, emoji, coloured
+from ...util import _Singleton
+from ..output import Settings as OutputSettings
+from ..verifiers import HTTPStatusCodeVerifier, Status
+
+
+class Worker(_Singleton):
+    """Implementation of methods executed in a parallel computation context."""
+
+    def __init__(self):
+        """Returns the instance that was loaded as a `Singleton`."""
+        if "_verifier" not in self.__dict__:
+            self._verifier = None
+
+    @staticmethod
+    def factory(verifier_class: Type, analyser: str):
+        """Initialises the `Singleton` with the required constructor args."""
+        obj = Worker()
+        obj._verifier = verifier_class(analyser)  # type: ignore
+        return obj
+
+    @property
+    def verifier(self):
+        return self._verifier
+
+    @staticmethod
+    def verify(task):
+        """Executes the worker implementation."""
+        verifier = Worker().verifier  # type: ignore
+        return verify_checker(verifier, *task)
+
+    @staticmethod
+    def reset(task):
+        """Executes the worker implementation."""
+        verifier = Worker().verifier  # type: ignore
+        return reset_checker(verifier, *task)
+
+    @staticmethod
+    def try_fix(task):
+        """Executes the worker implementation."""
+        verifier = Worker().verifier  # type: ignore
+        return try_fix_checker(verifier, *task)
+
+
+def verify_checker(verifier: HTTPStatusCodeVerifier,
+                   checker: str, url: str) -> Status:
+    """
+    Executes the verification that `checker` has a valid, accessible
+    documentation `doc_url` set.
+    """
+    analyser = verifier.analyser
+    status = verifier.skip(checker, url)
+    if status == Status.MISSING:
+        if OutputSettings.report_missing():
+            log("%s%s/%s: %s []",
+                emoji(":white_question_mark:  "),
+                analyser, checker,
+                coloured("MISSING", "yellow"),
+                file=sys.stdout)
+        return status
+    if status == Status.SKIP:
+        if GlobalOutputSettings.trace():
+            log("%s%s/%s: %s [%s]",
+                emoji(":screwdriver:  "),
+                analyser, checker,
+                coloured("SKIP", "light_magenta"),
+                url,
+                file=sys.stderr)
+        return status
+
+    status, _ = verifier.verify(checker, url)
+    if status == Status.OK:
+        if OutputSettings.report_ok():
+            log("%s%s/%s: %s [%s]",
+                emoji(":check_box_with_check:  "),
+                analyser, checker,
+                coloured("OK", "green"),
+                url,
+                file=sys.stdout)
+    elif status == Status.NOT_OK:
+        log("%s%s/%s: %s [%s]",
+            emoji(":cross_mark:  "),
+            analyser, checker,
+            coloured("NOT OK", "red"),
+            url,
+            file=sys.stdout)
+    return status
+
+
+def run_verification(pool: Pool, urls: SingleLabels) \
+        -> Tuple[List[str], int, List[str], List[str]]:
+    ok: List[str] = list()
+    skip = 0
+    not_ok: List[str] = list()
+    missing: List[str] = list()
+
+    def _consume_result(checker: str,  s: Status):
+        if s == Status.OK:
+            ok.append(checker)
+        elif s == Status.SKIP:
+            nonlocal skip
+            skip += 1
+        elif s == Status.NOT_OK:
+            not_ok.append(checker)
+        elif s == Status.MISSING:
+            missing.append(checker)
+
+    for (checker, _), verified in zip(
+            urls.items(), pool.map(Worker.verify, urls.items())):
+        _consume_result(checker, verified)
+
+    return ok, skip, not_ok, missing
+
+
+def reset_checker(verifier: HTTPStatusCodeVerifier,
+                  checker: str, url: str) -> Tuple[bool, Optional[str]]:
+    analyser = verifier.analyser
+    status = verifier.skip(checker, url)
+    if status == Status.SKIP:
+        return False, None
+
+    after_reset = verifier.reset(checker, url)
+    if not after_reset or after_reset == url:
+        return True, None
+
+    if GlobalOutputSettings.trace():
+        log("%s%s/%s: %s [%s] -> [%s]",
+            emoji(":right_arrow_curving_left:  "),
+            analyser, checker,
+            coloured("RESET", "cyan"),
+            url, after_reset,
+            file=sys.stdout)
+    return True, after_reset
+
+
+def run_reset(pool: Pool, urls: SingleLabels) -> Tuple[int, SingleLabels]:
+    attempted = 0
+    new_urls: SingleLabels = dict()
+
+    def _consume_result(checker: str,
+                        was_attempted: bool,
+                        new_url: Optional[str]):
+        if was_attempted:
+            nonlocal attempted
+            attempted += 1
+        if new_url:
+            new_urls[checker] = new_url
+
+    for (checker, _), (was_attempted, new_url) in zip(
+            urls.items(), pool.map(Worker.reset, urls.items())):
+        _consume_result(checker, was_attempted, new_url)
+
+    return attempted, new_urls
+
+
+def try_fix_checker(verifier: HTTPStatusCodeVerifier,
+                    checker: str, url: str) -> Optional[str]:
+    analyser = verifier.analyser
+    status = verifier.skip(checker, url)
+    if status == Status.SKIP:
+        return None
+
+    maybe_fixed = verifier.try_fix(checker, url)
+    if not maybe_fixed:
+        log("%s%s/%s: %s [%s]",
+            emoji(":ghost:  "),
+            analyser, checker,
+            coloured("PERMANENTLY GONE", "red"),
+            url,
+            file=sys.stdout)
+    else:
+        log("%s%s/%s: %s [%s] -> [%s]",
+            emoji(":sparkles:  "),
+            analyser, checker,
+            coloured("FOUND", "green"),
+            coloured(url, "red"),
+            coloured(maybe_fixed, "green"),
+            file=sys.stdout)
+    return maybe_fixed
+
+
+def run_fixes(pool: Pool, urls: SingleLabels) -> Tuple[SingleLabels,
+                                                       SingleLabels]:
+    found: SingleLabels = dict()
+    gone: SingleLabels = dict()
+
+    def _consume_result(checker: str,
+                        old_url: Optional[str],
+                        new_url: Optional[str]):
+        if new_url:
+            found[checker] = new_url
+        else:
+            gone[checker] = old_url
+
+    for (checker, old_url), new_url in zip(
+            urls.items(), pool.map(Worker.try_fix, urls.items())):
+        _consume_result(checker, old_url, new_url)
+
+    return found, gone

--- a/scripts/labels/label_tool/doc_url/verify_tool/report.py
+++ b/scripts/labels/label_tool/doc_url/verify_tool/report.py
@@ -1,0 +1,133 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Provides implementations for the high-level reports printed to the user."""
+from collections import deque
+from typing import List
+
+from ...checker_labels import SingleLabels
+from ...output import log, coloured, emoji
+from ...util import plural
+from ..output import Settings as OutputSettings
+
+
+def print_verifications(analyser: str,
+                        urls: SingleLabels,
+                        ok: List[str],
+                        not_ok: List[str],
+                        missing: List[str]):
+    if missing:
+        log("%s%s: %s %s %s not have a `doc_url` label!",
+            emoji(":magnifying_glass_tilted_left:"
+                  ":magnifying_glass_tilted_right:  "),
+            analyser,
+            coloured("%d" % len(missing), "yellow"),
+            plural(missing, "checker", "checkers"),
+            plural(missing, "does", "do"),
+            )
+        if OutputSettings.report_missing():
+            deque((log("    %s· %s ",
+                       emoji(":bookmark:  "),
+                       coloured(checker, "yellow"))
+                   for checker in sorted(missing)),
+                  maxlen=0)
+
+    if not not_ok:
+        if ok:
+            log("%s%s: All %s %s successfully verified.",
+                emoji(":magnifying_glass_tilted_left::check_mark_button:  "),
+                analyser,
+                coloured("%d" % len(ok), "green"),
+                plural(ok, "checker", "checkers"),
+                )
+    else:
+        log("%s%s: %s %s failed documentation verification. (%s succeeded.)",
+            emoji(":magnifying_glass_tilted_left::warning:  "),
+            analyser,
+            coloured("%d" % len(not_ok), "red"),
+            plural(not_ok, "checker", "checkers"),
+            coloured("%d" % len(ok), "green")
+            if ok else coloured("0", "red"),
+            )
+
+    for checker in sorted((ok if OutputSettings.report_ok() else []) +
+                          not_ok):
+        is_ok = (checker in ok) if OutputSettings.report_ok() else False
+        icon = ":globe_showing_Europe-Africa:" if is_ok \
+            else ":skull_and_crossbones:  "
+        colour = "green" if is_ok else "red"
+
+        log("    %s· %s [%s]", emoji(icon), coloured(checker, colour),
+            urls[checker])
+
+
+def print_resets(analyser: str,
+                 attempted: int,
+                 new_urls: SingleLabels):
+    if not attempted:
+        log("%s%s: Did not attempt any resets.",
+            emoji(":magnifying_glass_tilted_left:"
+                  ":left_arrow_curving_right:  "),
+            analyser,
+            )
+        return
+
+    log("%s%s: Tried to reset %s %s documentation URL. %s changed.",
+        emoji(":magnifying_glass_tilted_left::right_arrow_curving_left:  "),
+        analyser,
+        coloured("%d" % attempted, "magenta"),
+        plural(attempted, "checker's", "checkers'"),
+        coloured("%d" % len(new_urls), "cyan")
+        if new_urls else coloured("0", "red"),
+        )
+    deque((log("    %s· %s [%s]",
+               emoji(":magic_wand:  "),
+               coloured(checker, "cyan"),
+               new_urls[checker])
+           for checker in sorted(new_urls)),
+          maxlen=0)
+
+
+def print_fixes(analyser: str,
+                urls: SingleLabels,
+                found: SingleLabels,
+                gone: SingleLabels):
+    if not gone:
+        if found:
+            log("%s%s: Found new documentation for all %s %s.",
+                emoji(":magnifying_glass_tilted_left::telescope:  "),
+                analyser,
+                coloured("%d" % len(found), "green"),
+                plural(len(found), "checker", "checkers"),
+                )
+    else:
+        if not found:
+            log("%s%s: All %s %s gone.",
+                emoji(":magnifying_glass_tilted_left::headstone:  "),
+                analyser,
+                coloured("%d" % len(gone), "red"),
+                plural(len(gone), "checker", "checkers"),
+                )
+        else:
+            log("%s%s: %s %s gone. (Found %s.)",
+                emoji(":magnifying_glass_tilted_left::bar_chart:  "),
+                analyser,
+                coloured("%d" % len(gone), "red"),
+                plural(len(gone), "checker", "checkers"),
+                coloured("%d" % len(found), "green")
+                if found else coloured("0", "red")
+                )
+
+    for checker in sorted(found.keys() | gone.keys()):
+        is_found = checker in found
+        icon = ":globe_showing_Europe-Africa:  " if is_found \
+            else ":skull_and_crossbones:  "
+        colour = "green" if is_found else "red"
+        url_to_print = found[checker] if is_found else gone[checker]
+
+        log("    %s· %s [%s]", emoji(icon), coloured(checker, colour),
+            url_to_print)

--- a/scripts/labels/label_tool/doc_url/verify_tool/tool.py
+++ b/scripts/labels/label_tool/doc_url/verify_tool/tool.py
@@ -1,0 +1,119 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Provides implementations for the tool's pipeline."""
+from enum import IntFlag, auto as Enumerator
+from typing import NamedTuple, Optional, Tuple, Type, cast
+
+from codechecker_common.compatibility.multiprocessing import Pool
+
+from ...checker_labels import SingleLabels
+from ...output import trace
+from ...util import plural
+from . import action, report
+
+
+class Statistics(NamedTuple):
+    """
+    The result of the execution of one analyser's verification.
+    """
+
+    Analyser: str
+    Checkers: int
+    Verifier: str
+    Skipped: Optional[int]
+    Reset: Optional[int]
+    Missing: Optional[int]
+    Verified: Optional[int]
+    OK: Optional[int]
+    Not_OK: Optional[int]
+    Found: Optional[int]
+    Gone: Optional[int]
+
+
+class ReturnFlags(IntFlag):
+    """
+    A bit flag structure indicating the return value of the execution of the
+    tool's `execute` function.
+    """
+    # Zero indicates an all-success, but `Enumerator()` starts from 1.
+
+    # Reserved flags used for other purposes external to the tool.
+    GeneralError = Enumerator()
+    ConfigurationOrArgsError = Enumerator()
+
+    HadMissing = Enumerator()
+    HadNotOK = Enumerator()
+    HadFound = Enumerator()
+    HadGone = Enumerator()
+
+
+def execute(analyser: str,
+            verifier_class: Type,
+            labels: SingleLabels,
+            process_count: int,
+            skip_fixes: bool,
+            reset_urls: bool
+            ) -> Tuple[ReturnFlags, SingleLabels, Statistics]:
+    """Runs one instance of the verification pipeline."""
+    trace("Running over %d %s.",
+          process_count,
+          plural(process_count, "process", "processes"))
+    status = cast(ReturnFlags, 0)
+    stats = Statistics(Analyser=analyser,
+                       Checkers=len(labels),
+                       Verifier=verifier_class.kind,
+                       Skipped=None,
+                       Reset=None,
+                       Missing=None,
+                       Verified=None,
+                       OK=None,
+                       Not_OK=None,
+                       Found=None,
+                       Gone=None,
+                       )
+
+    with Pool(max_workers=process_count,
+              initializer=action.Worker.factory,
+              initargs=(verifier_class, analyser,)
+              ) as pool:
+        if reset_urls:
+            attempt, new_urls = action.run_reset(pool, labels)
+            report.print_resets(analyser, attempt, new_urls)
+            labels.update(new_urls)
+            stats = stats._replace(Reset=len(new_urls) if new_urls else None,
+                                   )
+
+        urls_to_save: SingleLabels = dict()
+        ok, skip, not_ok, missing = action.run_verification(pool, labels)
+        report.print_verifications(analyser, labels, ok, not_ok, missing)
+        urls_to_save.update({checker: labels[checker] for checker in ok})
+        verified = len(labels) - skip - len(missing)
+        stats = stats._replace(Skipped=skip if skip else None,
+                               Missing=len(missing) if missing else None,
+                               Verified=verified if verified else None,
+                               OK=len(ok) if ok else None,
+                               Not_OK=len(not_ok) if not_ok else None,
+                               )
+        status = status | (ReturnFlags.HadMissing if missing else 0)
+
+        if not_ok:
+            status |= ReturnFlags.HadNotOK
+            if not skip_fixes:
+                found, gone = action.run_fixes(
+                    pool, {checker: labels[checker] for checker
+                           in labels.keys() & not_ok}
+                )
+                report.print_fixes(analyser, labels, found, gone)
+                urls_to_save.update(found)
+                stats = stats._replace(Found=len(found) if found else None,
+                                       Gone=len(gone) if gone else None,
+                                       )
+                status = status | (ReturnFlags.HadFound if found else 0) \
+                    | (ReturnFlags.HadGone if gone else 0)
+
+    return status, urls_to_save, stats

--- a/scripts/labels/label_tool/http_.py
+++ b/scripts/labels/label_tool/http_.py
@@ -1,0 +1,155 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""HTTP connections and communication."""
+import datetime
+from http import HTTPStatus as HTTPStatusCode  # pylint: disable=unused-import
+from typing import Dict, Optional, Union, Tuple
+import urllib.parse
+
+from lxml import html
+import urllib3
+
+from .output import trace
+
+
+Response = urllib3.response.BaseHTTPResponse
+URL = Union[str, urllib.parse.ParseResult]
+
+
+class HTMLAcquirer:
+    """
+    Wrapper class that exposes fetching HTML pages over HTTP.
+    """
+
+    def __init__(self):
+        self._pool = urllib3.PoolManager()
+
+    def _get_url_raw(self, url: str) -> Response:
+        """
+        Downloads the contents of `url` and returns the raw HTTP response.
+        Appropriate HTTP Redirects, which would be respected by the user's
+        browser, are also transparently respected by this method.
+
+        Notes
+        -----
+        By default, urrlib3 will retry requests 3 times and follow up to
+        3 redirects.
+        """
+        trace("HTTP GET '%s'", url)
+        return self._pool.request("GET", url)
+
+    def get_url(self, url: URL) -> Response:
+        """
+        Downloads the content of `url` and returns the raw HTTP response.
+        """
+        if isinstance(url, urllib.parse.ParseResult):
+            url = url.geturl()
+        return self._get_url_raw(url)
+
+    def _get_dom_raw(self, url: str) -> Optional[html.HtmlElement]:
+        """
+        Downloads the content of `url`.
+        If the download is successful, parses the obtained HTML and returns the
+        parsed `ElementTree` corresponding to its DOM.
+        """
+        response = self._get_url_raw(url)
+        dom = html.fromstring(response.data) if response.data else None
+        return dom
+
+    def get_dom(self, url: URL) -> Optional[html.HtmlElement]:
+        """
+        Downloads the content of `url`.
+        If the download is successful, parses the obtained HTML and returns the
+        parsed `ElementTree` corresponding to its DOM.
+        """
+        if isinstance(url, urllib.parse.ParseResult):
+            url = url.geturl()
+        return self._get_dom_raw(url)
+
+    def split_anchor(self, url: URL) -> Tuple[str, str]:
+        if isinstance(url, str) and '#' not in url:
+            return url, ""
+
+        url_s = url if isinstance(url, urllib.parse.ParseResult) \
+            else urllib.parse.urlparse(url)
+        if not url_s.fragment and isinstance(url, str):
+            return url, ""
+
+        # The `_replace()` method will return a new ParseResult object...
+        return url_s._replace(fragment="").geturl(), str(url_s.fragment) \
+            if url_s.fragment else ""
+
+
+class CachingHTMLAcquirer(HTMLAcquirer):
+    """
+    Wrapper class that exposes fetching and caching results of querying HTML
+    pages over HTTP.
+    """
+
+    DefaultCacheSize = 16
+    CacheType = Tuple[Response, Optional[html.HtmlElement]]
+
+    def __init__(self, cache_size: int = DefaultCacheSize):
+        super().__init__()
+        self._cache_capacity = cache_size
+        self._cache: Dict[str, CachingHTMLAcquirer.CacheType] = dict()
+        self._cache_lru: Dict[str, datetime.datetime] = dict()
+
+    def get_url(self, url: URL) -> Response:
+        """
+        Downloads the content of `url` after stripping the HTML anchor off of
+        the request, and returns the raw HTTP response.
+        """
+        url, _ = self.split_anchor(url)
+        cached = self._cache_get(url)
+        if not cached:
+            response = self._get_url_raw(url)
+            dom = html.fromstring(response.data) if response.data else None
+            cached = self._cache_set(url, (response, dom,))
+
+        response, _ = cached
+        return response
+
+    def get_dom(self, url: URL) -> Optional[html.HtmlElement]:
+        """
+        Downloads the content of `url` after stripping the HTML anchor off of
+        the request.
+        If the download is successful, or the page is already in the cache,
+        parses the obtained HTML and returns the parsed `ElementTree`
+        corresponding to its DOM.
+        """
+        url, _ = self.split_anchor(url)
+        cached = self._cache_get(url)
+        if not cached:
+            self.get_url(url)  # Populates the cache, if needed.
+            cached = self._cache_get(url)
+            if not cached:
+                return None
+
+        _, dom = cached
+        return dom
+
+    def _cache_get(self, k: str) -> Optional[CacheType]:
+        try:
+            o = self._cache[k]
+            self._cache_lru[k] = datetime.datetime.now()
+            return o
+        except KeyError:
+            return None
+
+    def _cache_set(self, k: str, v: CacheType) -> CacheType:
+        cache_hit = k in self._cache
+        if self._cache_capacity > 0 and not cache_hit:
+            while len(self._cache) >= self._cache_capacity:
+                del_k = min(self._cache_lru, key=self._cache_lru.__getitem__)
+                del self._cache[del_k]
+                del self._cache_lru[del_k]
+
+        self._cache[k] = v
+        self._cache_lru[k] = datetime.datetime.now()
+        return v

--- a/scripts/labels/label_tool/output.py
+++ b/scripts/labels/label_tool/output.py
@@ -1,0 +1,79 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Output to the user, formatting utilities."""
+import sys
+
+from emoji import emojize as emoji, replace_emoji
+from termcolor import colored as coloured  # pylint: disable=unused-import
+
+from .util import _Singleton
+
+
+class Settings(_Singleton):
+    """Package-level output settings."""
+
+    def __init__(self):
+        """Returns the instance that was loaded as a `_Singleton`."""
+        if "_trace" not in self.__dict__:
+            self._trace: bool = False
+
+    @staticmethod
+    def factory():
+        """Initialises the `_Singleton`."""
+        o = Settings()
+        return o
+
+    @staticmethod
+    def trace() -> bool:
+        return Settings.factory()._trace  # type: ignore
+
+    @staticmethod
+    def set_trace(v: bool):
+        Settings.factory()._trace = v  # type: ignore
+
+
+def _print(string: str, *args, **kwargs):
+    """
+    Wrapper over standard `print` which strips emojis if the output file is
+    not a terminal.
+    """
+    try:
+        isatty = kwargs["file"].isatty()
+    except KeyError:
+        isatty = sys.stdout.isatty() and sys.stderr.isatty()
+
+    if not isatty:
+        string = replace_emoji(string, '').strip()
+    print(string, *args, **kwargs)
+
+
+def log(fmt: str, *args, **kwargs):
+    """Logging stub."""
+    if "file" not in kwargs:
+        kwargs["file"] = sys.stderr
+
+    return _print(fmt % (args), **kwargs)
+
+
+def _log_with_prefix(prefix: str, fmt: str, *args, **kwargs):
+    """Logging stub."""
+    fmt = "%s: %s" % (prefix, fmt)
+    return log(fmt, *args, **kwargs)
+
+
+def error(fmt: str, *args, **kwargs):
+    """Logging stub."""
+    return _log_with_prefix("%sERROR" % emoji(":warning:  "),
+                            fmt, *args, **kwargs)
+
+
+def trace(fmt: str, *args, **kwargs):
+    """Logging stub."""
+    if Settings.trace():
+        return _log_with_prefix("%sTRACE" % emoji(":speech_balloon:  "),
+                                fmt, *args, **kwargs)

--- a/scripts/labels/label_tool/requirements.txt
+++ b/scripts/labels/label_tool/requirements.txt
@@ -1,0 +1,8 @@
+# codechecker==local
+emoji==2.11.0
+lxml==4.9.3
+packaging==24.0
+selenium==4.19.0
+tabulate==0.9.0
+termcolor==2.4.0
+urllib3==2.2.1

--- a/scripts/labels/label_tool/transformer.py
+++ b/scripts/labels/label_tool/transformer.py
@@ -1,0 +1,149 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Transform URLs based on patterns and heuristics."""
+import re
+from typing import Callable, Dict, Iterable, List, Optional, Union, cast
+
+import packaging.version
+from packaging.version import Version
+
+from .util import lower_bound
+
+
+Versions = List[Version]
+LazyVersions = Union[Versions, Callable[[], Versions]]
+
+
+class ReplacePatternApplicator:
+    """
+    Allows building strings by replacing `<VARIABLES>` in a pre-determined
+    pattern via the `__call__` operator.
+    """
+
+    placeholder_re = re.compile(r'<(.*?)>')
+
+    def __init__(self, pattern: str):
+        self._pattern = pattern
+        self._placeholder_matches = list(
+            self.placeholder_re.finditer(self._pattern))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__module__}." \
+            f"{self.__class__.__qualname__}" \
+            f"(\"{self._pattern}\")"
+
+    def __call__(self, **values) -> str:
+        """
+        Fills the placeholders in the `pattern` with the values specified in
+        `values`.
+        The values are specified case-insensitive.
+        """
+        r = str(self._pattern)
+        for key, (begin, end) in map(lambda m: (m.group(1), m.span(1)),
+                                     reversed(self._placeholder_matches)):
+            r = r[:begin - 1] + values[key.lower()] + r[end + 1:]
+
+        return r
+
+
+class PerReleaseRules:
+    """
+    Implements the logic for generating fixed documentation URLs based
+    on a rewriting patterns for cases where the requested documentation might
+    exist in an older release of the software.
+    """
+
+    def __init__(self, releases: LazyVersions):
+        """
+        Initialises the data structures for the release-based fixer.
+
+        A list of existing releases to check is required, either in an already
+        acquired, or in a lazy-loadable format.
+        """
+        if isinstance(releases, list):
+            self._releases = releases
+            self._releases.sort()
+            self._releases.reverse()
+        else:
+            self._releases = None
+            self._fetch_releases = releases
+
+        self._rules: Dict[Union[Version,
+                                packaging.version.InfinityType,
+                                packaging.version.NegativeInfinityType],
+                          Optional[Callable]] = dict()
+        self._rules[packaging.version.NegativeInfinity] = None
+        self._rules[packaging.version.Infinity] = None
+
+    @property
+    def releases(self) -> Versions:
+        if not self._releases and self._fetch_releases:
+            self._releases = self._fetch_releases()
+            self._releases.sort()
+            self._releases.reverse()
+        return cast(Versions, self._releases)
+
+    def add_rule(self, rule: Optional[Union[str, Callable]],
+                 min_: Optional[Version] = None):
+        """
+        Registers `rule` to be the fixer's rewrite rule applied if the
+        attempted version satisfies ``min_ <= V``.
+
+        If `min_` is unset, it is understood as the hypothetical minimum
+        version when rewriting, i.e., `releases()[0]`.
+        Specify `None` as  `rule` to turn off rule application for an interval
+        of versions.
+
+        `rule` can be either a `str`, in which placeholders, in the format of
+        `<KEY>` (e.g., `<VERSION>`) are rewritten (see `__call__`, and
+        `_Rule.__call__`), or a callback function, which receives the arguments
+        of `__call__` and is expected to produce a `str` result.
+        """
+        self._rules[min_ or packaging.version.NegativeInfinity] = \
+            ReplacePatternApplicator(rule) if isinstance(rule, str) \
+            else rule
+
+    def generate_url(self, version: Version, **opts: str) -> Optional[str]:
+        """
+        Generates an attemptible documentation URL for the given `version`
+        based on the input `opts` that are applied to the found rewriting rule
+        (see `add_rule()`).
+        """
+        release_bound = lower_bound(sorted(self._rules.keys()), version) \
+            or packaging.version.NegativeInfinity
+        rule_for_release = self._rules[release_bound]
+        if not rule_for_release:
+            return None
+
+        attempt = rule_for_release(version=str(version), **opts)
+        return attempt
+
+    def generate_urls(self, **opts: str) -> Iterable[str]:
+        """
+        Generates attemptible older documentation URL based on the input `opts`
+        that are applied to the rewriting rules (see `add_rule()`).
+        """
+        for release in self.releases:
+            attempt = self.generate_url(release, **opts)
+            if attempt:
+                yield attempt
+
+    def __call__(self, check: Callable[[str], bool], **opts: str) \
+            -> Optional[str]:
+        """
+        Performs the attempt at creating a verifiable and valid fixed older
+        documentation URL based on the input `opts` that are applied to the
+        rewriting rules (see `add_rule()`).
+
+        The results are intermittently checked by the provided `check`
+        callback, and the first `True` result's input is returned.
+        """
+        for attempt in self.generate_urls(**opts):
+            if check(attempt):
+                return attempt
+        return None

--- a/scripts/labels/label_tool/util.py
+++ b/scripts/labels/label_tool/util.py
@@ -1,0 +1,80 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""Helper functions, mixin classes, and miscellaneous utilities."""
+import bisect
+from typing import Any, Callable, Collection, Dict, List, Optional, \
+    Sequence, Type, TypeVar, Union
+
+
+_T = TypeVar("_T")
+
+Ternary = Optional[bool]
+
+
+class _Singleton:
+    """
+    Helper class to implement the global Singleton pattern.
+
+    This helper is needed because multiprocessed executions need to spawn a
+    globally available state such that `.map()` on the executor can work
+    without having to serialise a complex state object over the communication
+    channel between the manager and the processes.
+    """
+    _instances: Dict[Type, Any] = dict()
+
+    def __new__(cls, *args, **kwargs) -> object:
+        if cls not in cls._instances:
+            cls._instances[cls] = super(_Singleton, cls).__new__(cls)
+            cls._instances[cls].__init__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+def plural(c: Union[int, Collection], s: str, p: str) -> str:
+    if not isinstance(c, int):
+        c = len(c)
+    return s if c == 1 else p
+
+
+def find_if(s: Sequence[_T], p: Callable[[_T], bool]) -> Optional[int]:
+    """
+    Returns the index of the first element in the list `s` which satisfies the
+    given predicate `p`, or `None` if no such element exists.
+    """
+    return next((i for i, e in enumerate(s) if p(e)), None)
+
+
+def lower_bound(l_: List[_T], e: _T) -> Optional[_T]:
+    """
+    Searches for the first element in the list `l_` which is **not** ordered
+    before (using ``<``) `e`, i.e., an ``x`` that is ``max(x)`` such that
+    ``x <= e``.
+
+    `l_` must be sorted and must not contain duplicates.
+
+    If no such element is found (`l_` is empty, or `e` is either ``<`` or ``>``
+    than **all** elements of `l_`), returns `None`.
+    """
+    if not l_:
+        return None
+
+    idx = bisect.bisect_left(l_, e)  # type: ignore
+    if idx == len(l_):
+        # e > all elements of l, no element is <=.
+        return None
+    if idx == 0:
+        # e <= all elements of l.
+        if l_[0] == e:
+            return l_[0]
+
+        # e < all elements of l.
+        return None
+
+    # l[idx - 1] < l[idx] <= e < l[idx + 1]
+    if l_[idx] == e:
+        return l_[idx]
+    return l_[idx - 1]


### PR DESCRIPTION
The checker label configuration files most often contain a documentation page link that we suggest to the user when viewing the details of a report. These JSON files are always hard-baked into a released package, and the server serves information based on what is available in the deployed image. As all of these links point to **external** resources, these links are very susceptible to [**link rot**](http://enwp.org/Link_rot).

For example, suppose that an analysis was stored with the `alpha.Foo` checker, with the URL pointing to `.../alpha/Foo.html`. Once the underlying analyser's documentation changes (usually for two reasons: improving the checker and removing it from alpha, or the checker becoming completely removed from upstream!), this link is now dead. Newer reports stored with `core.Foo` (`.../core/Foo.html`) will point to a proper documentation, but re-routing `alpha.Foo`'s documentation page to `core.Foo`'s would be an invalid action, as the behaviour of the checker might have changed meanwhile, rendering the contents of the new document inapplicable to the old report! In addition, nothing prevents the user from running an older analyser with/through a newer CodeChecker package, and uploading new results from the `alpha.` version even when after `core.` analyser's release.

This patch introduces an opt-in tool which reads the configuration files and **verifies** whether the URL is available to a hypothetical user. If not, it attempts to employ a heuristic pipeline to attempt a URL that corresponds to the checker with the currently dead link, first by fixing the typos in the URL, and if that is still unsuccessful, trying the documentation sites of older releases. For now, this fixing logic is only implemented for the **LLVM**-based analysers, *Clang SA* and *Clang-Tidy*, as implementing it requires an accurate understanding of the documentation structure of the specific analyser.