### PR TITLE
[fix] CodeChecker checkers --label option:value doesn't list checkers

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/checkers.py
+++ b/analyzer/codechecker_analyzer/cmd/checkers.py
@@ -243,13 +243,14 @@ def __get_detailed_checker_info(
             if args.profile not in available_profiles:
                 LOG.error("Checker profile '%s' does not exist!",
                           args.profile)
-                LOG.error("To list available profiles, use '--profile list'.")
+                LOG.error("To list available profiles, use '--profile' "
+                          "without argument.")
                 sys.exit(1)
 
             profile_checkers.append((f'profile:{args.profile}', True))
 
         if 'label' in args:
-            profile_checkers.extend((label, True) for label in args.label)
+            profile_checkers.append((args.label, True))
 
         if 'severity' in args:
             profile_checkers.append((f'severity:{args.severity}', True))

--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -128,6 +128,31 @@ class TestCmdline(unittest.TestCase):
         self.assertEqual(0, out[0])
         self.assertEqual(True, "default" in out[1])
 
+    def test_checkers_label(self):
+        """ Listing checkers with given label. """
+
+        checkers_cmd = [env.codechecker_cmd(), 'checkers', '--label']
+        exit_code, out, _ = run_cmd(checkers_cmd)
+        self.assertEqual(0, exit_code)
+        self.assertIn('profile', out)
+        self.assertIn('severity', out)
+        self.assertIn('guideline', out)
+
+        checkers_cmd = [
+            env.codechecker_cmd(), 'checkers', '--label', 'severity']
+        exit_code, out, _ = run_cmd(checkers_cmd)
+        self.assertEqual(0, exit_code)
+        self.assertIn('HIGH', out)
+        self.assertIn('MEDIUM', out)
+        self.assertIn('LOW', out)
+
+        checkers_cmd = [
+            env.codechecker_cmd(), 'checkers', '--label', 'severity:HIGH']
+        exit_code, out, _ = run_cmd(checkers_cmd)
+        self.assertEqual(0, exit_code)
+        self.assertIn('core.DivideZero', out)
+        self.assertIn('core.CallAndMessage', out)
+
     def test_analyzers(self):
         """ Listing available analyzers. """
 


### PR DESCRIPTION
--labels flag is working properly in these cases:

CodeChecker checkers --label
CodeChecker checkers --label severity

But doesn't work in this case:

CodeChecker checkers --label severity:HIGH

This bug is now fixed.