### PR TITLE
[fix] Unique key constraint violation fix

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -618,7 +618,8 @@ class MassStoreRun:
                     session.commit()
                     return
             except (sqlalchemy.exc.OperationalError,
-                    sqlalchemy.exc.ProgrammingError) as ex:
+                    sqlalchemy.exc.ProgrammingError,
+                    sqlalchemy.exc.IntegrityError) as ex:
                 LOG.error("Storing checkers of run '%s' failed: %s.\n"
                           "Waiting %d before trying again...",
                           self.__name, ex, wait_time)


### PR DESCRIPTION
When checkers are stored in the "checkers" table, it is possible that a unique key constratint violation happens in case of parallel run storage. This event constitutes as an `sqlalchemy.exc.IntegrityError`. When it happens we just need to retry insertion.