### PR TITLE
Handle ambigous profile/group parameters

### DIFF
--- a/analyzer/codechecker_analyzer/checkers.py
+++ b/analyzer/codechecker_analyzer/checkers.py
@@ -23,7 +23,8 @@ def available(ordered_checkers, available_checkers):
         if checker_name.startswith('profile:') or \
                 checker_name.startswith('guideline:') or \
                 checker_name.startswith('severity:') or \
-                checker_name.startswith('sei-cert:'):
+                checker_name.startswith('sei-cert:') or \
+                checker_name.startswith('prefix:'):
             continue
 
         name_match = False

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -699,6 +699,22 @@ compiler errors are also collected as CodeChecker reports as
 Note that compiler errors and warnings are captured by CodeChecker only if it
 was emitted by clang-tidy.
 
+Checker prefix groups
+------------------------------------------------
+Checker prefix groups allow you to enable checkers that share a common
+prefix in their names. Checkers within a prefix group will have names that
+start with the same identifier, making it easier to manage and reference
+related checkers.
+
+You can enable/disable checkers belonging to a checker prefix group:
+'-e <label>:<value>', e.g. '-e prefix:security'.
+
+Note: The 'prefix' label is mandatory when there is ambiguity between the
+name of a checker prefix group and a checker profile or a guideline. This
+prevents conflicts and ensures the correct checkers are applied.
+
+See "CodeChecker checkers --help" to learn more.
+
 Checker labels
 ------------------------------------------------
 Each checker is assigned several '<label>:<value>' pairs. For instance,
@@ -707,6 +723,10 @@ goal of labels is that you can enable or disable a batch of checkers with them.
 
 You can enable/disable checkers belonging to a label: '-e <label>:<value>',
 e.g. '-e profile:default'.
+
+Note: The 'profile' label is mandatory when there is ambiguity between the
+name of a checker profile and a checker prefix group or a guideline. This
+prevents conflicts and ensures the correct checkers are applied.
 
 See "CodeChecker checkers --help" to learn more.
 
@@ -722,6 +742,10 @@ output of "CodeChecker checkers --guideline" command.
 
 Guidelines are labels themselves, and can be used as a label:
 '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+
+Note: The 'guideline' label is mandatory when there is ambiguity between the
+name of a guideline and a checker prefix group or a checker profile. This
+prevents conflicts and ensures the correct checkers are applied.
 
 Batch enabling/disabling checkers
 ------------------------------------------------
@@ -739,35 +763,37 @@ LLVM/Clang community, and thus discouraged.
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
                                action=OrderedCheckersAction,
-                               help="Set a checker (or checker group), "
-                                    "profile or guideline "
-                                    "to BE USED in the analysis. In case of "
-                                    "ambiguity the priority order is profile, "
-                                    "guideline, checker name (e.g. security "
-                                    "means the profile, not the checker "
-                                    "group). Moreover, labels can also be "
+                               help="Set a checker (or checker prefix group), "
+                                    "profile or guideline to BE USED in the "
+                                    "analysis. Labels can also be "
                                     "used for selecting checkers, for example "
                                     "profile:extreme or severity:STYLE. See "
                                     "'CodeChecker checkers --label' for "
-                                    "further details.")
+                                    "further details. In case of a name clash "
+                                    "between the checker prefix "
+                                    "group/profile/guideline name, the use of "
+                                    "one of the following labels is "
+                                    "mandatory: 'prefix:', 'profile:', "
+                                    "'guideline:'.")
 
     checkers_opts.add_argument('-d', '--disable',
                                dest="disable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
                                action=OrderedCheckersAction,
-                               help="Set a checker (or checker group), "
+                               help="Set a checker (or checker prefix group), "
                                     "profile or guideline "
                                     "to BE PROHIBITED from use in the "
-                                    "analysis. In case of "
-                                    "ambiguity the priority order is profile, "
-                                    "guideline, checker name (e.g. security "
-                                    "means the profile, not the checker "
-                                    "group). Moreover, labels can also be "
+                                    "analysis. Labels can also be "
                                     "used for selecting checkers, for example "
                                     "profile:extreme or severity:STYLE. See "
                                     "'CodeChecker checkers --label' for "
-                                    "further details.")
+                                    "further details. In case of a name clash "
+                                    "between the checker prefix "
+                                    "group/profile/guideline name, the use of "
+                                    "one of the following labels is "
+                                    "mandatory: 'prefix:', 'profile:', "
+                                    "'guideline:'.")
 
     checkers_opts.add_argument('--enable-all',
                                dest="enable_all",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -643,6 +643,22 @@ compiler errors are also collected as CodeChecker reports as
 Note that compiler errors and warnings are captured by CodeChecker only if it
 was emitted by clang-tidy.
 
+Checker prefix groups
+------------------------------------------------
+Checker prefix groups allow you to enable checkers that share a common
+prefix in their names. Checkers within a prefix group will have names that
+start with the same identifier, making it easier to manage and reference
+related checkers.
+
+You can enable/disable checkers belonging to a checker prefix group:
+'-e <label>:<value>', e.g. '-e prefix:security'.
+
+Note: The 'prefix' label is mandatory when there is ambiguity between the
+name of a checker prefix group and a checker profile or a guideline. This
+prevents conflicts and ensures the correct checkers are applied.
+
+See "CodeChecker checkers --help" to learn more.
+
 Checker labels
 ------------------------------------------------
 Each checker is assigned several '<label>:<value>' pairs. For instance,
@@ -651,6 +667,10 @@ goal of labels is that you can enable or disable a batch of checkers with them.
 
 You can enable/disable checkers belonging to a label: '-e <label>:<value>',
 e.g. '-e profile:default'.
+
+Note: The 'profile' label is mandatory when there is ambiguity between the
+name of a checker profile and a checker prefix group or a guideline. This
+prevents conflicts and ensures the correct checkers are applied.
 
 See "CodeChecker checkers --help" to learn more.
 
@@ -666,6 +686,10 @@ output of "CodeChecker checkers --guideline" command.
 
 Guidelines are labels themselves, and can be used as a label:
 '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+
+Note: The 'guideline' label is mandatory when there is ambiguity between the
+name of a guideline and a checker prefix group or a checker profile. This
+prevents conflicts and ensures the correct checkers are applied.
 
 Batch enabling/disabling checkers
 ------------------------------------------------

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -39,8 +39,16 @@ class MockClangsaCheckerLabels:
         if labels[0] == 'profile:default':
             return ['core', 'deadcode', 'security.FloatLoopCounter']
 
+        if labels[0] == 'prefix:security':
+            return ['security.insecureAPI.bzero',
+                    'security.insecureAPI.getpw']
+
         if labels[0] == 'profile:security':
             return ['alpha.security']
+
+        if labels[0] == 'profile:sensitive':
+            return ['alpha.core.BoolAssignment',
+                    'alpha.core.TestAfterDivZero']
 
         if labels[0] == 'guideline:sei-cert':
             return ['alpha.core.CastSize', 'alpha.core.CastToStruct']
@@ -154,6 +162,17 @@ class CheckerHandlingClangSATest(unittest.TestCase):
                 'alpha.security.ArrayBound',
                 'alpha.security.MallocOverflow']
 
+        # "security" checker prefix group
+        security_prefix = [
+            'security.insecureAPI.bzero',
+            'security.insecureAPI.getpw'
+        ]
+
+        # "sensitive" profile, but alpha -> not in default.
+        sensitive_profile_alpha = [
+                    'alpha.core.BoolAssignment',
+                    'alpha.core.TestAfterDivZero']
+
         # "default" profile.
         default_profile = [
                 'security.FloatLoopCounter',
@@ -175,6 +194,8 @@ class CheckerHandlingClangSATest(unittest.TestCase):
 
         checkers = []
         checkers.extend(map(add_description, security_profile_alpha))
+        checkers.extend(map(add_description, security_prefix))
+        checkers.extend(map(add_description, sensitive_profile_alpha))
         checkers.extend(map(add_description, default_profile))
         checkers.extend(map(add_description, cert_guideline))
         checkers.extend(map(add_description, statisticsbased))
@@ -197,15 +218,41 @@ class CheckerHandlingClangSATest(unittest.TestCase):
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), default_profile))
 
-        # Enable alpha checkers explicitly.
+        # Enable alpha checkers explicitly with prefix label.
+        # Using the "prefix" label is optional in this case, because the
+        # checker group name "alpha" does not conflict with any checker
+        # profiles or guidelines.
         cfg_handler = ClangSA.construct_config_handler(args)
-        cfg_handler.initialize_checkers(checkers, [('alpha', True)])
+        cfg_handler.initialize_checkers(checkers,
+                                        [('prefix:alpha', True)])
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), security_profile_alpha))
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), default_profile))
 
+        # Enable alpha checkers explicitly.
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('alpha', True)])
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), security_profile_alpha))
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), default_profile))
+
+        # Enable checkers of the "security" checker prefix group.
+        # Using the "prefix" label is mandatory in this case, because the
+        # checker group name "security" conflicts with a profile name.
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('prefix:security', True)])
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), security_prefix))
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), default_profile))
+
         # Enable "security" profile checkers.
+        # Using the "profile" label is mandatory in this case, because the
+        # profile name "security" conflicts with a checker group name.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
                                         [('profile:security', True)])
@@ -215,22 +262,46 @@ class CheckerHandlingClangSATest(unittest.TestCase):
                         (cfg_handler.checks(), default_profile))
 
         # Enable "security" profile checkers without "profile:" prefix.
+        # This should throw an error, because the profile name "security"
+        # conflicts with a checker group name.
+        cfg_handler = ClangSA.construct_config_handler(args)
+        with self.assertRaises(SystemExit) as e:
+            cfg_handler.initialize_checkers(checkers,
+                                            [('security', True)])
+        self.assertEqual(e.exception.code, 1)
+
+        # Enable "sensitive" profile checkers with the "profile:" label.
+        # Using the "profile" label is optional in this case, because the
+        # profile name "security" does not conflict with any checker
+        # prefix group names.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
-                                        [('security', True)])
+                                        [('profile:sensitive', True)])
         self.assertTrue(all_with_status(CheckerState.ENABLED)
-                        (cfg_handler.checks(), security_profile_alpha))
+                        (cfg_handler.checks(), sensitive_profile_alpha))
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), default_profile))
 
-        # Enable "sei-cert" guideline checkers.
+        # Enable "sensitive" profile checkers without the "profile:" label.
+        cfg_handler = ClangSA.construct_config_handler(args)
+        cfg_handler.initialize_checkers(checkers,
+                                        [('sensitive', True)])
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), sensitive_profile_alpha))
+        self.assertTrue(all_with_status(CheckerState.ENABLED)
+                        (cfg_handler.checks(), default_profile))
+
+        # Enable "sei-cert" guideline checkers with the "guideline:" label.
+        # Using the "guideline" label is optional in this case, because the
+        # guideline name "sei-cert" does not conflict with any checker
+        # prefix group names.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
                                         [('guideline:sei-cert', True)])
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), cert_guideline))
 
-        # Enable "sei-cert" guideline checkers.
+        # Enable "sei-cert" guideline checkers without the "guideline:" label.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
                                         [('sei-cert', True)])

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -272,7 +272,7 @@ class CheckerHandlingClangSATest(unittest.TestCase):
 
         # Enable "sensitive" profile checkers with the "profile:" label.
         # Using the "profile" label is optional in this case, because the
-        # profile name "security" does not conflict with any checker
+        # profile name "sensitive" does not conflict with any checker
         # prefix group names.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -389,6 +389,22 @@ checker configuration:
   Note that compiler errors and warnings are captured by CodeChecker only if it
   was emitted by clang-tidy.
 
+  Checker prefix groups
+  ------------------------------------------------
+  Checker prefix groups allow you to enable checkers that share a common 
+  prefix in their names. Checkers within a prefix group will have names that 
+  start with the same identifier, making it easier to manage and reference 
+  related checkers.
+  
+  You can enable/disable checkers belonging to a checker prefix group: 
+  '-e <label>:<value>', e.g. '-e prefix:security'.
+  
+  Note: The 'prefix' label is mandatory when there is ambiguity between the
+  name of a checker prefix group and a checker profile or a guideline. This 
+  prevents conflicts and ensures the correct checkers are applied.
+  
+  See "CodeChecker checkers --help" to learn more.
+
   Checker labels
   ------------------------------------------------
   Each checker is assigned several '<label>:<value>' pairs. For instance,
@@ -397,6 +413,10 @@ checker configuration:
 
   You can enable/disable checkers belonging to a label: '-e <label>:<value>',
   e.g. '-e profile:default'.
+  
+  Note: The 'profile' label is mandatory when there is ambiguity between the
+  name of a checker profile and a checker prefix group or a guideline. This 
+  prevents conflicts and ensures the correct checkers are applied.
 
   See "CodeChecker checkers --help" to learn more.
 
@@ -412,6 +432,10 @@ checker configuration:
 
   Guidelines are labels themselves, and can be used as a label:
   '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+  
+  Note: The 'guideline' label is mandatory when there is ambiguity between the
+  name of a guideline and a checker prefix group or a checker profile. This 
+  prevents conflicts and ensures the correct checkers are applied.
 
   Batch enabling/disabling checkers
   ------------------------------------------------


### PR DESCRIPTION
Introduce the -e prefix: option, to improve handling of ambigous parameters.
such as "security" which is a checker prefix group and a profile at the same time