### PR TITLE
Display warning if the compilation database is empty

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -1066,9 +1066,9 @@ def main(args):
         analyzer_clang_version)
 
     if not actions:
-        LOG.info("No analysis is required.\nThere were no compilation "
-                 "commands in the provided compilation database or "
-                 "all of them were skipped.")
+        LOG.warning("No analysis is required.")
+        LOG.warning("There were no compilation commands in the provided "
+                    "compilation database or all of them were skipped.")
         sys.exit(0)
 
     uniqued_compilation_db_file = os.path.join(


### PR DESCRIPTION
Change the log level from info to warning when
nothing was analyzed due to eg an empty
compilation database.
Fixes #4222