### PR TITLE
[NFC] Remove deprecated ::set-output usage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -31,7 +31,7 @@ jobs:
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         id: get_version
         run: |
-          echo ::set-output name=VERSION::$(echo ${GITHUB_REF#refs/tags/v} | sed 's/-//')
+          echo "VERSION=$(echo ${GITHUB_REF#refs/tags/v} | sed 's/-//')" >> $GITHUB_OUTPUT
 
       # Set package version information in the 'setup.py' file based on the
       # released git tag information.


### PR DESCRIPTION
The recommended way of output has changed.
See this discussion for details:
https://github.com/orgs/community/discussions/35994