### PR TITLE
[feat] Return custom message in cli upon failed authentication

### DIFF
--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -52,6 +52,10 @@ is handled.
 
     The error message shown in the browser when the user fails to authenticate
 
+  * `failed_auth_message`
+
+    The message shown upon failed authentication in the CodeChecker CLI
+
  * `logins_until_cleanup`
 
     After this many login attempts made towards the server, it will perform an

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -274,6 +274,10 @@ class ThriftAuthHandler:
                 msg = f"Invalid credentials supplied for user " \
                     f"'{user_name}'. Refusing authentication!"
 
+                auth_msg = self.__manager.get_failed_auth_message().get('msg')
+                if auth_msg:
+                    msg += f"\nNote: {auth_msg}"
+
                 LOG.warning(msg)
                 raise codechecker_api_shared.ttypes.RequestFailed(
                     codechecker_api_shared.ttypes.ErrorCode.AUTH_DENIED,

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -389,6 +389,11 @@ class SessionManager:
             "error": self.__auth_config.get('realm_error')
         }
 
+    def get_failed_auth_message(self):
+        return {
+            "msg": self.__auth_config.get('failed_auth_message'),
+        }
+
     @property
     def get_super_user(self):
         return {

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -17,6 +17,7 @@
     "enabled" : false,
     "realm_name" : "CodeChecker Privileged server",
     "realm_error" : "Access requires valid credentials.",
+    "failed_auth_message": "",
     "session_lifetime" : 300,
     "refresh_time" : 60,
     "logins_until_cleanup" : 30,

--- a/web/tests/functional/authentication/test_authentication.py
+++ b/web/tests/functional/authentication/test_authentication.py
@@ -430,6 +430,21 @@ class DictAuth(unittest.TestCase):
 
         cred_manager.save_token(host, port, session_token, True)
 
+    def test_config_failed_auth_message_showing_in_cli(self):
+        """
+        Test if the failed_auth_message from the server config shows up in
+        cli upon failed authentication.
+        """
+
+        auth_client = env.setup_auth_client(self._test_workspace,
+                                            session_token='_PROHIBIT')
+
+        with self.assertRaises(RequestFailed) as msg:
+            auth_client.performLogin("Username:Password", "invalid:invalid")
+
+        self.assertIn("Note: Personal access token based authentication only",
+                      str(msg.exception))
+
     def test_announcement_showing_in_cli(self):
         """
         Test if the announcement message posted on the CodeChecker GUI shows

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -348,6 +348,8 @@ def enable_auth(workspace):
 
     scfg_dict = load_json(server_cfg_file, {})
     scfg_dict["authentication"]["enabled"] = True
+    scfg_dict["authentication"]["failed_auth_message"] = \
+        "Personal access token based authentication only"
     scfg_dict["authentication"]["super_user"] = "root"
     scfg_dict["authentication"]["method_dictionary"]["enabled"] = True
     scfg_dict["authentication"]["method_dictionary"]["auths"] = \


### PR DESCRIPTION
A customizable message from the server config file should be shown in cli upon failed authentication via CodeChecker cmd login.
As part of this PR, such message was added to the server config file for feature demonstration. This can be removed before merging.

