### PR TITLE
Add OWASP Top 10 guideline

### DIFF
--- a/config/guidelines/owasp-top-10-2021.yaml
+++ b/config/guidelines/owasp-top-10-2021.yaml
@@ -1,0 +1,33 @@
+guideline: owasp-top-10-2021
+guideline_title: OWASP Top 10 Web Application Security Risks 2021
+rules:
+- rule_id: owasp-A01-2021
+  title: Broken Access Control
+  rule_url: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- rule_id: owasp-A02-2021
+  title: Cryptographic Failures
+  rule_url: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
+- rule_id: owasp-A03-2021
+  title: Injection
+  rule_url: https://owasp.org/Top10/A03_2021-Injection/
+- rule_id: owasp-A04-2021
+  title: Insecure Design
+  rule_url: https://owasp.org/Top10/A04_2021-Insecure_Design/
+- rule_id: owasp-A05-2021
+  title: Security Misconfiguration
+  rule_url: https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
+- rule_id: owasp-A06-2021
+  title: Vulnerable and Outdated Components
+  rule_url: https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
+- rule_id: owasp-A07-2021
+  title: Identification and Authentication Failures
+  rule_url: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+- rule_id: owasp-A08-2021
+  title: Software and Data Integrity Failures
+  rule_url: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
+- rule_id: owasp-A09-2021
+  title: Security Logging and Monitoring Failures
+  rule_url: https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/
+- rule_id: owasp-A10-2021
+  title: Server-Side Request Forgery (SSRF)
+  rule_url: https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -139,6 +139,8 @@
     ],
     "android-cloexec-open": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-open.html",
+      "guideline:owasp-top-10-2021",
+      "owasp-top-10-2021:owasp-A01-2021",
       "severity:HIGH"
     ],
     "android-cloexec-pipe": [
@@ -649,11 +651,13 @@
     "bugprone-suspicious-memset-usage": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-memset-usage.html",
       "guideline:sei-cert-c",
+      "guideline:owasp-top-10-2021",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:int31-c",
+      "owasp-top-10-2021:owasp-A04-2021",
       "severity:HIGH"
     ],
     "bugprone-suspicious-missing-comma": [
@@ -743,12 +747,14 @@
     "bugprone-undefined-memory-manipulation": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/undefined-memory-manipulation.html",
       "guideline:sei-cert-cpp",
+      "guideline:owasp-top-10-2021",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-cpp:exp62-cpp",
       "sei-cert-cpp:oop57-cpp",
+      "owasp-top-10-2021:owasp-A01-2021",
       "severity:MEDIUM"
     ],
     "bugprone-undelegated-constructor": [
@@ -792,6 +798,7 @@
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unsafe-functions.html",
       "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
@@ -800,6 +807,7 @@
       "cwe-top-25-2024:cwe-787",
       "sei-cert-c:msc24-c",
       "sei-cert-c:msc33-c",
+      "owasp-top-10-2021:owasp-A04-2021",
       "severity:LOW"
     ],
     "bugprone-unused-local-non-trivial-variable": [
@@ -923,10 +931,12 @@
     "cert-env33-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/env33-c.html",
       "guideline:sei-cert-c",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:env33-c",
+      "owasp-top-10-2021:owasp-A03-2021",
       "severity:MEDIUM"
     ],
     "cert-err09-cpp": [
@@ -1029,10 +1039,14 @@
     ],
     "cert-msc30-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc30-c.html",
+      "guideline:owasp-top-10-2021",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:LOW"
     ],
     "cert-msc32-c": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc32-c.html",
+      "guideline:owasp-top-10-2021",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:MEDIUM"
     ],
     "cert-msc33-c": [
@@ -1047,22 +1061,26 @@
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc50-cpp.html",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:msc30-c",
       "sei-cert-cpp:msc50-cpp",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:LOW"
     ],
     "cert-msc51-cpp": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/msc51-cpp.html",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:msc32-c",
       "sei-cert-cpp:msc51-cpp",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:MEDIUM"
     ],
     "cert-msc54-cpp": [
@@ -5897,8 +5915,10 @@
     "concurrency-mt-unsafe": [
       "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html",
       "guideline:sei-cert-c",
+      "guideline:owasp-top-10-2021",
       "profile:security",
       "sei-cert-c:con33-c",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:MEDIUM"
     ],
     "concurrency-thread-canceltype-asynchronous": [

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -802,6 +802,7 @@
     "optin.taint.GenericTaint": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint-c-c",
       "guideline:cwe-top-25-2024",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-20",
@@ -811,18 +812,27 @@
       "cwe-top-25-2024:cwe-79",
       "cwe-top-25-2024:cwe-89",
       "cwe-top-25-2024:cwe-94",
+      "owasp-top-10-2021:owasp-A01-2021",
+      "owasp-top-10-2021:owasp-A03-2021",
+      "owasp-top-10-2021:owasp-A04-2021",
+      "owasp-top-10-2021:owasp-A08-2021",
+      "owasp-top-10-2021:owasp-A10-2021",
       "severity:HIGH"
     ],
     "optin.taint.TaintedAlloc": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc-c-c",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:sensitive",
+      "owasp-top-10-2021:owasp-A03-2021",
       "severity:HIGH"
     ],
     "optin.taint.TaintedDiv": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-tainteddiv-c-c-objc",
+      "guideline:owasp-top-10-2021",
       "profile:extreme",
       "profile:sensitive",
+      "owasp-top-10-2021:owasp-A03-2021",
       "severity:HIGH"
     ],
     "optin.taint.TaintPropagation": [
@@ -970,11 +980,13 @@
     "security.SetgidSetuidOrder": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c",
       "guideline:sei-cert-c",
+      "guideline:owasp-top-10-2021",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:pos36-c",
+      "owasp-top-10-2021:owasp-A04-2021",
       "severity:MEDIUM"
     ],
     "security.cert.env.InvalidPtr": [
@@ -1051,16 +1063,20 @@
     ],
     "security.insecureAPI.mktemp": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp-c",
+      "guideline:owasp-top-10-2021",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "owasp-top-10-2021:owasp-A01-2021",
       "severity:MEDIUM"
     ],
     "security.insecureAPI.rand": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand-c",
+      "guideline:owasp-top-10-2021",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "owasp-top-10-2021:owasp-A02-2021",
       "severity:MEDIUM"
     ],
     "security.insecureAPI.strcpy": [

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -182,6 +182,11 @@ export default {
         id: "cwe-top-25-2024",
         name: "CWE Top 25 Most Dangerous Software Weaknesses 2024",
         value: 2
+      },
+      {
+        id: "owasp-top-10-2021",
+        name: "OWASP Top 10 Web Application Security Risks 2021",
+        value: 3
       }
     ];
 
@@ -196,7 +201,7 @@ export default {
       runs: null,
       runData: [],
       selectedCheckerName: null,
-      selectedGuidelineIndexes: [ 0, 1, 2 ],
+      selectedGuidelineIndexes: [ 0, 1, 2, 3 ],
       showRuns: {
         enabled: false,
         disabled: false,


### PR DESCRIPTION
Introduce the owasp-top-10-2021 guideline to CodeChecker, which consists of the corresponding clang and clang-tidy checkers of the OWASP Top 10 Web Application Security Risks (2021).