### PR TITLE
fix(report-converter): Support null column in eslint reports

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/eslint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/eslint/analyzer_result.py
@@ -59,7 +59,7 @@ class AnalyzerResult(AnalyzerResultBase):
                     get_or_create_file(
                         os.path.abspath(file_path), file_cache),
                     int(bug['line']),
-                    int(bug['column']),
+                    int(bug['column']) if bug['column'] else 0,
                     bug['message'],
                     bug['ruleId']))
 


### PR DESCRIPTION
ESLint reports may contain bugs with "column": null. Thus, report-converter tool raises an exception:

TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

We set column number to 0 in such cases.