### PR TITLE
[doc] Update the GitLab CI integration guide

### DIFF
--- a/docs/gitlab_integration.md
+++ b/docs/gitlab_integration.md
@@ -29,7 +29,6 @@ within each project. Create this file in your project root directory:
 
 ```yml
 code_quality:
-  allow_failure: false
   script:
     - bash .gitlab/ci/run_codechecker.sh
   after_script:
@@ -39,6 +38,7 @@ code_quality:
       codequality: gl-code-quality-report.json
     paths: [gl-code-quality-report.json]
     expire_in: '2 mos'
+    expose_as: 'Code Quality Report'
   stage: test
 ```
 
@@ -46,6 +46,9 @@ code_quality:
 expire and are therefore deleted. You can set it to a lower or a higher value.
 For more information
 [see](https://docs.gitlab.com/ee/ci/yaml/README.html#artifactsexpire_in).
+
+`expose_as` makes the report JSON file downloadable directly from the ongoing
+merge requests.
 
 Script is a shell script which will be executed by the Runner.
 
@@ -74,9 +77,9 @@ CodeChecker parse \
   -e codeclimate \
   ./reports > gl-code-quality-report.json
 
-# Exit with status code 1 if there is any report in the output file.
-status=$(cat gl-code-quality-report.json)
-if [[ -n "$status" && "$status" != "[]" ]]; then
+# Exit with status code 1 if the report file was not generated.
+if [ ! -f "gl-code-quality-report.json" ]; then
+  echo Report file (gl-code-quality-report.json) does not exist."
   exit 1
 fi
 ```
@@ -106,17 +109,11 @@ CodeChecker cmd diff \
 out_file="codeclimate/codeclimate_issues.json"
 
 if [ ! -f "$out_file" ]; then
-  echo "${out_file} does not exists."
+  echo "Report file (${out_file}) does not exist."
   exit 1
 fi
 
 cp $out_file gl-code-quality-report.json
-
-# Exit with status code 1 if there is any report in the output file.
-status=$(cat gl-code-quality-report.json)
-if [[ -n "$status" && "$status" != "[]" ]]; then
-  exit 1
-fi
 ```
 
 # 4. Create a merge request


### PR DESCRIPTION
There is an issue with the CodeChecker integration into GitLab CI as a Code Quality tool, which this PR aims to fix.
I have possible 2 solutions. This PR provides the fix for the 1. solution, as the suggested one.

1. The built-in code quality template jobs - depending on CodeClimate - succeed in case issues were found, and the results are made available usually as a general artifact (downloadable JSON, XML file) and also as a special *report artifact*, which is used by GitLab to visually display the issues, both at the pipeline and at MRs. This is also the usual workflow of GitHub's approach with CodeQL by the way: code quality CI jobs fail only in case of execution error and not because of found code quality issues.

   **The current guide of the CodeChecker integration does not follow this pattern, as it fails the CI job in case any issues in the code was found. I think this will usually not be expected by developers, and instead the convention should be followed.**

2. Even if you think otherwise, the current guide needs to updated. By default GitLab CI will only upload artifacts upon job successfulness, see the reference: [artifacts:when](https://docs.gitlab.com/ee/ci/yaml/#artifactswhen). This means that with the current configuration the code quality job will fail in case any issues were reported and then the artifact (`gl-code-quality-report.json`) will not be uploaded to the GitLab server.
Note: the special *report artifact* will be uploaded though and visualized by GitLab, but not as "normal" JSON file artifact, and therefore it won't be downloadable when required. (As stated at the above link: *"The artifacts created for `artifacts:reports` are always uploaded, regardless of the job results (success or failure)."*)

   This could be fixed by adding a `when: on_failure` or a `when: always` configuration for the artifact.