### PR TITLE
ci: Sync pylint usage of CC gating with style tests

### DIFF
--- a/.github/workflows/codechecker_pr_analysis.yml
+++ b/.github/workflows/codechecker_pr_analysis.yml
@@ -10,8 +10,6 @@ jobs:
     name: CodeChecker analyze PR
 
     runs-on: ubuntu-24.04
-    env:
-      PR_NUMBER: ${{ github.event.number }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -29,7 +27,6 @@ jobs:
       - name: Run CodeChecker analysis
         env:
           CODECHECKER_TOKEN: ${{ secrets.CODECHECKER_STORE_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
         run: |
           echo "{\"client_autologin\" : true,\"credentials\": {\"https://codechecker-demo.eastus.cloudapp.azure.com\": \"demo:demo\"}}" > ~/.codechecker.passwords.json
           bash ./ci/github_analysis/codechecker_gate_pr.sh $GITHUB_REF

--- a/.pylintrc
+++ b/.pylintrc
@@ -478,7 +478,8 @@ disable=raw-checker-failed,
         protected-access,  # TODO: Used in test code, but not elegant
         global-statement,
         consider-using-get,  # Unnecessary style checker
-        attribute-defined-outside-init  # Too many reports from test codes
+        attribute-defined-outside-init,  # Too many reports from test codes
+        no-name-in-module  # TODO: Could be fixed
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ci/github_analysis/codechecker_gate_pr.sh
+++ b/ci/github_analysis/codechecker_gate_pr.sh
@@ -10,7 +10,7 @@ fi
 report-converter -c -t pylint -o ./reports-pylint ./pylint-reports.json
 CodeChecker cmd diff --url "$CC_URL" -b master -n ./reports-pylint --new
 if [ "$?" -ne 0 ]; then
-    echo "ERROR. YOUR PR FAILED GATING! Please check new reports at $CC_URL/reports?run=master&newcheck=$1"
+    echo "ERROR. YOUR PR FAILED GATING!"
     exit 1
 else
     echo "Gating successful. No new report found. Your PR is ready to be merged."

--- a/ci/github_analysis/pylint_analyze.sh
+++ b/ci/github_analysis/pylint_analyze.sh
@@ -1,5 +1,44 @@
 #!/bin/bash
 
 pylint --version
-disabled_checkers="duplicate-code,fixme,consider-using-get,too-many-instance-attributes"
-pylint --rcfile=.pylintrc -j0 --disable $disabled_checkers -f json --output ./pylint-reports.json ./build/CodeChecker/lib/python3/*
+
+ROOT=$(pwd)
+
+JSON_DIR='reports/'
+mkdir -p $JSON_DIR
+
+WORKDIR="$ROOT"/analyzer/tools/merge_clang_extdef_mappings
+pylint --rcfile="$WORKDIR"/.pylintrc -f json --output $JSON_DIR/pylint-reports-clang.json -j0 --py-version=3.10 \
+    "$WORKDIR"/codechecker_merge_clang_extdef_mappings \
+    "$WORKDIR"/tests/**
+
+WORKDIR="$ROOT"/analyzer/tools/statistics_collector
+pylint --rcfile="$WORKDIR"/.pylintrc -f json --output $JSON_DIR/pylint-reports-statictics-collector.json -j0 --py-version=3.10 \
+    "$WORKDIR"/codechecker_statistics_collector \
+    "$WORKDIR"/tests/**
+
+
+WORKDIR="$ROOT"/web
+pylint --rcfile="$WORKDIR"/../.pylintrc -f json --output $JSON_DIR/pylint-reports-web.json -j0 --py-version=3.10 \
+    --ignore="$WORKDIR"/server/codechecker_server/migrations/report,"$WORKDIR"/server/codechecker_server/migrations/report/versions,"$WORKDIR"/server/codechecker_server/migrations/config,"$WORKDIR"/server/codechecker_server/migrations/config/versions \
+    "$WORKDIR"/codechecker_web \
+    "$WORKDIR"/client/codechecker_client \
+    "$WORKDIR"/server/codechecker_server \
+    "$WORKDIR"/server/tests/unit \
+    "$WORKDIR"/tests/functional \
+    "$WORKDIR"/tests/libtest \
+    "$WORKDIR"/tests/tools \
+    "$WORKDIR"/../tools/report-converter/codechecker_report_converter
+
+WORKDIR="$ROOT"
+pylint --rcfile="$WORKDIR"/.pylintrc -f json --output $JSON_DIR/pylint-reports-root.json -j0 --py-version=3.10 \
+    "$WORKDIR"/bin/** \
+    "$WORKDIR"/codechecker_common \
+    "$WORKDIR"/scripts/** \
+    "$WORKDIR"/scripts/build/** \
+    "$WORKDIR"/scripts/debug_tools/** \
+    "$WORKDIR"/scripts/resources/** \
+    "$WORKDIR"/scripts/test/** \
+    "$WORKDIR"/scripts/thrift/**
+
+jq -s 'add' $JSON_DIR/* > pylint-reports.json


### PR DESCRIPTION
Use the same directories and ignores in CC gating as pylint uses when ran with the tests on github. Pylint uses the pylintrc file to set up itself when it comes to disabled checkers.