### PR TITLE
[fix] Replace UTF-8 dash characters

### DIFF
--- a/web/server/codechecker_server/migrations/report/versions/c3dad71f8e6b_store_information_about_enabled_and_disabled_checkers_for_a_run.py
+++ b/web/server/codechecker_server/migrations/report/versions/c3dad71f8e6b_store_information_about_enabled_and_disabled_checkers_for_a_run.py
@@ -207,7 +207,7 @@ def upgrade():
         num_batches = report_count // REPORT_UPDATE_CHUNK_SIZE + 1
 
         def _print_progress(batch: int):
-            LOG.info("[%d/%d] Upgrading 'reports'... (%d–%d) %.0f%% done.",
+            LOG.info("[%d/%d] Upgrading 'reports'... (%d-%d) %.0f%% done.",
                      batch, num_batches,
                      (REPORT_UPDATE_CHUNK_SIZE * i) + 1,
                      (REPORT_UPDATE_CHUNK_SIZE * (i + 1))
@@ -479,7 +479,7 @@ def downgrade():
         num_batches = report_count // REPORT_UPDATE_CHUNK_SIZE + 1
 
         def _print_progress(batch: int):
-            LOG.info("[%d/%d] Downgrading 'reports'... (%d–%d) %.0f%% done.",
+            LOG.info("[%d/%d] Downgrading 'reports'... (%d-%d) %.0f%% done.",
                      batch, num_batches,
                      (REPORT_UPDATE_CHUNK_SIZE * i) + 1,
                      (REPORT_UPDATE_CHUNK_SIZE * (i + 1))


### PR DESCRIPTION
Two log messages contained an UTF-8 dash characters that crashed logging in some environment.