### PR TITLE
Add memory-safety guideline

### DIFF
--- a/config/guidelines/memory-safety.yaml
+++ b/config/guidelines/memory-safety.yaml
@@ -1,5 +1,5 @@
 guideline: memory-safety
-guideline_title: Memory-safety related CWEs based on Juliet test suite
+guideline_title: Memory-safety related CWEs
 rules:
 - rule_id: cwe-121
   title: Stack-Based Buffer Overflow

--- a/config/guidelines/memory-safety.yaml
+++ b/config/guidelines/memory-safety.yaml
@@ -1,0 +1,60 @@
+guideline: memory-safety
+guideline_title: Memory-safety related CWEs based on Juliet test suite
+rules:
+- rule_id: cwe-121
+  title: Stack-Based Buffer Overflow
+  rule_url: https://cwe.mitre.org/data/definitions/121.html
+- rule_id: cwe-122
+  title: Heap-based Buffer Overflow
+  rule_url: https://cwe.mitre.org/data/definitions/122.html
+- rule_id: cwe-123
+  title: Write-what-where Condition
+  rule_url: https://cwe.mitre.org/data/definitions/123.html
+- rule_id: cwe-124
+  title: Buffer Underwrite ('Buffer Underflow')
+  rule_url: https://cwe.mitre.org/data/definitions/124.html
+- rule_id: cwe-126
+  title: Buffer Over-read
+  rule_url: https://cwe.mitre.org/data/definitions/126.html
+- rule_id: cwe-127
+  title: Buffer Under-read
+  rule_url: https://cwe.mitre.org/data/definitions/127.html
+- rule_id: cwe-244
+  title: Improper Clearing of Heap Memory Before Release ('Heap Inspection')
+  rule_url: https://cwe.mitre.org/data/definitions/244.html
+- rule_id: cwe-401
+  title: Missing Release of Memory after Effective Lifetime ('Memory Leak')
+  rule_url: https://cwe.mitre.org/data/definitions/401.html
+- rule_id: cwe-415
+  title: Double Free
+  rule_url: https://cwe.mitre.org/data/definitions/415.html
+- rule_id: cwe-416
+  title: Use After Free
+  rule_url: https://cwe.mitre.org/data/definitions/416.html
+- rule_id: cwe-457
+  title: Use of Uninitialized Variable
+  rule_url: https://cwe.mitre.org/data/definitions/457.html
+- rule_id: cwe-476
+  title: Nullptr Dereference
+  rule_url: https://cwe.mitre.org/data/definitions/476.html
+- rule_id: cwe-562
+  title: Return of Stack Variable Address
+  rule_url: https://cwe.mitre.org/data/definitions/562.html
+- rule_id: cwe-590
+  title: Free of Memory not on the Heap
+  rule_url: https://cwe.mitre.org/data/definitions/590.html
+- rule_id: cwe-761
+  title: Free of Pointer not at Start of Buffer
+  rule_url: https://cwe.mitre.org/data/definitions/761.html
+- rule_id: cwe-762
+  title: Mismatched Memory Management Routines
+  rule_url: https://cwe.mitre.org/data/definitions/762.html
+- rule_id: cwe-785
+  title: Use of Path Manipulation Function without Maximum Sized Buffer
+  rule_url: https://cwe.mitre.org/data/definitions/785.html
+- rule_id: cwe-789
+  title: Uncontrolled Memory Allocation
+  rule_url: https://cwe.mitre.org/data/definitions/789.html
+- rule_id: cwe-843
+  title: Access of Resource Using Incompatible Type ('Type Confusion')
+  rule_url: https://cwe.mitre.org/data/definitions/843.html

--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -4943,6 +4943,7 @@
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-stack-address",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
@@ -4950,6 +4951,7 @@
       "sei-cert-c:dcl30-c",
       "sei-cert-cpp:exp54-cpp",
       "sei-cert-cpp:exp61-cpp",
+      "memory-safety:cwe-562",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-return-std-move": [
@@ -5727,12 +5729,14 @@
     "clang-diagnostic-uninitialized": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wuninitialized",
       "guideline:sei-cert-c",
+      "guideline:memory-safety",
       "label-tool-skip:severity",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-c:exp33-c",
+      "memory-safety:cwe-457",
       "severity:HIGH"
     ],
     "clang-diagnostic-uninitialized-const-reference": [

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -334,12 +334,14 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference-c-c-objc",
       "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-476",
       "sei-cert-c:exp34-c",
+      "memory-safety:cwe-476",
       "severity:HIGH"
     ],
     "core.StackAddrEscapeBase": [
@@ -357,6 +359,7 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape-c",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
@@ -364,6 +367,8 @@
       "sei-cert-c:dcl30-c",
       "sei-cert-cpp:exp54-cpp",
       "sei-cert-cpp:exp61-cpp",
+      "memory-safety:cwe-123",
+      "memory-safety:cwe-562",
       "severity:HIGH"
     ],
     "core.UndefinedBinaryOperatorResult": [
@@ -504,6 +509,7 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete-c",
       "guideline:cwe-top-25-2024",
       "guideline:sei-cert-cpp",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
@@ -513,16 +519,21 @@
       "sei-cert-cpp:mem50-cpp",
       "sei-cert-cpp:mem51-cpp",
       "sei-cert-cpp:oop54-cpp",
+      "memory-safety:cwe-415",
+      "memory-safety:cwe-416",
+      "memory-safety:cwe-590",
       "severity:HIGH"
     ],
     "cplusplus.NewDeleteLeaks": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks-c",
       "guideline:sei-cert-cpp",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-cpp:mem51-cpp",
+      "memory-safety:cwe-401",
       "severity:HIGH"
     ],
     "cplusplus.PlacementNew": [
@@ -767,9 +778,11 @@
     "optin.taint.TaintedAlloc": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc-c-c",
       "guideline:owasp-top-10-2021",
+      "guideline:memory-safety",
       "profile:extreme",
       "profile:sensitive",
       "owasp-top-10-2021:owasp-A03-2021",
+      "memory-safety:cwe-789",
       "severity:HIGH"
     ],
     "optin.taint.TaintedDiv": [
@@ -868,12 +881,18 @@
     "security.ArrayBound": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#security-arraybound-c-c",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "profile:default",
       "profile:security",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-119",
       "cwe-top-25-2024:cwe-125",
       "cwe-top-25-2024:cwe-787",
+      "memory-safety:cwe-121",
+      "memory-safety:cwe-122",
+      "memory-safety:cwe-124",
+      "memory-safety:cwe-126",
+      "memory-safety:cwe-127",
       "severity:HIGH"
     ],
     "security.FloatLoopCounter": [
@@ -1082,6 +1101,7 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc-c",
       "guideline:cwe-top-25-2024",
       "guideline:sei-cert-c",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
@@ -1094,7 +1114,11 @@
       "sei-cert-c:mem34-c",
       "sei-cert-c:mem35-c",
       "sei-cert-c:mem36-c",
-      "severity:MEDIUM"
+      "memory-safety:cwe-401",
+      "memory-safety:cwe-415",
+      "memory-safety:cwe-416",
+      "memory-safety:cwe-590",
+      "severity:HIGH"
     ],
     "unix.MallocSizeof": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof-c",
@@ -1111,12 +1135,14 @@
     "unix.MismatchedDeallocator": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator-c-c",
       "guideline:sei-cert-cpp",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "sei-cert-cpp:mem51-cpp",
-      "severity:MEDIUM"
+      "memory-safety:cwe-762",
+      "severity:HIGH"
     ],
     "unix.StdCLibraryFunctions": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions-c",

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -1118,7 +1118,7 @@
       "memory-safety:cwe-415",
       "memory-safety:cwe-416",
       "memory-safety:cwe-590",
-      "severity:HIGH"
+      "severity:MEDIUM"
     ],
     "unix.MallocSizeof": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof-c",
@@ -1142,7 +1142,7 @@
       "profile:sensitive",
       "sei-cert-cpp:mem51-cpp",
       "memory-safety:cwe-762",
-      "severity:HIGH"
+      "severity:MEDIUM"
     ],
     "unix.StdCLibraryFunctions": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions-c",

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -51,9 +51,13 @@
       "severity:LOW"
     ],
     "cppcheck-arrayIndexOutOfBounds": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-121",
+      "memory-safety:cwe-122",
+      "memory-safety:cwe-126",
       "severity:HIGH"
     ],
     "cppcheck-arrayIndexOutOfBoundsCond": [
@@ -99,9 +103,11 @@
       "severity:HIGH"
     ],
     "cppcheck-autovarInvalidDeallocation": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-590",
       "severity:HIGH"
     ],
     "cppcheck-badBitmaskCheck": [
@@ -120,9 +126,12 @@
       "severity:HIGH"
     ],
     "cppcheck-bufferAccessOutOfBounds": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-121",
+      "memory-safety:cwe-122",
       "severity:HIGH"
     ],
     "cppcheck-catchExceptionByValue": [
@@ -305,9 +314,11 @@
       "severity:HIGH"
     ],
     "cppcheck-deallocuse": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "cppcheck-derefInvalidIterator": [
@@ -323,9 +334,11 @@
       "severity:MEDIUM"
     ],
     "cppcheck-doubleFree": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-415",
       "severity:HIGH"
     ],
     "cppcheck-duplInheritedMember": [
@@ -758,9 +771,11 @@
       "severity:MEDIUM"
     ],
     "cppcheck-mismatchAllocDealloc": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-762",
       "severity:HIGH"
     ],
     "cppcheck-mismatchSize": [
@@ -842,9 +857,12 @@
       "severity:MEDIUM"
     ],
     "cppcheck-negativeIndex": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-124",
+      "memory-safety:cwe-127",
       "severity:HIGH"
     ],
     "cppcheck-negativeMemoryAllocationSize": [
@@ -1117,9 +1135,11 @@
       "severity:LOW"
     ],
     "cppcheck-returnDanglingLifetime": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-562",
       "severity:HIGH"
     ],
     "cppcheck-returnLocalVariable": [
@@ -1417,9 +1437,11 @@
       "severity:HIGH"
     ],
     "cppcheck-uninitvar": [
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "memory-safety:cwe-457",
       "severity:HIGH"
     ],
     "cppcheck-unknownEvaluationOrder": [

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -18,7 +18,9 @@
     ],
     "gcc-double-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-free",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-415",
       "severity:HIGH"
     ],
     "gcc-exposure-through-output-file": [
@@ -73,7 +75,9 @@
     ],
     "gcc-free-of-non-heap": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-free-of-non-heap",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-590",
       "severity:HIGH"
     ],
     "gcc-imprecise-fp-arithmetic": [
@@ -93,12 +97,17 @@
     ],
     "gcc-malloc-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-malloc-leak",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-401",
+      "memory-safety:cwe-761",
       "severity:HIGH"
     ],
     "gcc-mismatching-deallocation": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-mismatching-deallocation",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-762",
       "severity:HIGH"
     ],
     "gcc-null-argument": [
@@ -108,12 +117,21 @@
     ],
     "gcc-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-dereference",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-476",
       "severity:HIGH"
     ],
     "gcc-out-of-bounds": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-out-of-bounds",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-121",
+      "memory-safety:cwe-122",
+      "memory-safety:cwe-124",
+      "memory-safety:cwe-126",
+      "memory-safety:cwe-127",
+      "memory-safety:cwe-843",
       "severity:HIGH"
     ],
     "gcc-possible-null-argument": [
@@ -183,7 +201,9 @@
     ],
     "gcc-use-after-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-after-free",
+      "guideline:memory-safety",
       "profile:extreme",
+      "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "gcc-use-of-pointer-in-stale-stack-frame": [

--- a/config/labels/descriptions.json
+++ b/config/labels/descriptions.json
@@ -18,6 +18,7 @@
     "cwe-top-25-2024": "https://cwe.mitre.org/top25/",
     "sei-cert-c": "https://wiki.sei.cmu.edu/confluence/display/c/SEI+CERT+C+Coding+Standard",
     "sei-cert-cpp": "https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88046682",
-    "misra-c": "https://www.misra.org.uk/"
+    "misra-c": "https://www.misra.org.uk/",
+    "memory-safety": "https://cwe.mitre.org/data/definitions/1399.html"
   }
 }

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -194,6 +194,11 @@ export default {
         id: "owasp-top-10-2021",
         name: "OWASP Top 10 Web Application Security Risks 2021",
         value: 3
+      },
+      {
+        id: "memory-safety",
+        name: "Memory-safety related CWEs",
+        value: 4
       }
     ];
 
@@ -208,7 +213,7 @@ export default {
       runs: null,
       runData: [],
       selectedCheckerName: null,
-      selectedGuidelineIndexes: [ 0, 1, 2, 3 ],
+      selectedGuidelineIndexes: [ 0, 1, 2, 3, 4 ],
       showRuns: {
         enabled: false,
         disabled: false,


### PR DESCRIPTION
This PR adds a new guideline, `memory-safety`, which can be useful for developers who are interested in catching specifically memory-safety bugs. 

Furthermore, my suggestion (included in the PR) is to raise `unix.MismatchedDeallocator` and `unix.Malloc` to `HIGH` severity. The former _always_ leads to UB on true positives, and the latter almost always.