### PR TITLE
[fix] ld_logger not available in MacOS

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer_context.py
+++ b/analyzer/codechecker_analyzer/analyzer_context.py
@@ -87,9 +87,12 @@ class Context(metaclass=Singleton):
         # Add all children (architecture) paths to be later used in the
         # LD_LIBRARY_PATH environment variable during logging of compiler
         # invocations.
-        self.logger_lib_dir_path = ":".join(
-            [str(arch) for arch in ld_logger_path.iterdir() if arch.is_dir()]
-        )
+        if ld_logger_path.is_dir():
+            self.logger_lib_dir_path = ":".join(
+                str(arch) for arch in ld_logger_path.iterdir() if arch.is_dir()
+            )
+        else:
+            self.logger_lib_dir_path = ""
 
         self.logger_bin = None
         self.logger_file = None

--- a/analyzer/codechecker_analyzer/env.py
+++ b/analyzer/codechecker_analyzer/env.py
@@ -72,10 +72,9 @@ def get_log_env(logfile, original_env, use_absolute_ldpreload_path=False):
         preload_value = context.logger_lib_name
 
         try:
-            original_ld_library_path = new_env["LD_LIBRARY_PATH"]
-            new_env["LD_LIBRARY_PATH"] = (
-                context.path_logger_lib + ":" + original_ld_library_path
-            )
+            if context.path_logger_lib:
+                new_env["LD_LIBRARY_PATH"] = \
+                    f'{context.path_logger_lib}:{new_env["LD_LIBRARY_PATH"]}'
         except KeyError:
             new_env["LD_LIBRARY_PATH"] = context.path_logger_lib
         LOG.debug(


### PR DESCRIPTION
`ld_logger` is not available in MacOS environment. This causes a crash when the environment discovery tries to gather library folders in this logger lib.

Fixes #4646
Fixes #4509