### PR TITLE
[fix] Prevent overlapping report groups

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2089,6 +2089,13 @@ class ThriftRequestHandler:
                                        sort_type_map,
                                        order_type_map)
 
+                # Most queries are using paging of reports due their great
+                # number. This is implemented by LIMIT and OFFSET in the SQL
+                # queries. However, if there is no ordering in the query, then
+                # the reports in different pages may overlap. This ordering
+                # prevents it.
+                q = q.order_by(Report.id)
+
                 if report_filter.annotations is not None:
                     annotations = defaultdict(list)
                     for annotation in report_filter.annotations:


### PR DESCRIPTION
When getRunResults() API function queries the reports, the query uses LIMIT and OFFSET for returning the given page of the results due to their huge number. However, it is possible that different pages have overlapping reports. This way the resulting report list may contain duplicate reports.
In this commit we apply an ordering on report id in order to prevent this.