### PR TITLE
[fix] Cppcheck version parse fix

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -67,7 +67,12 @@ def parse_version(cppcheck_output) -> Optional[Version]:
     version_re = re.compile(r'^Cppcheck(.*?)(?P<version>[\d\.]+)')
     match = version_re.match(cppcheck_output)
     if match:
-        return Version.parse(match.group('version'))
+        version = match.group('version')
+        # semver.Version handles only version numbers with 3 sections.
+        # For example: 2.7.0
+        if version.count('.') < 2:  # Cppcheck 2.7
+            version += '.0'
+        return Version.parse(version)
     return None
 
 

--- a/analyzer/tests/unit/test_cppcheck_version_parsing.py
+++ b/analyzer/tests/unit/test_cppcheck_version_parsing.py
@@ -28,3 +28,6 @@ class CppcheckVersionTest(unittest.TestCase):
         self.assertEqual(
             parse_version('Cppcheck Premium 1.2.3'),
             Version(1, 2, 3))
+        self.assertEqual(
+            parse_version('Cppcheck 2.7'),
+            Version(2, 7, 0))


### PR DESCRIPTION
The `semver` python module handles version numbers only with 3 sections, like 1.2.3
Cppcheck 2.7 prints only a 2-section version number that fails version parser.