### PR TITLE
Install "requests" Python dependency

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,4 +1,5 @@
 Authlib==1.3.1
+requests==2.32.4  # Required by Authlib. Not installed automatically for some reason.
 lxml==5.3.0
 sqlalchemy==1.3.23
 alembic==1.5.5


### PR DESCRIPTION
"Authlib" uses "requests" library, but this dependency is not installed automatically.