### PR TITLE
[fix] Fix missing CC_LIB_DIR when dev_package is used

### DIFF
--- a/codechecker_common/cli.py
+++ b/codechecker_common/cli.py
@@ -95,7 +95,7 @@ def main():
     """
     if not os.environ.get('CC_LIB_DIR'):
         os.environ['CC_LIB_DIR'] = \
-                os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+                os.path.dirname(os.path.dirname(__file__))
 
     data_files_dir_path = get_data_files_dir_path()
     os.environ['CC_DATA_FILES_DIR'] = data_files_dir_path


### PR DESCRIPTION
If you are developing CodeChecker, you should likely build the 'dev_package' target instead of 'package', as it symlinks instead of copied implementation files. However, CodeChecker will immediately crash if the CC_LIB_DIR environmental variable is not set.

Based on the comment of @bruntib in #4491, this is a one-line fix. The issue is that CodeChecker (for historical reasons) has a non-standar library layout. Instead of every library being on the same level (codechecker_analyzer, codechecker_client, codechecker_web etc), they are all over the place in the source code. The "package" make target that "builds" CodeChecker solves this by copying the libraries in the same directory, with them finally being on the same level.

The "dev_package" target symlinks instead, so that changes in the actual source code are immediately refected without a need to build CodeChecker again.

CC_LIB_DIR points to this copied and corrected layout. However, if it was symlinked, we mistakenly resolved that symlink through os.path.realpath() -- but that points to the different directory layout, so removing or adding a directory from this path will land you in the wrong place.

Traditionally, we circumvented this by explicitly set the CC_LIB_DIR variable, in which case CodeChecker does no symlink resolving.

The patch now no longer resolves this symlink in any case.