### PR TITLE
[feat][server] Logging: show package schema revision on startup

### DIFF
--- a/web/server/codechecker_server/database/database.py
+++ b/web/server/codechecker_server/database/database.py
@@ -265,6 +265,8 @@ class SQLServer(metaclass=ABCMeta):
 
                 LOG.debug("Checking schema versions in the package.")
                 schema_config_head = scriptt.get_current_head()
+                LOG.debug("Schema revision in the package: %s",
+                          str(schema_config_head))
 
                 if database_schema_revision != schema_config_head:
                     LOG.debug("Database schema mismatch detected "


### PR DESCRIPTION
On startup, codechecker checks the alembic version of the codechecker database(s) to see if they match the expected value. Prior to this commit, the version found in the database was displayed in the logging, but the expected version was not always displayed. This added an uneccesary complication when debugging a database mismatch (eg during local testing)

As of this commit, the found version and the expected version are both logged