### PR TITLE
[analyzer] Add --use-absolute-ldpreload-path flag to log command

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -53,8 +53,14 @@ def execute_buildcmd(command, silent=False, environ=None, cwd=None):
     return proc.returncode
 
 
-def perform_build_command(logfile, command, keep_link, silent=False,
-                          verbose=None):
+def perform_build_command(
+    logfile,
+    command,
+    keep_link,
+    silent=False,
+    verbose=None,
+    use_absolute_ldpreload_path=False,
+):
     """
     Build the project and create a log file.
     """
@@ -82,7 +88,8 @@ def perform_build_command(logfile, command, keep_link, silent=False,
 
         # Same as linux's touch.
         open(logfile, 'a', encoding="utf-8", errors="ignore").close()
-        log_env = env.get_log_env(logfile, original_env)
+        log_env = env.get_log_env(
+            logfile, original_env, use_absolute_ldpreload_path)
         if 'CC_LOGGER_GCC_LIKE' not in log_env:
             log_env['CC_LOGGER_GCC_LIKE'] = 'gcc:g++:clang:clang++:/cc:c++'
         if keep_link or ('CC_LOGGER_KEEP_LINK' in log_env and

--- a/analyzer/codechecker_analyzer/cli/check.py
+++ b/analyzer/codechecker_analyzer/cli/check.py
@@ -189,6 +189,22 @@ used to generate a log file on the fly.""")
                           help="Use an already existing JSON compilation "
                                "command database file specified at this path.")
 
+    log_args = parser.add_argument_group(
+        "log extra arguments",
+        "Additional arguments which can be forwarded to the logging phase.",
+    )
+
+    log_args.add_argument(
+        "--use-absolute-ldpreload-path",
+        dest="use_absolute_ldpreload_path",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        required=False,
+        help="Use absolute paths in LD_PRELOAD environment "
+        "variable instead of relying on LD_LIBRARY_PATH "
+        "for loading the ldlogger.so library.",
+    )
+
     analyzer_opts = parser.add_argument_group("analyzer arguments")
     analyzer_opts.add_argument('-j', '--jobs',
                                type=int,
@@ -899,11 +915,11 @@ def main(args):
 
             # Translate the argument list between check and log.
             log_args = argparse.Namespace(
-                command=args.command,
-                logfile=logfile
-            )
-            __update_if_key_exists(args, log_args, 'quiet')
-            __update_if_key_exists(args, log_args, 'verbose')
+                command=args.command, logfile=logfile)
+            __update_if_key_exists(args, log_args, "quiet")
+            __update_if_key_exists(args, log_args, "verbose")
+            __update_if_key_exists(
+                args, log_args, "use_absolute_ldpreload_path")
 
             import codechecker_analyzer.cli.log as log_module
             LOG.debug("Calling LOG with args:")

--- a/analyzer/codechecker_analyzer/cli/log.py
+++ b/analyzer/codechecker_analyzer/cli/log.py
@@ -138,6 +138,17 @@ def add_arguments_to_parser(parser):
                         help="Do not print the output of the build tool into "
                              "the output of this command.")
 
+    parser.add_argument(
+        "--use-absolute-ldpreload-path",
+        dest="use_absolute_ldpreload_path",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        required=False,
+        help="Use absolute paths in LD_PRELOAD environment "
+        "variable instead of relying on LD_LIBRARY_PATH "
+        "for loading the ldlogger.so library.",
+    )
+
     parser.add_argument('--verbose',
                         type=str,
                         dest='verbose',
@@ -175,8 +186,11 @@ def main(args):
 
     verbose = args.verbose if 'verbose' in args else None
 
-    build_manager.perform_build_command(args.logfile,
-                                        args.command,
-                                        'keep_link' in args,
-                                        silent='quiet' in args,
-                                        verbose=verbose)
+    build_manager.perform_build_command(
+        args.logfile,
+        args.command,
+        "keep_link" in args,
+        silent="quiet" in args,
+        verbose=verbose,
+        use_absolute_ldpreload_path="use_absolute_ldpreload_path" in args,
+    )

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -820,8 +820,22 @@ object files as input) should be captured. For further details see
 If your build tool overrides `LD_LIBRARY_PATH` during the build process, then
 `ldlogger.so` will not be found. The best solution is to making sure
 that the LD_LIBRARY_PATH is not overridden, only extended.
-If this is not possible, you can work around the situation by
-specifying the absolute path of the `ldlogger.so` in the `LD_PRELOAD`:
+
+If this is not possible, you have two options:
+
+1. Use the `--use-absolute-ldpreload-path` flag which automatically uses the absolute path to the appropriate `ldlogger.so` in the `LD_PRELOAD` environment variable instead of relying on `LD_LIBRARY_PATH`:
+
+```sh
+CodeChecker log --use-absolute-ldpreload-path -o compile_commands.json -b "make -j2"
+```
+
+This flag is also available for the `check` command:
+
+```sh
+CodeChecker check --use-absolute-ldpreload-path -b "make -j2" -o ./reports
+```
+
+2. Manually specify the absolute path of the `ldlogger.so` in the `LD_PRELOAD`:
 
 ```sh
 # For 64-bit compilers


### PR DESCRIPTION
Allows using absolute paths in LD_PRELOAD instead of relying on LD_LIBRARY_PATH for loading ldlogger.so. Helps when build tools override LD_LIBRARY_PATH during build process.