### PR TITLE
[cmd] Add --anywhere-on-report-path flag to CLI

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -773,6 +773,10 @@ filter arguments:
                         'year:month:day:hour:minute:second' (the "time" part
                         can be omitted, in which case midnight (00:00:00) is
                         used).
+  --anywhere-on-report-path
+                        Filter reports where the report path not only ends in
+                        the files given by --file or --component, but goes
+                        through them. (default: False)
 ```
 
 #### Source components (`components`)

--- a/web/client/codechecker_client/cmd/cmd.py
+++ b/web/client/codechecker_client/cmd/cmd.py
@@ -29,7 +29,8 @@ from codechecker_common.output import USER_FORMATS
 DEFAULT_FILTER_VALUES = {
     'review_status': ['unreviewed', 'confirmed'],
     'detection_status': ['new', 'reopened', 'unresolved'],
-    'uniqueing': 'off'
+    'uniqueing': 'off',
+    'anywhere_on_report_path': False
 }
 
 DEFAULT_OUTPUT_FORMATS = ["plaintext"] + USER_FORMATS
@@ -423,6 +424,15 @@ def __add_filtering_arguments(parser, defaults=None, diff_mode=False):
                               "'year:month:day:hour:minute:second' (the "
                               "\"time\" part can be omitted, in which case "
                               "midnight (00:00:00) is used).")
+
+    f_group.add_argument('--anywhere-on-report-path',
+                         dest='anywhere_on_report_path',
+                         required=False,
+                         default=init_default('anywhere_on_report_path'),
+                         action="store_true",
+                         help="Filter reports where the report path not only "
+                              "ends in the files given by --file or "
+                              "--component, but goes through them.")
 
 
 def __register_results(parser):


### PR DESCRIPTION
The "anywhere on report path" feature exists in the web GUI. This feature controls --component and --file filters in order to return reports of which the report path not only ends in, but goes through them.
In this commit this feature is added to the CLI, too.