### PR TITLE
Fix over-eager file matching in skip files and `--file` option

### DIFF
--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -51,8 +51,6 @@ class SkipListHandler:
         the regular expressions.
         """
         for skip_line in skip_lines:
-            if skip_line[-1] == '/':
-                skip_line += '*'
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
             rexpr = re.compile(
                 fnmatch.translate(norm_skip_path))

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -66,7 +66,7 @@ class SkipListHandler:
             elif translated_glob.endswith(r"\Z"):
                 translated_glob = translated_glob[:-2]
             rexpr = re.compile(
-                translated_glob + r"(?:/.*)?$")
+                translated_glob + r"(?:" + os.path.normpath("/") + r".*)?$")
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -51,6 +51,8 @@ class SkipListHandler:
         the regular expressions.
         """
         for skip_line in skip_lines:
+            if skip_line[-1] == '/':
+                skip_line += '*'
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
             rexpr = re.compile(
                 fnmatch.translate(norm_skip_path))

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -61,9 +61,7 @@ class SkipListHandler:
             # Note: normalization removes '/' from the end, see:
             # https://docs.python.org/3/library/os.path.html#os.path.normpath
             translated_glob = fnmatch.translate(norm_skip_path)
-            if sys.version_info.minor >= 9:
-                translated_glob = translated_glob.removesuffix(r"\Z")
-            elif translated_glob.endswith(r"\Z"):
+            if translated_glob.endswith(r"\Z"):
                 translated_glob = translated_glob[:-2]
             rexpr = re.compile(
                 translated_glob + fr"(?:\{os.path.sep}.*)?$")

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -52,8 +52,15 @@ class SkipListHandler:
         """
         for skip_line in skip_lines:
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
+            # fnmatch places a '\Z' at the end, this  is equivalent to '$'
+            # (end of input) so it must be removed.
+            # Optionally we match the user given path with a '/.*' ending.
+            # This, if the given input is a folder will
+            # resolve all files contained within.
+            # Note: normalization removes '/' from the end, see:
+            # https://docs.python.org/3/library/os.path.html#os.path.normpath
             rexpr = re.compile(
-                fnmatch.translate(norm_skip_path) + r"(?:\/.*)?")
+                fnmatch.translate(norm_skip_path)[:-2] + r"(?:/.*)?\Z")
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -66,7 +66,7 @@ class SkipListHandler:
             elif translated_glob.endswith(r"\Z"):
                 translated_glob = translated_glob[:-2]
             rexpr = re.compile(
-                translated_glob + r"(?:" + os.path.normpath("/") + r".*)?$")
+                translated_glob + fr"(?:{os.path.sep}.*)?$")
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -66,7 +66,7 @@ class SkipListHandler:
             elif translated_glob.endswith(r"\Z"):
                 translated_glob = translated_glob[:-2]
             rexpr = re.compile(
-                translated_glob + fr"(?:{os.path.sep}.*)?$")
+                translated_glob + fr"(?:\{os.path.sep}.*)?$")
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -53,7 +53,7 @@ class SkipListHandler:
         for skip_line in skip_lines:
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
             rexpr = re.compile(
-                fnmatch.translate(norm_skip_path))
+                fnmatch.translate(norm_skip_path) + r"(?:\/.*)?")
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):

--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -53,7 +53,7 @@ class SkipListHandler:
         for skip_line in skip_lines:
             norm_skip_path = os.path.normpath(skip_line[1:].strip())
             rexpr = re.compile(
-                fnmatch.translate(norm_skip_path + '*'))
+                fnmatch.translate(norm_skip_path))
             self.__skip.append((skip_line, rexpr))
 
     def __check_line_format(self, skip_lines):


### PR DESCRIPTION
Why:
In the current implementation of the skipfiles, every file declared will match any other file that contains the declared file name at the beginning of its name. An example would be: `simple.c` and `simple.cpp`. Specifying `simple.c` with the `--flag` option would result in a regex: `/path/to/simple.c.*`

What:
Removed adding '*' to the end of any regex given through `--file` or the skipfile.

Notes:
According to the [documentation](https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip-file), this change is breaking, but I could see some users declaring directories in their skip file without placing a '*' at the end.

Fixes: #4664 