### PR TITLE
Add Vue redirect on invalid product name

### DIFF
--- a/web/server/vue-cli/src/main.js
+++ b/web/server/vue-cli/src/main.js
@@ -26,7 +26,7 @@ import {
   GET_CURRENT_PRODUCT,
   GET_CURRENT_PRODUCT_CONFIG
 } from "@/store/actions.type";
-import { CLEAR_QUERIES, SET_QUERIES } from "@/store/mutations.type";
+import { ADD_ERROR, CLEAR_QUERIES, SET_QUERIES } from "@/store/mutations.type";
 import convertOldUrlToNew from "./router/backward-compatible-url";
 
 import router from "./router";
@@ -45,6 +45,12 @@ let isFirstRouterResolve = true;
 
 // Ensure we checked auth before each page load.
 router.beforeResolve((to, from, next) => {
+  // Bail early when encountering an invalid endpoint.
+  if (to.params.endpoint && !to.params.endpoint.match(/^[A-Za-z0-9_\\-]+$/)) {
+    store.commit(ADD_ERROR, "Invalid product endpoint name!");
+    return next("/");
+  }
+
   // Update Thrift API services on endpoint change.
   if (from.params.endpoint === undefined ||
       to.params.endpoint !== from.params.endpoint


### PR DESCRIPTION
Previously when a product endpoint was opened in the browser that was invalid on the server side, such as `localhost:8001/$$`, there were confusing errors, as the API endpoints threw inconsistent errors separately. This change adds an early bail-out when encountering such an endpoint.