### PR TITLE
[bugfix] Pass the correct interpreter from bin/CodeChecker to the analyzers

### DIFF
--- a/bin/CodeChecker
+++ b/bin/CodeChecker
@@ -42,11 +42,10 @@ def run_codechecker(checker_env, subcommand=None):
     checker_env['PYTHONPATH'] = lib_dir_path
     checker_env['CC_BIN_DIR'] = package_bin
 
-    python3 = os.path.join('python3')
     codechecker_main = \
         os.path.join(lib_dir_path, 'codechecker_common', 'cli.py')
 
-    checker_cmd = [python3, codechecker_main]
+    checker_cmd = [sys.executable, codechecker_main]
 
     if subcommand:
         # If a subcommand is specified (script is executed from a


### PR DESCRIPTION
This caused a bug when codechecker_bazel rules wiped the environment, and while CodeChecker was invoked with the correct interpreter, it failed to retrieve it from PATH. Lets just reuse the interpreter we were invoked with.