### PR TITLE
[fix] Fix updating fixed_at time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,12 @@ test_unit_cov_in_env:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_ANALYZER) test_unit_cov_in_env
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) test_unit_cov_in_env
 
-test_functional:
+test_functional: test_analyzer_functional test_web_functional
+
+test_analyzer_functional:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_ANALYZER) test_functional
+
+test_web_functional:
 	BUILD_DIR=$(BUILD_DIR) $(MAKE) -C $(CC_WEB) test_functional
 
 test_functional_in_env:

--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -1130,7 +1130,7 @@ class MassStoreRun:
                 # rules, only review status source code comments
                 if old_report and old_report.review_status in \
                         ['false_positive', 'intentional']:
-                    fixed_at = old_report.review_status_date
+                    fixed_at = old_report.fixed_at
                 else:
                     fixed_at = run_history_time
 
@@ -1322,7 +1322,7 @@ class MassStoreRun:
                 # rules, only review status source code comments
                 if old_report and old_report.review_status in \
                         ['false_positive', 'intentional']:
-                    fixed_at = old_report.review_status_date
+                    fixed_at = old_report.fixed_at
                 else:
                     fixed_at = run_history_time
 

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -885,14 +885,13 @@ int main() {
         self.assertEqual(report.fixedAt, fixed_at)
 
         # A reopened and false positive report gets its "fixed at" date from
-        # ReviewStatus table. This is the date when the false positive review
-        # status was assigned to this bug.
+        # where the false positive status firstly given.
 
         setup_test_project(3)
         report = get_report()
         self.assertEqual(report.detectionStatus, DetectionStatus.REOPENED)
         self.assertEqual(report.reviewData.status, ReviewStatus.FALSE_POSITIVE)
-        self.assertNotEqual(report.fixedAt, fixed_at)
+        self.assertEqual(report.fixedAt, fixed_at)
 
         # Setting its review status to confirmed makes it outstanding.
 


### PR DESCRIPTION
Fix updating fixed_at time on every store command. Now it should only update if there is no fixed_at timestamp present, yet.