### PR TITLE
Only respond to valid endpoints on the frontend

### DIFF
--- a/web/server/codechecker_server/routing.py
+++ b/web/server/codechecker_server/routing.py
@@ -52,6 +52,7 @@ def is_valid_product_endpoint(uripart):
     if uripart in NON_PRODUCT_ENDPOINTS:
         return False
 
+    # Should be kept in sync with the regex in router/index.js on the frontend.
     pattern = r'^[A-Za-z0-9_\-]+$'
     if not re.match(pattern, uripart):
         return False

--- a/web/server/vue-cli/src/router/index.js
+++ b/web/server/vue-cli/src/router/index.js
@@ -42,7 +42,9 @@ export default new Router({
       component: () => import("@/views/NotFound")
     },
     {
-      path: "/:endpoint",
+      // Should be kept in sync with the regex from is_valid_product_endpoint
+      // on the backend.
+      path: "/:endpoint([A-Za-z0-9_-]+)",
       meta: {
         requiresAuth: true
       },
@@ -132,6 +134,10 @@ CheckerCoverageStatistics"),
           component: () => import("@/views/SourceComponent")
         },
       ]
+    },
+    {
+      path: "/:unknown(.*)*",
+      redirect: "/404"
     }
   ]
 });


### PR DESCRIPTION
Previously, endpoint validity was only checked on the backend.
Added a redirect to the 404 page on unknown URLs in general as well.