### PR TITLE
[NFC] Eliminate the "W" form of clang-tidy warnings

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/config_handler.py
@@ -12,13 +12,7 @@ Config handler for Clang Tidy analyzer.
 
 from codechecker_common.logger import get_logger
 
-from ..config_handler import AnalyzerConfigHandler, CheckerState, \
-                             get_compiler_warning_name_and_type
-
-
-def is_compiler_warning(checker_name):
-    name, _ = get_compiler_warning_name_and_type(checker_name)
-    return name is not None
+from ..config_handler import AnalyzerConfigHandler, CheckerState
 
 
 LOG = get_logger('analyzer.tidy')
@@ -37,7 +31,7 @@ class ClangTidyConfigHandler(AnalyzerConfigHandler):
         """
         if self.analyzer_config and \
            self.analyzer_config.get('take-config-from-directory') == 'true':
-            if is_compiler_warning(checker_name):
+            if checker_name.startswith('clang-diagnostic-'):
                 return
 
         super().add_checker(checker_name, description, state)

--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -42,25 +42,6 @@ class CheckerType(Enum):
     COMPILER = 1  # A checker which specified as "-W<name>" or "-Wno-<name>".
 
 
-def get_compiler_warning_name_and_type(checker_name):
-    """
-    Removes 'W' or 'Wno' from the compiler warning name, if this is a
-    compiler warning and returns the name and CheckerType.compiler.
-    If it is a clang-diagnostic-<name> warning then it returns the name
-    and CheckerType.analyzer.
-    Otherwise returns None and CheckerType.analyzer.
-    """
-    # Checker name is a compiler warning.
-    if checker_name.startswith('W'):
-        name = checker_name[4:] if \
-            checker_name.startswith('Wno-') else checker_name[1:]
-        return name, CheckerType.COMPILER
-    elif checker_name.startswith('clang-diagnostic-'):
-        return checker_name[17:], CheckerType.ANALYZER
-    else:
-        return None, CheckerType.ANALYZER
-
-
 class AnalyzerConfigHandler(metaclass=ABCMeta):
     """
     Handle the checker configurations and enabled disabled checkers lists.

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -23,7 +23,7 @@ from codechecker_analyzer.analyzers.clangtidy.analyzer import ClangTidy
 from codechecker_analyzer.analyzers.cppcheck.analyzer import Cppcheck
 from codechecker_analyzer.analyzers.config_handler import CheckerState
 from codechecker_analyzer.analyzers.clangtidy.config_handler \
-        import is_compiler_warning, ClangTidyConfigHandler
+    import ClangTidyConfigHandler
 from codechecker_analyzer.arg import AnalyzerConfig, CheckerConfig, \
     analyzer_config
 from codechecker_analyzer.cmd.analyze import \
@@ -398,7 +398,7 @@ class CheckerHandlingClangSATest(unittest.TestCase):
 
 
 class MockClangTidyCheckerLabels:
-    def checkers_by_labels(self, labels):
+    def checkers_by_labels(self, labels, _=None):
         if labels[0] == 'profile:default':
             return [
                 'bugprone-assert-side-effect',
@@ -643,9 +643,6 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
         self.assertTrue(self._is_disabled(
             'clang-analyzer',
             analyzer.construct_analyzer_cmd(result_handler)))
-
-        self.assertTrue(is_compiler_warning('Wreserved-id-macro'))
-        self.assertFalse(is_compiler_warning('hicpp'))
 
         analyzer = create_analyzer_tidy(['--enable', 'Wreserved-id-macro'])
         result_handler = create_result_handler(analyzer)

--- a/codechecker_common/checker_labels.py
+++ b/codechecker_common/checker_labels.py
@@ -40,7 +40,8 @@ class CheckerLabels:
     # violated then an error is thrown during label JSON file parse. The
     # default value of the label also needs to be provided here.
     UNIQUE_LABELS = {
-        'severity': 'UNSPECIFIED'}
+        'severity': 'UNSPECIFIED',
+        'blacklist': 'false'}
 
     def __init__(self, checker_labels_dir: str):
         if not os.path.isdir(checker_labels_dir):

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -2709,10 +2709,12 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-frame-larger-than": [
+      "blacklist:true",
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-frame-larger-than=": [
+      "blacklist:true",
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#id1",
       "severity:MEDIUM"
     ],


### PR DESCRIPTION
Earlier "clang-diagnostic-..." checkers could have been provided with their original "W" warning flag form. For example Wformat vs. clang-diagnostic-format. The "W" form is deprecated for a while and the late CodeChecker versions emit a hard error when using them. For this reason there is no need to distinguish "W" form as a warning anymore.