### PR TITLE
[fix] Fix github gating authentication issue

### DIFF
--- a/.github/workflows/codechecker_pr_analysis.yml
+++ b/.github/workflows/codechecker_pr_analysis.yml
@@ -31,5 +31,5 @@ jobs:
           CODECHECKER_TOKEN: ${{ secrets.CODECHECKER_STORE_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          echo "{\"client_autologin\" : true,\"credentials\": {\"https://codechecker-demo.eastus.cloudapp.azure.com\": \"store:${CODECHECKER_TOKEN}\"}}" > ~/.codechecker.passwords.json
+          echo "{\"client_autologin\" : true,\"credentials\": {\"https://codechecker-demo.eastus.cloudapp.azure.com\": \"demo:demo\"}}" > ~/.codechecker.passwords.json
           bash ./ci/github_analysis/codechecker_gate_pr.sh $GITHUB_REF

--- a/ci/github_analysis/codechecker_gate_pr.sh
+++ b/ci/github_analysis/codechecker_gate_pr.sh
@@ -8,8 +8,7 @@ fi
 
 ./ci/github_analysis/pylint_analyze.sh
 report-converter -c -t pylint -o ./reports-pylint ./pylint-reports.json
-CodeChecker store -f ./reports-pylint --url "$CC_URL" --trim-path-prefix "$(pwd)" -n "$1"
-CodeChecker cmd diff --url "$CC_URL" -b master -n "$1" --new
+CodeChecker cmd diff --url "$CC_URL" -b master -n ./reports-pylint --new
 if [ "$?" -ne 0 ]; then
     echo "ERROR. YOUR PR FAILED GATING! Please check new reports at $CC_URL/reports?run=master&newcheck=$1"
     exit 1


### PR DESCRIPTION
Fix an issue with authentication of the gating script on CodeChecker server. GitHub does not pass secrets to forked repository PRs.