### PR TITLE
Restrict the SQL database creation to the config directory

### DIFF
--- a/codechecker_common/util.py
+++ b/codechecker_common/util.py
@@ -135,7 +135,7 @@ def path_for_fake_root(full_path: str, root_path: str = '/') -> str:
     """Normalize and sanitize full_path, then make it relative to root_path."""
     relative_path = os.path.relpath(full_path, '/')
     fake_root_path = os.path.join(root_path, relative_path)
-    return os.path.realpath(fake_root_path)
+    return os.path.abspath(fake_root_path)
 
 
 def strtobool(value: str) -> bool:

--- a/docs/web/products.md
+++ b/docs/web/products.md
@@ -46,6 +46,12 @@ with a SQLite database file next to the configuration database, in
 This does NOT hold true for PostgreSQL configuration backends. These servers,
 as PostgreSQL is advanced usage, must be configured manually.
 
+**Note:** In earlier versions, absolute paths to SQLite databases were allowed.
+These databases will continue to work, but new SQLite databases can only be
+created in the CodeChecker server's configuration directory
+(`/home/<username>/.codechecker` by default). If an SQLite database needs to be
+stored in another directory, place symlinks inside the config directory.
+
 # Managing products through the command-line tool, `CodeChecker cmd` <a name="cmd"></a>
 
 Please see the [User guide](user_guide.md) for overview on the `cmd`
@@ -151,9 +157,11 @@ database arguments:
   NOTE: These database arguments are relative to the server machine, as it
   is the server which will make the database connection.
 
-  --sqlite SQLITE_FILE  Path of the SQLite database file to use. Not absolute
-                        paths will be relative to the server's
-                        <CONFIG_DIRECTORY>. (default: <ENDOPINT>.sqlite)
+  --sqlite SQLITE_FILE  Path of the SQLite database file to use. All paths will
+                        be relative to the server's <CONFIG_DIRECTORY>. If an 
+                        SQLite server needs to have a different directory, use
+                        symlinks inside the config directory.
+                        (default: <ENDOPINT>.sqlite)
   --postgresql          Specifies that a PostgreSQL database is to be used
                         instead of SQLite. See the "PostgreSQL arguments"
                         section on how to configure the database connection.

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -250,7 +250,7 @@ To run CodeChecker server in Docker see the [Docker](docker.md) documentation.
 
 
 CodeChecker server can use PostgreSQL or SQLite databases to store the analysis
-results. SQlite is only recommended high volume production usage,
+results. SQLite is not recommended for high volume production usage,
 only for small test installations.
 
 

--- a/web/client/codechecker_client/cli/cmd.py
+++ b/web/client/codechecker_client/cli/cmd.py
@@ -778,8 +778,10 @@ def __register_products(parser):
                              default=sqlite_product_endpoint_default_var,
                              required=False,
                              help="Path of the SQLite database file to use. "
-                                  "Not absolute paths will be relative to "
-                                  "the server's <CONFIG_DIRECTORY>.")
+                                  "All paths will be relative to the server's "
+                                  "<CONFIG_DIRECTORY>. If an SQLite server "
+                                  "needs to have a different directory, use "
+                                  "symlinks inside the config directory.")
 
         dbmodes.add_argument('--postgresql',
                              dest="postgresql",

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -986,6 +986,12 @@ class CCSimpleHttpServer(HTTPServer):
         self.cfg_sess_private.commit()
         self.cfg_sess_private.close()
 
+        # the config database counts as an open database as well
+        cfg_url = self.__engine.url
+        cfg_entry = (cfg_url.drivername, cfg_url.database, cfg_url.host,
+                     cfg_url.port)
+        current_connected_databases.append(cfg_entry)
+
         # True if found, False otherwise
         return to_add in current_connected_databases
 

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -159,8 +159,7 @@ class TestProductConfigShare(unittest.TestCase):
                     port=None,
                     username_b64='',
                     password_b64='',
-                    database=os.path.join(self.test_workspace_secondary,
-                                          'data.sqlite')))
+                    database='data.sqlite'))
 
         product_cfg = create_test_product('producttest_second',
                                           'producttest_second')

--- a/web/tests/functional/products/test_products.py
+++ b/web/tests/functional/products/test_products.py
@@ -122,6 +122,10 @@ class TestProducts(unittest.TestCase):
             product_cfg.endpoint = "CodeCheckerService"
             self._root_client.addProduct(product_cfg)
 
+        with self.assertRaises(RequestFailed):
+            product_cfg.endpoint = "config.sqlite"
+            self._root_client.addProduct(product_cfg)
+
     def test_get_product_data(self):
         """
         Test getting product configuration from server.

--- a/web/tests/libtest/codechecker.py
+++ b/web/tests/libtest/codechecker.py
@@ -737,7 +737,7 @@ def start_server(codechecker_cfg, event, server_args=None, pg_config=None):
 def add_test_package_product(server_data, test_folder, check_env=None,
                              protocol='http', report_limit=None,
                              user_permissions=None,
-                             database_name="data.sqlite"):
+                             database_name="default"):
     """
     Add a product for a test suite to the server provided by server_data.
     Server must be running before called.
@@ -784,8 +784,10 @@ def add_test_package_product(server_data, test_folder, check_env=None,
         add_command += _pg_db_config_to_cmdline_params(pg_config)
     else:
         # SQLite databases are put under the workspace of the appropriate test.
-        add_command += ['--sqlite',
-                        os.path.join(test_folder, database_name)]
+        if database_name == 'default':
+            database_name = os.path.basename(test_folder)
+        database_name += '.sqlite'
+        add_command += ['--sqlite', database_name]
 
     print(' '.join(add_command))
 


### PR DESCRIPTION
Previously, SQL files could be created anywhere on the server. This change restricts them always to inside the config directory.

The old behavior can be brought back by creating symlinks manually in the config dir.