### PR TITLE
integrated signum fetching and using it as optional username

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -378,7 +378,11 @@ CodeChecker also supports OAuth-based authentication. The `authentication.method
 
       * `user_groups_url`
 
-          `Microsoft` specific field to request security groups that the user is member of.
+          `Microsoft`-specific field used to request security groups that the user is member of.
+
+      * `jwks_url`
+
+          `Microsoft`-specific field used to request public signing keys for decoding JWT tokens.
 
       * `scope`
 

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -391,12 +391,26 @@ CodeChecker also supports OAuth-based authentication. The `authentication.method
           * `username`
 
               Field for the username.
-          * `email`
 
-              Field for the email.
-          * `fullname`
+        The `username` field defines what value will be used as the user's unique identifier (i.e. their "username") depending on the OAuth provider.
 
-              Field for the fullname.
+        Supported Providers and Options:
+
+        `github`
+          * Key: `login`
+          * Important: To ensure consistency with other providers, we currently fetch the user's primary email address instead.
+          * If the user's email is hidden (private), this will result in an error.
+
+        `google`
+          * Key: `email` – uses the user's email address.
+
+        `microsoft`
+
+          * You can choose between:
+
+            Key: `mail` – uses the user's email address.
+
+            Key: `signum` – uses the user's Signum (a company-specific unique identifier).
 ~~~{.json}
 "method_oauth": {
       "enabled": false,

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -415,27 +415,60 @@ CodeChecker also supports OAuth-based authentication. The `authentication.method
         `microsoft`
           * `username` - Company's signum will be the user's identifier.
           * `email` - an email associated with this Microsoft account will be used as user's identifier.
-~~~{.json}
-"method_oauth": {
-    "enabled": false,
-    "providers": {
-      "example_provider": {
-        "enabled": false,
-        "client_id": "client id",
-        "client_secret": "client secret",
-        "authorization_url": "https://accounts.google.com/o/oauth2/auth",
-        "callback_url": "http://localhost:8080/login/OAuthLogin/provider",
-        "token_url": "https://accounts.google.com/o/oauth2/token",
-        "user_info_url": "https://www.googleapis.com/oauth2/v1/userinfo",
-        "user_emails_url": "https://api.github.com/user/emails",
-        "scope": "openid email profile",
-        "user_info_mapping": {
-          "username": "email"
-        }
+
+    ### 🔧 Example: OAuth Configuration for GitHub
+    ~~~{.json}
+    "github": {
+      "enabled": false,
+      "client_id": "<ExampleClientID>",
+      "client_secret": "<ExampleClientSecret>",
+      "authorization_url": "https://github.com/login/oauth/authorize",
+      "callback_url": "https://<server_host>/login/OAuthLogin/github",
+      "token_url": "https://github.com/login/oauth/access_token",
+      "user_info_url": "https://api.github.com/user",
+      "user_emails_url": "https://api.github.com/user/emails",
+      "scope": "user:email",
+      "user_info_mapping": {
+        "username": "username"
       }
     }
-  }
-~~~
+    ~~~
+    ### 🔧 Example: OAuth Configuration for Google
+    ~~~{.json}
+    "google": {
+      "enabled": false,
+      "client_id": "<ExampleClientID>",
+      "client_secret": "<ExampleClientSecret>",
+      "authorization_url": "https://accounts.google.com/o/oauth2/auth",
+      "callback_url": "https://<server_host>/login/OAuthLogin/google",
+      "token_url": "https://accounts.google.com/o/oauth2/token",
+      "user_info_url": "https://www.googleapis.com/oauth2/v1/userinfo",
+      "scope": "openid email profile",
+      "user_info_mapping": {
+        "username": "email"
+      }
+    }
+    ~~~
+    ### 🔧 Example: OAuth Configuration for Microsoft
+    ~~~{.json}
+    "microsoft": {
+      "enabled": false,
+      "client_id": "<ExampleClientID>",
+      "client_secret": "<ExampleClientSecret>",
+      "authorization_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize",
+      "callback_url": "https://<server_host>/login/OAuthLogin/microsoft",
+      "token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
+      "user_groups_url": "https://graph.microsoft.com/v1.0/me/memberOf",
+      "jwks_url": "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys",
+      "user_info_url": "https://graph.microsoft.com/v1.0/me",
+      "scope": "User.Read email profile openid offline_access",
+      "user_info_mapping": {
+        "username": "email"
+      }
+    }
+    ~~~
+
+
 
 #### OAuth Details per each provider <a name ="oauth-details-per-each-provider"></a>
 

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -413,24 +413,24 @@ CodeChecker also supports OAuth-based authentication. The `authentication.method
             Key: `signum` – uses the user's Signum (a company-specific unique identifier).
 ~~~{.json}
 "method_oauth": {
-      "enabled": false,
-      "providers": {
-        "example_provider": {
-          "enabled": false,
-          "client_id": "client id",
-          "client_secret": "client secret",
-          "authorization_url": "https://accounts.google.com/o/oauth2/auth",
-          "callback_url": "http://localhost:8080/login/OAuthLogin/provider",
-          "token_url": "https://accounts.google.com/o/oauth2/token",
-          "user_info_url": "https://www.googleapis.com/oauth2/v1/userinfo",
-          "user_emails_url": "https://api.github.com/user/emails",
-          "scope": "openid email profile",
-          "user_info_mapping": {
-            "username": "email"
-          }
+    "enabled": false,
+    "providers": {
+      "example_provider": {
+        "enabled": false,
+        "client_id": "client id",
+        "client_secret": "client secret",
+        "authorization_url": "https://accounts.google.com/o/oauth2/auth",
+        "callback_url": "http://localhost:8080/login/OAuthLogin/provider",
+        "token_url": "https://accounts.google.com/o/oauth2/token",
+        "user_info_url": "https://www.googleapis.com/oauth2/v1/userinfo",
+        "user_emails_url": "https://api.github.com/user/emails",
+        "scope": "openid email profile",
+        "user_info_mapping": {
+          "username": "email"
         }
       }
     }
+  }
 ~~~
 
 #### OAuth Details per each provider <a name ="oauth-details-per-each-provider"></a>

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -394,23 +394,23 @@ CodeChecker also supports OAuth-based authentication. The `authentication.method
 
         The `username` field defines what value will be used as the user's unique identifier (i.e. their "username") depending on the OAuth provider.
 
-        Supported Providers and Options:
+        Currently there are only 2 options for this:
+         * `username`
+         * `email`
+
+        Expected output for each provider:
 
         `github`
-          * Key: `login`
-          * Important: To ensure consistency with other providers, we currently fetch the user's primary email address instead.
-          * If the user's email is hidden (private), this will result in an error.
+          * `username` - user's GitHub `login` will be user's identifier
+          * `email` - a request will be sent to fetch the primary email of account to be used as the user's identifier.
+            If it is hidden, an error will be thrown.
 
         `google`
-          * Key: `email` – uses the user's email address.
+          * Only supports `email`, and user's Gmail email will be considered his username.
 
         `microsoft`
-
-          * You can choose between:
-
-            Key: `mail` – uses the user's email address.
-
-            Key: `signum` – uses the user's Signum (a company-specific unique identifier).
+          * `username` - Company's signum will be the user's identifier.
+          * `email` - an email associated with this Microsoft account will be used as user's identifier.
 ~~~{.json}
 "method_oauth": {
     "enabled": false,

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -369,9 +369,7 @@ class ThriftAuthHandler:
                      f" for provider: {provider}")
 
             try:
-                user_info_response = oauth2_session.get(user_info_url)
-                user_info_response.raise_for_status()
-                user_info = user_info_response.json()
+                user_info = oauth2_session.get(user_info_url).json()
 
                 # request group memberships for Microsoft
                 groups = []

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -376,7 +376,7 @@ class ThriftAuthHandler:
                 # request group memberships for Microsoft
                 groups = []
                 if provider == 'microsoft':
-                    #decoding
+                    # decoding
                     id_token = oauth_token['id_token']
                     jwks_url = oauth_config["jwks_url"]
 
@@ -400,9 +400,9 @@ class ThriftAuthHandler:
                             if group_name:
                                 groups.append(group_name)
 
-                if(oauth_config["user_info_mapping"]["username"]=="signum"):
-                        esignum = claims.get('Signum')
-                        username = esignum
+                if oauth_config["user_info_mapping"]["username"] == "signum":
+                    esignum = claims.get('Signum')
+                    username = esignum
                 else:
                     username = user_info[
                         oauth_config["user_info_mapping"]["username"]]

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -394,18 +394,16 @@ class ThriftAuthHandler:
                                 group.get("securityEnabled"):
                             groups.append(group["displayName"])
 
-                    username_key = oauth_config.get(
-                        "user_info_mapping", {}).get("username")
-
-                    if username_key == "signum":
-                        username = claims.get("Signum")
-                    elif username_key == "mail":
-                        username = user_info.get("mail")
-                    else:
-                        username = user_info.get("mail")
+                username_key = oauth_config.get(
+                    "user_info_mapping", {}).get("username")
+                if username_key == "signum":
+                    username = claims.get("Signum")
+                elif username_key == "email":
+                    username = user_info.get("email")
+                else:
+                    username = user_info.get("mail")
 
                 LOG.info("User info fetched, username: %s", username)
-
             except Exception as ex:
                 LOG.error("User info fetch failed: %s", str(ex))
                 raise codechecker_api_shared.ttypes.RequestFailed(

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -410,15 +410,15 @@ class ThriftAuthHandler:
                 if provider == "github":
                     if username_key == "email":
                         if "localhost" not in \
-                            user_info_url:
-                                user_emails_url = \
-                                    oauth_config["user_emails_url"]
-                                for email in oauth2_session \
-                                        .get(user_emails_url).json():
-                                    if email['primary']:
-                                        username = email['email']
-                                        LOG.info("Primary email found: %s", \
-                                                username)
+                                user_info_url:
+                            user_emails_url = \
+                                oauth_config["user_emails_url"]
+                            for email in oauth2_session \
+                                    .get(user_emails_url).json():
+                                if email['primary']:
+                                    username = email['email']
+                                    LOG.info("Primary email found: %s",
+                                             username)
                     else:
                         username = user_info.get("login")
                 elif provider == "google":

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -428,6 +428,9 @@ class ThriftAuthHandler:
                         username = claims.get("Signum")
                     else:
                         username = user_info.get("mail")
+
+                LOG.debug(f"groups fetched for {username}, are: {groups}")
+
                 LOG.info("Username fetched, for username: %s", username)
             except Exception as ex:
                 LOG.error("Username fetch failed: %s", str(ex))

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -389,23 +389,23 @@ class ThriftAuthHandler:
                     claims.validate()
 
                     user_groups_url = oauth_config["user_groups_url"]
-                    group_response = oauth2_session.get(user_groups_url)
-                    group_response.raise_for_status()
-                    response = group_response.json()
+                    response = oauth2_session.get(user_groups_url).json()
 
                     for group in response["value"]:
                         if group.get("onPremisesSyncEnabled") and \
                                 group.get("securityEnabled"):
-                            group_name = group.get("displayName")
-                            if group_name:
-                                groups.append(group_name)
+                            groups.append(group["displayName"])
 
-                if oauth_config["user_info_mapping"]["username"] == "signum":
-                    esignum = claims.get('Signum')
-                    username = esignum
-                else:
-                    username = user_info[
-                        oauth_config["user_info_mapping"]["username"]]
+                    username_key = oauth_config.get(
+                        "user_info_mapping", {}).get("username")
+
+                    if username_key == "signum":
+                        username = claims.get("Signum")
+                    elif username_key == "mail":
+                        username = user_info.get("mail")
+                    else:
+                        username = user_info.get("mail")
+
                 LOG.info("User info fetched, username: %s", username)
 
             except Exception as ex:

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -710,6 +710,8 @@ class SessionManager:
         if groups is None:
             groups = []
 
+        LOG.debug(f"groups assigned to oauth_session: {groups}")
+
         if not self.__is_method_enabled('oauth'):
             return False
 

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -95,7 +95,7 @@
           "user_info_url": "https://graph.microsoft.com/v1.0/me",
           "scope": "User.Read email profile openid offline_access",
           "user_info_mapping": {
-            "username": "mail"
+            "username": "email"
           }
         }
       }

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -92,6 +92,7 @@
           "callback_url": "https://<server_host>/login/OAuthLogin/microsoft",
           "token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
           "user_groups_url" : "https://graph.microsoft.com/v1.0/me/memberOf",
+          "jwks_url": "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys",
           "user_info_url": "https://graph.microsoft.com/v1.0/me",
           "scope": "User.Read email profile openid offline_access",
           "user_info_mapping": {

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -68,7 +68,7 @@
           "user_emails_url": "https://api.github.com/user/emails",
           "scope": "user:email",
           "user_info_mapping": {
-            "username": "login"
+            "username": "username"
           }
         },
         "google": {


### PR DESCRIPTION
integrated fetching of signum from `id_token` so it can be used as username for Microsoft.
Can be configured in configuration file what will be username:
`"username": "mail"` or `"username": "signum"`.