### PR TITLE
[fix] Minor fixing for statistics tabs

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -3072,7 +3072,7 @@ class ThriftRequestHandler:
                         checkerName=checker_name,
                         analyzerName=analyzer_name,
                         enabled=[],
-                        disabled=all_run_id,
+                        disabled=all_run_id.copy(),
                         severity=severity,
                         closed=0,
                         outstanding=0

--- a/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatistics.vue
@@ -190,12 +190,6 @@ export default {
 
     async runIds() {
       this.noProperRun = false;
-    },
-
-    "$route"() {
-      if (this.runs && this.$route.query.run !== this.actualRunNames) {
-        this.$router.go();
-      }
     }
   },
 

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -7,7 +7,8 @@
         :show-remove-filtered-reports="false"
         :report-count="reportCount"
         :show-diff-type="false"
-        :show-compare-to="false"
+        :show-compare-to="
+          $router.currentRoute.name != 'checker-coverage-statistics'"
         @refresh="refresh"
       />
     </pane>


### PR DESCRIPTION
The `compare to` filter was turned off for statistics tabs. It is a user request to restore it. Every tabs gets back the filter except checker coverage.

Switching between tabs was problematic. When we want to switch from checker coverage to others tab, it triggers a full page refresh. Now, it is fixed.

The status of the checkere coverage does not show the number of disabled runs for checkers. With this PR, the users can be informed about the number of runs the checker is off and they can also open the disabled runs modal to list them.