### PR TITLE
[fix] Fix migration logging

### DIFF
--- a/web/server/codechecker_server/migrations/logging.py
+++ b/web/server/codechecker_server/migrations/logging.py
@@ -63,7 +63,10 @@ def setup_logger(schema: str):
     logger = logging.getLogger(f"migration/{schema}")
     logging.setLoggerClass(existing_logger_cls)
 
-    if not logger.hasHandlers():
+    # logger.hasHandlers() falls back on parent's handlers, however,
+    # logger.handlers contains the immediate handlers only. It is important to
+    # check this list directly otherwise list indexing fails on "else" branch.
+    if not logger.handlers:
         fmt = MigrationFormatter(schema)
         handler = logging.StreamHandler()
         handler.setFormatter(fmt)


### PR DESCRIPTION
Python "logging" module handles a hierarchy of loggers. Loggers can be given handlers to handle the actual log message. If a logger doesn't have a handler then the parent's handler will be used. "logger.handlers" is an array containing the direct handlers, but "logger.hasHandlers()" returns true even if the parent has a handler. So, the array can be empty and "hasHandlers()" still returns True.