### PR TITLE
Guideline stats sorting issue

### DIFF
--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -20,10 +20,11 @@
         "marked": "^4.0.10",
         "semver": "^5.7.1",
         "splitpanes": "^2.3.8",
+        "uuid": "^13.0.0",
         "vue": "^2.6.14",
         "vue-chartjs": "^3.5.1",
         "vue-router": "^3.5.3",
-        "vuetify": "^2.6.10",
+        "vuetify": "^2.7.2",
         "vuex": "^3.6.2"
       },
       "devDependencies": {
@@ -14295,6 +14296,16 @@
         "request": "^2.34"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -16248,13 +16259,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -16508,9 +16521,10 @@
       "dev": true
     },
     "node_modules/vuetify": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.13.tgz",
-      "integrity": "sha512-HhJi52IzhfrmWFwcYFUiA1GRIzz9smbR06Lj61Ml5HgD5PBcMiDywUnNPVid1VsXO4qWpBU6kO3O89uTxH1yzw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.7.2.tgz",
+      "integrity": "sha512-qr04ww7uzAPQbpk751x4fSdjsJ+zREzjQ/rBlcQGuWS6MIMFMXcXcwvp4+/tnGsULZxPMWfQ0kmZmg5Yc/XzgQ==",
+      "deprecated": "This version is deprecated",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"

--- a/web/server/vue-cli/package.json
+++ b/web/server/vue-cli/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@mdi/font": "^6.5.95",
-    "codechecker-api": "file:../../api/js/codechecker-api-node/dist/codechecker-api-6.66.0.tgz",
     "chart.js": "^2.9.4",
     "chartjs-plugin-datalabels": "^0.7.0",
+    "codechecker-api": "file:../../api/js/codechecker-api-node/dist/codechecker-api-6.66.0.tgz",
     "codemirror": "^5.65.0",
     "date-fns": "^2.28.0",
     "js-cookie": "^3.0.1",
@@ -38,10 +38,11 @@
     "marked": "^4.0.10",
     "semver": "^5.7.1",
     "splitpanes": "^2.3.8",
+    "uuid": "^13.0.0",
     "vue": "^2.6.14",
     "vue-chartjs": "^3.5.1",
     "vue-router": "^3.5.3",
-    "vuetify": "^2.6.10",
+    "vuetify": "^2.7.2",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
@@ -1,13 +1,13 @@
 <template>
   <base-statistics-table
     :headers="tableHeaders"
-    :items="items"
+    :items="itemsWithUuid"
     :loading="loading"
     :mobile-breakpoint="1000"
     :item-class="getRowClass"
     loading-text="Loading guideline statistics..."
     no-data-text="No guideline statistics available"
-    item-key="guidelineRule"
+    item-key="uuid"
     sort-by="checkers.severity"
     sort-desc
     @enabled-click="enabledClick"
@@ -16,6 +16,7 @@
 
 <script>
 import { BaseStatisticsTable } from "@/components/Statistics";
+import { v4 as uuidv4 } from "uuid";
 
 export default {
   name: "GuidelineStatisticsTable",
@@ -84,6 +85,13 @@ export default {
 
         return true;
       });
+    },
+
+    itemsWithUuid() {
+      return this.items.map(item => ({
+        ...item,
+        uuid: item.uuid || uuidv4()
+      }));
     }
   },
 

--- a/web/server/vue-cli/src/mixins/severity.mixin.js
+++ b/web/server/vue-cli/src/mixins/severity.mixin.js
@@ -22,6 +22,9 @@ export default {
     },
 
     severityFromStringToCode(severity) {
+      if (!severity) {
+        return -1;
+      }
       switch (severity.toLowerCase()) {
       case "unspecified":
         return Severity.UNSPECIFIED;


### PR DESCRIPTION
**What have been done:**

In this change, a new UUID was introduced to the guideline statistics page where the items previously did not have any real unique key to use. This UUID field is unique and can be used as a key when displaying or more importantly, sorting the data.