### PR TITLE
[cfg] Add setuptools as a dependency

### DIFF
--- a/analyzer/tools/merge_clang_extdef_mappings/requirements_py/dev/requirements.txt
+++ b/analyzer/tools/merge_clang_extdef_mappings/requirements_py/dev/requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.3.1
 pycodestyle==2.12.0
 pylint==3.2.4
+setuptools==70.2.0

--- a/analyzer/tools/statistics_collector/requirements_py/dev/requirements.txt
+++ b/analyzer/tools/statistics_collector/requirements_py/dev/requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.3.1
 pycodestyle==2.12.0
 pylint==3.2.4
+setuptools==70.2.0

--- a/codechecker_common/requirements_py/dev/requirements.txt
+++ b/codechecker_common/requirements_py/dev/requirements.txt
@@ -3,3 +3,4 @@ coverage==5.5.0
 mypy==1.7.1
 PyYAML==6.0.1
 types-PyYAML==6.0.12.12
+setuptools==70.2.0

--- a/tools/bazel/requirements_py/dev/requirements.txt
+++ b/tools/bazel/requirements_py/dev/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.3.1
 pycodestyle==2.12.0
 pylint==3.2.4
 mypy==1.7.1
+setuptools==70.2.0

--- a/tools/report-converter/requirements_py/dev/requirements.txt
+++ b/tools/report-converter/requirements_py/dev/requirements.txt
@@ -4,3 +4,4 @@ pycodestyle==2.12.0
 pylint==3.2.4
 portalocker==2.2.1
 mypy==1.7.1
+setuptools==70.2.0

--- a/tools/tu_collector/requirements_py/dev/requirements.txt
+++ b/tools/tu_collector/requirements_py/dev/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.3.1
 pycodestyle==2.12.0
 pylint==3.2.4
 mypy==1.7.1
+setuptools==70.2.0


### PR DESCRIPTION
Some platforms don't come with pre-installed setuptools module. However, some CodeChecker modules need this library as a dependency.

Fixes #4278