### PR TITLE
[fix] Emit error message when SQLite DB is not under workspace dir

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -934,6 +934,13 @@ class CCSimpleHttpServer(HTTPServer):
 
         # Update the product database status.
         prod.connect()
+
+        if prod.db_status == DBStatus.FAILED_TO_CONNECT:
+            LOG.debug(
+                "Failed to connect to database for product '%s'",
+                orm_product.endpoint)
+            return
+
         if prod.db_status == DBStatus.SCHEMA_MISSING and init_db:
             LOG.debug("Schema was missing in the database. Initializing new")
             prod.connect(init_db=True)

--- a/web/server/vue-cli/src/components/Product/EditProductBtn.vue
+++ b/web/server/vue-cli/src/components/Product/EditProductBtn.vue
@@ -147,8 +147,6 @@ export default {
           this.success = true;
           this.$emit("on-complete",
             new ProductConfiguration(this.productConfig));
-        }, () => {
-          this.error = true;
         }));
 
       // Save permissions.


### PR DESCRIPTION
When the SQLite database file's directory is given as an absolute path that is not under the workspace directory, then a meaningful error message should be printed to the user.