### PR TITLE
[fix] Blank page on invalid session token

### DIFF
--- a/web/server/vue-cli/src/main.js
+++ b/web/server/vue-cli/src/main.js
@@ -64,7 +64,8 @@ router.beforeResolve((to, from, next) => {
   store.dispatch(GET_AUTH_PARAMS).then(() => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
       if (store.getters.authParams.requiresAuthentication &&
-        !store.getters.isAuthenticated
+        (!store.getters.authParams.sessionStillActive ||
+         !store.getters.isAuthenticated)
       ) {
         // Redirect the user to the login page but keep the original path to
         // redirect the user back once logged in.

--- a/web/server/vue-cli/src/store/modules/auth.js
+++ b/web/server/vue-cli/src/store/modules/auth.js
@@ -37,8 +37,6 @@ const getters = {
 
 const actions = {
   [GET_AUTH_PARAMS]({ commit }) {
-    if (state.authParams) return state.authParams;
-
     return new Promise(resolve => {
       authService.getClient().getAuthParameters(
         handleThriftError(params => {

--- a/web/server/vue-cli/src/views/Login.vue
+++ b/web/server/vue-cli/src/views/Login.vue
@@ -167,6 +167,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      "authParams",
       "isAuthenticated"
     ]),
     ssoButtonText() {
@@ -185,7 +186,7 @@ export default {
   },
 
   created() {
-    if (this.isAuthenticated) {
+    if (this.isAuthenticated && this.authParams.sessionStillActive) {
       const returnTo = this.$router.currentRoute.query["return_to"];
       this.$router.replace(returnTo || { name: "products" });
     }


### PR DESCRIPTION
When the browser has an auth session token that is not found on server side, then a blank page was loaded. As a workaround the user had to manually clear the token from the browser and reload the page. Now we redirect the user back to the login page when this situation occurs.

The problem was that the "authParams" was cached in a state that its "sessionStillActive" field is false. Now these auth parameters are not cached but loaded from the server.