### PR TITLE
[fix] Parallelize parse_unique_log to speed-up ~nproc times

### DIFF
--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -1329,6 +1329,7 @@ def main(args):
         compiler_info_file,
         args.keep_gcc_include_fixed,
         args.keep_gcc_intrin,
+        args.jobs,
         skip_handlers,
         pre_analysis_skip_handlers,
         ctu_or_stats_enabled,


### PR DESCRIPTION
See https://github.com/Ericsson/codechecker/pull/4479#issuecomment-2704631041 parse_options is very slow.
In this PR I parallelize calls to it.