### PR TITLE
[Refactor] Guideline stat parser

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -52,7 +52,7 @@
 
         <div v-if="!problematicRuns.length">
           <v-row align="center">
-            <v-col cols="3">
+            <v-col cols="6">
               <v-select
                 v-model="selectedGuidelineIndexes"
                 :items="guidelineOptions"
@@ -60,8 +60,14 @@
                 label="Select guidelines"
                 outlined
                 multiple
-                dense
-              />
+                density="comfortable"
+              >
+                <template v-slot:selection="{ item }">
+                  <div class="selection-item">
+                    {{ item.name }}
+                  </div>
+                </template>
+              </v-select>
             </v-col>
           </v-row>
           <guideline-statistics-table
@@ -282,6 +288,7 @@ export default {
           const value = [
             stat.guidelineName,
             stat.guidelineRule,
+            stat.guidelineRuleTitle,
             checker.name,
             this.severityFromCodeToString(checker.severity),
             checker.enabledInAllRuns
@@ -297,7 +304,7 @@ export default {
 
       const data = [
         [
-          "Guideline Name", "Rule Name", "Related Checker(s)",
+          "Guideline Name", "Rule Name", "Rule Title", "Related Checker(s)",
           "Checker Severity", "Checker Status", "Closed Reports",
           "Outstanding Reports"
         ],
@@ -313,45 +320,53 @@ export default {
           this.selectedGuidelines,
           handleThriftError(async guidelines => {
             for (const [ guideline, rules ] of Object.entries(guidelines)) {
-              guidelines[guideline] = await Promise.all(
-                rules.map(async rule => {
-                  const checkers = await Promise.all(
-                    rule.checkers.map(async checker => {
-                      const severity = await new Promise(resolve => {
-                        ccService.getClient().getCheckerLabels(
-                          [
-                            new Checker({
-                              analyzerName: null,
-                              checkerId: checker
-                            })
-                          ],
-                          handleThriftError(labels => {
-                            const severityLabels = labels[0].filter(param =>
-                              param.startsWith("severity")
-                            );
-                            const severity = severityLabels.length
-                              ? severityLabels[0].split("severity:")[1]
-                              : null;
-                            resolve(severity);
-                          })
+              const all_checkers = [];
+              rules.forEach(rule => {
+                rule.checkers.map(checker => {
+                  const chk = new Checker({
+                    analyzerName: null,
+                    checkerId: checker
+                  });
+
+                  if (!all_checkers.some(
+                    c => c.checkerId === chk.checkerId)) {
+                    all_checkers.push(chk);
+                  }
+                });
+              });
+
+              const checkers_with_severity = await new Promise(resolve => {
+                ccService.getClient().getCheckerLabels(
+                  all_checkers, handleThriftError(labels => {
+                    resolve(
+                      labels.map((label, i) => {
+                        const severityLabels = label.filter(param =>
+                          param.startsWith("severity")
                         );
-                      });
+                        return severityLabels.length
+                          ? {
+                            checkerName: all_checkers[i].checkerId,
+                            severity: severityLabels[0].split("severity:")[1]
+                          }
+                          : {
+                            checkerName: all_checkers[i].checkerId,
+                            severity: null
+                          };
+                      })
+                    );
+                  })
+                );
+              });
 
-                      return {
-                        checkerName: checker,
-                        severity: severity
-                      };
-                    })
-                  );
-
-                  return {
-                    ruleId: rule.ruleId,
-                    title: rule.title,
-                    url: rule.url,
-                    checkers: checkers
-                  };
-                })
-              );
+              guidelines[guideline] = rules.map(rule => {
+                return {
+                  ruleId: rule.ruleId,
+                  title: rule.title,
+                  url: rule.url,
+                  checkers: checkers_with_severity.filter(
+                    cws => rule.checkers.includes(cws.checkerName))
+                };
+              });
             }
 
             resolve(guidelines);
@@ -491,3 +506,10 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+  .selection-item {
+    display: block;
+    width: 100%;
+  }
+</style>

--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -90,9 +90,9 @@
               example <code>CodeChecker analyze -e security command</code> is
               ambiguous as <code>security</code> is a checker group (all
               checkers starting with <code>security</code>), and a profile at
-              the same time. Please define explicitly <code>CodeChecker -e
-              prefix:security</code> if you mean the prefix group, or
-              <code>profile:security</code> if you mean the security profile.
+              the same time. Please define explicitly <code>CodeChecker -e prefix:security</code>
+              if you mean the prefix group, or <code>profile:security</code>
+              if you mean the security profile.
             </p>
             <p>
               <code>CodeChecker -e clang-diagnostic-format</code> will give an
@@ -116,8 +116,8 @@
               <code>guideline:</code> - to match checkers belonging to a guideline
               <br>
               <code>severity:</code> - to match checkers belonging to a given severity
-              </p>
-              <br>
+            </p>
+            <br>
             <p>
               <b>The skip file handling was changed</b>
             </p>
@@ -130,7 +130,7 @@
               By default CodeChecker used to filter out all reports from files
               which were on the skip list. This can hide true positive reports
               starting from unskipped code and ending in skipped files (typical
-               with CTU and header related findings). This patch removes the
+              with CTU and header related findings). This patch removes the
               default report filtering post processing step from
               <code>CodeChecker analyze --skip SKIPFILE</code> operation.
               The legacy functionality is still available with the
@@ -152,8 +152,7 @@
             <p>
               Clang warnings only appear as <code>clang-diagnostic-*</code>
               checkers and they can be enabled using the standard checker
-              checker on/off mechanism e.g. <code>CodeChecker analyze -e
-              clang-diagnostic-unused-function</code>
+              checker on/off mechanism e.g. <code>CodeChecker analyze -e clang-diagnostic-unused-function</code>
             </p>
           </new-feature-item>
         </new-release-item>


### PR DESCRIPTION
Speeding up guideline stat parser to have a efficient solution and better UX.

It is not neccessary to create an API request for each checker when the severity is needed to match the ceckers. Only one API request/guideline type is sufficient.

There are some other minor fixes in this PR: solving html indent warrning for NewFeatures and exporting guideline stat to csv with rule title.