### PR TITLE
Fix a legacy mistake in the test

### DIFF
--- a/analyzer/tests/unit/test_option_parser.py
+++ b/analyzer/tests/unit/test_option_parser.py
@@ -348,7 +348,7 @@ class OptionParserTest(unittest.TestCase):
     def test_ignore_xclang_flags_clang(self):
         """Skip some specific xclang constructs"""
 
-        def fake_clang_version(_a, _b):
+        def fake_clang_version(_a):
             return True
 
         clang_flags = ["-std=gnu++14",


### PR DESCRIPTION
The code has been refactored in the following PR, but the test hasn't.
It doesn't fail now only because of cached `ImplicitCompilerInfo.compiler_versions.get`
Run the only test and see the failure.


commit dcc47a515b56a8a91a350389e994587dcbf423e2
Author: bruntib <bruntib@gmail.com>
Date:   Tue Jan 3 12:45:11 2023 +0100

    [refactor] Analyzer context as singleton
