### PR TITLE
[fix] Use module uuid instead of tempfile

### DIFF
--- a/web/client/codechecker_client/cmd/store.py
+++ b/web/client/codechecker_client/cmd/store.py
@@ -20,6 +20,7 @@ import os
 import signal
 import sys
 import tempfile
+import uuid
 import zipfile
 import zlib
 import shutil
@@ -502,8 +503,8 @@ def assemble_zip(inputs,
         for analyzer_name, reports in analyzer_reports.items():
             if not analyzer_name:
                 analyzer_name = 'unknown'
-            _, tmpfile = tempfile.mkstemp(
-                f'-{analyzer_name}.plist', dir=temp_dir)
+            tmpfile = os.path.join(
+                temp_dir, f'{uuid.uuid4()}-{analyzer_name}.plist')
 
             report_file.create(tmpfile, reports, checker_labels,
                                AnalyzerInfo(analyzer_name))


### PR DESCRIPTION
The problem with tempfile.mkstem() is that it opens the created file, and it must be closed through its file descriptor, otherwise some dangling .nfs files remain when CodeChecker is used in an NFS drive. For this reason we use uuid instead.