### PR TITLE
[analyzer] Adds -fno-freestanding to ignored GCC compiler flags

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -94,7 +94,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-delete-null-pointer-checks',
     '-fno-defer-pop',
     '-fno-extended-identifiers',
-    '-fno-freestanding'
+    '-fno-freestanding',
     '-fno-jump-table',
     '-fno-keep-inline-dllexport'
     '-fno-keep-static-consts',

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -94,6 +94,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-delete-null-pointer-checks',
     '-fno-defer-pop',
     '-fno-extended-identifiers',
+    '-f(no-)?freestanding'
     '-fno-jump-table',
     '-fno-keep-inline-dllexport'
     '-fno-keep-static-consts',

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -94,7 +94,7 @@ IGNORED_OPTIONS_GCC = [
     '-fno-delete-null-pointer-checks',
     '-fno-defer-pop',
     '-fno-extended-identifiers',
-    '-f(no-)?freestanding'
+    '-fno-freestanding'
     '-fno-jump-table',
     '-fno-keep-inline-dllexport'
     '-fno-keep-static-consts',


### PR DESCRIPTION
`-ffreestanding` and `-fno-freestanding` are common in embedded systems but clang does not support it. This PR adds them both to the ignored GCC compiler flags list.