### PR TITLE
[fix] Fixing getReportAnnotations subquery

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2179,7 +2179,7 @@ class ThriftRequestHandler:
                 extended_table = extended_table.add_columns(
                     ReportAnnotations.key.label('annotations_key'),
                     ReportAnnotations.value.label('annotations_value')
-                )
+                ).group_by(ReportAnnotations.key, ReportAnnotations.value)
 
                 extended_table = extended_table.subquery()
 


### PR DESCRIPTION
It's a follow up PR to fix SQL Alchemy query in #4157. PostgreSQL does not support getting a column without adding it to the group by list or using aggregate functions.