### PR TITLE
[feat][report-converter][fix][server] Add support for bug path arrows into sarif parser.

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
@@ -143,25 +143,29 @@ class Parser(BaseParser):
 
         thread_flow_info = ThreadFlowInfo()
 
-        # TODO: Currently, we only collect bug path events.
-
         for code_flow in result.get("codeFlows", []):
             for thread_flow in code_flow.get("threadFlows", []):
                 for location_data in thread_flow["locations"]:
-                    # There are a lot data stored alongside the location worth
-                    # parsing, but we only need the actual location now.
-                    location = location_data["location"]
-
-                    if "message" not in location:
-                        # TODO: This might be a bug path position (for arrows).
+                    if "location" not in location_data:
                         continue
 
-                    message = self._process_message(
-                        location["message"], rule_id, rules)
+                    # There is a lot data stored alongside the location worth
+                    # parsing, but we only need the actual location now.
+                    location = location_data["location"]
 
                     file, rng = self._process_location(location)
                     if not (file and rng):
                         continue
+
+                    thread_flow_info.bug_path_positions.append(
+                        BugPathPosition(file, rng)
+                    )
+
+                    if "message" not in location:
+                        continue
+
+                    message = self._process_message(
+                        location["message"], rule_id, rules)
 
                     thread_flow_info.bug_path_events.append(BugPathEvent(
                         message, file, rng.start_line, rng.start_col, rng))

--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -993,34 +993,76 @@ class MassStoreRun:
             for db_report, report in self.__added_reports:
                 LOG.debug("Storing bug path positions.")
                 for i, p in enumerate(report.bug_path_positions):
-                    session.add(BugReportPoint(
-                        p.range.start_line, p.range.start_col,
-                        p.range.end_line, p.range.end_col,
-                        i, file_path_to_id[p.file.path], db_report.id))
+                    if not p:
+                        LOG.error("Missing range at index: %s", i)
+                        continue
+                    if p.range:
+                        session.add(BugReportPoint(
+                            p.range.start_line, p.range.start_col,
+                            p.range.end_line, p.range.end_col,
+                            i, file_path_to_id[p.file.path], db_report.id))
+                    elif hasattr(p, "line") and hasattr(p, "column"):
+                        session.add(BugReportPoint(
+                            p.line, p.column,
+                            p.line, p.column,
+                            i, file_path_to_id[p.file.path], db_report.id))
+                    else:
+                        LOG.error("Missing position info from range: %s", p)
+                        continue
 
                 LOG.debug("Storing bug path events.")
                 for i, event in enumerate(report.bug_path_events):
-                    session.add(BugPathEvent(
-                        event.range.start_line, event.range.start_col,
-                        event.range.end_line, event.range.end_col,
-                        i, event.message, file_path_to_id[event.file.path],
-                        db_report.id))
+                    if not event:
+                        LOG.error("Missing range at index: %s", i)
+                        continue
+                    if event.range:
+                        session.add(BugPathEvent(
+                            event.range.start_line, event.range.start_col,
+                            event.range.end_line, event.range.end_col,
+                            i, event.message, file_path_to_id[event.file.path],
+                            db_report.id))
+                    elif hasattr(event, "line") and hasattr(event, "column"):
+                        session.add(BugPathEvent(
+                            event.line, event.column,
+                            event.line, event.column,
+                            i, event.message, file_path_to_id[event.file.path],
+                            db_report.id))
+                    else:
+                        LOG.error(
+                            "Missing position info from range: %s", event
+                        )
+                        continue
 
                 LOG.debug("Storing notes.")
                 for note in report.notes:
                     data_type = report_extended_data_type_str(
                         ttypes.ExtendedReportDataType.NOTE)
-
-                    session.add(ExtendedReportData(
-                        note.range.start_line, note.range.start_col,
-                        note.range.end_line, note.range.end_col,
-                        note.message, file_path_to_id[note.file.path],
-                        db_report.id, data_type))
+                    if not note:
+                        LOG.error("Missing range at index: %s", i)
+                        continue
+                    if note.range:
+                        session.add(ExtendedReportData(
+                            note.range.start_line, note.range.start_col,
+                            note.range.end_line, note.range.end_col,
+                            note.message, file_path_to_id[note.file.path],
+                            db_report.id, data_type))
+                    elif hasattr(note, "line") and hasattr(note, "column"):
+                        session.add(ExtendedReportData(
+                            note.line, note.column,
+                            note.line, note.column,
+                            note.message, file_path_to_id[note.file.path],
+                            db_report.id, data_type))
+                    else:
+                        LOG.error("Missing position info from: %s", note)
+                        continue
 
                 LOG.debug("Storing macro expansions.")
                 for macro in report.macro_expansions:
                     data_type = report_extended_data_type_str(
                         ttypes.ExtendedReportDataType.MACRO)
+                    if macro and not macro.range:
+                        LOG.error("Missing range from: %s", macro)
+                        continue
 
                     session.add(ExtendedReportData(
                         macro.range.start_line, macro.range.start_col,


### PR DESCRIPTION
The current status quo supports SARIF but doesn't allow you to use the "show arrows" feature within the report detail view. This PR extracts the relevant data from the SARIF files and provides the database the means to draw the arrows, making "show arrows" usable.

This exposed an issue with the current server ingest process, in that it assumes a certain format for the BugPath positions and event objects. This PR also adds a number of checks to correctly extract the data as required.