### PR TITLE
[fix][report-converter] Fix hash where file was pulled from report instead of event.

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/hash.py
+++ b/tools/report-converter/codechecker_report_converter/report/hash.py
@@ -80,7 +80,7 @@ def __get_report_hash_path_sensitive(report: Report) -> List[str]:
 
         # WARNING!!! Changing the error handling type for encoding errors
         # can influence the hash content!
-        line_content = report.file.get_line(event.line)
+        line_content = event.file.get_line(event.line)
 
         if line_content == '' and \
                 not os.path.isfile(report.file.original_path):


### PR DESCRIPTION
This is due to the issue described at:
https://github.com/Ericsson/codechecker/issues/4402