### PR TITLE
Add OAuth templates, simplify OAuth configuration flow

### DIFF
--- a/web/api/README.md
+++ b/web/api/README.md
@@ -46,6 +46,8 @@ git reset HEAD web/server/vue-cli/package-lock.json
   * Github doesn't support PKCE and If GitHub starts supporting PKCE in the future, the code should automatically
   start using it ,and in that case, this note can be removed.
 
+  * If a new OAuth provider is added, add it to `OAUTH_TEMPLATES`, instead of the `server-config.json`.
+
   * Important: for different providers there are different requirements for providing refresh token.
 
     In case of of google you need to specify these 2 attributes `access_type='offline'` and `prompt='consent'` prompts `google` to return `refresh_token`.
@@ -60,7 +62,7 @@ git reset HEAD web/server/vue-cli/package-lock.json
     Whereas GitHub return refresh token by default.
 
 ```.py
-  if provider == "google":
+  if template == "google/v1":
               url, state = session.create_authorization_url(
                   url=authorization_url,
                   state=stored_state,

--- a/web/codechecker_web/server/__init__.py
+++ b/web/codechecker_web/server/__init__.py
@@ -1,0 +1,7 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------

--- a/web/codechecker_web/server/oauth_templates.py
+++ b/web/codechecker_web/server/oauth_templates.py
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+OAUTH_TEMPLATES = {
+    "default": {
+        "callback_url": "{host}/login/OAuthLogin/{provider}",
+    },
+    "github/v1": {
+        "authorization_url": "https://github.com/login/oauth/authorize",
+        "callback_url": "{host}/login/OAuthLogin/{provider}",
+        "token_url": "https://github.com/login/oauth/access_token",
+        "user_info_url": "https://api.github.com/user",
+        "user_emails_url": "https://api.github.com/user/emails",
+        "scope": "user:email",
+        "user_info_mapping": {
+            "username": "email"
+        }
+    },
+    "google/v1": {
+        "authorization_url": "https://accounts.google.com/o/oauth2/auth",
+        "callback_url": "{host}/login/OAuthLogin/{provider}",
+        "token_url": "https://accounts.google.com/o/oauth2/token",
+        "user_info_url": "https://www.googleapis.com/oauth2/v1/userinfo",
+        "scope": "openid email profile",
+        "user_info_mapping": {
+            "username": "email"
+        }
+    },
+    "ms_entra/v2.0": {
+        "authorization_url":
+            "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",  # noqa
+        "callback_url": "{host}/login/OAuthLogin/{provider}",
+        "token_url":
+            "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+        "user_groups_url":
+            "https://graph.microsoft.com/v1.0/me/memberOf",
+        "jwks_url":
+            "https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys",  # noqa
+        "user_info_url": "https://graph.microsoft.com/v1.0/me",
+        "scope": "User.Read email profile openid offline_access",
+        "user_info_mapping": {
+            "username": "email"
+        }
+    }
+}

--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -219,6 +219,7 @@ class ThriftAuthHandler:
         stored_state = generate_token()
         client_id = oauth_config["client_id"]
         client_secret = oauth_config["client_secret"]
+        template = oauth_config.get("template", "default")
         scope = oauth_config["scope"]
         authorization_url = oauth_config["authorization_url"]
         callback_url = oauth_config["callback_url"]
@@ -234,7 +235,7 @@ class ThriftAuthHandler:
 
         # each provider has different requirements
         # for requesting refresh token
-        if provider == "google":
+        if template == "google/v1":
             url, state = oauth2_session.create_authorization_url(
                 url=authorization_url,
                 state=stored_state,
@@ -332,6 +333,7 @@ class ThriftAuthHandler:
 
             client_id = oauth_config["client_id"]
             client_secret = oauth_config["client_secret"]
+            template = oauth_config.get("template", "default")
             scope = oauth_config["scope"]
             token_url = oauth_config["token_url"]
             user_info_url = oauth_config["user_info_url"]
@@ -377,7 +379,7 @@ class ThriftAuthHandler:
 
                 # request group memberships for Microsoft
                 groups = []
-                if provider == 'microsoft':
+                if template == 'ms_entra/v2.0':
                     # decoding
                     id_token = oauth_token['id_token']
                     jwks_url = oauth_config["jwks_url"]
@@ -418,7 +420,7 @@ class ThriftAuthHandler:
             # from another api endpoint to maintain username as email
             # consistency between GitHub and other providers
             try:
-                if provider == "github":
+                if template == "github/v1":
                     if username_key == "email":
                         if "localhost" not in \
                                 user_info_url:
@@ -432,9 +434,9 @@ class ThriftAuthHandler:
                                              username)
                     else:
                         username = user_info.get("login")
-                elif provider == "google":
+                elif template == "google/v1":
                     username = user_info.get("email")
-                elif provider == "microsoft":
+                elif template == "ms_entra/v2.0":
                     if username_key == "username":
                         username = claims.get("Signum")
                     else:

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -23,6 +23,7 @@ from codechecker_common.util import load_json
 
 from codechecker_web.shared.env import check_file_owner_rw
 from codechecker_web.shared.version import SESSION_COOKIE_NAME as _SCN
+from codechecker_web.server.oauth_templates import OAUTH_TEMPLATES
 
 from .database.config_db_model import Session as SessionRecord
 from .database.config_db_model import OAuthToken
@@ -255,7 +256,18 @@ class SessionManager:
 
             if 'method_oauth' in self.__auth_config and \
                     self.__auth_config['method_oauth'].get('enabled'):
-                found_auth_method = True
+                self.__oauth_apply_templates()
+
+                for _, provider in self.__auth_config['method_oauth'] \
+                                       .get("providers").items():
+                    if provider.get("enabled"):
+                        found_auth_method = True
+                        break
+                else:
+                    LOG.warning("OAuth authentication was enabled but "
+                                "no OAuth provider was enabled"
+                                "... Disabling OAuth authentication.")
+                    self.__auth_config['method_oauth']['enabled'] = False
 
             if not found_auth_method:
                 if force_auth:
@@ -268,6 +280,64 @@ class SessionManager:
                                 "authentication backends are configured... "
                                 "Falling back to no authentication.")
                     self.__auth_config['enabled'] = False
+
+    def __oauth_apply_templates(self):
+        providers = self.__auth_config.get(
+            'method_oauth', {}).get('providers', {})
+
+        shared_variables = self.__auth_config.get(
+            'method_oauth', {}).get('shared_variables', {})
+
+        for provider_name, provider in providers.items():
+            if not provider.get('enabled'):
+                continue
+
+            template_name = provider.get('template', 'default')
+
+            if not OAUTH_TEMPLATES.get(template_name):
+                LOG.warning(f"OAuth provider {provider_name} tried to use "
+                            f"template '{template_name}', but it "
+                            " does not exist... Disabling OAuth provider "
+                            f"{provider_name}.")
+                provider['enabled'] = False
+                continue
+
+            if template_name == 'default':
+                LOG.warning(f"OAuth provider {provider_name} tried to use the "
+                            "default template. This template does not support"
+                            " fetching of users or emails in this release. "
+                            "Please use one of the available templates"
+                            f"... Disabling OAuth provider {provider_name}.")
+                provider['enabled'] = False
+                continue
+
+            for item, default_value in OAUTH_TEMPLATES[template_name].items():
+                provider.setdefault(item, default_value)
+
+            # Shared variables are overridden by the provider's own variables.
+            variables = {}
+            variables.update(shared_variables)
+            variables.update(provider.get('variables', {}))
+            variables['provider'] = provider_name
+
+            # Host has not been set, unset the default value.
+            if variables.get('host') == "https://<server_host>":
+                del variables['host']
+
+            for param, param_value in provider.items():
+                if param in ['enabled', 'client_id', 'client_secret',
+                             'template', 'variables', 'user_info_mapping']:
+                    continue
+
+                try:
+                    provider[param] = param_value.format(**variables)
+                except KeyError as e:
+                    LOG.warning(f"Parameter {param} in OAuth provider "
+                                f"{provider_name} tried accessing variable "
+                                f"{e.args[0]}, but it was not defined... "
+                                f"Disabling OAuth provider {provider_name}.")
+                    provider['enabled'] = False
+                    break
 
     def get_oauth_providers(self):
         result = []

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -56,47 +56,45 @@
     },
     "method_oauth": {
       "enabled": false,
+      "shared_variables" : {
+        "host": "https://<server_host>"
+      },
       "providers" : {
         "github" : {
           "enabled" : false,
           "client_id" : "<ExampleClientID>",
           "client_secret": "<ExampleClientSecret>",
-          "authorization_url": "https://github.com/login/oauth/authorize",
-          "callback_url": "https://<server_host>/login/OAuthLogin/github",
-          "token_url": "https://github.com/login/oauth/access_token",
-          "user_info_url": "https://api.github.com/user",
-          "user_emails_url": "https://api.github.com/user/emails",
-          "scope": "user:email",
-          "user_info_mapping": {
-            "username": "username"
-          }
+          "template": "github/v1"
         },
         "google": {
           "enabled" : false,
           "client_id" : "<ExampleClientID>",
           "client_secret" : "<ExampleClientSecret>",
-          "authorization_url" : "https://accounts.google.com/o/oauth2/auth",
-          "callback_url" : "https://<server_host>/login/OAuthLogin/google",
-          "token_url" : "https://accounts.google.com/o/oauth2/token",
-          "user_info_url" : "https://www.googleapis.com/oauth2/v1/userinfo",
-          "scope" : "openid email profile",
-          "user_info_mapping" : {
-            "username" : "email"
-          }
+          "template": "google/v1"
         },
         "microsoft": {
           "enabled": false,
           "client_id": "<ExampleClientID>",
           "client_secret": "<ExampleClientSecret>",
-          "authorization_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize",
-          "callback_url": "https://<server_host>/login/OAuthLogin/microsoft",
-          "token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
-          "user_groups_url" : "https://graph.microsoft.com/v1.0/me/memberOf",
-          "jwks_url": "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys",
-          "user_info_url": "https://graph.microsoft.com/v1.0/me",
-          "scope": "User.Read email profile openid offline_access",
+          "template": "ms_entra/v2.0",
+          "variables": {
+            "tenant_id": "common"
+          }
+        },
+        "custom": {
+          "enabled": false,
+          "client_id": "<ExampleClientID>",
+          "client_secret": "<ExampleClientSecret>",
+          "variables": {
+            "github_api_host": "https://api.github.com"
+          },
+          "authorization_url": "https://github.com/login/oauth/authorize",
+          "callback_url": "{host}/login/OAuthLogin/{provider}",
+          "token_url": "https://github.com/login/oauth/access_token",
+          "user_info_url": "{github_api_host}/user",
+          "scope": "user:email",
           "user_info_mapping": {
-            "username": "email"
+              "username": "username"
           }
         }
       }

--- a/web/server/config/server_config.json
+++ b/web/server/config/server_config.json
@@ -80,22 +80,6 @@
           "variables": {
             "tenant_id": "common"
           }
-        },
-        "custom": {
-          "enabled": false,
-          "client_id": "<ExampleClientID>",
-          "client_secret": "<ExampleClientSecret>",
-          "variables": {
-            "github_api_host": "https://api.github.com"
-          },
-          "authorization_url": "https://github.com/login/oauth/authorize",
-          "callback_url": "{host}/login/OAuthLogin/{provider}",
-          "token_url": "https://github.com/login/oauth/access_token",
-          "user_info_url": "{github_api_host}/user",
-          "scope": "user:email",
-          "user_info_mapping": {
-              "username": "username"
-          }
         }
       }
     },

--- a/web/tests/libtest/env.py
+++ b/web/tests/libtest/env.py
@@ -360,16 +360,19 @@ def enable_auth(workspace):
 
     scfg_dict["authentication"]["method_oauth"] = {
         "enabled": True,
+        "shared_variables": {
+            "host": "http://localhost:8080",
+            "oauth_host": "http://localhost:3000"
+        },
         "providers": {
             "github": {
                 "enabled": True,
                 "client_id": "1",
                 "client_secret": "1",
-                "authorization_url": "http://localhost:3000/login",
-                "callback_url": "http://localhost:8080/login/" +
-                                "OAuthLogin/github",
-                "token_url": "http://localhost:3000/token",
-                "user_info_url": "http://localhost:3000/get_user",
+                "template": "github/v1",
+                "authorization_url": "{oauth_host}/login",
+                "token_url": "{oauth_host}/token",
+                "user_info_url": "{oauth_host}/get_user",
                 "user_emails_url": "https://api.github.com/user/emails",
                 "scope": "openid email profile",
                 "user_info_mapping": {
@@ -380,11 +383,10 @@ def enable_auth(workspace):
                 "enabled": True,
                 "client_id": "2",
                 "client_secret": "2",
-                "authorization_url": "http://localhost:3000/login",
-                "callback_url": "http://localhost:8080/login/" +
-                                "OAuthLogin/google",
-                "token_url": "http://localhost:3000/token",
-                "user_info_url": "http://localhost:3000/get_user",
+                "template": "google/v1",
+                "authorization_url": "{oauth_host}/login",
+                "token_url": "{oauth_host}/token",
+                "user_info_url": "{oauth_host}/get_user",
                 "scope": "openid email profile",
                 "user_info_mapping": {
                     "username": "email"
@@ -394,11 +396,10 @@ def enable_auth(workspace):
                 "enabled": True,
                 "client_id": "3",
                 "client_secret": "3",
-                "authorization_url": "http://localhost:3000/login",
-                "callback_url": "http://localhost:8080/login/" +
-                                "OAuthLogin/dummy",
-                "token_url": "http://localhost:3000/token",
-                "user_info_url": "http://localhost:3000/get_user",
+                "template": "github/v1",
+                "authorization_url": "{oauth_host}/login",
+                "token_url": "{oauth_host}/token",
+                "user_info_url": "{oauth_host}/get_user",
                 "scope": "openid email profile",
                 "user_info_mapping": {
                     "username": "email"


### PR DESCRIPTION
Simplified the configuration of OAuth by introducing variables and templates.
In the general case, the user shouldn't ever need to specify any OAuth endpoint URLs.

Instead of relying on the name of the OAuth provider, the configuration now uses so-called "templates" to specify a behavior when logging in. 
Even if the user wants to override a default URL, `{variables}` such as `{host}` help streamline defining URLs.

Example OAuth configuration using templates:
```jsonc
"method_oauth": {
  "enabled": true,
  "shared_variables" : {
    "host": "https://example.com:8123" // must include protocol
  },
  "providers" : {
    "microsoft": {
      "enabled": true,
      "client_id": "<ExampleClientID>",
      "client_secret": "<ExampleClientSecret>",

      "template": "ms_entra/v2.0",
      "variables": {
        "tenant_id": "common" // replace with tenant ID, if not using multi-tenant mode
      },

      "user_info_mapping": { // optional
        "username": "email"
      }
    }
  }
}
```

while an URL could be specified as: ``"authorization_url": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize"``

Currently a template must be specified, but in the future there could be handling for a "default" OAuth endpoint type.
Supported providers are the same ones as before: `github => github/v1`, `google => google/v1`, `microsoft => ms_entra/v2.0`, named after the OAuth API versions of each service.

[See the docs for more details.](https://github.com/Discookie/codechecker/blob/oauth-config/docs/web/authentication.md#oauth-authentication)

[See the oauth_templates.py file for the currently available templates.](https://github.com/Discookie/codechecker/tree/oauth-config/web/codechecker_web/server/oauth_templates.py)