### PR TITLE
Update versioned step dependencies in GH actions

### DIFF
--- a/.github/workflows/config_coverage.yml
+++ b/.github/workflows/config_coverage.yml
@@ -28,8 +28,8 @@ jobs:
     name: "Config coverage of checkers"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: "Install dependencies"
@@ -48,7 +48,7 @@ jobs:
       # We do this BEFORE grabbing Clang, so a potentially broken Clang binary
       # won't miscompile Cppcheck itself.
       - name: "Download Cppcheck source code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "danmar/cppcheck"
           path: "cppcheck"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: ./web/docker/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '16.x'
 
@@ -61,7 +61,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
         id: build
       - uses: snapcore/action-publish@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Install dependencies
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup Bazel
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -114,8 +114,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -150,8 +150,8 @@ jobs:
         database: [sqlite, psql_pg8000, psql_psycopg2]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -195,11 +195,11 @@ jobs:
         browser: [firefox]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '16.x'
 


### PR DESCRIPTION
Repos for upgraded steps:
https://github.com/abhinavsingh/setup-bazel
https://github.com/actions/checkout
https://github.com/actions/setup-node
https://github.com/actions/setup-python
https://github.com/docker/build-push-action
https://github.com/docker/login-action
https://github.com/docker/setup-buildx-action
https://github.com/pypa/gh-action-pypi-publish
https://github.com/snapcore/action-build
https://github.com/snapcore/action-publish

These steps are not upgraded on purpose:
https://github.com/actions/download-artifact
https://github.com/actions/upload-artifact