### PR TITLE
[bugfix] Emit an error instead of crash for missing CC_LIB_DIR

### DIFF
--- a/analyzer/codechecker_analyzer/cmd/analyzers.py
+++ b/analyzer/codechecker_analyzer/cmd/analyzers.py
@@ -14,6 +14,8 @@ analyzers available in CodeChecker.
 import argparse
 import subprocess
 
+from portalocker.portalocker import sys
+
 from codechecker_report_converter import twodim
 
 from codechecker_analyzer import analyzer_context
@@ -190,6 +192,17 @@ def main(args):
     rows = []
     for analyzer_name, analyzer_class in \
             analyzer_types.supported_analyzers.items():
+
+        if not analyzer_class.analyzer_binary():
+            LOG.error("Failed to locate binary for the "
+                      f"'{analyzer_class.ANALYZER_NAME}' analyzer!")
+            LOG.info(
+                "Was CodeChecker built through the 'dev_package' make target? "
+                "If so, try 'export CC_LIB_DIR="
+                "/path/to/repo/build/CodeChecker/lib/python3/'.")
+            LOG.info("Alternatively, build the 'package' target instead.")
+            sys.exit(1)
+
         version = analyzer_class.get_binary_version()
         if not version:
             version = 'NOT FOUND'

--- a/codechecker_common/cli.py
+++ b/codechecker_common/cli.py
@@ -47,6 +47,16 @@ def add_subcommand(subparsers, sub_cmd, cmd_module_path, lib_dir_path):
     # Load the module named as the argument.
     cmd_spec = machinery.PathFinder().find_spec(module_name,
                                                 target)
+    if not cmd_spec:
+        # Logger is not initialized just yet.
+        print(f"ERROR: Failed to locate module '{module_name}'!")
+        print(
+            "hint: Was CodeChecker built through the 'dev_package' make "
+            "target? If so, try 'export CC_LIB_DIR="
+            "/path/to/repo/build/CodeChecker/lib/python3/'.")
+        print("hint: Alternatively, build the 'package' target instead.")
+        sys.exit(1)
+
     command_module = cmd_spec.loader.load_module(module_name)
 
     # Now that the module is loaded, construct an ArgumentParser for it.


### PR DESCRIPTION
If you are developing CodeChecker, you should likely build the 'dev_package' target instead of 'package', as it symlinks instead of copied implementation files. However, CodeChecker will immediately crash if the CC_LIB_DIR environmental variable is not set. Instead, lets just emit an error.