### PR TITLE
[fix] fix compare_results.py sciprt

### DIFF
--- a/scripts/result_listing/compare_results.py
+++ b/scripts/result_listing/compare_results.py
@@ -11,8 +11,10 @@ import json
 import sys
 
 def __sorted_results(result_file):
-    return json.load(result_file).sort(
+    results = json.load(result_file)
+    results.sort(
         key=lambda report: report['bugHash'] + str(report['reportId']))
+    return results
 
 def __print_missing(needles, haystack, haystack_name):
     for needle in needles:


### PR DESCRIPTION
The list.sort() function doesn't return a sorted list but sorts inplace.