### PR TITLE
[cfg] Update labels file for updated checkers

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -159,6 +159,7 @@
     ],
     "boost-use-ranges": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html",
+      "profile:extreme",
       "severity:LOW"
     ],
     "boost-use-to-string": [
@@ -200,6 +201,10 @@
     ],
     "bugprone-bitwise-pointer-cast": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/bitwise-pointer-cast.html",
+      "profile:default",
+      "profile:extreme",
+      "profile:security",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "bugprone-bool-pointer-implicit-conversion": [
@@ -463,6 +468,9 @@
     ],
     "bugprone-nondeterministic-pointer-iteration-order": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/nondeterministic-pointer-iteration-order.html",
+      "profile:default",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "bugprone-optional-value-conversion": [
@@ -480,6 +488,10 @@
     ],
     "bugprone-pointer-arithmetic-on-polymorphic-object": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html",
+      "guideline:sei-cert",
+      "profile:extreme",
+      "profile:security",
+      "sei-cert:ctr56-cpp",
       "severity:HIGH"
     ],
     "bugprone-posix-return": [
@@ -505,6 +517,8 @@
     ],
     "bugprone-return-const-ref-from-parameter": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "bugprone-shared-ptr-array-mismatch": [
@@ -665,6 +679,8 @@
     ],
     "bugprone-tagged-union-member-count": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/tagged-union-member-count.html",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "bugprone-suspicious-stringview-data-usage": [
@@ -812,26 +828,12 @@
       "profile:sensitive",
       "severity:MEDIUM"
     ],
-    "cert-arr39-c": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/arr39-c.html",
-      "guideline:sei-cert",
-      "profile:security",
-      "sei-cert:arr39-c",
-      "severity:HIGH"
-    ],
     "cert-con36-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con36-c.html",
       "severity:MEDIUM"
     ],
     "cert-con54-cpp": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con54-cpp.html",
-      "severity:MEDIUM"
-    ],
-    "cert-ctr56-cpp": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html",
-      "guideline:sei-cert",
-      "profile:security",
-      "sei-cert:ctr56-cpp",
       "severity:MEDIUM"
     ],
     "cert-dcl03-c": [
@@ -6629,9 +6631,12 @@
     ],
     "misc-sizeof-expression": [
       "doc_url:https://releases.llvm.org/6.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/misc-sizeof-expression.html",
+      "guideline:sei-cert",
       "profile:default",
       "profile:extreme",
+      "profile:security",
       "profile:sensitive",
+      "sei-cert:arr39-c",
       "severity:HIGH"
     ],
     "misc-static-assert": [
@@ -6772,6 +6777,7 @@
     ],
     "misc-use-internal-linkage": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html",
+      "profile:extreme",
       "severity:LOW"
     ],
     "misc-virtual-near-miss": [
@@ -6829,6 +6835,9 @@
     ],
     "modernize-min-max-use-initializer-list": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html",
+      "profile:default",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:LOW"
     ],
     "modernize-pass-by-value": [
@@ -6945,6 +6954,7 @@
     ],
     "modernize-use-ranges": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html",
+      "profile:extreme",
       "severity:LOW"
     ],
     "modernize-use-starts-ends-with": [
@@ -6954,6 +6964,7 @@
     ],
     "modernize-use-std-format": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html",
+      "profile:extreme",
       "severity:LOW"
     ],
     "modernize-use-std-numbers": [
@@ -7173,10 +7184,13 @@
     ],
     "portability-template-virtual-member-function": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/portability/template-virtual-member-function.html",
+      "profile:extreme",
+      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "readability-math-missing-parentheses": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html",
+      "profile:extreme",
       "severity:LOW"
     ],
     "readability-avoid-const-params-in-decls": [

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -828,6 +828,10 @@
       "profile:sensitive",
       "severity:MEDIUM"
     ],
+    "cert-arr39-c": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/arr39-c.html",
+      "severtiy:HIGH"
+    ],
     "cert-con36-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con36-c.html",
       "severity:MEDIUM"
@@ -835,6 +839,10 @@
     "cert-con54-cpp": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con54-cpp.html",
       "severity:MEDIUM"
+    ],
+    "cert-ctr56-cpp": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html",
+      "severity:HIGH"
     ],
     "cert-dcl03-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/dcl03-c.html",

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -157,6 +157,10 @@
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/android/comparison-in-temp-failure-retry.html",
       "severity:MEDIUM"
     ],
+    "boost-use-ranges": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html",
+      "severity:LOW"
+    ],
     "boost-use-to-string": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/boost/use-to-string.html",
       "profile:extreme",
@@ -192,6 +196,10 @@
       "profile:security",
       "profile:sensitive",
       "sei-cert:pos44-c",
+      "severity:MEDIUM"
+    ],
+    "bugprone-bitwise-pointer-cast": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/bitwise-pointer-cast.html",
       "severity:MEDIUM"
     ],
     "bugprone-bool-pointer-implicit-conversion": [
@@ -453,6 +461,10 @@
       "profile:sensitive",
       "severity:MEDIUM"
     ],
+    "bugprone-nondeterministic-pointer-iteration-order": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/nondeterministic-pointer-iteration-order.html",
+      "severity:MEDIUM"
+    ],
     "bugprone-optional-value-conversion": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/optional-value-conversion.html",
       "profile:default",
@@ -465,6 +477,10 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM"
+    ],
+    "bugprone-pointer-arithmetic-on-polymorphic-object": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html",
+      "severity:HIGH"
     ],
     "bugprone-posix-return": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/posix-return.html",
@@ -486,6 +502,10 @@
       "sei-cert:dcl37-c",
       "sei-cert:dcl51-cpp",
       "severity:LOW"
+    ],
+    "bugprone-return-const-ref-from-parameter": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html",
+      "severity:MEDIUM"
     ],
     "bugprone-shared-ptr-array-mismatch": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/shared-ptr-array-mismatch.html",
@@ -643,6 +663,10 @@
       "profile:sensitive",
       "severity:MEDIUM"
     ],
+    "bugprone-tagged-union-member-count": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/tagged-union-member-count.html",
+      "severity:MEDIUM"
+    ],
     "bugprone-suspicious-stringview-data-usage": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.html",
       "profile:default",
@@ -788,12 +812,26 @@
       "profile:sensitive",
       "severity:MEDIUM"
     ],
+    "cert-arr39-c": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/arr39-c.html",
+      "guideline:sei-cert",
+      "profile:security",
+      "sei-cert:arr39-c",
+      "severity:HIGH"
+    ],
     "cert-con36-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con36-c.html",
       "severity:MEDIUM"
     ],
     "cert-con54-cpp": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/con54-cpp.html",
+      "severity:MEDIUM"
+    ],
+    "cert-ctr56-cpp": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html",
+      "guideline:sei-cert",
+      "profile:security",
+      "sei-cert:ctr56-cpp",
       "severity:MEDIUM"
     ],
     "cert-dcl03-c": [
@@ -6732,6 +6770,10 @@
       "profile:sensitive",
       "severity:LOW"
     ],
+    "misc-use-internal-linkage": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html",
+      "severity:LOW"
+    ],
     "misc-virtual-near-miss": [
       "doc_url:https://releases.llvm.org/6.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/misc-virtual-near-miss.html",
       "profile:default",
@@ -6783,6 +6825,10 @@
     "modernize-make-unique": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/make-unique.html",
       "profile:extreme",
+      "severity:LOW"
+    ],
+    "modernize-min-max-use-initializer-list": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html",
       "severity:LOW"
     ],
     "modernize-pass-by-value": [
@@ -6897,9 +6943,17 @@
       "profile:extreme",
       "severity:LOW"
     ],
+    "modernize-use-ranges": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html",
+      "severity:LOW"
+    ],
     "modernize-use-starts-ends-with": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-starts-ends-with.html",
       "profile:extreme",
+      "severity:LOW"
+    ],
+    "modernize-use-std-format": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html",
       "severity:LOW"
     ],
     "modernize-use-std-numbers": [
@@ -7116,6 +7170,14 @@
     "portability-std-allocator-const": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/portability/std-allocator-const.html",
       "severity:STYLE"
+    ],
+    "portability-template-virtual-member-function": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/portability/template-virtual-member-function.html",
+      "severity:MEDIUM"
+    ],
+    "readability-math-missing-parentheses": [
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html",
+      "severity:LOW"
     ],
     "readability-avoid-const-params-in-decls": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html",

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -679,6 +679,7 @@
     ],
     "bugprone-tagged-union-member-count": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/tagged-union-member-count.html",
+      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM"

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -248,14 +248,9 @@
       "profile:sensitive",
       "severity:HIGH"
     ],
-    "alpha.security.taint.TaintPropagation": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-taint-taintpropagation-c-c",
-      "profile:extreme",
-      "profile:sensitive",
-      "severity:HIGH"
-    ],
-    "alpha.unix.BlockInCriticalSection": [
+    "unix.BlockInCriticalSection": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-blockincriticalsection-c",
+      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:LOW"
@@ -278,7 +273,7 @@
       "profile:sensitive",
       "severity:HIGH"
     ],
-    "alpha.unix.SimpleStream": [
+    "unix.SimpleStream": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-simplestream-c",
       "profile:extreme",
       "severity:MEDIUM"
@@ -774,6 +769,30 @@
       "sei-cert:mem30-c",
       "severity:MEDIUM"
     ],
+    "optin.taint.GenericTaint": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint-c-c",
+      "profile:extreme",
+      "profile:sensitive",
+      "severity:HIGH"
+    ],
+    "optin.taint.TaintedAlloc": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc-c-c",
+      "profile:extreme",
+      "profile:sensitive",
+      "severity:HIGH"
+    ],
+    "optin.taint.TaintedDiv": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-tainteddiv-c-c-objc",
+      "profile:extreme",
+      "profile:sensitive",
+      "severity:HIGH"
+    ],
+    "optin.taint.TaintPropagation": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint-c-c",
+      "profile:extreme",
+      "profile:sensitive",
+      "severity:HIGH"
+    ],
     "osx.API": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#osx-api-c"
     ],
@@ -867,6 +886,44 @@
       "profile:security",
       "profile:sensitive",
       "sei-cert:flp30-c",
+      "severity:MEDIUM"
+    ],
+    "security.MmapWriteExec": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-mmapwriteexec-c",
+      "profile:default",
+      "profile:extreme",
+      "profile:security",
+      "profile:sensitive",
+      "severity:MEDIUM"
+    ],
+    "security.PointerSub": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-pointersub-c",
+      "guideline:sei-cert",
+      "profile:default",
+      "profile:extreme",
+      "profile:security",
+      "profile:sensitive",
+      "sei-cert:arr36-c",
+      "severity:HIGH"
+    ],
+    "security.PutenvStackArray": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-putenvstackarray-c",
+      "guideline:sei-cert",
+      "profile:default",
+      "profile:extreme",
+      "profile:security",
+      "profile:sensitive",
+      "sei-cert:pos34-c",
+      "severity:HIGH"
+    ],
+    "security.SetgidSetuidOrder": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c",
+      "guideline:sei-cert",
+      "profile:default",
+      "profile:extreme",
+      "profile:security",
+      "profile:sensitive",
+      "sei-cert:pos36-c",
       "severity:MEDIUM"
     ],
     "security.cert.env.InvalidPtr": [

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -273,7 +273,7 @@
       "profile:sensitive",
       "severity:HIGH"
     ],
-    "unix.SimpleStream": [
+    "alpha.unix.SimpleStream": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-simplestream-c",
       "profile:extreme",
       "severity:MEDIUM"
@@ -285,6 +285,7 @@
     ],
     "alpha.unix.Stream": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-stream-c",
+      "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM"

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -350,6 +350,12 @@
       "profile:sensitive",
       "severity:HIGH"
     ],
+    "cppcheck-eraseIteratorOutOfBounds": [
+      "severity:HIGH"
+    ],
+    "cppcheck-eraseIteratorOutOfBoundsCond": [
+      "severity:HIGH"
+    ],
     "cppcheck-exceptDeallocThrow": [
       "profile:default",
       "profile:extreme",
@@ -1483,6 +1489,15 @@
     ],
     "cppcheck-uselessCallsSwap": [
       "severity:LOW"
+    ],
+    "cppcheck-uselessOverride": [
+      "severity:STYLE"
+    ],
+    "cppcheck-returnByReference": [
+      "severity:LOW"
+    ],
+    "cppcheck-suspiciousFloatingPointCast": [
+      "severity:STYLE"
     ],
     "cppcheck-va_end_missing": [
       "profile:default",


### PR DESCRIPTION
Since the last release some ClangSA checkers were moved to different packages and some new checkers were introduced. This change updates the label configuration of CodeChecker to reflect this.

I just eyeballed the severities and the profiles, so it's open for suggestions.

Notes:
alpha.security.taint.TaintPropagation does not have a documentation link, so I just put the GenericTaintChecker link as doc-url. Alternatively, we could use doc entry: https://clang.llvm.org/docs/analyzer/user-docs/TaintAnalysisConfiguration.html

With this patch, all the taint-related checkers share the same severity and profiles as the now-removed alpha.security.taint.TaintPropagation.

I put BlockInCriticalSection in the default profile, as I have deemed it not too noisy, and the results were meaningful IMO.