### PR TITLE
fixed url strip error

### DIFF
--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -281,7 +281,7 @@ class ThriftAuthHandler:
         elif auth_method == "oauth":
 
             provider, url = auth_string.split("@", 1)
-            url.strip("#")
+            url = url.rstrip("#")
 
             oauth_config = self.__manager.get_oauth_config(provider)
             if not oauth_config.get('enabled'):


### PR DESCRIPTION
This line is necessary for the OAuth login flow to work correctly due to the way Microsoft includes data in the `callback_url`.