### PR TITLE
[fix] Get product configuration with view permission

### DIFF
--- a/web/server/codechecker_server/api/product_server.py
+++ b/web/server/codechecker_server/api/product_server.py
@@ -67,6 +67,8 @@ class ThriftProductHandler:
         with DBSession(self.__session) as session:
             if args is None:
                 args = dict(self.__permission_args)
+
+            if 'config_db_session' not in args:
                 args['config_db_session'] = session
 
             # Anonymous access is only allowed if authentication is
@@ -254,7 +256,9 @@ class ThriftProductHandler:
         Get the product configuration --- WITHOUT THE DB PASSWORD --- of the
         given product.
         """
-        self.__require_permission([permissions.PRODUCT_VIEW])
+        self.__require_permission([permissions.PRODUCT_VIEW], {
+            'productID': product_id
+        })
 
         with DBSession(self.__session) as session:
             product = session.query(Product).get(product_id)

--- a/web/tests/functional/products/__init__.py
+++ b/web/tests/functional/products/__init__.py
@@ -96,6 +96,7 @@ def setup_class_common(workspace_name):
 
     # Export the test configuration to the workspace.
     env.export_test_cfg(TEST_WORKSPACE, test_config)
+    env.enable_auth(TEST_WORKSPACE)
 
 
 def teardown_class_common():

--- a/web/tests/functional/products/test_products.py
+++ b/web/tests/functional/products/test_products.py
@@ -181,6 +181,19 @@ class TestProducts(unittest.TestCase):
                          Confidentiality.CONFIDENTIAL,
                          "Default Confidentiality was not Confidential")
 
+    def test_get_product_config_auth_server(self):
+        """
+        Test if product configuration can be retrieved from an authenticated
+        server.
+        """
+        pr_client = env.setup_product_client(
+            self.test_workspace, product=self.product_name)
+        product_id = pr_client.getCurrentProduct().id
+
+        pr_client = env.setup_product_client(self.test_workspace)
+        pr_config = pr_client.getProductConfiguration(product_id)
+        self.assertIsNotNone(pr_config)
+
     def test_editing(self):
         """
         Test editing the product details (without reconnecting it).


### PR DESCRIPTION
The getProductConfiguration() function on Product endpoint requires a current product in the URL for checking view permission. The requirement of having view permission has been added in
8953b30f6d17597635ec59bb943683aacb216619. However there is no "current product" in the Product endpoint URL queries, but the product id is provided through a function parameter.