### PR TITLE
CodeChecker authentication fixed

### DIFF
--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -539,6 +539,9 @@ class SessionManager:
 
     def __is_root_user(self, user_name):
         """ Return True if the given user has system permissions. """
+        if 'super_user' not in self.__auth_config:
+            return False
+
         if self.__auth_config['super_user'] == user_name:
             return True
 


### PR DESCRIPTION
If the super_user field was missing from the
config file, CodeChecker authentication failed
for all users.