### PR TITLE
[fix] Don't capture cc1 by the logger.

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -85,7 +85,7 @@ def perform_build_command(logfile, command, keep_link, silent=False,
         open(logfile, 'a', encoding="utf-8", errors="ignore").close()
         log_env = env.get_log_env(logfile, original_env)
         if 'CC_LOGGER_GCC_LIKE' not in log_env:
-            log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:cc:c++'
+            log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:/cc:c++'
         if keep_link or ('CC_LOGGER_KEEP_LINK' in log_env and
                          log_env['CC_LOGGER_KEEP_LINK'] == 'true'):
             log_env['CC_LOGGER_KEEP_LINK'] = 'true'

--- a/analyzer/codechecker_analyzer/cmd/log.py
+++ b/analyzer/codechecker_analyzer/cmd/log.py
@@ -42,7 +42,7 @@ EPILOG_ENV_VAR = """
   CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
                            compilers should be logged. For example (default):
                            export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
-                           cc:c++". The logger will match any compilers with
+                           /cc:c++". The logger will match any compilers with
                            'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
                            their filenames.
   CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be

--- a/analyzer/tools/build-logger/README.md
+++ b/analyzer/tools/build-logger/README.md
@@ -1,7 +1,7 @@
 # Build Logger
 
 This tool can capture the build process and generate a
-[JSON Compilation Database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) 
+[JSON Compilation Database](https://clang.llvm.org/docs/JSONCompilationDatabase.html)
 
 ## Compilation
 
@@ -15,7 +15,7 @@ make all test
 Set the following environment variables:
 ~~~~~~~
 export LD_PRELOAD=`pwd`/build/lib/`uname -m`/ldlogger.so
-export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:cc:c++"
+export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:/cc:c++"
 # The output compilation JSON file.
 export CC_LOGGER_FILE=`pwd`/compilation.json
 # Log linker build actions to the JSON file. Optional. Default: false
@@ -42,34 +42,57 @@ compilation.json:
 
 ## Environment Variables
 
-### `CC_LOGGER_GCC_LIKE` 
-You can change the compilers that should be logged. 
+### `CC_LOGGER_GCC_LIKE`
+You can change the compilers that should be logged.
 Set `CC_LOGGER_GCC_LIKE` environment variable to a colon separated list.
 
- For example (default):
+For example (default):
 
- ```export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:cc:c++"```
+```export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:/cc:c++"```
 
- The logger will match any compilers with `gcc`,`g++`, `clang`, `clang++`, `cc`
- and `c++` in their filenames.
+The logger will match any compilers with `gcc`,`g++`, `clang`, `clang++`, `cc`
+and `c++` in their filenames.
 
+This colon separated list may contain compiler names or paths. In case an
+element of this list contains at least one slash (/) character then this is
+considered a path. The logger will capture only those build actions which have
+this postfix:
+
+```sh
+export CC_LOGGER_GCC_LIKE="gcc:/bin/g++:clang:clang++:/cc:c++"
+
+# "gcc" has to be infix of the compiler's name because it contains no slash.
+# "/bin/g++" has to be postfix of the compiler's path because it contains slash.
+
+my/gcc/compiler/g++ main.cpp  # Not captured because there is no match.
+my/gcc/compiler/gcc-7 main.c  # Captured because "gcc" is infix of "gcc-7".
+/usr/bin/g++ main.cpp         # Captured because "/bin/g++" is postfix of the compiler path.
+/usr/bin/g++-7 main.cpp       # Not captured because "/bin/g++" is not postfix of the compiler path.
+
+# For an exact compiler binary name match start the binary name with a "/".
+/clang # Will not log clang++ calls only the clang binary calls will be captured.
+clang  # Will capture clang-tidy (which is not wanted) calls too because of a partial match.
+```
+
+The reason of having a slash before `cc` is that `cc1` binary is executed as
+a sub-process by some compilers and that shouldn't be captured.
 
 ### `CC_LOGGER_FILE`
-Output file to generate compilation database into. 
+Output file to generate compilation database into.
 This can be a relative or absolute path.
 
-### `CC_LOGGER_JAVAC_LIKE` 
-You can specify the `javac` like 
+### `CC_LOGGER_JAVAC_LIKE`
+You can specify the `javac` like
 compilers that should be logged as a colon separated string list.
 
-### `CC_LOGGER_DEF_DIRS` 
+### `CC_LOGGER_DEF_DIRS`
 If the environment variable is defined, the logger will extend the compiler
 argument list in the compilation database with the pre-configured include paths
 of the logged compiler.
 
 ### `CC_LOGGER_ABS_PATH`
-If the environment variable is defined, 
-all relative paths in the compilation commands after 
+If the environment variable is defined,
+all relative paths in the compilation commands after
 `-I, -idirafter, -imultilib, -iquote, -isysroot -isystem,
 -iwithprefix, -iwithprefixbefore, -sysroot, --sysroot`
 will be converted to absolute PATH when written into the compilation database.

--- a/analyzer/tools/build-logger/tests/unit/__init__.py
+++ b/analyzer/tools/build-logger/tests/unit/__init__.py
@@ -113,7 +113,7 @@ class BasicLoggerTest(unittest.TestCase):
                                        "lib",
                                        machine,
                                        "ldlogger.so"),
-            "CC_LOGGER_GCC_LIKE": "gcc:g++:clang:clang++:cc:c++",
+            "CC_LOGGER_GCC_LIKE": "gcc:g++:clang:clang++:/cc:c++",
             "CC_LOGGER_FILE": self.logger_file,
             "CC_LOGGER_DEBUG_FILE": self.logger_debug_file,
         }

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -483,7 +483,7 @@ Environment variables for 'CodeChecker log' command:
   CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
                            compilers should be logged. For example (default):
                            export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
-                           cc:c++". The logger will match any compilers with
+                           /cc:c++". The logger will match any compilers with
                            'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
                            their filenames.
   CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
@@ -682,7 +682,7 @@ Environment variables
   CC_LOGGER_GCC_LIKE       Set to to a colon separated list to change which
                            compilers should be logged. For example (default):
                            export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:
-                           cc:c++". The logger will match any compilers with
+                           /cc:c++". The logger will match any compilers with
                            'gcc', 'g++', 'clang', 'clang++', 'cc' and 'c++' in
                            their filenames.
   CC_LOGGER_KEEP_LINK      If its value is not 'true' then object files will be
@@ -707,7 +707,7 @@ Set `CC_LOGGER_GCC_LIKE` environment variable to a colon separated list.
 For example (default):
 
 ```sh
-export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:cc:c++"
+export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:/cc:c++"
 ```
 
 This colon separated list may contain compiler names or paths. In case an
@@ -716,7 +716,7 @@ considered a path. The logger will capture only those build actions which have
 this postfix:
 
 ```sh
-export CC_LOGGER_GCC_LIKE="gcc:/bin/g++:clang:clang++:cc:c++"
+export CC_LOGGER_GCC_LIKE="gcc:/bin/g++:clang:clang++:/cc:c++"
 
 # "gcc" has to be infix of the compiler's name because it contains no slash.
 # "/bin/g++" has to be postfix of the compiler's path because it contains slash.
@@ -730,6 +730,9 @@ my/gcc/compiler/gcc-7 main.c  # Captured because "gcc" is infix of "gcc-7".
 /clang # Will not log clang++ calls only the clang binary calls will be captured.
 clang  # Will capture clang-tidy (which is not wanted) calls too because of a partial match.
 ```
+
+The reason of having a slash before `cc` is that `cc1` binary is executed as
+a sub-process by some compilers and that shouldn't be captured.
 
 Example:
 
@@ -1351,7 +1354,7 @@ CodeChecker will get the hardcoded values for the compilers set in the
 `CC_LOGGER_GCC_LIKE` environment variable.
 
 ```sh
-export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:cc:c++"
+export CC_LOGGER_GCC_LIKE="gcc:g++:clang:clang++:/cc:c++"
 ```
 
 GCC specific hard-coded values are detected during the analysis and


### PR DESCRIPTION
After make-4.3 the compilers are executed in a way that cc1 binary is also captured by the logger. This accomplishes only a partial phase of the compilation process and this shouldn't be captured. As a solution we use the fact that having a slash (/) in a compiler's name in CC_LOGGER_GCC_LIKE makes a suffix search.