### PR TITLE
Fix CodeChecker analyzer config exception

### DIFF
--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -902,14 +902,18 @@ def is_analyzer_config_valid(
             continue
 
     for cfg_arg in analyzer_config_args:
+        if enabled_analyzers and cfg_arg.analyzer not in enabled_analyzers:
+            wrong_config_messages.append(
+                f"The analyzer '{cfg_arg.analyzer}' is not enabled. Enable it "
+                "first using --analyzers to set the config "
+                f"'{cfg_arg.option}'.")
+            continue
+
         if cfg_arg.analyzer not in available_analyzers:
             wrong_config_messages.append(
                 f"Invalid argument to --analyzer-config: '{cfg_arg.analyzer}' "
                 f"is not an available analyzer. Available analyzers are: "
                 f"{', '.join(a for a in available_analyzers)}.")
-            continue
-
-        if enabled_analyzers and cfg_arg.analyzer not in enabled_analyzers:
             continue
 
         try:

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 from typing import List
 from pathlib import Path
+from functools import partial
 
 from tu_collector import tu_collector
 
@@ -862,6 +863,7 @@ LLVM/Clang community, and thus discouraged.
 
 
 def is_analyzer_config_valid(
+    args,
     analyzer_config_args: List[AnalyzerConfigArg]
 ) -> bool:
     """
@@ -869,26 +871,59 @@ def is_analyzer_config_valid(
     by verifying if it belongs to the set of allowed values.
     """
     wrong_config_messages = []
-    supported_analyzers = analyzer_types.supported_analyzers
+    available_analyzers = {}
 
-    analyzer_configs = {
-        analyzer_name: analyzer_class.get_analyzer_config()
-        for analyzer_name, analyzer_class
-        in supported_analyzers.items()
-    }
+    for analyzer_name, analyzer_class in \
+            analyzer_types.supported_analyzers.items():
+        if analyzer_class.get_binary_version() is not None:
+            available_analyzers[analyzer_name] = analyzer_class
 
-    for cfg_arg in analyzer_config_args:
-        if cfg_arg.analyzer not in supported_analyzers:
+    enabled_analyzers = {}
+    if args.analyzers:
+        enabled_analyzer_names = \
+            set(args.analyzers).intersection(available_analyzers)
+        enabled_analyzers = {
+            analyzer_name: available_analyzers[analyzer_name]
+            for analyzer_name in enabled_analyzer_names
+        }
+
+    if enabled_analyzers:
+        available_analyzers = enabled_analyzers
+
+    analyzer_configs = {}
+    for analyzer_name, analyzer_class in available_analyzers.items():
+        try:
+            analyzer_configs[analyzer_name] = \
+                analyzer_class.get_analyzer_config()
+        except Exception as e:
             wrong_config_messages.append(
-                f"Invalid argument to --analyzer-config: '{cfg_arg.analyzer}' "
-                f"is not a supported analyzer. Supported analyzers are: "
-                f"{', '.join(a for a in supported_analyzers)}.")
+                f"Could not get config for analyzer '{analyzer_name}'. "
+                f"Error: {e}")
             continue
 
-        analyzer_cfg = next(
-            (x for x in analyzer_configs[cfg_arg.analyzer]
-             if x.option == cfg_arg.option),
-            None)
+    for cfg_arg in analyzer_config_args:
+        if cfg_arg.analyzer not in available_analyzers:
+            wrong_config_messages.append(
+                f"Invalid argument to --analyzer-config: '{cfg_arg.analyzer}' "
+                f"is not an available analyzer. Available analyzers are: "
+                f"{', '.join(a for a in available_analyzers)}.")
+            continue
+
+        if enabled_analyzers and cfg_arg.analyzer not in enabled_analyzers:
+            continue
+
+        try:
+            analyzer_cfg = next(
+                (x for x in analyzer_configs[cfg_arg.analyzer]
+                 if x.option == cfg_arg.option),
+                None)
+        except Exception:
+            wrong_config_messages.append(
+                f"The analyzer '{cfg_arg.analyzer}' is not found! Make sure "
+                "it is loaded or exists with the command "
+                "'CodeChecker analyzers'"
+            )
+            continue
 
         if analyzer_cfg is None:
             wrong_config_messages.append(
@@ -1180,7 +1215,7 @@ def main(args):
 
     # Validate analyzer and checker config (if any)
     config_validator = {
-        'analyzer_config': is_analyzer_config_valid,
+        'analyzer_config': partial(is_analyzer_config_valid, args),
         'checker_config': is_checker_config_valid
     }
 

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -1139,7 +1139,10 @@ class TestAnalyze(unittest.TestCase):
             cppcheck_args.write("--std=c++11")
             cppcheck_args.flush()
 
-            analyze_cmd.extend(['--cppcheckargs', cppcheck_args.name])
+            analyze_cmd.extend([
+                '--analyzer-config',
+                f'cppcheck:cc-verbatim-args-file={cppcheck_args.name}'
+            ])
 
             out = subprocess.run(analyze_cmd,
                                  cwd=self.test_dir,

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -663,13 +663,16 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
         --analyzer-config or --checker-config parameter is specified.
         """
 
+        args = create_analyze_argparse()
+        args.analyzers = ["clangsa", "clang-tidy"]
+
         analyzer_cfg_valid = [AnalyzerConfigArg(
             'clangsa', 'faux-bodies', 'false')]
         checker_cfg_valid = [CheckerConfigArg(
             'clang-tidy', 'performance-unnecessary-value-param',
             'IncludeStyle', 'false')]
 
-        self.assertTrue(is_analyzer_config_valid(analyzer_cfg_valid))
+        self.assertTrue(is_analyzer_config_valid(args, analyzer_cfg_valid))
         self.assertTrue(is_checker_config_valid(checker_cfg_valid))
 
         analyzer_cfg_invalid_analyzer = [AnalyzerConfigArg(
@@ -687,9 +690,10 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
             'asd', 'false')]
 
         self.assertFalse(is_analyzer_config_valid(
+            args,
             analyzer_cfg_invalid_analyzer))
         self.assertFalse(
-            is_analyzer_config_valid(analyzer_cfg_invalid_conf))
+            is_analyzer_config_valid(args, analyzer_cfg_invalid_conf))
 
         self.assertFalse(is_checker_config_valid(checker_cfg_invalid_analyzer))
         self.assertFalse(is_checker_config_valid(checker_cfg_invalid_checker))

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -657,6 +657,20 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
         self.assertNotIn("Wreserved-id-macro",
                          analyzer.config_handler.checks().keys())
 
+    def test_analyze_correct_analyzer_not_enabled(self):
+        """
+        This test checks if an analyzer is not enabled but a config
+        for it is getting set.
+        """
+
+        args = create_analyze_argparse()
+        args.analyzers = ["gcc"]
+
+        analyzer_cfg = [AnalyzerConfigArg(
+            'clangsa', 'faux-bodies', 'false')]
+
+        self.assertFalse(is_analyzer_config_valid(args, analyzer_cfg))
+
     def test_analyze_wrong_parameters(self):
         """
         This test checks whether the analyze command detects if a wrong
@@ -837,6 +851,7 @@ class CheckerHandlingCppcheckTest(unittest.TestCase):
                 f.write('--max-ctu-depth=42')
 
             args = Namespace()
+            args.analyzers = ["clang-tidy"]
             args.analyzer_config = [analyzer_config(
                 f"cppcheck:cc-verbatim-args-file={cppcheckargs}")]
 


### PR DESCRIPTION
Fix a CodeChecker exception which occurs when the analyze command has an analyzer config set which' analyzer is not enabled.

This fix collects all the enabled analyzers and skips the config checks for the analyzers which are not enabled.