### PR TITLE
[feat] Introduce cc-verbatim-args-file

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -5,12 +5,13 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # -------------------------------------------------------------------------
-from collections import defaultdict
 from packaging.version import Version
 import shlex
 import subprocess
+import sys
 
 from codechecker_common.logger import get_logger
+from codechecker_common import util
 
 from codechecker_analyzer import analyzer_context
 
@@ -80,6 +81,8 @@ class Gcc(analyzer_base.SourceAnalyzer):
         if not has_flag('-x', analyzer_cmd):
             analyzer_cmd.extend(['-x', compile_lang])
 
+        analyzer_cmd.extend(config.analyzer_extra_arguments)
+
         analyzer_cmd.append(self.source_file)
 
         LOG.debug_analyzer("Running analysis command "
@@ -126,7 +129,11 @@ class Gcc(analyzer_base.SourceAnalyzer):
         Config options for gcc.
         """
         # TODO
-        return []
+        return [
+            ('cc-verbatim-args-file',
+             'A file path containing flags that are forwarded verbatim to the '
+             'analyzer tool. E.g.: cc-verbatim-args-file=<filepath>')
+        ]
 
     @classmethod
     def get_checker_config(cls):
@@ -216,15 +223,21 @@ class Gcc(analyzer_base.SourceAnalyzer):
     def construct_config_handler(cls, args):
         handler = GccConfigHandler()
 
-        analyzer_config = defaultdict(list)
-
         if 'analyzer_config' in args and \
                 isinstance(args.analyzer_config, list):
             for cfg in args.analyzer_config:
-                if cfg.analyzer == cls.ANALYZER_NAME:
-                    analyzer_config[cfg.option].append(cfg.value)
+                # TODO: The analyzer plugin should get only its own analyzer
+                # config options from outside.
+                if cfg.analyzer != cls.ANALYZER_NAME:
+                    continue
 
-        handler.analyzer_config = analyzer_config
+                if cfg.option == 'cc-verbatim-args-file':
+                    try:
+                        handler.analyzer_extra_arguments = \
+                            util.load_args_from_file(cfg.value)
+                    except FileNotFoundError:
+                        LOG.error(f"File not found: {cfg.value}")
+                        sys.exit(1)
 
         checkers = cls.get_analyzer_checkers()
 

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -71,7 +71,16 @@ class OrderedConfigAction(argparse.Action):
                f"--analyzer-config or --checker-config value ({value}) is " \
                "not a list, but should be if nargs is not None!"
 
-        if not hasattr(namespace, self.dest):
+        # When the default value is empty list, it's passed by reference and
+        # that default object will be used for further computations.
+        # For example: CodeChecker analyze --analyzer-config blabla --help
+        # This command above presents wrongly [blabla] as default value for
+        # --analyzer-config, because the code below inserts this value to the
+        # default empty list even if --help is printed.
+        # For this list we change falsey default values to another empty list
+        # object.
+        if not hasattr(namespace, self.dest) or \
+                not getattr(namespace, self.dest):
             setattr(namespace, self.dest, [])
 
         dest = getattr(namespace, self.dest)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -433,13 +433,6 @@ def add_arguments_to_parser(parser):
                                help="File containing argument which will be "
                                     "forwarded verbatim for Clang-Tidy.")
 
-    analyzer_opts.add_argument('--inferargs',
-                               dest="infer_args_cfg_file",
-                               required=False,
-                               default=argparse.SUPPRESS,
-                               help="File containing argument which will be "
-                                    "forwarded verbatim for Facebook Infer.")
-
     analyzer_opts.add_argument('--tidy-config',
                                dest='tidy_config',
                                required=False,

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -349,24 +349,39 @@ used to generate a log file on the fly.""")
                                dest="cppcheck_args_cfg_file",
                                required=False,
                                default=argparse.SUPPRESS,
-                               help="File containing argument which will be "
-                                    "forwarded verbatim for Cppcheck.")
+                               help="DEPRECATED. "
+                                    "File containing argument which will be "
+                                    "forwarded verbatim for Cppcheck. The "
+                                    "option has been migrated under the "
+                                    "cppcheck anayzer options: "
+                                    "--analyzer-config "
+                                    "cppcheck:cc-verbatim-args-file="
+                                    "<filepath>")
 
     analyzer_opts.add_argument('--saargs',
                                dest="clangsa_args_cfg_file",
                                required=False,
                                default=argparse.SUPPRESS,
-                               help="File containing argument which will be "
+                               help="DEPRECATED. "
+                                    "File containing argument which will be "
                                     "forwarded verbatim for the Clang Static "
-                                    "analyzer.")
+                                    "Analyzer. The opion has been migrated "
+                                    "under the clangsa analyzer options: "
+                                    "--analyzer-config "
+                                    "clangsa:cc-verbatim-args-file=<filepath>")
 
     analyzer_opts.add_argument('--tidyargs',
                                dest="tidy_args_cfg_file",
                                required=False,
                                default=argparse.SUPPRESS,
-                               help="File containing argument which will be "
-                                    "forwarded verbatim for the Clang-Tidy "
-                                    "analyzer.")
+                               help="DEPRECATED. "
+                                    "File containing argument which will be "
+                                    "forwarded verbatim for Clang-Tidy. "
+                                    "The opion has been migrated under the "
+                                    "clang-tidy analyzer options: "
+                                    "--analyzer-config "
+                                    "clang-tidy:cc-verbatim-args-file="
+                                    "<filepath>")
 
     analyzer_opts.add_argument('--tidy-config',
                                dest='tidy_config',
@@ -384,7 +399,7 @@ used to generate a log file on the fly.""")
                                dest='analyzer_config',
                                nargs='*',
                                action=OrderedConfigAction,
-                               default=argparse.SUPPRESS,
+                               default=[],
                                help="Analyzer configuration options in the "
                                     "following format: analyzer:key=value. "
                                     "The collection of the options can be "

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -368,13 +368,6 @@ used to generate a log file on the fly.""")
                                     "forwarded verbatim for the Clang-Tidy "
                                     "analyzer.")
 
-    analyzer_opts.add_argument('--inferargs',
-                               dest="infer_args_cfg_file",
-                               required=False,
-                               default=argparse.SUPPRESS,
-                               help="File containing argument which will be "
-                                    "forwarded verbatim for Facebook Infer.")
-
     analyzer_opts.add_argument('--tidy-config',
                                dest='tidy_config',
                                required=False,
@@ -935,7 +928,6 @@ def main(args):
                           'cppcheck_args_cfg_file',
                           'clangsa_args_cfg_file',
                           'tidy_args_cfg_file',
-                          'infer_args_cfg_file',
                           'analyzer_config',
                           'checker_config',
                           'capture_analysis_output',

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -99,22 +99,6 @@ def extend(path_env_extra, ld_lib_path_extra):
     return new_env
 
 
-def replace_env_var(cfg_file):
-    """
-    Returns a replacement function which can be used in RegEx functions such as
-    re.sub to replace matches with a string from the OS environment.
-    """
-    def replacer(matchobj):
-        env_var = matchobj.group(1)
-        if env_var not in os.environ:
-            LOG.error('%s environment variable not set in %s', env_var,
-                      cfg_file)
-            return ''
-        return os.environ[env_var]
-
-    return replacer
-
-
 def find_by_regex_in_envpath(pattern, environment):
     """
     Searches for files matching the pattern string in the environment's PATH.

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -1137,7 +1137,7 @@ class TestAnalyze(unittest.TestCase):
                 json.dump(build_log, outfile)
 
             cppcheck_args.write("--std=c++11")
-            cppcheck_args.close()
+            cppcheck_args.flush()
 
             analyze_cmd.extend(['--cppcheckargs', cppcheck_args.name])
 

--- a/analyzer/tests/functional/analyze_and_parse/test_files/saargs_forward.output
+++ b/analyzer/tests/functional/analyze_and_parse/test_files/saargs_forward.output
@@ -6,6 +6,7 @@ CHECK#CodeChecker check --build "make saargs_forward" --output $OUTPUT$ --quiet 
 [] - Starting build...
 [] - Using CodeChecker ld-logger.
 [] - Build finished successfully.
+[] - "--saargs" is deprecated. Use "--analyzer-config clangsa:cc-verbatim-args-file=<filepath>" instead.
 [] - Starting static analysis ...
 [] - [1/1] clangsa analyzed saargs_forward.cpp successfully.
 [] - ----==== Summary ====----

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -24,7 +24,8 @@ from codechecker_analyzer.analyzers.cppcheck.analyzer import Cppcheck
 from codechecker_analyzer.analyzers.config_handler import CheckerState
 from codechecker_analyzer.analyzers.clangtidy.config_handler \
         import is_compiler_warning, ClangTidyConfigHandler
-from codechecker_analyzer.arg import AnalyzerConfig, CheckerConfig
+from codechecker_analyzer.arg import AnalyzerConfig, CheckerConfig, \
+    analyzer_config
 from codechecker_analyzer.cmd.analyze import \
     is_analyzer_config_valid, is_checker_config_valid
 
@@ -835,7 +836,8 @@ class CheckerHandlingCppcheckTest(unittest.TestCase):
                 f.write('--max-ctu-depth=42')
 
             args = Namespace()
-            args.cppcheck_args_cfg_file = cppcheckargs
+            args.analyzer_config = [analyzer_config(
+                f"cppcheck:cc-verbatim-args-file={cppcheckargs}")]
 
             analyzer = create_analyzer_cppcheck(args, tmp_ws)
             result_handler = create_result_handler(analyzer)

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -140,6 +140,7 @@ usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q]
                          [--analyzers ANALYZER [ANALYZER ...]]
                          [--capture-analysis-output] [--generate-reproducer]
                          [--config CONFIG_FILE]
+                         [--cppcheckargs CPPCHECK_ARGS_CFG_FILE]
                          [--saargs CLANGSA_ARGS_CFG_FILE]
                          [--tidyargs TIDY_ARGS_CFG_FILE]
                          [--analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]]
@@ -283,12 +284,24 @@ analyzer arguments:
                         For more information see the docs: https://github.com/
                         Ericsson/codechecker/tree/master/docs/config_file.md
                         (default: None)
+  --cppcheckargs CPPCHECK_ARGS_CFG_FILE
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for Cppcheck. The option has been
+                        migrated under the cppcheck anayzer options:
+                        --analyzer-config
+                        cppcheck:cc-verbatim-args-file=<filepath>
   --saargs CLANGSA_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for the Clang Static analyzer.
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for the Clang Static Analyzer.
+                        The opion has been migrated under the clangsa analyzer
+                        options: --analyzer-config
+                        clangsa:cc-verbatim-args-file=<filepath>
   --tidyargs TIDY_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for the Clang-Tidy analyzer.
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for the Clang-Tidy. The opion has
+                        been migrated under the clang-tidy analyzer options:
+                        --analyzer-config
+                        clang-tidy:cc-verbatim-args-file=<filepath>
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the
@@ -391,18 +404,18 @@ checker configuration:
 
   Checker prefix groups
   ------------------------------------------------
-  Checker prefix groups allow you to enable checkers that share a common 
-  prefix in their names. Checkers within a prefix group will have names that 
-  start with the same identifier, making it easier to manage and reference 
+  Checker prefix groups allow you to enable checkers that share a common
+  prefix in their names. Checkers within a prefix group will have names that
+  start with the same identifier, making it easier to manage and reference
   related checkers.
-  
-  You can enable/disable checkers belonging to a checker prefix group: 
+
+  You can enable/disable checkers belonging to a checker prefix group:
   '-e <label>:<value>', e.g. '-e prefix:security'.
-  
+
   Note: The 'prefix' label is mandatory when there is ambiguity between the
-  name of a checker prefix group and a checker profile or a guideline. This 
+  name of a checker prefix group and a checker profile or a guideline. This
   prevents conflicts and ensures the correct checkers are applied.
-  
+
   See "CodeChecker checkers --help" to learn more.
 
   Checker labels
@@ -413,9 +426,9 @@ checker configuration:
 
   You can enable/disable checkers belonging to a label: '-e <label>:<value>',
   e.g. '-e profile:default'.
-  
+
   Note: The 'profile' label is mandatory when there is ambiguity between the
-  name of a checker profile and a checker prefix group or a guideline. This 
+  name of a checker profile and a checker prefix group or a guideline. This
   prevents conflicts and ensures the correct checkers are applied.
 
   See "CodeChecker checkers --help" to learn more.
@@ -432,9 +445,9 @@ checker configuration:
 
   Guidelines are labels themselves, and can be used as a label:
   '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
-  
+
   Note: The 'guideline' label is mandatory when there is ambiguity between the
-  name of a guideline and a checker prefix group or a checker profile. This 
+  name of a guideline and a checker prefix group or a checker profile. This
   prevents conflicts and ensures the correct checkers are applied.
 
   Batch enabling/disabling checkers
@@ -1205,14 +1218,23 @@ analyzer arguments:
                         Ericsson/codechecker/tree/master/docs/config_file.md
                         (default: None)
   --cppcheckargs CPPCHECK_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for Cppcheck.
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for Cppcheck. The option has been
+                        migrated under the cppcheck anayzer options:
+                        --analyzer-config
+                        cppcheck:cc-verbatim-args-file=<filepath>
   --saargs CLANGSA_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for the Clang Static Analyzer.
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for the Clang Static Analyzer.
+                        The opion has been migrated under the clangsa analyzer
+                        options: --analyzer-config
+                        clangsa:cc-verbatim-args-file=<filepath>
   --tidyargs TIDY_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for Clang-Tidy.
+                        DEPRECATED. File containing argument which will be
+                        forwarded verbatim for the Clang-Tidy. The opion has
+                        been migrated under the clang-tidy analyzer options:
+                        --analyzer-config
+                        clang-tidy:cc-verbatim-args-file=<filepath>
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the
@@ -1551,12 +1573,12 @@ and disabled flags starting from the bigger groups and going inwards. For
 example
 
 ```sh
---enable prefix:clang-diagnostic-unused 
+--enable prefix:clang-diagnostic-unused
 --disable checker:clang-diagnostic-unused-parameter
 ```
 or
 ```sh
---enable prefix:clang-diagnostic-unused 
+--enable prefix:clang-diagnostic-unused
 --disable clang-diagnostic-unused-parameter
 ```
 will enable every `unused` warnings except `unused-parameter`. To turn off a

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -142,7 +142,6 @@ usage: CodeChecker check [-h] [-o OUTPUT_DIR] [-t {plist}] [-q]
                          [--config CONFIG_FILE]
                          [--saargs CLANGSA_ARGS_CFG_FILE]
                          [--tidyargs TIDY_ARGS_CFG_FILE]
-                         [--inferargs INFER_ARGS_CFG_FILE]
                          [--analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]]
                          [--checker-config [CHECKER_CONFIG [CHECKER_CONFIG ...]]]
                          [--timeout TIMEOUT]
@@ -290,9 +289,6 @@ analyzer arguments:
   --tidyargs TIDY_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for the Clang-Tidy analyzer.
-  --inferargs INFER_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for the Facebook Infer.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the
@@ -395,18 +391,18 @@ checker configuration:
 
   Checker prefix groups
   ------------------------------------------------
-  Checker prefix groups allow you to enable checkers that share a common
-  prefix in their names. Checkers within a prefix group will have names that
-  start with the same identifier, making it easier to manage and reference
+  Checker prefix groups allow you to enable checkers that share a common 
+  prefix in their names. Checkers within a prefix group will have names that 
+  start with the same identifier, making it easier to manage and reference 
   related checkers.
-
-  You can enable/disable checkers belonging to a checker prefix group:
+  
+  You can enable/disable checkers belonging to a checker prefix group: 
   '-e <label>:<value>', e.g. '-e prefix:security'.
-
+  
   Note: The 'prefix' label is mandatory when there is ambiguity between the
-  name of a checker prefix group and a checker profile or a guideline. This
+  name of a checker prefix group and a checker profile or a guideline. This 
   prevents conflicts and ensures the correct checkers are applied.
-
+  
   See "CodeChecker checkers --help" to learn more.
 
   Checker labels
@@ -417,9 +413,9 @@ checker configuration:
 
   You can enable/disable checkers belonging to a label: '-e <label>:<value>',
   e.g. '-e profile:default'.
-
+  
   Note: The 'profile' label is mandatory when there is ambiguity between the
-  name of a checker profile and a checker prefix group or a guideline. This
+  name of a checker profile and a checker prefix group or a guideline. This 
   prevents conflicts and ensures the correct checkers are applied.
 
   See "CodeChecker checkers --help" to learn more.
@@ -436,9 +432,9 @@ checker configuration:
 
   Guidelines are labels themselves, and can be used as a label:
   '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
-
+  
   Note: The 'guideline' label is mandatory when there is ambiguity between the
-  name of a guideline and a checker prefix group or a checker profile. This
+  name of a guideline and a checker prefix group or a checker profile. This 
   prevents conflicts and ensures the correct checkers are applied.
 
   Batch enabling/disabling checkers
@@ -996,7 +992,6 @@ usage: CodeChecker analyze [-h] [-j JOBS]
                            [--cppcheckargs CPPCHECK_ARGS_CFG_FILE]
                            [--saargs CLANGSA_ARGS_CFG_FILE]
                            [--tidyargs TIDY_ARGS_CFG_FILE]
-                           [--inferargs INFER_ARGS_CFG_FILE]
                            [--timeout TIMEOUT]
                            [--ctu | --ctu-collect | --ctu-analyze]
                            [--ctu-ast-mode {load-from-pch, parse-on-demand}]
@@ -1218,9 +1213,6 @@ analyzer arguments:
   --tidyargs TIDY_ARGS_CFG_FILE
                         File containing argument which will be forwarded
                         verbatim for Clang-Tidy.
-  --inferargs TIDY_ARGS_CFG_FILE
-                        File containing argument which will be forwarded
-                        verbatim for Facebook Infer.
   --analyzer-config [ANALYZER_CONFIG [ANALYZER_CONFIG ...]]
                         Analyzer configuration options in the following
                         format: analyzer:key=value. The collection of the
@@ -1559,12 +1551,12 @@ and disabled flags starting from the bigger groups and going inwards. For
 example
 
 ```sh
---enable prefix:clang-diagnostic-unused
+--enable prefix:clang-diagnostic-unused 
 --disable checker:clang-diagnostic-unused-parameter
 ```
 or
 ```sh
---enable prefix:clang-diagnostic-unused
+--enable prefix:clang-diagnostic-unused 
 --disable clang-diagnostic-unused-parameter
 ```
 will enable every `unused` warnings except `unused-parameter`. To turn off a


### PR DESCRIPTION
The `--saargs`, `--tidyargs` and `--cppcheckargs` files are now
deprecated. These config files can now be provided through
`--analyzer-config` flag with a common config named
`cc-verbatim-args-file`.