### PR TITLE
[feat] Accept non-existing file paths in report-converter

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/parser.py
@@ -90,16 +90,12 @@ class SANParser(BaseParser):
             return None
 
         file_path = file_match.group('path')
-        if file_path and os.path.exists(file_path):
-            col = file_match.group('column')
-            return BugPathEvent(
-                line.rstrip(),
-                get_or_create_file(
-                    os.path.abspath(file_path), self._file_cache),
-                int(file_match.group('line')),
-                int(col) if col else 0)
-
-        return None
+        col = file_match.group('column')
+        return BugPathEvent(
+            line.rstrip(),
+            get_or_create_file(os.path.abspath(file_path), self._file_cache),
+            int(file_match.group('line')),
+            int(col) if col else 0)
 
     def create_report(
         self,

--- a/tools/report-converter/codechecker_report_converter/report/hash.py
+++ b/tools/report-converter/codechecker_report_converter/report/hash.py
@@ -137,8 +137,9 @@ def __get_report_hash_context_free(report: Report) -> List[str]:
 
         if line_content == '' and \
                 not os.path.isfile(report.file.original_path):
-            LOG.error("Failed to include source line in the report hash.")
-            LOG.error('%s does not exists!', report.file.original_path)
+            LOG.warning(
+                "Failed to include source line in the report hash. "
+                '%s does not exist!', report.file.original_path)
 
         return [
             report.file.name,

--- a/tools/report-converter/codechecker_report_converter/util.py
+++ b/tools/report-converter/codechecker_report_converter/util.py
@@ -58,7 +58,7 @@ def get_line(file_path: str, line_no: int, errors: str = 'ignore') -> str:
         with open(file_path, mode='r', encoding='utf-8', errors=errors) as f:
             return get_linef(f, line_no)
     except IOError:
-        LOG.error("Failed to open file %s", file_path)
+        LOG.warning("Failed to open file %s", file_path)
         return ''
 
 


### PR DESCRIPTION
Some analyzer tools (e.g. sanitizers) give an output that contains relative source file paths. When report-converter is executed from a directory where these absolute paths are not valid, then reports are simply not generated. If all reports contain such a relative path, then this message is given by report-converter:

No 'lsan' results can be found in '...'

This message is obviously false.

This patch allows non-existing file paths in the analyzer outputs. Using further CodeChecker commands (store, parse, etc.) will emit an error message on these paths anyway, but at least we get rid of the incomprehensible error message above.

Fixes #4280