### PR TITLE
[cmd] Emit errors instead of hiding flags

### DIFF
--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -12,8 +12,6 @@ import argparse
 import collections
 import os
 import re
-#
-# from codechecker_analyzer.analyzers import analyzer_types
 
 
 AnalyzerConfig = collections.namedtuple(
@@ -22,25 +20,6 @@ CheckerConfig = collections.namedtuple(
     "CheckerConfig", ["analyzer", "checker", "option", "value"])
 AnalyzerBinary = collections.namedtuple(
     "AnalyzerBinary", ["analyzer", "path"])
-
-#
-# class CheckAvailabilityAction(argparse.Action):
-#     """
-#     TODO
-#     """
-#
-#     def is_availble():
-#         raise NotImplementedError
-#
-#     def __init__(self, option_strings, dest, nargs=None, **kwargs):
-#         if nargs:
-#             raise ValueError("nargs not allowed")
-#         super().__init__(option_strings, dest, **kwargs)
-#
-#     def __call__(self, parser, namespace, value, option_string=None):
-#         print(value)
-#         assert analyzer_types.is_statistics_capable()
-#
 
 
 class OrderedCheckersAction(argparse.Action):

--- a/analyzer/codechecker_analyzer/arg.py
+++ b/analyzer/codechecker_analyzer/arg.py
@@ -12,6 +12,8 @@ import argparse
 import collections
 import os
 import re
+#
+# from codechecker_analyzer.analyzers import analyzer_types
 
 
 AnalyzerConfig = collections.namedtuple(
@@ -20,6 +22,25 @@ CheckerConfig = collections.namedtuple(
     "CheckerConfig", ["analyzer", "checker", "option", "value"])
 AnalyzerBinary = collections.namedtuple(
     "AnalyzerBinary", ["analyzer", "path"])
+
+#
+# class CheckAvailabilityAction(argparse.Action):
+#     """
+#     TODO
+#     """
+#
+#     def is_availble():
+#         raise NotImplementedError
+#
+#     def __init__(self, option_strings, dest, nargs=None, **kwargs):
+#         if nargs:
+#             raise ValueError("nargs not allowed")
+#         super().__init__(option_strings, dest, **kwargs)
+#
+#     def __call__(self, parser, namespace, value, option_string=None):
+#         print(value)
+#         assert analyzer_types.is_statistics_capable()
+#
 
 
 class OrderedCheckersAction(argparse.Action):

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -611,11 +611,6 @@ Cross-TU analysis. By default, no CTU analysis is run when
                                "available if CTU mode is enabled. "
                                "(default: parse-on-demand)")
 
-    # def suppress_if_stats_incapable(helpmsg : str):
-    #     if analyzer_types.is_statistics_capable():
-    #         return helpmsg
-    #     return argparse.SUPPRESS
-
     stats_capable = analyzer_types.is_statistics_capable()
 
     stat_opts = parser.add_argument_group(

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -508,179 +508,181 @@ def add_arguments_to_parser(parser):
                                     "the analysis is considered as a failed "
                                     "one.")
 
-    clang_has_z3 = analyzer_types.is_z3_capable()
-
-    if clang_has_z3:
-        analyzer_opts.add_argument('--z3',
-                                   dest='enable_z3',
-                                   choices=['on', 'off'],
-                                   default='off',
-                                   help="Enable Z3 as the solver backend. "
-                                        "This allows reasoning over more "
-                                        "complex queries, but performance is "
-                                        "much worse than the default "
-                                        "range-based constraint solver "
-                                        "system. WARNING: Z3 as the only "
-                                        "backend is a highly experimental "
-                                        "and likely unstable feature.")
+    analyzer_opts.add_argument('--z3',
+                               dest='enable_z3',
+                               choices=['on', 'off'],
+                               default='off',
+                               help="Enable Z3 as the solver backend. "
+                                    "This allows reasoning over more "
+                                    "complex queries, but performance is "
+                                    "much worse than the default "
+                                    "range-based constraint solver "
+                                    "system. WARNING: Z3 as the only "
+                                    "backend is a highly experimental "
+                                    "and likely unstable feature.")
 
     clang_has_z3_refutation = analyzer_types.is_z3_refutation_capable()
 
-    if clang_has_z3_refutation:
-        analyzer_opts.add_argument('--z3-refutation',
-                                   dest='enable_z3_refutation',
-                                   choices=['on', 'off'],
-                                   default='on' if clang_has_z3_refutation
-                                   else 'off',
-                                   help="Switch on/off the Z3 SMT Solver "
-                                        "backend to "
-                                        "reduce false positives. The results "
-                                        "of the ranged based constraint "
-                                        "solver in the Clang Static Analyzer "
-                                        "will be cross checked with the Z3 "
-                                        "SMT solver. This should not cause "
-                                        "that much of a slowdown compared to "
-                                        "using only the Z3 solver.")
+    analyzer_opts.add_argument('--z3-refutation',
+                               dest='enable_z3_refutation',
+                               choices=['on', 'off'],
+                               default='on' if clang_has_z3_refutation
+                               else 'off',
+                               help="Switch on/off the Z3 SMT Solver "
+                                    "backend to "
+                                    "reduce false positives. The results "
+                                    "of the ranged based constraint "
+                                    "solver in the Clang Static Analyzer "
+                                    "will be cross checked with the Z3 "
+                                    "SMT solver. This should not cause "
+                                    "that much of a slowdown compared to "
+                                    "using only the Z3 solver.")
 
-    if analyzer_types.is_ctu_capable():
-        ctu_opts = parser.add_argument_group(
-            "cross translation unit analysis arguments",
-            """
+    ctu_opts = parser.add_argument_group(
+        "cross translation unit analysis arguments",
+        """
 These arguments are only available if the Clang Static Analyzer supports
 Cross-TU analysis. By default, no CTU analysis is run when
 'CodeChecker analyze' is called.""")
 
-        ctu_modes = ctu_opts.add_mutually_exclusive_group()
-        ctu_modes.add_argument('--ctu', '--ctu-all',
-                               action='store_const',
-                               const=[True, True],
-                               dest='ctu_phases',
-                               default=argparse.SUPPRESS,
-                               help="Perform Cross Translation Unit (CTU) "
-                                    "analysis, both 'collect' and 'analyze' "
-                                    "phases. In this mode, the extra files "
-                                    "created by 'collect' are cleaned up "
-                                    "after the analysis.")
+    ctu_modes = ctu_opts.add_mutually_exclusive_group()
+    ctu_modes.add_argument('--ctu', '--ctu-all',
+                           action='store_const',
+                           const=[True, True],
+                           dest='ctu_phases',
+                           default=argparse.SUPPRESS,
+                           help="Perform Cross Translation Unit (CTU) "
+                                "analysis, both 'collect' and 'analyze' "
+                                "phases. In this mode, the extra files "
+                                "created by 'collect' are cleaned up "
+                                "after the analysis.")
 
-        ctu_modes.add_argument('--ctu-collect',
-                               action='store_const',
-                               const=[True, False],
-                               dest='ctu_phases',
-                               default=argparse.SUPPRESS,
-                               help="Perform the first, 'collect' phase of "
-                                    "Cross-TU analysis. This phase generates "
-                                    "extra files needed by CTU analysis, and "
-                                    "puts them into '<OUTPUT_DIR>/ctu-dir'. "
-                                    "NOTE: If this argument is present, "
-                                    "CodeChecker will NOT execute the "
-                                    "analyzers!")
+    ctu_modes.add_argument('--ctu-collect',
+                           action='store_const',
+                           const=[True, False],
+                           dest='ctu_phases',
+                           default=argparse.SUPPRESS,
+                           help="Perform the first, 'collect' phase of "
+                                "Cross-TU analysis. This phase generates "
+                                "extra files needed by CTU analysis, and "
+                                "puts them into '<OUTPUT_DIR>/ctu-dir'. "
+                                "NOTE: If this argument is present, "
+                                "CodeChecker will NOT execute the "
+                                "analyzers!")
 
-        ctu_modes.add_argument('--ctu-analyze',
-                               action='store_const',
-                               const=[False, True],
-                               dest='ctu_phases',
-                               default=argparse.SUPPRESS,
-                               help="Perform the second, 'analyze' phase of "
-                                    "Cross-TU analysis, using already "
-                                    "available extra files in "
-                                    "'<OUTPUT_DIR>/ctu-dir'. (These files "
-                                    "will not be cleaned up in this mode.)")
+    ctu_modes.add_argument('--ctu-analyze',
+                           action='store_const',
+                           const=[False, True],
+                           dest='ctu_phases',
+                           default=argparse.SUPPRESS,
+                           help="Perform the second, 'analyze' phase of "
+                                "Cross-TU analysis, using already "
+                                "available extra files in "
+                                "'<OUTPUT_DIR>/ctu-dir'. (These files "
+                                "will not be cleaned up in this mode.)")
 
-        ctu_opts.add_argument('--ctu-reanalyze-on-failure',
-                              action='store_true',
-                              dest='ctu_reanalyze_on_failure',
-                              default=argparse.SUPPRESS,
-                              help="If Cross-TU analysis is enabled and fails "
-                                   "for some reason, try to re analyze the "
-                                   "same translation unit without "
-                                   "Cross-TU enabled.")
+    ctu_opts.add_argument('--ctu-reanalyze-on-failure',
+                          action='store_true',
+                          dest='ctu_reanalyze_on_failure',
+                          default=argparse.SUPPRESS,
+                          help="If Cross-TU analysis is enabled and fails "
+                               "for some reason, try to re analyze the "
+                               "same translation unit without "
+                               "Cross-TU enabled.")
 
-        # Only check for AST loading modes if CTU is available.
-        if analyzer_types.is_ctu_on_demand_available():
-            ctu_opts.add_argument('--ctu-ast-mode',
-                                  action='store',
-                                  dest='ctu_ast_mode',
-                                  choices=['load-from-pch', 'parse-on-demand'],
-                                  default=argparse.SUPPRESS,
-                                  help="Choose the way ASTs are loaded during "
-                                       "CTU analysis. Only available if CTU "
-                                       "mode is enabled. Mode 'load-from-pch' "
-                                       "generates PCH format serialized ASTs "
-                                       "during the 'collect' phase. Mode "
-                                       "'parse-on-demand' only generates the "
-                                       "invocations needed to parse the ASTs. "
-                                       "Mode 'load-from-pch' can use "
-                                       "significant disk-space for the "
-                                       "serialized ASTs, while mode "
-                                       "'parse-on-demand' can incur some "
-                                       "runtime CPU overhead in the second "
-                                       "phase of the analysis. (default: "
-                                       "parse-on-demand)")
+    # Only check for AST loading modes if CTU is available.
+    ctu_opts.add_argument('--ctu-ast-mode',
+                          action='store',
+                          dest='ctu_ast_mode',
+                          choices=['load-from-pch', 'parse-on-demand'],
+                          default=argparse.SUPPRESS,
+                          help="Choose the way ASTs are loaded during "
+                               "CTU analysis. Mode 'load-from-pch' "
+                               "generates PCH format serialized ASTs "
+                               "during the 'collect' phase. Mode "
+                               "'parse-on-demand' only generates the "
+                               "invocations needed to parse the ASTs. "
+                               "Mode 'load-from-pch' can use "
+                               "significant disk-space for the "
+                               "serialized ASTs, while mode "
+                               "'parse-on-demand' can incur some "
+                               "runtime CPU overhead in the second "
+                               "phase of the analysis. NOTE: Only "
+                               "available if CTU mode is enabled. "
+                               "(default: parse-on-demand)")
 
-    if analyzer_types.is_statistics_capable():
-        stat_opts = parser.add_argument_group(
-            "Statistics analysis feature arguments",
-            """
+    # def suppress_if_stats_incapable(helpmsg : str):
+    #     if analyzer_types.is_statistics_capable():
+    #         return helpmsg
+    #     return argparse.SUPPRESS
+
+    stats_capable = analyzer_types.is_statistics_capable()
+
+    stat_opts = parser.add_argument_group(
+        "Statistics analysis feature arguments",
+        """
 These arguments are only available if the Clang Static Analyzer supports
 Statistics-based analysis (e.g. statisticsCollector.ReturnValueCheck,
 statisticsCollector.SpecialReturnValue checkers are available).""")
 
-        stat_opts.add_argument('--stats-collect', '--stats-collect',
-                               action='store',
-                               default=argparse.SUPPRESS,
-                               dest='stats_output',
-                               help="Perform the first, 'collect' phase of "
-                                    "Statistical analysis. This phase "
-                                    "generates extra files needed by "
-                                    "statistics analysis, and "
-                                    "puts them into "
-                                    "'<STATS_OUTPUT>'."
-                                    " NOTE: If this argument is present, "
-                                    "CodeChecker will NOT execute the "
-                                    "analyzers!")
+    stat_opts.add_argument('--stats-collect', '--stats-collect',
+                           action='store',
+                           default=argparse.SUPPRESS,
+                           dest='stats_output',
+                           help="Perform the first, 'collect' phase of "
+                                "Statistical analysis. This phase "
+                                "generates extra files needed by "
+                                "statistics analysis, and "
+                                "puts them into "
+                                "'<STATS_OUTPUT>'."
+                                " NOTE: If this argument is present, "
+                                "CodeChecker will NOT execute the "
+                                "analyzers!")
 
-        stat_opts.add_argument('--stats-use', '--stats-use',
-                               action='store',
-                               default=argparse.SUPPRESS,
-                               dest='stats_dir',
-                               help="Use the previously generated statistics "
-                                    "results for the analysis from the given "
-                                    "'<STATS_DIR>'.")
+    stat_opts.add_argument('--stats-use', '--stats-use',
+                           action='store',
+                           default=argparse.SUPPRESS,
+                           dest='stats_dir',
+                           help="Use the previously generated statistics "
+                                "results for the analysis from the given "
+                                "'<STATS_DIR>'.")
 
-        stat_opts.add_argument('--stats',
-                               action='store_true',
-                               default=argparse.SUPPRESS,
-                               dest='stats_enabled',
-                               help="Perform both phases of "
-                                    "Statistical analysis. This phase "
-                                    "generates extra files needed by "
-                                    "statistics analysis and enables "
-                                    "the statistical checkers. "
-                                    "No need to enable them explicitly.")
+    stat_opts.add_argument('--stats',
+                           action="store_true",
+                           default=argparse.SUPPRESS,
+                           dest='stats_enabled',
+                           help="Perform both phases of "
+                                "Statistical analysis. This phase "
+                                "generates extra files needed by "
+                                "statistics analysis and enables "
+                                "the statistical checkers. "
+                                "No need to enable them explicitly.")
 
-        stat_opts.add_argument('--stats-min-sample-count',
-                               action='store',
-                               default="10",
-                               type=int,
-                               dest='stats_min_sample_count',
-                               help="Minimum number of samples (function call"
-                                    " occurrences) to be collected"
-                                    " for a statistics to be relevant "
-                                    "'<MIN-SAMPLE-COUNT>'.")
+    stat_opts.add_argument('--stats-min-sample-count',
+                           action='store',
+                           default="10" if stats_capable
+                                   else argparse.SUPPRESS,
+                           type=int,
+                           dest='stats_min_sample_count',
+                           help="Minimum number of samples (function call"
+                                " occurrences) to be collected"
+                                " for a statistics to be relevant "
+                                "'<MIN-SAMPLE-COUNT>'.")
 
-        stat_opts.add_argument('--stats-relevance-threshold',
-                               action='store',
-                               default="0.85",
-                               type=float,
-                               dest='stats_relevance_threshold',
-                               help="The minimum ratio of calls of function "
-                                    "f that must have a certain property "
-                                    "property to consider it true for that "
-                                    "function (calculated as calls "
-                                    "with a property/all calls)."
-                                    " CodeChecker will warn for"
-                                    " calls of f do not have that property."
-                                    "'<RELEVANCE_THRESHOLD>'.")
+    stat_opts.add_argument('--stats-relevance-threshold',
+                           action='store',
+                           default="0.85" if stats_capable
+                                   else argparse.SUPPRESS,
+                           type=float,
+                           dest='stats_relevance_threshold',
+                           help="The minimum ratio of calls of function "
+                                "f that must have a certain property "
+                                "property to consider it true for that "
+                                "function (calculated as calls "
+                                "with a property/all calls)."
+                                " CodeChecker will warn for"
+                                " calls of f do not have that property."
+                                "'<RELEVANCE_THRESHOLD>'.")
 
     checkers_opts = parser.add_argument_group(
         "checker configuration",
@@ -1109,6 +1111,53 @@ def __transform_deprecated_flags(args):
             'cppcheck:cc-verbatim-args-file=<filepath>" instead.')
 
 
+def check_satisfied_capabilities(args):
+    has_error = False
+    for attr in dir(args):
+        # NOTE: This is a heuristic: there are many arguments for statistics
+        # and for ctu, but conveniently, all of them store to stats* or ctu*
+        # names fields of args. Lets exploit that instead of manually listing
+        # args.
+        if attr.startswith("stats") and not \
+                analyzer_types.is_statistics_capable():
+            LOG.error("Statistics options can only be enabled if clang has "
+                      "statistics checkers available!")
+            LOG.info("CodeChecker has not found Clang Static Analyzer "
+                     "checkers statisticsCollector.ReturnValueCheck and "
+                     "statisticsCollector.SpecialReturnValue")
+            has_error = True
+            break
+        if attr.startswith("ctu") and not \
+                analyzer_types.is_ctu_capable():
+            LOG.error("CrossTranslation Unit options can only be enabled if "
+                      "clang itself supports it!")
+            LOG.info("hint: Clang 8.0.0 is the earliest version to support it")
+            has_error = True
+            break
+
+    if 'ctu_ast_mode' in args and not \
+            analyzer_types.is_ctu_on_demand_available():
+        LOG.error("Clang does not support on-demand Cross Translation Unit"
+                  "analysis!")
+        LOG.info("hint: Clang 11.0.0 is the earliest version to support it")
+        has_error = True
+
+    if args.enable_z3 == 'on' and not analyzer_types.is_z3_capable():
+        LOG.error("Z3 solver cannot be enabled as Clang was not compiled with "
+                  "Z3!")
+        has_error = True
+
+    if args.enable_z3_refutation == 'on' and not \
+            analyzer_types.is_z3_capable():
+        LOG.error("Z3 refutation cannot be enabled as Clang was not compiled "
+                  "with Z3!")
+        has_error = True
+
+    if has_error:
+        LOG.info("hint: Maybe CodeChecker found the wrong analyzer binary?")
+        sys.exit(1)
+
+
 def main(args):
     """
     Perform analysis on the given inputs. Possible inputs are a compilation
@@ -1145,6 +1194,8 @@ def main(args):
     if 'ctu_ast_mode' in args and 'ctu_phases' not in args:
         LOG.error("Analyzer option 'ctu-ast-mode' requires CTU mode enabled")
         sys.exit(1)
+
+    check_satisfied_capabilities(args)
 
     try:
         cmd_config.check_config_file(args)

--- a/analyzer/codechecker_analyzer/cmd/analyze.py
+++ b/analyzer/codechecker_analyzer/cmd/analyze.py
@@ -1142,13 +1142,14 @@ def check_satisfied_capabilities(args):
         LOG.info("hint: Clang 11.0.0 is the earliest version to support it")
         has_error = True
 
-    if args.enable_z3 == 'on' and not analyzer_types.is_z3_capable():
+    if 'enable_z3' in args and args.enable_z3 == 'on' and not \
+            analyzer_types.is_z3_capable():
         LOG.error("Z3 solver cannot be enabled as Clang was not compiled with "
                   "Z3!")
         has_error = True
 
-    if args.enable_z3_refutation == 'on' and not \
-            analyzer_types.is_z3_capable():
+    if 'enable_z3_refutation' in args and args.enable_z3_refutation == 'on' \
+            and not analyzer_types.is_z3_capable():
         LOG.error("Z3 refutation cannot be enabled as Clang was not compiled "
                   "with Z3!")
         has_error = True

--- a/analyzer/codechecker_analyzer/cmd/check.py
+++ b/analyzer/codechecker_analyzer/cmd/check.py
@@ -858,54 +858,6 @@ LLVM/Clang community, and thus discouraged.
         func=main, func_process_config_file=cmd_config.process_config_file)
 
 
-def check_satisfied_capabilities(args):
-    has_error = False
-    for attr in dir(args):
-        # NOTE: This is a heuristic: there are many arguments for statistics
-        # and for ctu, but conveniently, all of them store to stats* or ctu*
-        # names fields of args. Lets exploit that instead of manually listing
-        # args.
-        if attr.startswith("stats") and not \
-                analyzer_types.is_statistics_capable():
-            LOG.error("Statistics options can only be enabled if clang has "
-                      "statistics checkers available!")
-            LOG.info("CodeChecker has not found Clang Static Analyzer "
-                     "checkers statisticsCollector.ReturnValueCheck and "
-                     "statisticsCollector.SpecialReturnValue")
-            has_error = True
-            break
-        if attr.startswith("ctu") and not \
-                analyzer_types.is_ctu_capable():
-            LOG.error("CrossTranslation Unit options can only be enabled if "
-                      "clang itself supports it!")
-            LOG.info("hint: Clang 8.0.0 is the earliest version to support it")
-            has_error = True
-            break
-
-    if 'ctu_ast_mode' in args and not \
-            analyzer_types.is_ctu_on_demand_available():
-        LOG.error("Clang does not support on-demand Cross Translation Unit"
-                  "analysis!")
-        LOG.info("hint: Clang 11.0.0 is the earliest version to support it")
-        has_error = True
-
-    if 'enable_z3' in args and args.enable_z3 == 'on' and not \
-            analyzer_types.is_z3_capable():
-        LOG.error("Z3 solver cannot be enabled as Clang was not compiled with "
-                  "Z3!")
-        has_error = True
-
-    if 'enable_z3_refutation' in args and args.enable_z3_refutation == 'on' \
-            and not analyzer_types.is_z3_capable():
-        LOG.error("Z3 refutation cannot be enabled as Clang was not compiled "
-                  "with Z3!")
-        has_error = True
-
-    if has_error:
-        LOG.info("hint: Maybe CodeChecker found the wrong analyzer binary?")
-        sys.exit(1)
-
-
 def main(args):
     """
     Execute a wrapper over log-analyze-parse, aka 'check'.
@@ -940,7 +892,6 @@ def main(args):
     logfile = None
     analysis_exit_status = 1  # CodeChecker error.
 
-    check_satisfied_capabilities(args)
     try:
         # --- Step 1.: Perform logging if build command was specified.
         if 'command' in args:

--- a/analyzer/tests/functional/z3/test_z3.py
+++ b/analyzer/tests/functional/z3/test_z3.py
@@ -108,7 +108,6 @@ class TestSkeleton(unittest.TestCase):
 
         self.env = env.codechecker_env()
 
-
         test_project_path = self._testproject_data['project_path']
         test_project_build = shlex.split(self._testproject_data['build_cmd'])
         test_project_clean = shlex.split(self._testproject_data['clean_cmd'])

--- a/analyzer/tests/functional/z3/test_z3.py
+++ b/analyzer/tests/functional/z3/test_z3.py
@@ -108,19 +108,6 @@ class TestSkeleton(unittest.TestCase):
 
         self.env = env.codechecker_env()
 
-        # Get if the package is z3 compatible.
-        cmd = [self._codechecker_cmd, 'analyze', '-h']
-        output, _, _ = call_command(cmd, cwd=test_workspace, env=self.env)
-        self.z3_capable = '--z3' in output
-        print(f"'analyze' reported z3 compatibility? {self.z3_capable}")
-
-        if not self.z3_capable:
-            try:
-                self.z3_capable = strtobool(
-                    os.environ['CC_TEST_FORCE_Z3_CAPABLE']
-                )
-            except (ValueError, KeyError):
-                pass
 
         test_project_path = self._testproject_data['project_path']
         test_project_build = shlex.split(self._testproject_data['build_cmd'])
@@ -140,6 +127,24 @@ class TestSkeleton(unittest.TestCase):
             log_cmd, cwd=test_project_path, env=self.env)
         print(output)
         print(err)
+
+        # Get if the package is z3 compatible.
+        cmd = [self._codechecker_cmd,
+               'analyze', 'compile_command.json',
+               '-o', 'reports',
+               '--z3', 'on']
+        test_project_path = self._testproject_data['project_path']
+        output, _, _ = call_command(cmd, cwd=test_project_path, env=self.env)
+        self.z3_capable = 'Z3 solver cannot be enabled' not in output
+        print(f"'analyze' reported z3 compatibility? {self.z3_capable}")
+
+        if not self.z3_capable:
+            try:
+                self.z3_capable = strtobool(
+                    os.environ['CC_TEST_FORCE_Z3_CAPABLE']
+                )
+            except (ValueError, KeyError):
+                pass
 
     def test_z3(self):
         """ Enable z3 during analysis. """

--- a/web/tests/functional/statistics/test_statistics.py
+++ b/web/tests/functional/statistics/test_statistics.py
@@ -116,8 +116,8 @@ class TestSkeleton(unittest.TestCase):
 
         # Clean the test project before logging the compiler commands.
         out, err = call_command(test_project_clean,
-                                   cwd=test_project_path,
-                                   environ=self.env)
+                                cwd=test_project_path,
+                                environ=self.env)
         print(out)
         print(err)
 
@@ -126,8 +126,8 @@ class TestSkeleton(unittest.TestCase):
                    '-b']
         log_cmd.extend(test_project_build)
         out, err = call_command(log_cmd,
-                                   cwd=test_project_path,
-                                   environ=self.env)
+                                cwd=test_project_path,
+                                environ=self.env)
         print(out)
         print(err)
 
@@ -140,10 +140,10 @@ class TestSkeleton(unittest.TestCase):
         out, _ = call_command(cmd, cwd=test_project_path, environ=self.env)
 
         self.stats_capable = \
-                'Statistics options can only be enabled' not in out
+            'Statistics options can only be enabled' not in out
 
         print("'analyze' reported statistics collector-compatibility? " +
-            str(self.stats_capable))
+              str(self.stats_capable))
 
         if not self.stats_capable:
             try:

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -56,7 +56,6 @@ def call_command(cmd, cwd, environ):
         if proc.returncode == 1:
             show(out, err)
             print('Unsuccessful run: "' + ' '.join(cmd) + '"')
-            raise OSError("Unsuccessful run of command.")
         return out, err
     except OSError:
         show(out, err)


### PR DESCRIPTION
One of the great annoyances with any tool, but in particular with CodeChecker is that we have a habit of hiding, suppressing stuff instead of just telling the user whats up. Such is the case with `--stats`, `--ctu`, etc. These flags can only be used if the clang CodeChecker found supports statistics generation or CTU analysis. However, if you try to invoke CodeChecker with an incompatible flag, you get something like this:

```bash
$ CodeChecker analyze compile_commands.json  --stats -o output
usage: CodeChecker [-h] {analyze} ...
CodeChecker: error: unrecognized arguments: --stats
```

That is nuts! Not only do we emit this message, it doesn't even show up in `--help`. How is a user supposed to know about z3 analyses, if we never show it in the first place? If we did, a user might get a hold of a clang that supports it, there is literally zero reason to just outright hide it.

With this patch, all flags that depend on an analyzer tool having a specific capability are displayed by default, and a helpful error message is shown if its not available. Here is an example:

```bash
$ CodeChecker analyze compile_commands.json  --stats -o output
[ERROR 2025-02-20 15:04] - Statistics options can only be enabled if clang has statistics checkers available!
[INFO 2025-02-20 15:04] - CodeChecker has not found Clang Static Analyzer checkers statisticsCollector.ReturnValueCheck and statisticsCollector.SpecialReturnValue
[INFO 2025-02-20 15:04] - hint: Maybe CodeChecker found the wrong analyzer binary?
```

The change is as trivial as it looks, the only thing I changed is that some statistics related option's default value now depends on whether clang is stats capable (similarly to how its always been done for ctu flags), and since the z3 tests checked z3 compliance from CodeChecker's own error message, that needed adjustment as well. In the Z3 tests, the command that runs `CodeChecker anayze` were moved below the part where the compile_commands.json is copied.