### PR TITLE
[fix] Resolve checker enable/disable ambiguity

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -288,6 +288,9 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                 ("clang-diagnostic-" + warning, "")
                 for warning in get_warnings())
 
+            checker_description.append(("clang-diagnostic-error",
+                                        "Indicates compiler errors."))
+
             cls.__analyzer_checkers = checker_description
 
             return checker_description

--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
@@ -41,13 +41,3 @@ class ClangTidyConfigHandler(AnalyzerConfigHandler):
                 return
 
         super().add_checker(checker_name, description, state)
-
-    def set_checker_enabled(self, checker_name, enabled=True):
-        """
-        Enable checker, keep description if already set.
-        """
-        if checker_name.startswith('W') or \
-           checker_name.startswith('clang-diagnostic'):
-            self.add_checker(checker_name)
-
-        super().set_checker_enabled(checker_name, enabled)

--- a/analyzer/codechecker_analyzer/checkers.py
+++ b/analyzer/codechecker_analyzer/checkers.py
@@ -19,12 +19,7 @@ def available(ordered_checkers, available_checkers):
     """
     missing_checkers = set()
     for checker_name, _ in ordered_checkers:
-        # TODO: This label list shouldn't be hard-coded here.
-        if checker_name.startswith('profile:') or \
-                checker_name.startswith('guideline:') or \
-                checker_name.startswith('severity:') or \
-                checker_name.startswith('sei-cert:') or \
-                checker_name.startswith('prefix:'):
+        if ":" in checker_name:
             continue
 
         name_match = False

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -773,8 +773,11 @@ LLVM/Clang community, and thus discouraged.
                                     "between the checker prefix "
                                     "group/profile/guideline name, the use of "
                                     "one of the following labels is "
-                                    "mandatory: 'prefix:', 'profile:', "
-                                    "'guideline:'.")
+                                    "mandatory: 'checker:', 'prefix:', "
+                                    "'profile:', 'guideline:'. If a checker "
+                                    "name matches multiple checkers as a "
+                                    "prefix, 'checker:' or 'prefix:' "
+                                    "namespace is required")
 
     checkers_opts.add_argument('-d', '--disable',
                                dest="disable",
@@ -792,8 +795,11 @@ LLVM/Clang community, and thus discouraged.
                                     "between the checker prefix "
                                     "group/profile/guideline name, the use of "
                                     "one of the following labels is "
-                                    "mandatory: 'prefix:', 'profile:', "
-                                    "'guideline:'.")
+                                    "mandatory: 'checker:', 'prefix:', "
+                                    "'profile:', 'guideline:'. If a checker "
+                                    "name matches multiple checkers as a "
+                                    "prefix, 'checker:' or 'prefix:' "
+                                    "namespace is required")
 
     checkers_opts.add_argument('--enable-all',
                                dest="enable_all",

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -707,35 +707,43 @@ LLVM/Clang community, and thus discouraged.
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
                                action=OrderedCheckersAction,
-                               help="Set a checker (or checker group), "
-                                    "profile or guideline "
-                                    "to BE USED in the analysis. In case of "
-                                    "ambiguity the priority order is profile, "
-                                    "guideline, checker name (e.g. security "
-                                    "means the profile, not the checker "
-                                    "group). Moreover, labels can also be "
+                               help="Set a checker (or checker prefix group), "
+                                    "profile or guideline to BE USED in the "
+                                    "analysis. Labels can also be "
                                     "used for selecting checkers, for example "
                                     "profile:extreme or severity:STYLE. See "
                                     "'CodeChecker checkers --label' for "
-                                    "further details.")
+                                    "further details. In case of a name clash "
+                                    "between the checker prefix "
+                                    "group/profile/guideline name, the use of "
+                                    "one of the following labels is "
+                                    "mandatory: 'checker:', 'prefix:', "
+                                    "'profile:', 'guideline:'. If a checker "
+                                    "name matches multiple checkers as a "
+                                    "prefix, 'checker:' or 'prefix:' "
+                                    "namespace is required")
 
     checkers_opts.add_argument('-d', '--disable',
                                dest="disable",
                                metavar='checker/group/profile',
                                default=argparse.SUPPRESS,
                                action=OrderedCheckersAction,
-                               help="Set a checker (or checker group), "
+                               help="Set a checker (or checker prefix group), "
                                     "profile or guideline "
                                     "to BE PROHIBITED from use in the "
-                                    "analysis. In case of "
-                                    "ambiguity the priority order is profile, "
-                                    "guideline, checker name (e.g. security "
-                                    "means the profile, not the checker "
-                                    "group). Moreover, labels can also be "
+                                    "analysis. Labels can also be "
                                     "used for selecting checkers, for example "
                                     "profile:extreme or severity:STYLE. See "
                                     "'CodeChecker checkers --label' for "
-                                    "further details.")
+                                    "further details. In case of a name clash "
+                                    "between the checker prefix "
+                                    "group/profile/guideline name, the use of "
+                                    "one of the following labels is "
+                                    "mandatory: 'checker:', 'prefix:', "
+                                    "'profile:', 'guideline:'. If a checker "
+                                    "name matches multiple checkers as a "
+                                    "prefix, 'checker:' or 'prefix:' "
+                                    "namespace is required")
 
     checkers_opts.add_argument('--enable-all',
                                dest="enable_all",

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -886,7 +886,7 @@ class TestAnalyze(unittest.TestCase):
         analyze_cmd = [self._codechecker_cmd, "check", "-l", build_json,
                        "--analyzers", "clang-tidy",
                        "-d", "clang-diagnostic",
-                       "-e", "clang-diagnostic-unused"]
+                       "-e", "prefix:clang-diagnostic-unused"]
 
         source_file = os.path.join(self.test_dir, "compiler_warning.c")
         build_log = [{"directory": self.test_workspace,

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_group.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_group.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make compiler_warning_wno_group" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -e clang-diagnostic-unused
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -e prefix:clang-diagnostic-unused
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make compiler_warning_wno_group" --output $OUTPUT$ --quiet --analyzers clang-tidy -e clang-diagnostic-unused
+CHECK#CodeChecker check --build "make compiler_warning_wno_group" --output $OUTPUT$ --quiet --analyzers clang-tidy -e prefix:clang-diagnostic-unused
 --------------------------------------------------------------------------------
 [] - Starting build...
 [] - Using CodeChecker ld-logger.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_simple2.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wno_simple2.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make compiler_warning_unused" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -d clang-diagnostic-unused
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -d prefix:clang-diagnostic-unused
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make compiler_warning_unused" --output $OUTPUT$ --quiet --analyzers clang-tidy -d clang-diagnostic-unused
+CHECK#CodeChecker check --build "make compiler_warning_unused" --output $OUTPUT$ --quiet --analyzers clang-tidy -d prefix:clang-diagnostic-unused
 --------------------------------------------------------------------------------
 [] - Starting build...
 [] - Using CodeChecker ld-logger.

--- a/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wunused.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/compiler_warning_wunused.output
@@ -1,7 +1,7 @@
 NORMAL#CodeChecker log --output $LOGFILE$ --build "make compiler_warning_unused" --quiet
-NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -d clang-diagnostic-unused
+NORMAL#CodeChecker analyze $LOGFILE$ --output $OUTPUT$ --analyzers clang-tidy -d prefix:clang-diagnostic-unused
 NORMAL#CodeChecker parse $OUTPUT$
-CHECK#CodeChecker check --build "make compiler_warning_unused" --output $OUTPUT$ --quiet --analyzers clang-tidy -d clang-diagnostic-unused
+CHECK#CodeChecker check --build "make compiler_warning_unused" --output $OUTPUT$ --quiet --analyzers clang-tidy -d prefix:clang-diagnostic-unused
 --------------------------------------------------------------------------------
 [] - Starting build...
 [] - Using CodeChecker ld-logger.

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -2345,7 +2345,10 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-error": [
-      "severity:CRITICAL"
+      "severity:CRITICAL",
+      "profile:default",
+      "profile:extreme",
+      "profile:sensitive"
     ],
     "clang-diagnostic-exceptions": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wexceptions",

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -449,22 +449,40 @@ checker configuration:
 
 
   -e checker/group/profile, --enable checker/group/profile
-                        Set a checker (or checker group), profile or guideline
-                        to BE USED in the analysis. In case of ambiguity the
-                        priority order is profile, guideline, checker name
-                        (e.g. security means the profile, not the checker
-                        group). Moreover, labels can also be used for
-                        selecting checkers, for example profile:extreme or
-                        severity:STYLE. See 'CodeChecker checkers --label' for
+                        Enable a checker or checker group to BE USED in the
+                        analysis. Exact checker name, prefix, profile,
+                        guideline or any label can be used for selecting
+                        checkers. These namespace can be specified by
+                        'checker:' 'prefix:', 'profile:', 'guideline:',
+                        'severity:', etc. Normally, It is not necessary to
+                        give a namespace but in case of ambiguity, the
+                        CodeChecker returns with an error and suggests options
+                        for clarification. For example the extreme profile can
+                        be set by 'profile:extreme' or 'extreme' but security
+                        can be also a prefix and in this case the namespace
+                        must be given like 'profile:security' to set security
+                        profile. If an exact checker name matches multiple
+                        checkers as a prefix, 'checker:' or 'prefix:'
+                        namespace is required. Any labels can be used for set
+                        checker group. See 'CodeChecker checkers --label' for
                         further details.
   -d checker/group/profile, --disable checker/group/profile
-                        Set a checker (or checker group), profile or guideline
-                        to BE PROHIBITED from use in the analysis. In case of
-                        ambiguity the priority order is profile, guideline,
-                        checker name (e.g. security means the profile, not the
-                        checker group). Moreover, labels can also be used for
-                        selecting checkers, for example profile:extreme or
-                        severity:STYLE. See 'CodeChecker checkers --label' for
+                        Disable a checker or checker group to BE PROHIBITED in
+                        the analysis. Exact checker name, prefix, profile,
+                        guideline or any label can be used for selecting
+                        checkers. These namespace can be specified by
+                        'checker:' 'prefix:', 'profile:', 'guideline:',
+                        'severity:', etc. Normally, It is not necessary to
+                        give a namespace but in case of ambiguity, the
+                        CodeChecker returns with an error and suggests options
+                        for clarification. For example the extreme profile can
+                        be set by 'profile:extreme' or 'extreme' but security
+                        can be also a prefix and in this case the namespace
+                        must be given like 'profile:security' to set security
+                        profile. If an exact checker name matches multiple
+                        checkers as a prefix, 'checker:' or 'prefix:'
+                        namespace is required. Any labels can be used for set
+                        checker group. See 'CodeChecker checkers --label' for
                         further details.
   --enable-all          Force the running analyzers to use almost every
                         checker available. The checker groups 'alpha.',
@@ -1438,23 +1456,41 @@ available checkers in the binaries installed on your system.
 ```
 checker configuration:
 
-  -e checker/group/profile, --enable checker/group/profile
-                        Set a checker (or checker group or checker profile)
-                        to BE USED in the analysis. In case of ambiguity the
-                        priority order is profile, guideline, checker name
-                        (e.g. security means the profile, not the checker
-                        group). Moreover, labels can also be used for
-                        selecting checkers, for example profile:extreme or
-                        severity:STYLE. See 'CodeChecker checkers --label' for
+    -e checker/group/profile, --enable checker/group/profile
+                        Enable a checker or checker group to BE USED in the
+                        analysis. Exact checker name, prefix, profile,
+                        guideline or any label can be used for selecting
+                        checkers. These namespace can be specified by
+                        'checker:' 'prefix:', 'profile:', 'guideline:',
+                        'severity:', etc. Normally, It is not necessary to
+                        give a namespace but in case of ambiguity, the
+                        CodeChecker returns with an error and suggests options
+                        for clarification. For example the extreme profile can
+                        be set by 'profile:extreme' or 'extreme' but security
+                        can be also a prefix and in this case the namespace
+                        must be given like 'profile:security' to set security
+                        profile. If an exact checker name matches multiple
+                        checkers as a prefix, 'checker:' or 'prefix:'
+                        namespace is required. Any labels can be used for set
+                        checker group. See 'CodeChecker checkers --label' for
                         further details.
   -d checker/group/profile, --disable checker/group/profile
-                        Set a checker (or checker group or checker profile)
-                        to BE PROHIBITED from use in the analysis. In case of
-                        ambiguity the priority order is profile, guideline,
-                        checker name (e.g. security means the profile, not the
-                        checker group). Moreover, labels can also be used for
-                        selecting checkers, for example profile:extreme or
-                        severity:STYLE. See 'CodeChecker checkers --label' for
+                        Disable a checker or checker group to BE PROHIBITED in
+                        the analysis. Exact checker name, prefix, profile,
+                        guideline or any label can be used for selecting
+                        checkers. These namespace can be specified by
+                        'checker:' 'prefix:', 'profile:', 'guideline:',
+                        'severity:', etc. Normally, It is not necessary to
+                        give a namespace but in case of ambiguity, the
+                        CodeChecker returns with an error and suggests options
+                        for clarification. For example the extreme profile can
+                        be set by 'profile:extreme' or 'extreme' but security
+                        can be also a prefix and in this case the namespace
+                        must be given like 'profile:security' to set security
+                        profile. If an exact checker name matches multiple
+                        checkers as a prefix, 'checker:' or 'prefix:'
+                        namespace is required. Any labels can be used for set
+                        checker group. See 'CodeChecker checkers --label' for
                         further details.
   --enable-all          Force the running analyzers to use almost every
                         checker available. The checker groups 'alpha.',
@@ -1492,10 +1528,11 @@ Checkers are taken into account based on the following order:
   "debug" checker groups. `osx` checker group is also not included unless the
   target platform is Darwin.
 - Command line `--enable/--disable` flags.
-  - Their arguments may start with `profile:` of `guideline:` prefix which
-    makes the choice explicit.
-  - Without prefix it means a profile name, a guideline name or a checker
-    group/name in this priority order.
+  - Their arguments may start with `checker:`, `prefix:`, `profile:`,
+    `guideline:` or any existing label type as a namespace which makes the
+    choice explicit.
+  - Without namespace it can be a checker name, a checker prefix, a profile
+    name or a guideline name. in case of ambiguity, namespace is expected.
 
 Disabling certain checkers - such as the `core` group - is unsupported by
 the LLVM/Clang community, and thus discouraged.
@@ -1511,23 +1548,23 @@ and disabled flags starting from the bigger groups and going inwards. For
 example
 
 ```sh
---enable Wunused --disable Wno-unused-parameter
+--enable prefix:clang-diagnostic-unused 
+--disable checker:clang-diagnostic-unused-parameter
 ```
 or
 ```sh
---enable Wunused --disable Wunused-parameter
+--enable prefix:clang-diagnostic-unused 
+--disable clang-diagnostic-unused-parameter
 ```
-will enable every `unused` warnings except `unused-parameter`. These flags
-should start with a capital `W` or `Wno-` prefix followed by the warning name
-(E.g.: `-e Wliteral-conversion`, `-d Wno-literal-conversion` or
-`-d Wliteral-conversion`). To turn off a compiler warning you can use the
-negative form beginning with `Wno-` (e.g.: `--disable Wno-literal-conversion`)
-or you can use the positive form beginning with `W` (e.g.:
-`--enable Wliteral-conversion`). For more information see:
+will enable every `unused` warnings except `unused-parameter`. To turn off a
+compiler warning you should use `clang-diagnostic-` instead of `W` or `Wno`
+followed by the warning name. These flags may start with `checker:`,
+`prefix:`, `profile:`, `guideline:` or any existing label type as a namespace
+which makes the choice explicit. Namespace is only required when the given
+flag is ambiguity. (E.g.: `clang-diagnostic-unused` is both a checker name
+that represents unused warning and a prefix that is the group of the unused
+warrnings). For more information see:
 https://clang.llvm.org/docs/DiagnosticsReference.html.
-
-A warning can be referred in both formats: `-d Wunused-parameter` and
-`-d clang-diagnostic-unused-parameter` are the same.
 
 `clang-diagnostic-error` is a special one, since it doesn't refer a warning but
 a compilation error. This is enabled by default and will be stored as a

--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -1314,10 +1314,12 @@ analyzer:
             There is a new syntax extended with guideline support which can be
             used to enable checker sets. With the new syntax the checkers,
             profiles and guideline can be enabled or disabled even if there is
-            a conflict in their name. The arguments may start with
-            <i>profile:</i> of <i>guideline:</i> prefix which makes the choice
-            explicit. Without prefix it means a profile name, a guideline
-            name or a checker group/name in this priority order.<br>
+            a conflict in their name. Their arguments may start with
+            <i>checker:</i>, <i>prefix:</i>, <i>profile:</i>,
+            <i>guideline:</i> or any existing label type as a namespace which
+            makes the choice explicit. Without namespace it can be a checker
+            name, a checker prefix, a profile name or a guideline name. in
+            case of ambiguity, namespace is expected.<br>
             <code>
               CodeChecker analyze -o reports -e profile:sensitive -e guideline:sei-cert compile_command.json
             </code><br><br>
@@ -1328,7 +1330,7 @@ analyzer:
           </new-feature-item>
 
           <new-feature-item>
-            <template v-slot:title>
+            <template v-slot:title>unused
               New report converter for Markdownlint results
             </template>
             The reports from Markdownlint can be converted and stored to the

--- a/web/tests/functional/report_viewer_api/__init__.py
+++ b/web/tests/functional/report_viewer_api/__init__.py
@@ -85,7 +85,7 @@ def setup_class_common(workspace_name):
         'workspace': TEST_WORKSPACE,
         'checkers': ['-d', 'clang-diagnostic',
                      '-e', 'clang-diagnostic-division-by-zero',
-                     '-e', 'clang-diagnostic-return-type'],
+                     '-e', 'checker:clang-diagnostic-return-type'],
         'tag': tag,
         'analyzers': ['clangsa', 'clang-tidy']
     }
@@ -191,7 +191,8 @@ def setup_class_common(workspace_name):
                                    '-d', 'unix.Malloc',
                                    '-d', 'clang-diagnostic',
                                    '-e', 'clang-diagnostic-division-by-zero',
-                                   '-e', 'clang-diagnostic-return-type']
+                                   '-e',
+                                   'checker:clang-diagnostic-return-type']
     ret = codechecker.check_and_store(codechecker_cfg,
                                       test_project_name_third,
                                       project.path(test_project))


### PR DESCRIPTION
This PR fixes the enabling and disabling checker options, focusing on resolving ambiguities in option processing.

 Key updates:
  **Ambiguity handling:**
> When ambiguous checker options are provided with `-e` or `-d` flags, an error is now raised. The user receives suggestions for specifying the option by using namespaces (checker, prefix, guideline, etc.).
> If a checker name matches multiple checkers as a prefix, it triggers an ambiguity error. Suggestions are provided to help users choose between the checker name or the prefix.

 **Additional namespaces:**
>A new `checker` namespace is created. All label types can be a namespace as well, specified with a `:` separator before the checker option.

 **Default profile settings improvements:**
> Only those checkers enabled that has profile:default label in the label files. Prefix-based configuration is no longer applied for the default profile, ensuring precise and predictable behavior.

 **Getting rid of `W` prefix:**
> It is no longer available to enable or disable a warrning with W.