### PR TITLE
[fix] Add global view permission requirement for viewing products

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1468,7 +1468,10 @@ class ThriftRequestHandler:
         self.__require_permission([permissions.PRODUCT_STORE])
 
     def __require_view(self):
-        self.__require_permission([permissions.PRODUCT_VIEW])
+        self.__require_permission([
+            permissions.PRODUCT_VIEW,
+            permissions.PERMISSION_VIEW
+        ])
 
     def __add_comment(self, bug_id, message, kind=CommentKindValue.USER,
                       date=None):


### PR DESCRIPTION
Add the global view permission requirement for viewing products. This way if the user has the global view permission but no product related view permission can view any product on the server.