### PR TITLE
[cmd] Checker name prefixes are meant along separator characters

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -14,6 +14,7 @@ from abc import ABCMeta
 from enum import Enum
 import collections
 import platform
+import re
 
 from codechecker_analyzer import analyzer_context
 from codechecker_common.logger import get_logger
@@ -88,9 +89,10 @@ class AnalyzerConfigHandler(metaclass=ABCMeta):
         Explicitly handle checker state, keep description if already set.
         """
         changed_states = []
+        regex = "^" + re.escape(str(checker_name)) + "\\b.*$"
 
         for ch_name, values in self.__available_checkers.items():
-            if ch_name.startswith(checker_name):
+            if re.match(regex, ch_name):
                 _, description = values
                 state = CheckerState.ENABLED if enabled \
                     else CheckerState.DISABLED

--- a/analyzer/codechecker_analyzer/checkers.py
+++ b/analyzer/codechecker_analyzer/checkers.py
@@ -28,7 +28,7 @@ def available(ordered_checkers, available_checkers):
 
         name_match = False
         for available_checker in available_checkers:
-            regex = "^" + re.escape(str(checker_name)) + ".*$"
+            regex = "^" + re.escape(str(checker_name)) + "\\b.*$"
             c_name = available_checker
             match = re.match(regex, c_name)
             if match:

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -264,6 +264,27 @@ class CheckerHandlingClangSATest(unittest.TestCase):
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), low_severity))
 
+        # Enable checkers with a checker group prefix.
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('default', False),
+                                         ('cplusplus.NewDelete', True)])
+        self.assertTrue(
+            all_with_status(CheckerState.ENABLED)
+            (cfg_handler.checks(), ['cplusplus.NewDelete']))
+        self.assertTrue(
+            all_with_status(CheckerState.DISABLED)
+            (cfg_handler.checks(), ['cplusplus.NewDeleteLeaks']))
+
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('default', False),
+                                         ('cplusplus', True)])
+        self.assertTrue(
+            all_with_status(CheckerState.ENABLED)
+            (cfg_handler.checks(), ['cplusplus.NewDelete',
+                                    'cplusplus.NewDeleteLeaks']))
+
         # Test if statisticsbased checkers are enabled by --stats flag
         # by default.
         stats_capable = strtobool(


### PR DESCRIPTION
Checkers can be enabled by groups, e.g. unix.cstring enables all checkers starting with this prefix. However, unix.cs is not a checker group so this shouldn't be allowed. In this case an error message is printed and analysis doesn't start.