### PR TITLE
Fix SeverityIcon color error

### DIFF
--- a/web/server/vue-cli/src/components/Icons/SeverityIcon.vue
+++ b/web/server/vue-cli/src/components/Icons/SeverityIcon.vue
@@ -73,9 +73,13 @@ export default {
   },
   data() {
     return {
-      Severity,
-      color: this.severityFromCodeToColor(this.status)
+      Severity
     };
+  },
+  computed: {
+    color() {
+      return this.severityFromCodeToColor(this.status);
+    }
   }
 };
 </script>


### PR DESCRIPTION
The original code only updates the color once, so the severity icon in the checker retains the color of the first checker the user opens.

For example, if a `low` severity checker is opened first, the icon will appear green in all checker tabs, regardless of their actual severity:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/f4347bad-3c23-454d-810d-c727e4196bc6" />
