### PR TITLE
[fix] Missing analyzer error

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -142,10 +142,8 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
     ctu_reanalyze_on_failure = 'ctu_reanalyze_on_failure' in args and \
         args.ctu_reanalyze_on_failure
 
-    analyzers = args.analyzers if 'analyzers' in args \
-        else analyzer_types.supported_analyzers
-    analyzers, errored = analyzer_types.check_supported_analyzers(analyzers)
-    analyzer_types.check_available_analyzers(analyzers, errored)
+    analyzers, errored = \
+        analyzer_types.check_available_analyzers(args.analyzers)
 
     ctu_collect = False
     ctu_analyze = False

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -233,7 +233,7 @@ class Context(metaclass=Singleton):
                     self.__analyzers[name] = compiler_binary
 
     def get_analyzer_env(self, analyzer_name):
-        return self.__analyzer_envs[analyzer_name]
+        return self.__analyzer_envs.get(analyzer_name)
 
     def __populate_replacer(self):
         """ Set clang-apply-replacements tool. """

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -122,15 +122,28 @@ def print_unsupported_analyzers(errored):
                     analyzer_binary, reason)
 
 
-def check_available_analyzers(analyzers, errored):
-    """ Handle use case when no analyzer can be found on the user machine. """
-    if analyzers:
-        return
+def check_available_analyzers(args_analyzers=None):
+    """
+    Handle use case when no analyzer can be found or a supported, explicitly
+    given analyzer cannot be found on the user machine.
+    """
 
-    print_unsupported_analyzers(errored)
-    LOG.error("Failed to run command because no analyzers can be found on "
-              "your machine!")
-    sys.exit(1)
+    if args_analyzers:
+        analyzers, errored = check_supported_analyzers(args_analyzers)
+        if errored:
+            print_unsupported_analyzers(errored)
+            LOG.error("Failed to run command because the given analyzer(s) "
+                      "cannot be found on your machine!")
+            sys.exit(1)
+
+    else:
+        analyzers, errored = check_supported_analyzers(supported_analyzers)
+        if not analyzers:
+            print_unsupported_analyzers(errored)
+            LOG.error("Failed to run command because no analyzers can be "
+                      "found on your machine!")
+            sys.exit(1)
+    return analyzers, errored
 
 
 def check_supported_analyzers(analyzers):

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -372,7 +372,7 @@ def add_arguments_to_parser(parser):
                                metavar='ANALYZER',
                                required=False,
                                choices=analyzer_types.supported_analyzers,
-                               default=argparse.SUPPRESS,
+                               default=None,
                                help="Run analysis only with the analyzers "
                                     "specified. Currently supported analyzers "
                                     "are: " +

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -189,7 +189,7 @@ def main(args):
         check_env = context.get_analyzer_env(analyzer_name)
         version = analyzer_class.get_binary_version(check_env)
         if not version:
-            version = 'ERROR'
+            version = 'NOT FOUND'
 
         binary = context.analyzer_binaries.get(analyzer_name)
         rows.append([analyzer_name, binary, version])

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -305,7 +305,7 @@ used to generate a log file on the fly.""")
                                metavar='ANALYZER',
                                required=False,
                                choices=analyzer_types.supported_analyzers,
-                               default=argparse.SUPPRESS,
+                               default=None,
                                help="Run analysis only with the analyzers "
                                     "specified. Currently supported analyzers "
                                     "are: " +

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -522,9 +522,8 @@ def __print_checker_config(args: argparse.Namespace):
     if args.output_format == 'custom':
         args.output_format = 'rows'
 
-    working_analyzers, errored = analyzer_types.check_supported_analyzers(
-        args.analyzers)
-    analyzer_types.check_available_analyzers(working_analyzers, errored)
+    working_analyzers, errored = \
+        analyzer_types.check_available_analyzers(args.analyzers)
 
     if 'details' in args:
         header = ['Option', 'Description']


### PR DESCRIPTION
`CodeChecker analyzers` gives python error for the user if a supported analyzer is missing. In addition, CodeChecker `analyze` and `check` should have provided an error and sys.exit when the specified (with `--analyzers`) analyzer was missing.

With this PR, `CodeChecker analyzers` can give a warning message with `NOT FOUND` status if a supported analyzer can't be found on the machine.

In case of explicitly defined missing analyzer, the `analyze` and `check` command will be failed and will give warrning and error message for the user.