### PR TITLE
[tools] bump sarif-tools version from 1.0.0 to 3.0.4

### DIFF
--- a/analyzer/requirements.txt
+++ b/analyzer/requirements.txt
@@ -3,6 +3,6 @@ portalocker==2.2.1
 psutil==5.8.0
 PyYAML==6.0.1
 types-PyYAML==6.0.12.12
-sarif-tools==1.0.0
+sarif-tools==3.0.4
 multiprocess==0.70.15
 setuptools==70.2.0

--- a/tools/report-converter/requirements_py/dev/requirements.txt
+++ b/tools/report-converter/requirements_py/dev/requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.3.1
-sarif-tools==1.0.0
+sarif-tools==3.0.4
 pycodestyle==2.12.0
 pylint==3.2.4
 portalocker==2.2.1

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -8,7 +8,7 @@ thrift==0.13.0
 gitpython==3.1.41
 PyYAML==6.0.1
 types-PyYAML==6.0.12.12
-sarif-tools==1.0.0
+sarif-tools==3.0.4
 
 ./api/py/codechecker_api/dist/codechecker_api.tar.gz
 ./api/py/codechecker_api_shared/dist/codechecker_api_shared.tar.gz


### PR DESCRIPTION
sarif-tools is used to parse sarif results file in Parser class.

v3.0.4 comes with many bug fix, improvements, and new features [1].

[1] https://github.com/microsoft/sarif-tools/releases

Fix #4389