### PR TITLE
removing clang-diagnostic-implicit-void-ptr-cast from the sensitive p…

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -3188,7 +3188,6 @@
     "clang-diagnostic-implicit-void-ptr-cast": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-void-ptr-cast",
       "profile:extreme",
-      "profile:sensitive",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-implicitly-unsigned-literal": [


### PR DESCRIPTION
…rofile

The checker is too noisy on open source projects