### PR TITLE
Fix serving Bad request pages in case of some HTTP errors

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -209,7 +209,9 @@ class RequestHandler(SimpleHTTPRequestHandler):
         # Command-line clients ignore overwriting the cookie, but web clients
         # will remove the cookie from the browser.
         # DEPRECATED: Will be removed in a future version.
-        elif self.headers.get('Cookie'):
+        # Note that if a request fails early in the process (eg. with a
+        # bad HTTP header), the headers attribute might not exist yet.
+        elif hasattr(self, 'headers') and self.headers.get('Cookie'):
             self.send_header('Set-Cookie',
                              session_manager.SESSION_COOKIE_NAME + '=; ' +
                              'Path=/; ' +


### PR DESCRIPTION
When a request fails very early inside http.server's parse_request, the headers attribute might not exist yet. This makes requests fail in some cases where eg. the HTTP header is corrupted for some reason, instead of returning a graceful Bad request page.

This is a partial fix for issue #4449.