### PR TITLE
[fix] Apply heuristics when diagtool comes with version number

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -154,6 +154,12 @@ def get_diagtool_bin():
     if diagtool_bin.exists():
         return diagtool_bin
 
+    # Sometimes diagtool binary has a version number in its name: diagtool-14.
+    diagtool_bin = diagtool_bin.with_name(
+        f'diagtool-{str(ClangSA.version_info().major_version)}')
+    if diagtool_bin.exists():
+        return diagtool_bin
+
     LOG.warning(
         "'diagtool' can not be found next to the clang binary (%s)!",
         clang_bin)


### PR DESCRIPTION
In some environments "diagtool" doesn't exist with this name, but it exists with a name containing version number: "diagtool-14". In this patch we apply some heuristics to try finding diagtool with this extended name, too.

Fixes #4453