### PR TITLE
[fix] Links in static HTML files should be relative

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/output/html/html.py
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/html.py
@@ -309,7 +309,7 @@ class HtmlBuilder:
                 html_report_links.append({'link': html_file, 'report': report})
 
         table_reports = map(lambda data: {
-            'link': data['link'],
+            'link': os.path.basename(data['link']),
             'file-path': data['report']['fileId'],
             'report-hash': data['report']['reportHash'],
             'checker-name': data['report']['checker']['name'],

--- a/tools/report-converter/tests/unit/output/html/plist_to_html_test.py
+++ b/tools/report-converter/tests/unit/output/html/plist_to_html_test.py
@@ -186,4 +186,10 @@ class PlistToHtmlTest(unittest.TestCase):
         index_html = os.path.join(output_dir, "index.html")
 
         with open(index_html, 'r', encoding="utf-8", errors="ignore") as f:
-            self.assertEqual(len(re.findall('"link": "', f.read())), 3)
+            content = f.read()
+
+            # There are 3 reports in the test file.
+            self.assertEqual(len(re.findall('"link": "', content)), 3)
+            # The links should be relative so the static HTML folder is
+            # portable.
+            self.assertNotIn('"link": "/', content)


### PR DESCRIPTION
The links in the static HTML files generated by "CodeChecker parse -e html" should be relative, so the output folder of the above command is portable.