### PR TITLE
Fix return_to directive when the user is already logged in

### DIFF
--- a/web/server/vue-cli/src/views/Login.vue
+++ b/web/server/vue-cli/src/views/Login.vue
@@ -186,7 +186,8 @@ export default {
 
   created() {
     if (this.isAuthenticated) {
-      this.$router.replace({ name: "products" });
+      const returnTo = this.$router.currentRoute.query["return_to"];
+      this.$router.replace(returnTo || { name: "products" });
     }
   },
 


### PR DESCRIPTION
When the user was already logged in, the `return_to` directive on the `/login` page was ignored.