### PR TITLE
[fix] Don't enable checkers by suffix

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -90,8 +90,7 @@ class AnalyzerConfigHandler(metaclass=ABCMeta):
         changed_states = []
 
         for ch_name, values in self.__available_checkers.items():
-            if ch_name.startswith(checker_name) or \
-               ch_name.endswith(checker_name):
+            if ch_name.startswith(checker_name):
                 _, description = values
                 state = CheckerState.ENABLED if enabled \
                     else CheckerState.DISABLED

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -250,6 +250,13 @@ class CheckerHandlingClangSATest(unittest.TestCase):
         self.assertTrue(all_with_status(CheckerState.DISABLED)
                         (cfg_handler.checks(), cert_guideline))
 
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('default', False),
+                                         ('DeadStores', True)])
+        self.assertTrue(all_with_status(CheckerState.DISABLED)
+                        (cfg_handler.checks(), default_profile))
+
         # Enable "LOW" severity checkers.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,


### PR DESCRIPTION
Currently, checkers can be enabled by checker name prefix. For example, "--enable unix" enables all checkers starting with "unix". However, checkers shouldn't be enabled by suffix match: "--enable Malloc" shouldn't enable "unix.Malloc" checker.

The source of the confusion was that having "unix.Stream" checker in the "default" profile also enabled "alpha.unix.Stream", which is not an intended behavior.