### PR TITLE
[Fix] Sorting of the statistics

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
@@ -669,7 +669,16 @@ export default {
               a.checkers, prop, sortDesc[index]);
             bValue = this.getNestedTableContent(
               b.checkers, prop, sortDesc[index]);
-          }      
+          }
+          else if (column.includes(".")) {
+            const sub_columns = column.split(".");
+            aValue = sub_columns.reduce((element, sub_coulmn) => (
+              element && element[sub_coulmn] !== undefined
+                ? element[sub_coulmn] : undefined), a);
+            bValue = sub_columns.reduce((element, sub_coulmn) => (
+              element && element[sub_coulmn] !== undefined
+                ? element[sub_coulmn] : undefined), b);
+          }
           else {
             aValue = a[column];
             bValue = b[column];


### PR DESCRIPTION
Ordering by report counts did not work properly on Product overview, checker- and severity statistics page. Now it is fixed.