### PR TITLE
Analyzer binary dependent environment

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -248,9 +248,8 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
             if state == CheckerState.ENABLED:
                 enabled_checkers[analyzer].append(check)
 
-        # TODO: cppcheck may require a different environment than clang.
         version = analyzer_types.supported_analyzers[analyzer] \
-            .get_binary_version(context.analyzer_env)
+            .get_binary_version(context.get_analyzer_env(analyzer))
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_base.py
@@ -111,6 +111,10 @@ class SourceAnalyzer(metaclass=ABCMeta):
         LOG.debug_analyzer('\n%s',
                            ' '.join([shlex.quote(x) for x in analyzer_cmd]))
 
+        if env is None:
+            env = analyzer_context.get_context()\
+                .get_analyzer_env(self.ANALYZER_NAME)
+
         res_handler.analyzer_cmd = analyzer_cmd
         try:
             ret_code, stdout, stderr \
@@ -158,7 +162,10 @@ class SourceAnalyzer(metaclass=ABCMeta):
         signal.signal(signal.SIGINT, signal_handler)
 
         if env is None:
-            env = analyzer_context.get_context().analyzer_env
+            env = analyzer_context.get_context().cc_env
+
+        LOG.debug_analyzer('\nENV:\n')
+        LOG.debug_analyzer(env)
 
         proc = subprocess.Popen(
             command,

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -105,7 +105,8 @@ def is_ignore_conflict_supported():
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             env=context
-                            .get_analyzer_env("clang-apply-replacements"),
+                            .get_analyzer_env(
+                                os.path.basename(context.replacer_binary)),
                             encoding="utf-8", errors="ignore")
     out, _ = proc.communicate()
     return '--ignore-insert-conflict' in out

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -104,7 +104,8 @@ def is_ignore_conflict_supported():
     proc = subprocess.Popen([context.replacer_binary, '--help'],
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
-                            env=context.analyzer_env,
+                            env=context
+                            .get_analyzer_env("clang-apply-replacements"),
                             encoding="utf-8", errors="ignore")
     out, _ = proc.communicate()
     return '--ignore-insert-conflict' in out
@@ -144,7 +145,7 @@ def check_supported_analyzers(analyzers):
     """
 
     context = analyzer_context.get_context()
-    check_env = context.analyzer_env
+    check_env = context.cc_env
 
     analyzer_binaries = context.analyzer_binaries
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -51,7 +51,8 @@ def parse_clang_help_page(
         help_page = subprocess.check_output(
             command,
             stderr=subprocess.STDOUT,
-            env=analyzer_context.get_context().get_analyzer_env("clangsa"),
+            env=analyzer_context.get_context()\
+            .get_analyzer_env(ClangSA.ANALYZER_NAME),
             universal_newlines=True,
             encoding="utf-8",
             errors="ignore")
@@ -207,7 +208,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         if not cls.__ctu_autodetection:
             cls.__ctu_autodetection = CTUAutodetection(
                 cls.analyzer_binary(),
-                analyzer_context.get_context().get_analyzer_env("clangsa"))
+                analyzer_context.get_context()\
+                .get_analyzer_env(ClangSA.ANALYZER_NAME))
 
         return cls.__ctu_autodetection
 
@@ -606,7 +608,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     def construct_config_handler(cls, args):
 
         context = analyzer_context.get_context()
-        environ = context.get_analyzer_env("clangsa")
+        environ = context.get_analyzer_env(ClangSA.ANALYZER_NAME)
 
         handler = config_handler.ClangSAConfigHandler(environ)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -51,7 +51,7 @@ def parse_clang_help_page(
         help_page = subprocess.check_output(
             command,
             stderr=subprocess.STDOUT,
-            env=analyzer_context.get_context()\
+            env=analyzer_context.get_context()
             .get_analyzer_env(ClangSA.ANALYZER_NAME),
             universal_newlines=True,
             encoding="utf-8",
@@ -208,7 +208,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         if not cls.__ctu_autodetection:
             cls.__ctu_autodetection = CTUAutodetection(
                 cls.analyzer_binary(),
-                analyzer_context.get_context()\
+                analyzer_context.get_context()
                 .get_analyzer_env(ClangSA.ANALYZER_NAME))
 
         return cls.__ctu_autodetection

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -51,7 +51,7 @@ def parse_clang_help_page(
         help_page = subprocess.check_output(
             command,
             stderr=subprocess.STDOUT,
-            env=analyzer_context.get_context().analyzer_env,
+            env=analyzer_context.get_context().get_analyzer_env("clangsa"),
             universal_newlines=True,
             encoding="utf-8",
             errors="ignore")
@@ -207,7 +207,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         if not cls.__ctu_autodetection:
             cls.__ctu_autodetection = CTUAutodetection(
                 cls.analyzer_binary(),
-                analyzer_context.get_context().analyzer_env)
+                analyzer_context.get_context().get_analyzer_env("clangsa"))
 
         return cls.__ctu_autodetection
 
@@ -606,7 +606,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     def construct_config_handler(cls, args):
 
         context = analyzer_context.get_context()
-        environ = context.analyzer_env
+        environ = context.get_analyzer_env("clangsa")
 
         handler = config_handler.ClangSAConfigHandler(environ)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -77,7 +77,7 @@ def get(clang_binary):
     """
     compiler_version = subprocess.check_output(
         [clang_binary, '--version'],
-        env=analyzer_context.get_context().analyzer_env,
+        env=analyzer_context.get_context().get_analyzer_env("clangsa"),
         encoding="utf-8",
         errors="ignore")
     version_parser = ClangVersionInfoParser(clang_binary)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -271,7 +271,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                 return cls.__analyzer_checkers
 
             environ = analyzer_context\
-                .get_context().get_analyzer_env("clang-tidy")
+                .get_context().get_analyzer_env(cls.ANALYZER_NAME)
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-list-checks", "-checks=*"],
                 env=environ,
@@ -299,7 +299,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
                 env=analyzer_context.get_context()
-                .get_analyzer_env("clang-tidy"),
+                .get_analyzer_env(cls.ANALYZER_NAME),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")
@@ -316,7 +316,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
                 env=analyzer_context.get_context()
-                .get_analyzer_env("clang-tidy"),
+                .get_analyzer_env(cls.ANALYZER_NAME),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -270,7 +270,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             if cls.__analyzer_checkers:
                 return cls.__analyzer_checkers
 
-            environ = analyzer_context.get_context().analyzer_env
+            environ = analyzer_context\
+                .get_context().get_analyzer_env("clang-tidy")
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-list-checks", "-checks=*"],
                 env=environ,
@@ -297,7 +298,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         try:
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
-                env=analyzer_context.get_context().analyzer_env,
+                env=analyzer_context.get_context()
+                .get_analyzer_env("clang-tidy"),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")
@@ -313,7 +315,8 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         try:
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
-                env=analyzer_context.get_context().analyzer_env,
+                env=analyzer_context.get_context()
+                .get_analyzer_env("clang-tidy"),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -393,7 +393,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             # No cppcheck arguments file was given in the command line.
             LOG.debug_analyzer(aerr)
 
-        check_env = context.analyzer_env
+        check_env = context.get_analyzer_env("cppcheck")
 
         # Overwrite PATH to contain only the parent of the cppcheck binary.
         if os.path.isabs(Cppcheck.analyzer_binary()):

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -393,7 +393,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             # No cppcheck arguments file was given in the command line.
             LOG.debug_analyzer(aerr)
 
-        check_env = context.get_analyzer_env("cppcheck")
+        check_env = context.get_analyzer_env(cls.ANALYZER_NAME)
 
         # Overwrite PATH to contain only the parent of the cppcheck binary.
         if os.path.isabs(Cppcheck.analyzer_binary()):

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from packaging.version import Version
 from pathlib import Path
 import os
-import pickle
 import re
 import shlex
 import shutil
@@ -271,18 +270,6 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         TODO add config options for cppcheck checkers.
         """
         return []
-
-    def analyze(self, analyzer_cmd, res_handler, proc_callback=None, _=None):
-        environment = None
-
-        original_env_file = os.environ.get(
-            'CODECHECKER_ORIGINAL_BUILD_ENV')
-        if original_env_file:
-            with open(original_env_file, 'rb') as env_file:
-                environment = pickle.load(env_file, encoding='utf-8')
-
-        return super().analyze(
-            analyzer_cmd, res_handler, proc_callback, environment)
 
     def post_analyze(self, result_handler):
         """

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -7,8 +7,6 @@
 # -------------------------------------------------------------------------
 from collections import defaultdict
 from packaging.version import Version
-import os
-import pickle
 import shlex
 import subprocess
 
@@ -131,17 +129,6 @@ class Gcc(analyzer_base.SourceAnalyzer):
         """
         # TODO
         return []
-
-    def analyze(self, analyzer_cmd, res_handler, proc_callback=None, _=None):
-        env = None
-
-        original_env_file = os.environ.get(
-            'CODECHECKER_ORIGINAL_BUILD_ENV')
-        if original_env_file:
-            with open(original_env_file, 'rb') as env_file:
-                env = pickle.load(env_file, encoding='utf-8')
-
-        return super().analyze(analyzer_cmd, res_handler, proc_callback, env)
 
     def post_analyze(self, result_handler: GccResultHandler):
         """

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -186,7 +186,7 @@ def main(args):
     rows = []
     for analyzer_name, analyzer_class in \
             analyzer_types.supported_analyzers.items():
-        check_env = context.analyzer_env
+        check_env = context.get_analyzer_env(analyzer_name)
         version = analyzer_class.get_binary_version(check_env)
         if not version:
             version = 'ERROR'

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -9,6 +9,7 @@
 
 import os
 import re
+import pickle
 
 from codechecker_analyzer import analyzer_context
 from codechecker_common.logger import get_logger
@@ -33,6 +34,24 @@ def get_log_env(logfile, original_env):
     new_env[context.env_var_cc_logger_file] = logfile
 
     return new_env
+
+
+def get_original_env():
+    original_env = os.environ
+    try:
+        original_env_file = os.environ.get('CODECHECKER_ORIGINAL_BUILD_ENV')
+        if original_env_file:
+            LOG.debug_analyzer('Loading original build env from: %s',
+                               original_env_file)
+
+            with open(original_env_file, 'rb') as env_file:
+                original_env = pickle.load(env_file, encoding='utf-8')
+
+    except Exception as ex:
+        LOG.warning(str(ex))
+        LOG.warning('Failed to get saved original_env ')
+        original_env = None
+    return original_env
 
 
 def extend(path_env_extra, ld_lib_path_extra):

--- a/analyzer/codechecker_analyzer/host_check.py
+++ b/analyzer/codechecker_analyzer/host_check.py
@@ -59,7 +59,7 @@ def has_analyzer_config_option(clang_bin, config_option_name):
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=analyzer_context.get_context().analyzer_env,
+            env=analyzer_context.get_context().get_analyzer_env("clangsa"),
             encoding="utf-8", errors="ignore")
         out, err = proc.communicate()
         LOG.debug("stdout:\n%s", out)
@@ -92,7 +92,7 @@ def has_analyzer_option(clang_bin, feature):
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=analyzer_context.get_context().analyzer_env,
+                env=analyzer_context.get_context().get_analyzer_env("clangsa"),
                 encoding="utf-8", errors="ignore")
             out, err = proc.communicate()
             LOG.debug("stdout:\n%s", out)


### PR DESCRIPTION
If a pre-package analyzer binary (e.g. clang) is found first, the LD_LIBRARY_PATH must be extended. On the other hand, if the analyzer binary is taken from the users machine, the original environment must be used to execute the binary.

This patch introduces an analyzer binary dependent environment initialization.