### PR TITLE
Add CWE Top 25 guideline

### DIFF
--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -154,6 +154,13 @@ class TestCmdline(unittest.TestCase):
         """ Listing checkers by guideline. """
 
         checkers_cmd = [env.codechecker_cmd(), 'checkers',
+                        '--guideline', 'cwe-top-25-2024']
+        _, out, _ = run_cmd(checkers_cmd)
+
+        self.assertIn('NonNullParamChecker', out)
+        self.assertNotIn('CastToStruct', out)
+
+        checkers_cmd = [env.codechecker_cmd(), 'checkers',
                         '--guideline', 'sei-cert-cpp']
         _, out, _ = run_cmd(checkers_cmd)
 
@@ -184,7 +191,8 @@ class TestCmdline(unittest.TestCase):
         checkers_cmd = [env.codechecker_cmd(), 'checkers', '--guideline']
         _, out, _ = run_cmd(checkers_cmd)
 
-        self.assertTrue(out.strip().startswith('Guideline: sei-cert'))
+        self.assertTrue(out.strip().startswith('Guideline: cwe-top-25-2024'))
+        self.assertIn('Guideline: sei-cert-cpp', out)
 
     def test_checkers_warnings(self):
         """ Listing checkers for compiler warnings. """

--- a/codechecker_common/guidelines.py
+++ b/codechecker_common/guidelines.py
@@ -23,7 +23,8 @@ class Guidelines:
 
         guideline_yaml_files = map(
             lambda f: os.path.join(guidelines_dir, f),
-            os.listdir(guidelines_dir))
+            filter(lambda f: not f.endswith('.license'),
+                   os.listdir(guidelines_dir)))
 
         self.__all_rules = self.__union_guideline_files(guideline_yaml_files)
 

--- a/config/guidelines/cwe-top-25-2024.yaml
+++ b/config/guidelines/cwe-top-25-2024.yaml
@@ -1,0 +1,78 @@
+guideline: cwe-top-25-2024
+guideline_title: CWE Top 25 Most Dangerous Software Weaknesses 2024
+rules:
+- rule_id: cwe-20
+  rule_title: Improper Input Validation
+  rule_url: https://cwe.mitre.org/data/definitions/20.html
+- rule_id: cwe-22
+  rule_title: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+  rule_url: https://cwe.mitre.org/data/definitions/22.html
+- rule_id: cwe-77
+  rule_title: Improper Neutralization of Special Elements used in a Command ('Command Injection')
+  rule_url: https://cwe.mitre.org/data/definitions/77.html
+- rule_id: cwe-78
+  rule_title: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+  rule_url: https://cwe.mitre.org/data/definitions/78.html
+- rule_id: cwe-79
+  rule_title: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+  rule_url: https://cwe.mitre.org/data/definitions/79.html
+- rule_id: cwe-89
+  rule_title: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+  rule_url: https://cwe.mitre.org/data/definitions/89.html
+- rule_id: cwe-94
+  rule_title: Improper Control of Generation of Code ('Code Injection')
+  rule_url: https://cwe.mitre.org/data/definitions/94.html
+- rule_id: cwe-119
+  rule_title: Improper Restriction of Operations within the Bounds of a Memory Buffer
+  rule_url: https://cwe.mitre.org/data/definitions/119.html
+- rule_id: cwe-125
+  rule_title: Out-of-bounds Read
+  rule_url: https://cwe.mitre.org/data/definitions/125.html
+- rule_id: cwe-190
+  rule_title: Integer Overflow or Wraparound
+  rule_url: https://cwe.mitre.org/data/definitions/190.html
+- rule_id: cwe-200
+  rule_title: Exposure of Sensitive Information to an Unauthorized Actor
+  rule_url: https://cwe.mitre.org/data/definitions/200.html
+- rule_id: cwe-269
+  rule_title: Improper Privilege Management
+  rule_url: https://cwe.mitre.org/data/definitions/269.html
+- rule_id: cwe-287
+  rule_title: Improper Authentication
+  rule_url: https://cwe.mitre.org/data/definitions/287.html
+- rule_id: cwe-306
+  rule_title: Missing Authentication for Critical Function
+  rule_url: https://cwe.mitre.org/data/definitions/306.html
+- rule_id: cwe-352
+  rule_title: Cross-Site Request Forgery (CSRF)
+  rule_url: https://cwe.mitre.org/data/definitions/352.html
+- rule_id: cwe-400
+  rule_title: Uncontrolled Resource Consumption
+  rule_url: https://cwe.mitre.org/data/definitions/400.html
+- rule_id: cwe-416
+  rule_title: Use After Free
+  rule_url: https://cwe.mitre.org/data/definitions/416.html
+- rule_id: cwe-434
+  rule_title: Unrestricted Upload of File with Dangerous Type
+  rule_url: https://cwe.mitre.org/data/definitions/434.html
+- rule_id: cwe-476
+  rule_title: NULL Pointer Dereference
+  rule_url: https://cwe.mitre.org/data/definitions/476.html
+- rule_id: cwe-502
+  rule_title: Deserialization of Untrusted Data
+  rule_url: https://cwe.mitre.org/data/definitions/502.html
+- rule_id: cwe-787
+  rule_title: Out-of-bounds Write
+  rule_url: https://cwe.mitre.org/data/definitions/787.html
+- rule_id: cwe-798
+  rule_title: Use of Hard-coded Credentials
+  rule_url: https://cwe.mitre.org/data/definitions/798.html
+- rule_id: cwe-862
+  rule_title: Missing Authorization
+  rule_url: https://cwe.mitre.org/data/definitions/862.html
+- rule_id: cwe-863
+  rule_title: Incorrect Authorization
+  rule_url: https://cwe.mitre.org/data/definitions/863.html
+- rule_id: cwe-918
+  rule_title: Server-Side Request Forgery (SSRF)
+  rule_url: https://cwe.mitre.org/data/definitions/918.html

--- a/config/guidelines/mitre.license
+++ b/config/guidelines/mitre.license
@@ -1,0 +1,44 @@
+cwe-top-25-2024.yaml is under MITRE license.
+https://cwe.mitre.org/about/termsofuse.html
+
+Terms of Use
+
+CWE™ is free to use by any organization or individual for any research,
+development, and/or commercial purposes, per these CWE Terms of Use.
+Accordingly, The MITRE Corporation hereby grants you a non-exclusive,
+royalty-free license to use CWE for research, development, and commercial
+purposes. Any copy you make for such purposes is authorized on the condition
+that you reproduce MITRE’s copyright designation and this license in any such
+copy. CWE is a trademark of The MITRE Corporation. Please contact
+cwe@mitre.org if you require further clarification on this issue.
+
+DISCLAIMERS
+
+By accessing information through this site you (as “the user”) hereby agrees
+the site and the information is provided on an “as is” basis only without
+warranty of any kind, express or implied, including but not limited to implied
+warranties of merchantability, availability, accuracy, noninfringement, or
+fitness for a particular purpose. Use of this site and the information is at
+the user’s own risk. The user shall comply with all applicable laws, rules, and
+ regulations, and the data source’s restrictions, when using the site.
+
+By contributing information to this site you (as “the contributor”) hereby
+represents and warrants the contributor has obtained all necessary permissions
+from copyright holders and other third parties to allow the contributor to
+contribute, and this site to host and display, the information and any such
+contribution, hosting, and displaying will not violate any law, rule, or
+regulation. Additionally, the contributor hereby grants all users of such
+information a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute such information and all
+derivative works.
+
+The MITRE Corporation expressly disclaims any liability for any damages
+arising  from the contributor’s contribution of such information, the user’s
+use of  the site or such information, and The MITRE Corporation’s hosting the
+tool and displaying the information. The foregoing disclaimer specifically
+includes but is not limited to general, consequential, indirect, incidental,
+exemplary, or special or punitive damages (including but not limited to loss
+of income, program interruption, loss of information, or other pecuniary loss)
+arising out of use of this information, no matter the cause of action, even if
+The MITRE Corporation has been advised of the possibility of such damages.

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -344,9 +344,11 @@
     ],
     "bugprone-infinite-loop": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/infinite-loop.html",
+      "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "severity:MEDIUM"
     ],
     "bugprone-integer-division": [
@@ -438,10 +440,12 @@
     ],
     "bugprone-narrowing-conversions": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/narrowing-conversions.html",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-190",
       "sei-cert-c:exp45-c",
       "sei-cert-c:fio34-c",
       "sei-cert-c:flp34-c",
@@ -563,11 +567,13 @@
     ],
     "bugprone-sizeof-expression": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/sizeof-expression.html",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-190",
       "sei-cert-c:mem35-c",
       "severity:HIGH"
     ],
@@ -784,10 +790,14 @@
     ],
     "bugprone-unsafe-functions": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unsafe-functions.html",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "sei-cert-c:msc24-c",
       "sei-cert-c:msc33-c",
       "severity:LOW"
@@ -1011,6 +1021,10 @@
     ],
     "cert-msc24-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc24-c.html",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "severity:LOW"
     ],
     "cert-msc30-c": [
@@ -1023,6 +1037,10 @@
     ],
     "cert-msc33-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc33-c.html",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "severity:LOW"
     ],
     "cert-msc50-cpp": [
@@ -1464,6 +1482,8 @@
     ],
     "clang-diagnostic-builtin-memcpy-chk-size": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-memcpy-chk-size",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-119",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-builtin-requires-header": [
@@ -2609,11 +2629,13 @@
     ],
     "clang-diagnostic-format-security": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wformat-security",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-20",
       "sei-cert-c:fio30-c",
       "severity:MEDIUM"
     ],
@@ -2653,6 +2675,8 @@
     ],
     "clang-diagnostic-fortify-source": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wfortify-source",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-119",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-four-char-constants": [
@@ -3067,11 +3091,15 @@
     ],
     "clang-diagnostic-incompatible-pointer-types": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-pointer-types",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "sei-cert-c:exp32-c",
       "severity:MEDIUM"
     ],
@@ -3211,6 +3239,8 @@
     ],
     "clang-diagnostic-integer-overflow": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#winteger-overflow",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-interrupt-service-routine": [
@@ -4823,6 +4853,8 @@
     ],
     "clang-diagnostic-shift-count-overflow": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-overflow",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-shift-negative-value": [
@@ -4838,14 +4870,20 @@
     ],
     "clang-diagnostic-shift-overflow": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wshift-overflow",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-shift-sign-overflow": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wshift-sign-overflow",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-shorten-64-to-32": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wshorten-64-to-32",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-sign-compare": [
@@ -4857,6 +4895,8 @@
     ],
     "clang-diagnostic-sign-conversion": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wsign-conversion",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-sign-promo": [
@@ -5078,6 +5118,8 @@
     ],
     "clang-diagnostic-strncat-size": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wstrncat-size",
+      "guideline:cwe-top-25-2024",
+      "cwe-top-25-2024:cwe-119",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-suggest-destructor-override": [
@@ -5106,9 +5148,11 @@
     ],
     "clang-diagnostic-switch": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wswitch",
+      "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-190",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-switch-bool": [

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -322,23 +322,27 @@
     ],
     "core.BitwiseShift": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift-c-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-190",
       "sei-cert-c:int32-c",
       "sei-cert-c:int34-c",
       "severity:HIGH"
     ],
     "core.CallAndMessage": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage-c-c-objc",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "sei-cert-c:dcl41-c",
       "sei-cert-c:exp30-c",
       "sei-cert-c:exp33-c",
@@ -372,11 +376,13 @@
     ],
     "core.NonNullParamChecker": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker-c-c-objc",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "sei-cert-c:exp34-c",
       "severity:HIGH"
     ],
@@ -387,11 +393,13 @@
     ],
     "core.NullDereference": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference-c-c-objc",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "sei-cert-c:exp34-c",
       "severity:HIGH"
     ],
@@ -433,11 +441,13 @@
     ],
     "core.VLASize": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
       "sei-cert-c:arr32-c",
       "severity:HIGH"
     ],
@@ -455,11 +465,13 @@
     ],
     "core.uninitialized.ArraySubscript": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
       "sei-cert-c:exp33-c",
       "severity:HIGH"
     ],
@@ -495,11 +507,13 @@
     ],
     "core.uninitialized.NewArraySize": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
       "sei-cert-c:exp33-c",
       "severity:HIGH"
     ],
@@ -525,31 +539,37 @@
     ],
     "cplusplus.InnerPointer": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "sei-cert-cpp:mem50-cpp",
       "sei-cert-cpp:str52-cpp",
       "severity:HIGH"
     ],
     "cplusplus.Move": [
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "sei-cert-cpp:exp63-cpp",
       "severity:HIGH"
     ],
     "cplusplus.NewDelete": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "sei-cert-cpp:exp54-cpp",
       "sei-cert-cpp:mem50-cpp",
       "sei-cert-cpp:mem51-cpp",
@@ -599,11 +619,14 @@
     ],
     "cplusplus.StringChecker": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-476",
       "sei-cert-cpp:str51-cpp",
       "severity:HIGH"
     ],
@@ -684,9 +707,11 @@
     ],
     "nullability.NullReturnedFromNonnull": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull-objc",
+      "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "severity:HIGH"
     ],
     "nullability.NullabilityBase": [
@@ -776,8 +801,16 @@
     ],
     "optin.taint.GenericTaint": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint-c-c",
+      "guideline:cwe-top-25-2024",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-20",
+      "cwe-top-25-2024:cwe-22",
+      "cwe-top-25-2024:cwe-77",
+      "cwe-top-25-2024:cwe-78",
+      "cwe-top-25-2024:cwe-79",
+      "cwe-top-25-2024:cwe-89",
+      "cwe-top-25-2024:cwe-94",
       "severity:HIGH"
     ],
     "optin.taint.TaintedAlloc": [
@@ -883,6 +916,17 @@
     "osx.coreFoundation.containers.PointerSizedValues": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues-c"
     ],
+    "security.ArrayBound": [
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-arraybound-c-c",
+      "guideline:cwe-top-25-2024",
+      "profile:default",
+      "profile:security",
+      "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
+      "severity:HIGH"
+    ],
     "security.FloatLoopCounter": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter-c",
       "guideline:sei-cert-c",
@@ -903,11 +947,13 @@
     ],
     "security.PointerSub": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-pointersub-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
       "sei-cert-c:arr36-c",
       "severity:HIGH"
     ],
@@ -984,11 +1030,15 @@
     ],
     "security.insecureAPI.gets": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "sei-cert-c:str31-c",
       "severity:MEDIUM"
     ],
@@ -1015,10 +1065,14 @@
     ],
     "security.insecureAPI.strcpy": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:extreme",
       "profile:security",
       "sei-cert-c:str31-c",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-787",
       "severity:MEDIUM"
     ],
     "security.insecureAPI.vfork": [
@@ -1063,11 +1117,15 @@
     ],
     "unix.Malloc": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-20",
+      "cwe-top-25-2024:cwe-400",
+      "cwe-top-25-2024:cwe-416",
       "sei-cert-c:mem30-c",
       "sei-cert-c:mem31-c",
       "sei-cert-c:mem34-c",
@@ -1077,11 +1135,13 @@
     ],
     "unix.MallocSizeof": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-190",
       "sei-cert-c:mem35-c",
       "severity:MEDIUM"
     ],
@@ -1097,11 +1157,16 @@
     ],
     "unix.StdCLibraryFunctions": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-119",
+      "cwe-top-25-2024:cwe-125",
+      "cwe-top-25-2024:cwe-476",
+      "cwe-top-25-2024:cwe-787",
       "sei-cert-c:arr38-c",
       "sei-cert-c:err33-c",
       "sei-cert-c:pos52-c",
@@ -1109,11 +1174,13 @@
     ],
     "unix.Stream": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-400",
       "sei-cert-c:fio42-c",
       "severity:MEDIUM"
     ],
@@ -1144,11 +1211,13 @@
     ],
     "unix.cstring.NullArg": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg-c",
+      "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-476",
       "sei-cert-c:exp34-c",
       "severity:HIGH"
     ],

--- a/config/labels/descriptions.json
+++ b/config/labels/descriptions.json
@@ -15,6 +15,7 @@
     "UNSPECIFIED": "Checker severity is not specified for a checker."
   },
   "guideline": {
+    "cwe-top-25-2024": "https://cwe.mitre.org/top25/",
     "sei-cert-c": "https://wiki.sei.cmu.edu/confluence/display/c/SEI+CERT+C+Coding+Standard",
     "sei-cert-cpp": "https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88046682",
     "misra-c": "https://www.misra.org.uk/"

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -171,6 +171,11 @@ export default {
         id: "sei-cert-cpp",
         name: "SEI CERT Coding Standard (C++)",
         value: 1
+      },
+      {
+        id: "cwe-top-25-2024",
+        name: "CWE Top 25 Most Dangerous Software Weaknesses 2024",
+        value: 2
       }
     ];
 
@@ -185,7 +190,7 @@ export default {
       runs: null,
       runData: [],
       selectedCheckerName: null,
-      selectedGuidelineIndexes: [ 0, 1 ],
+      selectedGuidelineIndexes: [ 0, 1, 2 ],
       showRuns: {
         enabled: false,
         disabled: false,


### PR DESCRIPTION
Introduce the cwe-top-25 guideline to CodeChecker, which consists of the corresponding clang and clang-tidy checkers of the CWE Top 25 Most Dangerous Software Weaknesses.