### PR TITLE
Fix pypi.yml action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -75,7 +75,6 @@ jobs:
         run:
           sudo apt-get update && sudo apt-get install g++-13 clang clang-tidy cppcheck
         # https://github.com/facebook/infer/blob/main/docker/1.1.0/Dockerfile
-        run:
           INFER_VERSION=v1.2.0; \
           cd /opt && \
           curl -sL \


### PR DESCRIPTION
Fix the action by removing 2nd `run:`. Currently the action is complaining:
![image](https://github.com/user-attachments/assets/9c15a053-c3d8-4c95-ae23-c14c06302667)
