### PR TITLE
fix(analyzer): Support dev version of cppcheck

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -63,7 +63,7 @@ def parse_version(cppcheck_output):
     """
     Parse cppcheck version output and return the version number.
     """
-    version_re = re.compile(r'^Cppcheck(.*?)(?P<version>[\d\.]+)')
+    version_re = re.compile(r'^Cppcheck(.*?)(?P<version>[\d\.]+)( dev)?')
     match = version_re.match(cppcheck_output)
     if match:
         return match.group('version')


### PR DESCRIPTION
When installed via sudo snap install cppcheck --edge, cppcheck has version:

Cppcheck 2.18 dev