### PR TITLE
fix link ref in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -261,7 +261,7 @@ analyze only the changed files and all the files that are depending on the
 source code changes (in case of the update of a header file).
 
 b) If you only want to re-analyze changed source files, without re-building
-your project, you can use [skip](analyzer/user_guide.md#skip) list to tell
+your project, you can use [skip](analyzer/user_guide.md#skip-file) list to tell
 CodeChecker which files to analyze.
 
 ### Automatic fixing


### PR DESCRIPTION
Let the link point to the same place as it did in 1eaf280

#### Note

Or maybe the link should point to the heading "Using skip file to narrow analyzed files" in this file. There is a link to the other document if more details are desired.