### PR TITLE
[analyzer] Include arch subdirectories in LD_LIBRARY_PATH for logging

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -71,12 +71,19 @@ class Context(metaclass=Singleton):
         # Original caller environment of CodeChecker for external binaries
         self.__original_env = None
 
-        self.logger_lib_dir_path = os.path.join(
-            self._data_files_dir_path, 'ld_logger', 'lib')
-
-        if not os.path.exists(self.logger_lib_dir_path):
-            self.logger_lib_dir_path = os.path.join(
+        # Find the path which has the architectures for the built ld_logger
+        # shared objects.
+        ld_logger_path = Path(self._data_files_dir_path, 'ld_logger', 'lib')
+        if not ld_logger_path.is_dir():
+            ld_logger_path = Path(
                 self._lib_dir_path, 'codechecker_analyzer', 'ld_logger', 'lib')
+
+        # Add the ld_logger_path and all children (architecture) paths to be
+        # later used in the LD_LIBRARY_PATH environment variable during
+        # logging of compiler invocations.
+        self.logger_lib_dir_path = ':'.join(
+            [str(ld_logger_path)] +
+            [str(arch) for arch in ld_logger_path.iterdir() if arch.is_dir()])
 
         self.logger_bin = None
         self.logger_file = None

--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -73,17 +73,18 @@ class Context(metaclass=Singleton):
 
         # Find the path which has the architectures for the built ld_logger
         # shared objects.
-        ld_logger_path = Path(self._data_files_dir_path, 'ld_logger', 'lib')
+        ld_logger_path = Path(self._data_files_dir_path, "ld_logger", "lib")
         if not ld_logger_path.is_dir():
             ld_logger_path = Path(
-                self._lib_dir_path, 'codechecker_analyzer', 'ld_logger', 'lib')
+                self._lib_dir_path, "codechecker_analyzer", "ld_logger", "lib"
+            )
 
-        # Add the ld_logger_path and all children (architecture) paths to be
-        # later used in the LD_LIBRARY_PATH environment variable during
-        # logging of compiler invocations.
-        self.logger_lib_dir_path = ':'.join(
-            [str(ld_logger_path)] +
-            [str(arch) for arch in ld_logger_path.iterdir() if arch.is_dir()])
+        # Add all children (architecture) paths to be later used in the
+        # LD_LIBRARY_PATH environment variable during logging of compiler
+        # invocations.
+        self.logger_lib_dir_path = ":".join(
+            [str(arch) for arch in ld_logger_path.iterdir() if arch.is_dir()]
+        )
 
         self.logger_bin = None
         self.logger_file = None

--- a/analyzer/tests/functional/analyze_and_parse/test_files/mixed_arch_driver.c
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/mixed_arch_driver.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int main(void) {
+    // These commands are intended to test CodeChecker's ability to build-log
+    // cross compilations.
+    system("gcc -m32 simple.c -o simple32");
+    system("gcc -m64 simple.c -o simple64");
+    return 0;
+} 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/simple.c
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/simple.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+} 

--- a/analyzer/tools/build-logger/Makefile
+++ b/analyzer/tools/build-logger/Makefile
@@ -76,24 +76,18 @@ LIB_DIR = $(BUILD_DIR)/lib
 all: ldlogger ldlogger_32.so ldlogger_64.so pack32bit pack64bit
 
 pack32bit: 32bit packbin
-	for x86dir in 'i386' 'i486' 'i586' 'i686'; do \
-		mkdir -p $(LIB_DIR)/$$x86dir ; \
-		cp ldlogger_32.so $(LIB_DIR)/$$x86dir/ldlogger.so ; \
-	done
+	mkdir -p $(LIB_DIR)/32bit ; \
+	cp ldlogger_32.so $(LIB_DIR)/32bit/ldlogger.so ; \
 	rm -f ldlogger_32.so
 
 pack64bit: 64bit packbin
-	for x8664dir in 'x86_64'; do \
-		mkdir -p $(LIB_DIR)/$$x8664dir ; \
-		cp ldlogger_64.so $(LIB_DIR)/$$x8664dir/ldlogger.so ; \
-	done
+	mkdir -p $(LIB_DIR)/64bit ; \
+	cp ldlogger_64.so $(LIB_DIR)/64bit/ldlogger.so ; \
 	rm -f ldlogger_64.so
 
 pack64bit_only: 64bit_only packbin64
-	for x8664dir in 'x86_64'; do \
-		mkdir -p $(LIB_DIR)/$$x8664dir ; \
-		cp ldlogger_64.so $(LIB_DIR)/$$x8664dir/ldlogger.so ; \
-	done
+	mkdir -p $(LIB_DIR)/64bit ; \
+	cp ldlogger_64.so $(LIB_DIR)/64bit/ldlogger.so ; \
 	rm -f ldlogger_64.so
 
 # pack binary

--- a/analyzer/tools/build-logger/tests/unit/__init__.py
+++ b/analyzer/tools/build-logger/tests/unit/__init__.py
@@ -10,11 +10,11 @@
 
 import json
 import os
-import platform
 import shlex
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 from typing import Mapping, Optional, Tuple, Sequence
 
 REPO_ROOT = os.path.abspath(os.getenv("REPO_ROOT"))
@@ -106,10 +106,13 @@ class BasicLoggerTest(unittest.TestCase):
             return fd.read()
 
     def get_envvars(self) -> Mapping[str, str]:
+        libdir = Path(LOGGER_DIR, "lib")
         return {
             "PATH": os.getenv("PATH"),
             "LD_PRELOAD": "ldlogger.so",
-            "LD_LIBRARY_PATH": os.path.join(LOGGER_DIR, "lib"),
+            "LD_LIBRARY_PATH": ':'.join([str(arch) for arch in
+                                         libdir.iterdir()
+                                         if arch.is_dir()]),
             "CC_LOGGER_GCC_LIKE": "gcc:g++:clang:clang++:/cc:c++",
             "CC_LOGGER_FILE": self.logger_file,
             "CC_LOGGER_DEBUG_FILE": self.logger_debug_file,

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -793,7 +793,10 @@ If this is not possible, you can work around the situation by
 specifying the absolute path of the `ldlogger.so` in the `LD_PRELOAD`:
 
 ```sh
-LD_PRELOAD=<CODECHECKER_DIR>/ld_logger/lib/x86_64/ldlogger.so CodeChecker log -o compile_commands.json -b "make -j2"
+# For 64-bit compilers
+LD_PRELOAD=<CODECHECKER_DIR>/ld_logger/lib/64bit/ldlogger.so CodeChecker log -o compile_commands.json -b "make -j2"
+# For 32-bit compilers
+LD_PRELOAD=<CODECHECKER_DIR>/ld_logger/lib/32bit/ldlogger.so CodeChecker log -o compile_commands.json -b "make -j2"
 ```
 
 #### Change user inside the build command


### PR DESCRIPTION
The issue with logging (see https://github.com/Ericsson/codechecker/issues/4360 for details) came up on my Ubuntu24 machine, where only specifying the <data_files>/ldlogger/lib in the LD_LIBRARY_PATH was not enough for the dynamic loader to load the ldlogger.so inside <data_files>/ldlogger/lib/x86_64, so I observed there is no implicit architecture resolution in the logic of the loader. There were other tests on other distributions where this implicit architecture resolution seems to exist (rhel7, rhel8, ubuntu22, among others).

The solution implemented by this patch is adding all <data_files>/ldlogger/lib/* folders in addition to the current  <data_files>/ldlogger/lib folder to the LD_LIBRARY_PATH.

I have tested it on Ubuntu24, and the multiple .so files that are possibly reachable due to all of them being added are not an issue. The logger works as expected, and if I remove only the relevant ldlogger.so (x86_64 for my machine) but keep the others, the CodeChecker log command correctly detects that I meet neither the ld-logger nor the intercept-build requirement.