### PR TITLE
[doc] Add sarif to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setuptools.setup(
         "Documentation": "http://codechecker.readthedocs.io",
         "Issue Tracker": "http://github.com/Ericsson/CodeChecker/issues",
     },
-    keywords=['codechecker', 'plist'],
+    keywords=['codechecker', 'plist', 'sarif'],
     license='Apache-2.0 WITH LLVM-exception',
     packages=packages,
     package_dir={


### PR DESCRIPTION
CodeChecker offers limited support for static analysis results in Sarif format as of 6.24. This change helps those searching for packages using the keyword sarif.