### PR TITLE
[feat] Adding rule title column for Guideline stat

### DIFF
--- a/analyzer/tests/unit/test_guidelines.py
+++ b/analyzer/tests/unit/test_guidelines.py
@@ -35,28 +35,28 @@ class TestGuidelines(unittest.TestCase):
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON50-CPP.+Do+not+destroy+a+mutex"
                                 "+while+it+is+locked",
-                    "rule_title": ""
+                    "title": ""
                 },
                 {
                     "rule_id": "con51-cpp",
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON51-CPP.+Ensure+actively+held+"
                                 "locks+are+released+on+exceptional+conditions",
-                    "rule_title": ""
+                    "title": ""
                 },
                 {
                     "rule_id": "con52-cpp",
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON52-CPP.+Prevent+data+races+when"
                                 "+accessing+bit-fields+from+multiple+threads",
-                    "rule_title": ""
+                    "title": ""
                 },
                 {
                     "rule_id": "con53-cpp",
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON53-CPP.+Avoid+deadlock+by+"
                                 "locking+in+a+predefined+order",
-                    "rule_title": ""
+                    "title": ""
                 },
             ]
         }
@@ -81,24 +81,24 @@ class TestGuidelines(unittest.TestCase):
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON50-CPP.+Do+not+destroy+a+mutex"
                                 "+while+it+is+locked",
-                    "rule_title": ""
+                    "title": ""
                 },
                 "con51-cpp": {
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON51-CPP.+Ensure+actively+held+"
                                 "locks+are+released+on+exceptional+conditions",
-                    "rule_title": ""
+                    "title": ""
                 },
                 "con52-cpp": {
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON52-CPP.+Prevent+data+races+when"
                                 "+accessing+bit-fields+from+multiple+threads",
-                    "rule_title": ""
+                    "title": ""
                 },
                 "con53-cpp": {
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"
                                 "/cplusplus/CON53-CPP.+Avoid+deadlock+by+"
                                 "locking+in+a+predefined+order",
-                    "rule_title": ""
+                    "title": ""
                 },
             })

--- a/config/guidelines/cwe-top-25-2024.yaml
+++ b/config/guidelines/cwe-top-25-2024.yaml
@@ -2,77 +2,77 @@ guideline: cwe-top-25-2024
 guideline_title: CWE Top 25 Most Dangerous Software Weaknesses 2024
 rules:
 - rule_id: cwe-20
-  rule_title: Improper Input Validation
+  title: Improper Input Validation
   rule_url: https://cwe.mitre.org/data/definitions/20.html
 - rule_id: cwe-22
-  rule_title: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+  title: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
   rule_url: https://cwe.mitre.org/data/definitions/22.html
 - rule_id: cwe-77
-  rule_title: Improper Neutralization of Special Elements used in a Command ('Command Injection')
+  title: Improper Neutralization of Special Elements used in a Command ('Command Injection')
   rule_url: https://cwe.mitre.org/data/definitions/77.html
 - rule_id: cwe-78
-  rule_title: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+  title: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
   rule_url: https://cwe.mitre.org/data/definitions/78.html
 - rule_id: cwe-79
-  rule_title: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+  title: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
   rule_url: https://cwe.mitre.org/data/definitions/79.html
 - rule_id: cwe-89
-  rule_title: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+  title: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
   rule_url: https://cwe.mitre.org/data/definitions/89.html
 - rule_id: cwe-94
-  rule_title: Improper Control of Generation of Code ('Code Injection')
+  title: Improper Control of Generation of Code ('Code Injection')
   rule_url: https://cwe.mitre.org/data/definitions/94.html
 - rule_id: cwe-119
-  rule_title: Improper Restriction of Operations within the Bounds of a Memory Buffer
+  title: Improper Restriction of Operations within the Bounds of a Memory Buffer
   rule_url: https://cwe.mitre.org/data/definitions/119.html
 - rule_id: cwe-125
-  rule_title: Out-of-bounds Read
+  title: Out-of-bounds Read
   rule_url: https://cwe.mitre.org/data/definitions/125.html
 - rule_id: cwe-190
-  rule_title: Integer Overflow or Wraparound
+  title: Integer Overflow or Wraparound
   rule_url: https://cwe.mitre.org/data/definitions/190.html
 - rule_id: cwe-200
-  rule_title: Exposure of Sensitive Information to an Unauthorized Actor
+  title: Exposure of Sensitive Information to an Unauthorized Actor
   rule_url: https://cwe.mitre.org/data/definitions/200.html
 - rule_id: cwe-269
-  rule_title: Improper Privilege Management
+  title: Improper Privilege Management
   rule_url: https://cwe.mitre.org/data/definitions/269.html
 - rule_id: cwe-287
-  rule_title: Improper Authentication
+  title: Improper Authentication
   rule_url: https://cwe.mitre.org/data/definitions/287.html
 - rule_id: cwe-306
-  rule_title: Missing Authentication for Critical Function
+  title: Missing Authentication for Critical Function
   rule_url: https://cwe.mitre.org/data/definitions/306.html
 - rule_id: cwe-352
-  rule_title: Cross-Site Request Forgery (CSRF)
+  title: Cross-Site Request Forgery (CSRF)
   rule_url: https://cwe.mitre.org/data/definitions/352.html
 - rule_id: cwe-400
-  rule_title: Uncontrolled Resource Consumption
+  title: Uncontrolled Resource Consumption
   rule_url: https://cwe.mitre.org/data/definitions/400.html
 - rule_id: cwe-416
-  rule_title: Use After Free
+  title: Use After Free
   rule_url: https://cwe.mitre.org/data/definitions/416.html
 - rule_id: cwe-434
-  rule_title: Unrestricted Upload of File with Dangerous Type
+  title: Unrestricted Upload of File with Dangerous Type
   rule_url: https://cwe.mitre.org/data/definitions/434.html
 - rule_id: cwe-476
-  rule_title: NULL Pointer Dereference
+  title: NULL Pointer Dereference
   rule_url: https://cwe.mitre.org/data/definitions/476.html
 - rule_id: cwe-502
-  rule_title: Deserialization of Untrusted Data
+  title: Deserialization of Untrusted Data
   rule_url: https://cwe.mitre.org/data/definitions/502.html
 - rule_id: cwe-787
-  rule_title: Out-of-bounds Write
+  title: Out-of-bounds Write
   rule_url: https://cwe.mitre.org/data/definitions/787.html
 - rule_id: cwe-798
-  rule_title: Use of Hard-coded Credentials
+  title: Use of Hard-coded Credentials
   rule_url: https://cwe.mitre.org/data/definitions/798.html
 - rule_id: cwe-862
-  rule_title: Missing Authorization
+  title: Missing Authorization
   rule_url: https://cwe.mitre.org/data/definitions/862.html
 - rule_id: cwe-863
-  rule_title: Incorrect Authorization
+  title: Incorrect Authorization
   rule_url: https://cwe.mitre.org/data/definitions/863.html
 - rule_id: cwe-918
-  rule_title: Server-Side Request Forgery (SSRF)
+  title: Server-Side Request Forgery (SSRF)
   rule_url: https://cwe.mitre.org/data/definitions/918.html

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -229,6 +229,7 @@ export default {
                 guidelineName: guideline,
                 guidelineRule: rule.ruleId,
                 guidelineUrl: rule.url,
+                guidelineRuleTitle: rule.title,
                 checkers: filtered_stat.length
                   ? filtered_stat.map(checkerId => {
                     return {

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
@@ -1,6 +1,6 @@
 <template>
   <base-statistics-table
-    :headers="headers"
+    :headers="tableHeaders"
     :items="items"
     :loading="loading"
     :mobile-breakpoint="1000"
@@ -37,6 +37,10 @@ export default {
           value: "guidelineRule"
         },
         {
+          text: "Title",
+          value: "guidelineRuleTitle"
+        },
+        {
           text: "Related Checker(s)",
           value: "checkers.name"
         },
@@ -63,6 +67,25 @@ export default {
       ]
     };
   },
+
+  computed: {
+    hasTitle() {
+      return this.items.some(item => item.guidelineRuleTitle);
+    },
+
+    tableHeaders() {
+      if (!this.headers) return;
+
+      return this.headers.filter(header => {
+        if (header.value === "guidelineRuleTitle") {
+          return this.hasTitle;
+        }
+
+        return true;
+      });
+    }
+  },
+
   methods: {
     enabledClick(type, checker_name) {
       this.$emit("enabled-click", type, checker_name);


### PR DESCRIPTION
It's a minor feature for Guideline stat to have rule title column. The `Title` column on the Guideline stat page is disappeared when there is no title for any rule.