### PR TITLE
[report-converter] Improve documentation maintainability

### DIFF
--- a/tools/report-converter/README.md
+++ b/tools/report-converter/README.md
@@ -1,0 +1,46 @@
+# CodeChecker Report Converter
+
+A Python tool to parse and convert various code analyzer outputs into CodeChecker format. It can create HTML reports from analyzer outputs and store them in a CodeChecker server.
+
+## Quick Start
+
+```bash
+# Create a Python virtualenv and set it as your environment
+make venv
+source $PWD/venv/bin/activate
+
+# Build and install report-converter package
+make package
+```
+
+## Basic Usage
+
+```bash
+# Convert analyzer output to CodeChecker format
+report-converter --type clang-tidy --output /path/to/reports clang-tidy-output.txt
+
+# Generate HTML report
+plist-to-html --input /path/to/reports/*.plist --output /path/to/html
+```
+
+## Documentation
+
+For comprehensive documentation, including:
+- Complete list of supported analyzers
+- Detailed usage examples
+- Configuration options
+- Troubleshooting guide
+
+Please visit our [official documentation](https://codechecker.readthedocs.io/en/latest/tools/report-converter/).
+
+## Requirements
+
+- Python >= 3.8
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the LICENSE.txt file for details.
+
+## Authors
+
+CodeChecker Team (Ericsson)

--- a/tools/report-converter/setup.py
+++ b/tools/report-converter/setup.py
@@ -4,22 +4,27 @@ import os
 import setuptools
 import codechecker_report_converter
 
-readme_file_path = os.path.join(
-    "..", "..", "docs", "tools", "report-converter.md")
+# Use a focused description for PyPI while pointing to full documentation
+description = """
+CodeChecker Report Converter is a Python tool that converts various code analyzer outputs
+into CodeChecker format and generates HTML reports. It supports multiple analyzers including:
+- Clang-based tools (Clang-Tidy, Sanitizers)
+- Static analyzers (Cppcheck, GCC)
+- Language-specific linters (ESLint, Pylint, TSLint)
 
-with open(readme_file_path, "r", encoding="utf-8", errors="ignore") as fh:
-    long_description = fh.read()
+For comprehensive documentation, visit:
+https://codechecker.readthedocs.io/en/latest/tools/report-converter/
+"""
 
 setuptools.setup(
     name=codechecker_report_converter.__title__,
     version=codechecker_report_converter.__version__,
     author='CodeChecker Team (Ericsson)',
-    description="Parse and create HTML files from one or more '.plist' "
-                "result files.",
-    long_description=long_description,
+    description="Parse and create HTML files from various code analyzer outputs",
+    long_description=description,
     long_description_content_type="text/markdown",
     url="https://github.com/Ericsson/CodeChecker",
-    keywords=['report-converter', 'codechecker', 'plist'],
+    keywords=['report-converter', 'codechecker', 'static-analysis', 'linter'],
     license='LICENSE.txt',
     packages=setuptools.find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Reduce documentation duplication by:
- Create a concise package-level README focused on quick start (and silence a warning, as MANIFEST.in expects a README.md)
- Update setup.py to use a focused description, and as the scope of the tool expanded over time, keywords and general description now acknowledges that
- Point to official readthedocs.io documentation as single source of truth
- Remove redundant information from package documentation