### PR TITLE
Add -mmitigate-rop to ignored options

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -78,6 +78,7 @@ IGNORED_OPTIONS_GCC = [
     '-ffixed-r2',
     '-ffp$',
     '-mfp16-format',
+    '-mmitigate-rop',
     '-fgcse-lm',
     '-fhoist-adjacent-loads',
     '-findirect-inlining',


### PR DESCRIPTION
The -mmitigate-rop compilation flag is
unknown by clang, which might cause issues
if the gcc compiler is used. This change
adds -mmitigate-rop to the list of ignored
options to fix these issues.