### PR TITLE
fix: protect for missing clang binary

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -322,6 +322,9 @@ class ClangSA(analyzer_base.SourceAnalyzer):
     @classmethod
     def get_analyzer_config(cls) -> List[analyzer_base.AnalyzerConfig]:
         """Return the list of analyzer config options."""
+        if not cls.analyzer_binary():
+            return []
+
         command = [cls.analyzer_binary(), "-cc1"]
 
         cls.__add_plugin_load_flags(command)


### PR DESCRIPTION
When cli is validating analyzer configuration, it will call this method. This will fail with None error in file system functions since no binary is found.

This was introduced in 39666a7b71d0e79dd889791ab7a12770c7cb3a30