### PR TITLE
Environment initialization for binaries

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -355,7 +355,8 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
     end_time = time.time()
     LOG.info("Analysis length: %s sec.", end_time - start_time)
 
-    analyzer_types.print_unsupported_analyzers(errored)
+    if args.analyzers:
+        analyzer_types.print_unsupported_analyzers(errored)
 
     metadata_tool['timestamps'] = {'begin': start_time,
                                    'end': end_time}

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -247,7 +247,7 @@ def perform_analysis(args, skip_handlers, rs_handler: ReviewStatusHandler,
                 enabled_checkers[analyzer].append(check)
 
         version = analyzer_types.supported_analyzers[analyzer] \
-            .get_binary_version(context.get_analyzer_env(analyzer))
+            .get_binary_version()
         metadata_info['analyzer_statistics']['version'] = version
 
         metadata_tool['analyzers'][analyzer] = metadata_info

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -115,7 +115,7 @@ def is_ignore_conflict_supported():
 def print_unsupported_analyzers(errored):
     """ Print error messages which occured during analyzer detection. """
     for analyzer_binary, reason in errored:
-        LOG.warning("Analyzer '%s' is enabled but CodeChecker is failed to "
+        LOG.warning("Analyzer '%s' is enabled but CodeChecker failed to "
                     "execute analysis with it: '%s'. Please check your "
                     "'PATH' environment variable and the "
                     "'config/package_layout.json' file!",

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -105,8 +105,8 @@ def is_ignore_conflict_supported():
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             env=context
-                            .get_analyzer_env(
-                                os.path.basename(context.replacer_binary)),
+                            .get_env_for_bin(
+                                context.replacer_binary),
                             encoding="utf-8", errors="ignore")
     out, _ = proc.communicate()
     return '--ignore-insert-conflict' in out
@@ -159,7 +159,6 @@ def check_supported_analyzers(analyzers):
     """
 
     context = analyzer_context.get_context()
-    check_env = context.cc_env
 
     analyzer_binaries = context.analyzer_binaries
 
@@ -182,7 +181,8 @@ def check_supported_analyzers(analyzers):
         elif not os.path.isabs(analyzer_bin):
             # If the analyzer is not in an absolute path, try to find it...
             found_bin = supported_analyzers[analyzer_name].\
-                resolve_missing_binary(analyzer_bin, check_env)
+                resolve_missing_binary(analyzer_bin,
+                                       context.get_env_for_bin(analyzer_bin))
 
             # found_bin is an absolute path, an executable in one of the
             # PATH folders.
@@ -201,7 +201,7 @@ def check_supported_analyzers(analyzers):
         # Check version compatibility of the analyzer binary.
         if analyzer_bin:
             analyzer = supported_analyzers[analyzer_name]
-            error = analyzer.is_binary_version_incompatible(check_env)
+            error = analyzer.is_binary_version_incompatible()
             if error:
                 failed_analyzers.add((analyzer_name,
                                       f"Incompatible version: {error} "
@@ -211,7 +211,7 @@ def check_supported_analyzers(analyzers):
                 available_analyzer = False
 
         if not analyzer_bin or \
-           not host_check.check_analyzer(analyzer_bin, check_env):
+           not host_check.check_analyzer(analyzer_bin):
             # Analyzers unavailable under absolute paths are deliberately a
             # configuration problem.
             failed_analyzers.add((analyzer_name,

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -52,7 +52,7 @@ def parse_clang_help_page(
             command,
             stderr=subprocess.STDOUT,
             env=analyzer_context.get_context()
-            .get_analyzer_env(ClangSA.ANALYZER_NAME),
+            .get_env_for_bin(command[0]),
             universal_newlines=True,
             encoding="utf-8",
             errors="ignore")
@@ -172,8 +172,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.extend(["-load", plugin])
 
     @classmethod
-    def get_binary_version(cls, environ, details=False) -> str:
+    def get_binary_version(cls, details=False) -> str:
         # No need to LOG here, we will emit a warning later anyway.
+
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         if not cls.analyzer_binary():
             return None
 
@@ -209,7 +212,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             cls.__ctu_autodetection = CTUAutodetection(
                 cls.analyzer_binary(),
                 analyzer_context.get_context()
-                .get_analyzer_env(ClangSA.ANALYZER_NAME))
+                .get_env_for_bin(cls.analyzer_binary()))
 
         return cls.__ctu_autodetection
 
@@ -587,7 +590,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
         return clang
 
     @classmethod
-    def is_binary_version_incompatible(cls, environ):
+    def is_binary_version_incompatible(cls):
         """
         We support pretty much every ClangSA version.
         """
@@ -609,7 +612,8 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     def construct_config_handler(cls, args):
 
         context = analyzer_context.get_context()
-        environ = context.get_analyzer_env(ClangSA.ANALYZER_NAME)
+        environ = context.get_env_for_bin(
+            cls.analyzer_binary())
 
         handler = config_handler.ClangSAConfigHandler(environ)
 

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_manager.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/ctu_manager.py
@@ -126,11 +126,10 @@ def generate_ast(triple_arch, action, source, config):
             os.makedirs(ast_dir)
         except OSError:
             pass
-
     cmdstr = ' '.join(cmd)
     LOG.debug_analyzer("Generating AST using '%s'", cmdstr)
     ret_code, _, err = \
-        analyzer_base.SourceAnalyzer.run_proc(cmd, action.directory)
+        analyzer_base.SourceAnalyzer.run_proc(cmd, action.directory, None)
 
     if ret_code != 0:
         LOG.error("Error generating AST.\n\ncommand:\n\n%s\n\nstderr:\n\n%s",

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/version.py
@@ -77,7 +77,7 @@ def get(clang_binary):
     """
     compiler_version = subprocess.check_output(
         [clang_binary, '--version'],
-        env=analyzer_context.get_context().get_analyzer_env("clangsa"),
+        env=analyzer_context.get_context().get_env_for_bin(clang_binary),
         encoding="utf-8",
         errors="ignore")
     version_parser = ClangVersionInfoParser(clang_binary)

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -142,11 +142,12 @@ def get_diagtool_bin():
     return None
 
 
-def get_warnings(environment=None):
+def get_warnings():
     """
     Returns list of warning flags by using diagtool.
     """
     diagtool_bin = get_diagtool_bin()
+    environment = analyzer_context.get_context().get_env_for_bin(diagtool_bin)
 
     if not diagtool_bin:
         return []
@@ -284,7 +285,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
             checker_description.extend(
                 ("clang-diagnostic-" + warning, "")
-                for warning in get_warnings(environ))
+                for warning in get_warnings())
 
             cls.__analyzer_checkers = checker_description
 
@@ -314,6 +315,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         """
         Return the analyzer configuration with all checkers enabled.
         """
+        if not cls.analyzer_binary():
+            return []
+
         try:
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -236,8 +236,10 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             .analyzer_binaries[cls.ANALYZER_NAME]
 
     @classmethod
-    def get_binary_version(cls, environ, details=False) -> str:
+    def get_binary_version(cls, details=False) -> str:
         # No need to LOG here, we will emit a warning later anyway.
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         if not cls.analyzer_binary():
             return None
 
@@ -271,7 +273,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                 return cls.__analyzer_checkers
 
             environ = analyzer_context\
-                .get_context().get_analyzer_env(cls.ANALYZER_NAME)
+                .get_context().get_env_for_bin(cls.analyzer_binary())
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-list-checks", "-checks=*"],
                 env=environ,
@@ -299,7 +301,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
                 env=analyzer_context.get_context()
-                .get_analyzer_env(cls.ANALYZER_NAME),
+                .get_env_for_bin(cls.analyzer_binary()),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")
@@ -316,7 +318,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
             result = subprocess.check_output(
                 [cls.analyzer_binary(), "-dump-config", "-checks=*"],
                 env=analyzer_context.get_context()
-                .get_analyzer_env(cls.ANALYZER_NAME),
+                .get_env_for_bin(cls.analyzer_binary()),
                 universal_newlines=True,
                 encoding="utf-8",
                 errors="ignore")
@@ -567,7 +569,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         return clangtidy
 
     @classmethod
-    def is_binary_version_incompatible(cls, environ):
+    def is_binary_version_incompatible(cls):
         """
         We support pretty much every Clang-Tidy version.
         """

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -237,11 +237,11 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
     @classmethod
     def get_binary_version(cls, details=False) -> str:
+        if not cls.analyzer_binary():
+            return None
         # No need to LOG here, we will emit a warning later anyway.
         environ = analyzer_context.get_context().get_env_for_bin(
             cls.analyzer_binary())
-        if not cls.analyzer_binary():
-            return None
 
         version = [cls.analyzer_binary(), '--version']
         try:

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -82,9 +82,11 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             .analyzer_binaries[cls.ANALYZER_NAME]
 
     @classmethod
-    def get_binary_version(cls, environ, details=False) -> str:
+    def get_binary_version(cls, details=False) -> str:
         """ Get analyzer version information. """
         # No need to LOG here, we will emit a warning later anyway.
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         if not cls.analyzer_binary():
             return None
         version = [cls.analyzer_binary(), '--version']
@@ -324,11 +326,11 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         return cppcheck
 
     @classmethod
-    def is_binary_version_incompatible(cls, environ):
+    def is_binary_version_incompatible(cls):
         """
         Check the version compatibility of the given analyzer binary.
         """
-        analyzer_version = cls.get_binary_version(environ)
+        analyzer_version = cls.get_binary_version()
 
         # The analyzer version should be above 1.80 because '--plist-output'
         # argument was introduced in this release.

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -244,10 +244,13 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
         """
         Return the list of the supported checkers.
         """
+        if not cls.analyzer_binary():
+            return []
         command = [cls.analyzer_binary(), "--errorlist"]
-
+        environ = analyzer_context.get_context().get_env_for_bin(
+            command[0])
         try:
-            result = subprocess.check_output(command)
+            result = subprocess.check_output(command, env=environ)
             return parse_checkers(result)
         except (subprocess.CalledProcessError) as e:
             LOG.error(e.stderr)

--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -85,10 +85,10 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
     def get_binary_version(cls, details=False) -> str:
         """ Get analyzer version information. """
         # No need to LOG here, we will emit a warning later anyway.
-        environ = analyzer_context.get_context().get_env_for_bin(
-            cls.analyzer_binary())
         if not cls.analyzer_binary():
             return None
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         version = [cls.analyzer_binary(), '--version']
         try:
             output = subprocess.check_output(version,

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -153,11 +153,11 @@ class Gcc(analyzer_base.SourceAnalyzer):
         """
         Return the analyzer version.
         """
-        environ = analyzer_context.get_context().get_env_for_bin(
-            cls.analyzer_binary())
         # No need to LOG here, we will emit a warning later anyway.
         if not cls.analyzer_binary():
             return None
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         if details:
             version = [cls.analyzer_binary(), '--version']
         else:

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -55,6 +55,8 @@ class Gcc(analyzer_base.SourceAnalyzer):
         # unforeseen exceptions where a general catch is justified?
         config = self.config_handler
 
+        if not Gcc.analyzer_binary():
+            return None
         # We don't want GCC do start linking, but -fsyntax-only stops the
         # compilation process too early for proper diagnostics generation.
         analyzer_cmd = [Gcc.analyzer_binary(), '-fanalyzer', '-c',
@@ -91,10 +93,14 @@ class Gcc(analyzer_base.SourceAnalyzer):
         Return the list of the supported checkers.
         """
         command = [cls.analyzer_binary(), "--help=warning"]
+        if not cls.analyzer_binary():
+            return []
+        environ = analyzer_context.get_context().get_env_for_bin(
+            command[0])
         checker_list = []
 
         try:
-            output = subprocess.check_output(command)
+            output = subprocess.check_output(command, env=environ)
 
             # Still contains the help message we need to remove.
             for entry in output.decode().split('\n'):

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -149,10 +149,12 @@ class Gcc(analyzer_base.SourceAnalyzer):
         # TODO
 
     @classmethod
-    def get_binary_version(cls, environ, details=False) -> str:
+    def get_binary_version(cls, details=False) -> str:
         """
         Return the analyzer version.
         """
+        environ = analyzer_context.get_context().get_env_for_bin(
+            cls.analyzer_binary())
         # No need to LOG here, we will emit a warning later anyway.
         if not cls.analyzer_binary():
             return None
@@ -174,11 +176,11 @@ class Gcc(analyzer_base.SourceAnalyzer):
         return None
 
     @classmethod
-    def is_binary_version_incompatible(cls, environ):
+    def is_binary_version_incompatible(cls):
         """
         Check the version compatibility of the given analyzer binary.
         """
-        analyzer_version = cls.get_binary_version(environ)
+        analyzer_version = cls.get_binary_version()
 
         if analyzer_version is None:
             return "GCC binary is too old to support -dumpfullversion."

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -186,8 +186,7 @@ def main(args):
     rows = []
     for analyzer_name, analyzer_class in \
             analyzer_types.supported_analyzers.items():
-        check_env = context.get_analyzer_env(analyzer_name)
-        version = analyzer_class.get_binary_version(check_env)
+        version = analyzer_class.get_binary_version()
         if not version:
             version = 'NOT FOUND'
 

--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -118,10 +118,13 @@ def main(args):
 
     if args.dump_config:
         binary = context.analyzer_binaries.get(args.dump_config)
+        environ = analyzer_context.get_context().get_env_for_bin(
+            binary)
 
         if args.dump_config == 'clang-tidy':
             subprocess.call([binary, '-dump-config', '-checks=*'],
-                            encoding="utf-8", errors="ignore")
+                            encoding="utf-8", errors="ignore",
+                            env=environ)
         elif args.dump_config == 'clangsa':
             ret = subprocess.call([binary,
                                    '-cc1',
@@ -129,7 +132,8 @@ def main(args):
                                    '-analyzer-checker-option-help-alpha'],
                                   stderr=subprocess.PIPE,
                                   encoding="utf-8",
-                                  errors="ignore")
+                                  errors="ignore",
+                                  env=environ)
 
             if ret:
                 # This flag is supported from Clang 9.

--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -555,7 +555,10 @@ def __print_checker_config(args: argparse.Namespace):
     if rows:
         print(twodim.to_str(args.output_format, header, rows))
 
-    analyzer_types.print_unsupported_analyzers(errored)
+    # Don't print this warning unless the analyzer list is
+    # given by the user.
+    if args.analyzers:
+        analyzer_types.print_unsupported_analyzers(errored)
 
     if analyzer_failures:
         LOG.error("Failed to get checker configuration options for '%s' "

--- a/analyzer/codechecker_analyzer/cmd/fixit.py
+++ b/analyzer/codechecker_analyzer/cmd/fixit.py
@@ -285,10 +285,14 @@ def apply_fixits(inputs, checker_names, file_paths, interactive, reports):
         """
         Execute clang-apply-replacements binary.
         """
+        context = analyzer_context.get_context()
+        replacer_env = context.get_env_for_bin(
+            analyzer_context.get_context().replacer_binary)
         subprocess.Popen([
             analyzer_context.get_context().replacer_binary,
             *ignore_flag,
-            out_dir]).communicate()
+            out_dir],
+            env=replacer_env).communicate()
 
     not_existing_files = set()
     existing_files = set()

--- a/analyzer/codechecker_analyzer/host_check.py
+++ b/analyzer/codechecker_analyzer/host_check.py
@@ -21,24 +21,28 @@ from codechecker_common.logger import get_logger
 LOG = get_logger('analyzer')
 
 
-def check_analyzer(compiler_bin, env):
+def check_analyzer(compiler_bin):
     """
     Simple check if clang is available.
     """
     clang_version_cmd = [compiler_bin, '--version']
     LOG.debug_analyzer(' '.join(clang_version_cmd))
+    environ = analyzer_context.get_context().get_env_for_bin(
+        compiler_bin)
     try:
-        res = subprocess.call(
+        proc = subprocess.Popen(
             clang_version_cmd,
-            env=env,
+            env=environ,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
             errors="ignore")
-        if not res:
+        out, err = proc.communicate()
+        if not proc.returncode:
             return True
-
-        LOG.debug_analyzer('Failed to run: "%s"', ' '.join(clang_version_cmd))
+        LOG.error('Failed to run: "%s"', ' '.join(clang_version_cmd))
+        LOG.error('stdout: %s', out)
+        LOG.error('stderr: %s', err)
         return False
 
     except OSError as oerr:
@@ -53,13 +57,14 @@ def has_analyzer_config_option(clang_bin, config_option_name):
     cmd = [clang_bin, "-cc1", "-analyzer-config-help"]
 
     LOG.debug('run: "%s"', ' '.join(cmd))
+    context = analyzer_context.get_context()
 
     try:
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=analyzer_context.get_context().get_analyzer_env("clangsa"),
+            env=context.get_env_for_bin(clang_bin),
             encoding="utf-8", errors="ignore")
         out, err = proc.communicate()
         LOG.debug("stdout:\n%s", out)
@@ -92,7 +97,7 @@ def has_analyzer_option(clang_bin, feature):
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=analyzer_context.get_context().get_analyzer_env("clangsa"),
+                env=analyzer_context.get_context().get_env_for_bin(clang_bin),
                 encoding="utf-8", errors="ignore")
             out, err = proc.communicate()
             LOG.debug("stdout:\n%s", out)

--- a/analyzer/tests/unit/test_env_var.py
+++ b/analyzer/tests/unit/test_env_var.py
@@ -139,17 +139,20 @@ class EnvVarTest(unittest.TestCase):
         lcfg_dict = context._Context__get_package_layout()
         context._data_files_dir_path = data_files_dir
         context.pckg_layout = lcfg_dict['runtime']
+        context._Context__init_env()
         context._Context__populate_analyzers()
 
         # clang-19 is part of the codechecker package
         # so the internal package lib should be in the ld_library_path
-        clang_env = context.get_analyzer_env("clangsa")
+        clang_env = context.get_env_for_bin(
+            context.analyzer_binaries["clangsa"])
         env_txt = str(clang_env)
         self.assertTrue(env_txt.find("internal_package_lib") != -1)
 
         # clang-tidy is not part of the codechecker package
         # so internal package lib should not be in the ld_library_path
-        clang_env = context.get_analyzer_env("clang-tidy")
+        clang_env = context.get_env_for_bin(
+            context.analyzer_binaries["clang-tidy"])
         env_txt = str(clang_env)
         self.assertTrue(env_txt.find("internal_package_lib") == -1)
 


### PR DESCRIPTION
CodeChecker calls various binaries during analysis: clang, clang-tidy,
clang-extdef-mapping etc.
If the binary is delivered within the CodeChecker package,
LD_LIBRARY_PATH needs to be extended with it.

Otherwise the environment of the caller shell should be used
for excuting binaries.