### PR TITLE
Render the checker message as an individual elment in the code

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/output/html/static/js/bugviewer.js
+++ b/tools/report-converter/codechecker_report_converter/report/output/html/static/js/bugviewer.js
@@ -119,7 +119,7 @@ var BugViewer = {
       severity.className = 'severity-' + report.severity.toLowerCase();
 
       item.appendChild(severity);
-      item.appendChild(document.createTextNode(lastBugEvent.message));
+      item.appendChild(document.createTextNode(report.message));
 
       item.addEventListener('click', function () {
         that.navigate(report, item);
@@ -317,6 +317,30 @@ var BugViewer = {
       that._lineWidgets.push(that._codeMirror.addLineWidget(
         event.line - 1, element));
     });
+    // If there are no events, or the last event does not match
+    // the main warning message we print the warning message as a separate
+    // error node.
+    var lastEvent = null
+    if (currentEvents.length > 0)
+      lastEvent =currentEvents[currentEvents.length - 1];
+    if (!lastEvent ||
+          lastEvent.message != this._currentReport.message ||
+          lastEvent.line != this._currentReport.line){
+        var element = document.createElement('div');
+        var left = that._codeMirror.defaultCharWidth() * lastEvent.column + 'px';
+        element.setAttribute('style', 'margin-left: ' + left);
+        element.setAttribute('class', 'check-msg ' + "error");
+        var error_tag = document.createElement('span');
+        error_tag.setAttribute('class', 'checker-enum error');
+        error_tag.innerHTML = "E";
+        element.appendChild(error_tag);
+        var msg = document.createElement('span');
+        msg.innerHTML = that.escapeHTML(this._currentReport.message)
+          .replace(/(?:\r\n|\r|\n)/g, '<br>');
+        element.appendChild(msg);
+        that._lineWidgets.push(that._codeMirror.addLineWidget(
+          this._currentReport.line - 1, element));
+      }
   },
 
   jumpTo : function (line, column) {

--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -644,7 +644,6 @@ export default {
       this.clearLines();
 
       const reportId = this.report.reportId;
-
       const reportDetail = await new Promise(resolve => {
         ccService.getClient().getReportDetails(reportId,
           handleThriftError(reportDetail => {
@@ -663,7 +662,7 @@ export default {
             const docUrlLabels = labels[0].filter(
               param => param.startsWith("doc_url")
             );
-            this.docUrl = docUrlLabels.length ? 
+            this.docUrl = docUrlLabels.length ?
               docUrlLabels[0].split("doc_url:")[1] : null;
             resolve(this.docUrl);
           })
@@ -779,6 +778,23 @@ export default {
           this.addLineWidget(event, props);
         });
       });
+
+
+      //If the warning message or location is different than the
+      //the last bug path element, then we render the warning.
+
+      if (events.length == 0 ||
+          this.report.checkerMsg !==  events[events.length-1].msg ||
+          this.report.line.toNumber() !=
+            events[events.length-1].startLine.toNumber()
+      ){
+        const chkrmsg_data = { $id: 999,
+          $message:this.report.checkerMsg,
+          startLine:this.report.line, startCol:this.report.column };
+        const chrkmsg_props = { type: "error", index:"E", hideDocUrl:true };
+        this.addLineWidget(chkrmsg_data, chrkmsg_props);
+      }
+
     },
 
     addExtendedData(extendedData) {

--- a/web/server/vue-cli/src/components/Report/ReportStepMessage.vue
+++ b/web/server/vue-cli/src/components/Report/ReportStepMessage.vue
@@ -30,22 +30,23 @@
 
     <div>
       {{ value }}
-
-      <p v-if="type === 'error' && docUrl" class="mb-0 mt-2">
-        For more information see the
-        <a
-          class="show-documentation-btn"
-          @click="showDocumentation"
+      <div v-if="!hideDocUrl">
+        <p v-if="type === 'error' && docUrl" class="mb-0 mt-2">
+          For more information see the
+          <a
+            class="show-documentation-btn"
+            @click="showDocumentation"
+          >
+            checker documentation
+          </a>.
+        </p>
+        <p
+          v-else-if="type === 'error'"
+          class="no-documentation-msg-text mb-0 mt-2"
         >
-          checker documentation
-        </a>.
-      </p>
-      <p 
-        v-else-if="type === 'error'" 
-        class="no-documentation-msg-text mb-0 mt-2"
-      >
-        No documentation for checker.
-      </p>
+          No documentation for checker.
+        </p>
+      </div>
     </div>
 
     <v-btn
@@ -80,7 +81,8 @@ export default {
     bus: { type: Object, default: null },
     prevStep: { type: Object, default: null },
     nextStep: { type: Object, default: null },
-    docUrl: { type: String, default: null }
+    docUrl: { type: String, default: null },
+    hideDocUrl: { type: Boolean, default: false }
   },
   computed: {
     color() {


### PR DESCRIPTION
If the last bug path message or location is different than the warning text location render the warning text in the codeview in the web GUI. If this is not the case, the visualization remains the same as before.

New visualization in the static HTML
![image](https://github.com/user-attachments/assets/04bc7404-e696-4647-b335-0936f8b073c9)


New visualization in the GUI

![image](https://github.com/user-attachments/assets/14a9e943-1376-4432-9289-06325d6b1712)
