### PR TITLE
[fix] Significant speed-up for create_actions_map and start_workers

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import zipfile
 
+from functools import lru_cache
 from threading import Timer
 
 import multiprocess
@@ -781,9 +782,17 @@ def start_workers(actions_map, actions, analyzer_config_map,
                    'reproducer': reproducer_dir,
                    'ctu_connections': ctu_connections_dir}
 
+    @lru_cache
+    def __analyzer_config_map_get(analyzer_type):
+        """
+        analyzer_config_map is not a Dict, but multiprocess.managers.DictProxy,
+        so caching is necessary.
+        """
+        return analyzer_config_map.get(analyzer_type)
+
     analyzed_actions = [(actions_map,
                          build_action,
-                         analyzer_config_map.get(build_action.analyzer_type),
+                         __analyzer_config_map_get(build_action.analyzer_type),
                          output_path,
                          skip_handlers,
                          filter_handlers,

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -20,7 +20,7 @@ import time
 
 from multiprocess.managers import SyncManager
 
-from codechecker_common.logger import get_logger
+from codechecker_common.logger import get_logger, DEBUG
 from codechecker_common.review_status_handler import ReviewStatusHandler
 
 from . import analyzer_context, analysis_manager, pre_analysis_manager, \
@@ -55,16 +55,17 @@ def create_actions_map(actions, manager):
     Value: BuildAction
     """
 
-    result = manager.dict()
+    result = {}
 
+    check_for_unique_actions = LOG.isEnabledFor(DEBUG)
     for act in actions:
         key = act.source, act.target
-        if key in result:
+        if check_for_unique_actions and (key in result):
             LOG.debug("Multiple entires in compile database "
                       "with the same (source, target) pair: (%s, %s)",
                       act.source, act.target)
         result[key] = act
-    return result
+    return manager.dict(result)
 
 
 def __mgr_init():


### PR DESCRIPTION
`create_actions_map` is slow because it updates manager.dict() on every iteration via multiprocessing

Before

```
 ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.002    0.002  585.945  585.945 /home/zzz/Documents/Projects/codechecker/build/CodeChecker/lib/python3/codechecker_analyzer/analyzer.py:165(perform_analysis)
        1    1.037    1.037  579.764  579.764 /home/zzz/Documents/Projects/codechecker/build/CodeChecker/lib/python3/codechecker_analyzer/analyzer.py:82(create_actions_map)
   340784    0.932    0.000  578.300    0.002 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/managers.py:809(_callmethod)
   170392    0.126    0.000  499.783    0.003 <string>:1(__setitem__)
   340792    1.143    0.000  450.775    0.001 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/connection.py:204(send)
   340792    2.284    0.000  431.178    0.001 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/reduction.py:51(dumps)
   340792    0.394    0.000  425.367    0.001 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/dill/_dill.py:426(dump)
   340792    1.034    0.000  424.600    0.001 /usr/lib/python3.13/pickle.py:473(dump)
54480786/340792   27.259    0.000  420.493    0.001 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/dill/_dill.py:375(save)

```

After

```
    1    0.015    0.015  119.613  119.613 /home/zzz/Documents/Projects/codechecker/build/CodeChecker/lib/python3/codechecker_analyzer/analyzer.py:169(perform_analysis)
        1    0.240    0.240  113.686  113.686 /home/zzz/Documents/Projects/codechecker/build/CodeChecker/lib/python3/codechecker_analyzer/analyzer.py:82(create_actions_map)
        1    0.000    0.000  113.405  113.405 <string>:1(update)
        1    0.000    0.000  113.405  113.405 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/managers.py:809(_callmethod)
        9    0.046    0.005  106.810   11.868 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/connection.py:204(send)
        9    0.583    0.065  105.047   11.672 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/multiprocess/reduction.py:51(dumps)
        9    0.000    0.000  104.463   11.607 /home/zzz/Documents/Projects/codechecker/venv/lib/python3.13/site-packages/dill/_dill.py:426(dump)

```