### PR TITLE
Fix a crash where config handlers were built with missing binaries

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -184,12 +184,16 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
     # TODO: Its perfectly reasonable for an analyzer plugin to not be able to
     # build their config handler if the analyzer isn't supported in the first
     # place. For now, this seems to be okay, but may not be later.
+    # Even then, if we couldn't get hold of the analyzer binary, we can't do
+    # anything.
     errored_config_map = analyzer_types.build_config_handlers(
-        args, [x for (x, _) in errored])
+        args,
+        [x for (x, _) in errored
+         if analyzer_types.supported_analyzers[x].analyzer_binary()])
 
     no_checker_err_analyzers = \
-        [a for (a, _) in errored
-         if not __has_enabled_checker(errored_config_map[a])]
+        [analyzer for analyzer, config_h in errored_config_map.items()
+         if not __has_enabled_checker(config_h)]
 
     errored = [(an, msg) for an, msg in errored
                if an not in no_checker_err_analyzers]

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -241,6 +241,9 @@ def build_config_handlers(args, enabled_analyzers):
     analyzer_config_map = {}
 
     for ea in enabled_analyzers:
+        assert supported_analyzers[ea].analyzer_binary(), \
+            "At this point, we should've checked if this analyzer has a " \
+            "binary!"
         config_handler = supported_analyzers[ea].construct_config_handler(args)
         analyzer_config_map[ea] = config_handler
 


### PR DESCRIPTION
Original patch (that itroduces the crash):
https://github.com/Ericsson/codechecker/pull/4179
Revert attempt in https://github.com/Ericsson/codechecker/pull/4238.

The crash occurs because the original patch tries to create config handlers even if they are not supported. This is playing with fire already, but the crash occured when not even the analyzer binary is found.

In this patch, these analyzers are skipped from checking if they have any checkers enabled.