### PR TITLE
[cfg] Add info for new unix.Chroot Checker

### DIFF
--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -1037,6 +1037,12 @@
       "sei-cert:exp37-c",
       "severity:MEDIUM"
     ],
+    "unix.Chroot": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-chroot-c",
+      "profile:extreme",
+      "profile:sensitive",
+      "severity:MEDIUM"
+    ],
     "unix.DynamicMemoryModeling": [
       "profile:default",
       "profile:extreme",


### PR DESCRIPTION
The alpha.unix.Chroot checker was promoted in this MR, https://github.com/llvm/llvm-project/pull/117791, so adding severity and documentation links for newly promoted checker.