### PR TITLE
[fix] Don't reset PATH in Cppcheck plugin

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -380,12 +380,6 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             # No cppcheck arguments file was given in the command line.
             LOG.debug_analyzer(aerr)
 
-        check_env = context.get_analyzer_env(cls.ANALYZER_NAME)
-
-        # Overwrite PATH to contain only the parent of the cppcheck binary.
-        if os.path.isabs(Cppcheck.analyzer_binary()):
-            check_env['PATH'] = os.path.dirname(Cppcheck.analyzer_binary())
-
         checkers = cls.get_analyzer_checkers()
 
         # Cppcheck can and will report with checks that have a different


### PR DESCRIPTION
The Cppcheck plugin resets the PATH environment variable. It is usually not a good idea to overwrite PATH instead of extending it. In this specific case it caused an actual error: When tests are executed one after the other, this statement clears that PATH and later tests (e.g. test_env_var.py) run in an environment where PATH is technically empty. This test fails.