### PR TITLE
[test] Add tests for different report hashes

### DIFF
--- a/web/tests/functional/dynamic_results/test_dynamic_results.py
+++ b/web/tests/functional/dynamic_results/test_dynamic_results.py
@@ -102,7 +102,7 @@ class DynamicResults(unittest.TestCase):
         results = self._cc_client.getRunResults(
             None, 500, 0, None, ReportFilter(), None, False)
 
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)
 
         sort_timestamp = SortMode(SortType.TIMESTAMP, Order.ASC)
 
@@ -119,7 +119,7 @@ class DynamicResults(unittest.TestCase):
                'timestamp' not in results[i + 1].annotations:
                 continue
 
-            self.assertLess(
+            self.assertLessEqual(
                 results[i].annotations['timestamp'],
                 results[i + 1].annotations['timestamp'])
 
@@ -134,7 +134,7 @@ class DynamicResults(unittest.TestCase):
         results = self._cc_client.getRunResults(
             None, 500, 0, None, testcase_filter, None, False)
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
 
         self.assertTrue(all(map(
             lambda report: report.annotations['testcase'] == 'TC-1',
@@ -147,7 +147,7 @@ class DynamicResults(unittest.TestCase):
         results = self._cc_client.getRunResults(
             None, 500, 0, None, testcase_filter, None, False)
 
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
 
         self.assertTrue(all(map(
             lambda report: report.annotations['testcase'].startswith('TC-'),
@@ -160,7 +160,7 @@ class DynamicResults(unittest.TestCase):
         num = self._cc_client.getRunResultCount(
             None, ReportFilter(), None)
 
-        self.assertEqual(num, 5)
+        self.assertEqual(num, 6)
 
         testcase_filter = ReportFilter(annotations=[Pair(
             first='testcase',
@@ -169,7 +169,7 @@ class DynamicResults(unittest.TestCase):
         num = self._cc_client.getRunResultCount(
             None, testcase_filter, None)
 
-        self.assertEqual(num, 2)
+        self.assertEqual(num, 3)
 
     def test_unique_path_hash(self):
         """Test that the unique path hash is calculated when two reports differ
@@ -177,7 +177,8 @@ class DynamicResults(unittest.TestCase):
         results = self._cc_client.getRunResults(
             None, 500, 0, None, ReportFilter(), None, False)
 
-        # The main.c_lang-tidy<blabla>.plist test file contains two
-        # bugprone-sizeof-expression reports that differ in their annotations.
+        # The main.c_lang-tidy<blabla>.plist test file contains three
+        # bugprone-sizeof-expression reports. Two of them differ in their
+        # annotations two other differ in their report hash.
         # They should be considered as different reports.
-        self.assertEqual(len(results), 5)
+        self.assertEqual(len(results), 6)

--- a/web/tests/projects/dynamic/main.c_clang-tidy_0212cbc2c7194b7a5d431a18ff51bb1c.plist
+++ b/web/tests/projects/dynamic/main.c_clang-tidy_0212cbc2c7194b7a5d431a18ff51bb1c.plist
@@ -52,6 +52,58 @@
 				</dict>
 			</array>
 		</dict>
+		<!-- This report is the same as the first one, but with a different
+		     issue_hash_content_of_line_in_context. -->
+		<dict>
+			<key>category</key>
+			<string>bugprone</string>
+			<key>check_name</key>
+			<string>bugprone-sizeof-expression</string>
+			<key>description</key>
+			<string>suspicious usage of 'sizeof(K)'; did you mean 'K'?</string>
+			<key>issue_hash_content_of_line_in_context</key>
+			<string>11111111111111111111111111111111</string>
+			<key>report-annotation</key>
+			<dict>
+				<key>timestamp</key>
+				<string>2000-01-01 09:01</string>
+				<key>testcase</key>
+				<string>TS-1</string>
+				<key>testcase</key>
+				<string>TC-1</string>
+			</dict>
+			<key>location</key>
+			<dict>
+				<key>col</key>
+				<integer>3</integer>
+				<key>file</key>
+				<integer>0</integer>
+				<key>line</key>
+				<integer>7</integer>
+			</dict>
+			<key>path</key>
+			<array>
+				<dict>
+					<key>depth</key>
+					<integer>0</integer>
+					<key>kind</key>
+					<string>event</string>
+					<key>location</key>
+					<dict>
+						<key>col</key>
+						<integer>3</integer>
+						<key>file</key>
+						<integer>0</integer>
+						<key>line</key>
+						<integer>7</integer>
+					</dict>
+					<key>message</key>
+					<string>suspicious usage of 'sizeof(K)'; did you mean 'K'?</string>
+				</dict>
+			</array>
+		</dict>
+		<!-- This report is the same as the first one, but with a different
+		     report-annotation. -->
 		<dict>
 			<key>category</key>
 			<string>bugprone</string>


### PR DESCRIPTION
There are some tests already which check if two reports with different annotations are considered different reports.
Now we also check if two reports with different report hash are considered different.