### PR TITLE
[test] Modernize Pylint config

### DIFF
--- a/analyzer/tools/build-logger/.pylintrc
+++ b/analyzer/tools/build-logger/.pylintrc
@@ -374,4 +374,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/analyzer/tools/merge_clang_extdef_mappings/.pylintrc
+++ b/analyzer/tools/merge_clang_extdef_mappings/.pylintrc
@@ -374,4 +374,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/analyzer/tools/statistics_collector/.pylintrc
+++ b/analyzer/tools/statistics_collector/.pylintrc
@@ -374,4 +374,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtin.Exception

--- a/tools/report-converter/.pylintrc
+++ b/tools/report-converter/.pylintrc
@@ -374,4 +374,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/tools/tu_collector/.pylintrc
+++ b/tools/tu_collector/.pylintrc
@@ -374,4 +374,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
The reason for this change is that Pylint gives the following deprecation warning:
UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.BaseException' ?) instead.