### PR TITLE
[fix] Support joker characters at annotation filter

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -406,7 +406,8 @@ def process_report_filter(
             if keep_all_annotations:
                 OR.append(or_(
                     ReportAnnotations.key != key,
-                    ReportAnnotations.value.in_(values)))
+                    *[ReportAnnotations.value.ilike(conv(v))
+                      for v in values]))
             else:
                 OR.append(and_(
                     ReportAnnotations.key == key,
@@ -2012,7 +2013,8 @@ class ThriftRequestHandler:
 
                     OR = []
                     for key, values in annotations.items():
-                        OR.append(annotation_cols[key].in_(values))
+                        OR.extend([annotation_cols[key].ilike(conv(v))
+                                   for v in values])
                     sub_query = sub_query.having(or_(*OR))
 
                 sub_query = sort_results_query(sub_query,
@@ -2125,7 +2127,8 @@ class ThriftRequestHandler:
 
                     OR = []
                     for key, values in annotations.items():
-                        OR.append(annotation_cols[key].in_(values))
+                        OR.extend([annotation_cols[key].ilike(conv(v))
+                                   for v in values])
                     q = q.having(or_(*OR))
 
                 q = q.limit(limit).offset(offset)

--- a/web/tests/functional/dynamic_results/test_dynamic_results.py
+++ b/web/tests/functional/dynamic_results/test_dynamic_results.py
@@ -134,10 +134,23 @@ class DynamicResults(unittest.TestCase):
         results = self._cc_client.getRunResults(
             None, 500, 0, None, testcase_filter, None, False)
 
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 2)
 
         self.assertTrue(all(map(
             lambda report: report.annotations['testcase'] == 'TC-1',
+            results)))
+
+        testcase_filter = ReportFilter(annotations=[Pair(
+            first='testcase',
+            second='TC-*')])
+
+        results = self._cc_client.getRunResults(
+            None, 500, 0, None, testcase_filter, None, False)
+
+        self.assertEqual(len(results), 3)
+
+        self.assertTrue(all(map(
+            lambda report: report.annotations['testcase'].startswith('TC-'),
             results)))
 
     def test_count_by_attribute(self):
@@ -156,4 +169,4 @@ class DynamicResults(unittest.TestCase):
         num = self._cc_client.getRunResultCount(
             None, testcase_filter, None)
 
-        self.assertEqual(num, 3)
+        self.assertEqual(num, 2)

--- a/web/tests/projects/dynamic/main.c_cppcheck_0212cbc2c7194b7a5d431a18ff51bb1c.plist
+++ b/web/tests/projects/dynamic/main.c_cppcheck_0212cbc2c7194b7a5d431a18ff51bb1c.plist
@@ -20,7 +20,7 @@
 				<key>testcase</key>
 				<string>TS-1</string>
 				<key>testcase</key>
-				<string>TC-1</string>
+				<string>TC-2</string>
 			</dict>
 			<key>location</key>
 			<dict>


### PR DESCRIPTION
It is allowed now to use wildcards in the report annotation filter. For example, the reports generated by testcases starting with "TC-" can be queried by "TC-*".