### PR TITLE
[tools] Simplify static file handling in report-converter

### DIFF
--- a/tools/report-converter/setup.py
+++ b/tools/report-converter/setup.py
@@ -21,8 +21,8 @@ setuptools.setup(
     url="https://github.com/Ericsson/CodeChecker",
     keywords=['report-converter', 'codechecker', 'plist'],
     license='LICENSE.txt',
-    packages=setuptools.find_packages(),
-    include_package_data=True,
+    packages=setuptools.find_namespace_packages(include=['codechecker_report_converter*']),
+    include_package_data=True,  # This will use MANIFEST.in
     classifiers=[
         "Environment :: Console",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The report-converter package shows setuptools warnings during build about missing packages when using Python 3.12. This is due to stricter package discovery checks introduced in setuptools 61.0.0 [1], which now warns about directories that could be packages but aren't explicitly configured.

While we could address this with explicit package_data configuration, the package already has a correct MANIFEST.in file that handles static file inclusion.

This change:
- Relies on the existing MANIFEST.in pattern for static files
- Uses find_namespace_packages() to properly handle package structure
- Keeps include_package_data=True to ensure MANIFEST.in is respected

This approach is more maintainable as:
1. All static file patterns are managed in one place (MANIFEST.in)
2. New static files are automatically included if they follow the existing directory structure
3. setuptools will warn us if files specified in MANIFEST.in are missing

The change makes the package compatible with Python 3.12's stricter package discovery while maintaining a clean and maintainable solution for static file handling.

**I assume this is the intention: to include these static files in the package; please verify!**

Fixes #4422 

[1] https://setuptools.pypa.io/en/latest/history.html#v61-0-0
[2] https://setuptools.pypa.io/en/latest/userguide/package_discovery.html