### PR TITLE
Fix a code duplication

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -1026,12 +1026,11 @@ def parse_options(compilation_db_entry,
             LOG.error(cerr)
             compiler_version_info = False
 
-    ImplicitCompilerInfo.compiler_versions[details['compiler']] \
-        = compiler_version_info
+        ImplicitCompilerInfo.compiler_versions[details['compiler']] \
+            = compiler_version_info
 
     using_same_clang_to_compile_and_analyze = False
-    compiler_clang = \
-        ImplicitCompilerInfo.compiler_versions.get(details['compiler'])
+    compiler_clang = compiler_version_info
 
     if compiler_clang:
         # Based on the version information the compiler is clang.


### PR DESCRIPTION
Seems ImplicitCompilerInfo.compiler_versions can be re-set more rarely