### PR TITLE
Adding a --drop-reports-from-skipped-files parameter to analyze

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -216,7 +216,7 @@ def prepare_check(action, analyzer_config, output_dir,
 
 
 def handle_success(
-    rh, result_file, result_base, skip_handlers,
+    rh, result_file, result_base, filter_handlers,
     rs_handler: ReviewStatusHandler,
     capture_analysis_output, success_dir
 ):
@@ -230,7 +230,7 @@ def handle_success(
         save_output(os.path.join(success_dir, result_base),
                     rh.analyzer_stdout, rh.analyzer_stderr)
 
-    rh.postprocess_result(skip_handlers, rs_handler)
+    rh.postprocess_result(filter_handlers, rs_handler)
 
     # Generated reports will be handled separately at store.
 
@@ -487,7 +487,8 @@ def check(check_data):
     skiplist handler is None if no skip file was configured.
     """
     actions_map, action, analyzer_config, \
-        output_dir, skip_handlers, rs_handler, quiet_output_on_stdout, \
+        output_dir, skip_handlers, filter_handlers, \
+        rs_handler, quiet_output_on_stdout, \
         capture_analysis_output, generate_reproducer, analysis_timeout, \
         ctu_reanalyze_on_failure, \
         output_dirs, statistics_data = check_data
@@ -605,7 +606,7 @@ def check(check_data):
 
             if success:
                 handle_success(rh, result_file, result_base,
-                               skip_handlers, rs_handler,
+                               filter_handlers, rs_handler,
                                capture_analysis_output, success_dir)
             elif not generate_reproducer:
                 handle_failure(source_analyzer, rh,
@@ -719,7 +720,7 @@ def skip_cpp(compile_actions, skip_handlers):
 
 
 def start_workers(actions_map, actions, analyzer_config_map,
-                  jobs, output_path, skip_handlers,
+                  jobs, output_path, skip_handlers, filter_handlers,
                   rs_handler: ReviewStatusHandler, metadata_tool,
                   quiet_analyze, capture_analysis_output, generate_reproducer,
                   timeout, ctu_reanalyze_on_failure, statistics_data, manager,
@@ -785,6 +786,7 @@ def start_workers(actions_map, actions, analyzer_config_map,
                          analyzer_config_map.get(build_action.analyzer_type),
                          output_path,
                          skip_handlers,
+                         filter_handlers,
                          rs_handler,
                          quiet_analyze,
                          capture_analysis_output,

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -130,7 +130,8 @@ def __has_enabled_checker(ch: AnalyzerConfigHandler):
                for _, (state, _) in ch.checks().items())
 
 
-def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
+def perform_analysis(args, skip_handlers, filter_handlers,
+                     rs_handler: ReviewStatusHandler,
                      actions, metadata_tool, compile_cmd_count):
     """
     Perform static analysis via the given (or if not, all) analyzers,
@@ -335,6 +336,7 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
                                        config_map, args.jobs,
                                        args.output_path,
                                        skip_handlers,
+                                       filter_handlers,
                                        rs_handler,
                                        metadata_tool,
                                        'quiet' in args,

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -275,7 +275,7 @@ used to generate a log file on the fly.""")
                                     "more information.\n"
                                     "USE WISELY AND AT YOUR OWN RISK!")
 
-    skip_mode = analyzer_opts.add_mutually_exclusive_group()
+    skip_mode = parser.add_argument_group("file filter arguments")
     skip_mode.add_argument('-i', '--ignore', '--skip',
                            dest="skipfile",
                            required=False,
@@ -284,6 +284,14 @@ used to generate a log file on the fly.""")
                                 "files should be omitted from analysis. "
                                 "Please consult the User guide on how a "
                                 "Skipfile should be laid out.")
+
+    skip_mode.add_argument('--drop-reports-from-skipped-files',
+                           dest="drop_skipped_reports",
+                           required=False,
+                           action='store_true',
+                           default=False,
+                           help="Filter our reports from files that were  "
+                                "skipped from the analysis.")
 
     skip_mode.add_argument('--file',
                            nargs='+',
@@ -881,6 +889,7 @@ def main(args):
         # after the call.
         args_to_update = ['quiet',
                           'skipfile',
+                          'drop_skipped_reports',
                           'files',
                           'analyzers',
                           'add_compiler_defaults',

--- a/analyzer/tests/functional/skip/test_files/simple/skipfile_drop
+++ b/analyzer/tests/functional/skip/test_files/simple/skipfile_drop
@@ -1,0 +1,1 @@
+-*file_to_be_skipped.cpp


### PR DESCRIPTION
By default CodeChecker used to filter out all reports from files which were on the skip list. This can hide true positive reports strating from unskipped code and endingin skipped files (typical with CTU and header related findings).

This patch removes the  default report filtering post processing step from CodeChecker analyze --skip SKIPFILE operation.
The legacy functionality is still available with the --drop-reports-from-skipped-files paramer.

This way the reports are not skipped as a post processing step by default. 