### PR TITLE
[fix][server] Fix announcement message cannot be edited as superuser

### DIFF
--- a/web/server/codechecker_server/api/config_handler.py
+++ b/web/server/codechecker_server/api/config_handler.py
@@ -48,7 +48,7 @@ class ThriftConfigHandler:
                 codechecker_api_shared.ttypes.ErrorCode.UNAUTHORIZED,
                 "You are not authorized to execute this action.")
 
-        if (not (self.__auth_session is None) and
+        if (self.__auth_session is not None and
                 not self.__auth_session.is_root):
             raise codechecker_api_shared.ttypes.RequestFailed(
                 codechecker_api_shared.ttypes.ErrorCode.UNAUTHORIZED,
@@ -78,7 +78,7 @@ class ThriftConfigHandler:
     def setNotificationBannerText(self, notification_b64):
         """
         Sets the notification banner remove_products_except.
-        Beware: This method only works if the use is a SUPERUSER.
+        Beware: This method only works if the user is a SUPERUSER.
         """
 
         self.__require_supermission()

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -668,10 +668,8 @@ class SessionManager:
 
     def __is_root_user(self, user_name):
         """ Return True if the given user has system permissions. """
-        if 'super_user' not in self.__auth_config:
-            return False
-
-        if self.__auth_config['super_user'] == user_name:
+        if 'super_user' in self.__auth_config and \
+                self.__auth_config['super_user'] == user_name:
             return True
 
         transaction = None
@@ -780,7 +778,7 @@ class SessionManager:
         if groups is None:
             groups = []
 
-        LOG.debug(f"groups assigned to oauth_session: {groups}")
+        LOG.debug(f"Groups assigned to oauth_session: {groups}")
 
         if not self.__is_method_enabled('oauth'):
             return False


### PR DESCRIPTION
Fixed an issue with the root checking function where it returned false too early when super user was not defined in server config ignoring any permission settings.

Fixed typos