### PR TITLE
[ld_logger] Fix suffix match on non-absolute paths

### DIFF
--- a/analyzer/tools/build-logger/src/ldlogger-tool.c
+++ b/analyzer/tools/build-logger/src/ldlogger-tool.c
@@ -57,9 +57,29 @@ static int matchToProgramList(
 
     if (strchr(token, '/'))
     {
-      const char* posOfToken = strstr(progPath_, token);
-      if (posOfToken)
-        found = strcmp(posOfToken, token) == 0;
+      // When the token contains '/', then the program name is considered as a
+      // suffix:
+      //
+      //    token ->     /cc
+      // -------------------
+      // no match ->       c
+      //    match ->      cc
+      // no match ->     gcc
+      // no match ->  ccache
+      //    match -> bin2/cc
+      if (token[0] == '/')
+        ++token;
+
+      int len_token = strlen(token);
+      int len_prog = strlen(progPath_);
+
+      if (len_token >= len_prog)
+        found = strcmp(token, progPath_) == 0;
+      else
+      {
+        const char* suffix = progPath_ + len_prog - len_token;
+        found = suffix[-1] == '/' && strcmp(token, suffix) == 0;
+      }
     }
     else
     {


### PR DESCRIPTION
When using GNU make-4.2.1, then compiler binary names are not extended to absolute path. By setting "/cc" to CC_LOGGER_GCC_LIKE we assume that the compiler binary is provided by absolute path, since we are performing a suffix check. However, "/cc" is not suffix of "cc". This patch fixes the issue by virtually extending the compiler binary to absolute path.