### PR TITLE
[fix] diagtool get_warnings() returns if binary missing

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -173,10 +173,11 @@ def get_warnings():
     Returns list of warning flags by using diagtool.
     """
     diagtool_bin = get_diagtool_bin()
-    environment = analyzer_context.get_context().get_env_for_bin(diagtool_bin)
 
     if not diagtool_bin:
         return []
+
+    environment = analyzer_context.get_context().get_env_for_bin(diagtool_bin)
 
     try:
         result = subprocess.check_output(


### PR DESCRIPTION
# [fix] diagtool get_warnings() returns if binary missing

## Issue

Fixes [Crash when diagtool is missing #4554](https://github.com/Ericsson/codechecker/issues/4554)

If `diagtool` binary is not present, `get_diagtool_bin()` does not return a path string. Then return before calling `get_env_for_bin(self, binary)` that requires `binary must be a binary with full path`, because the environment will only be required if calling `diagtool`.




## CodeChecker Version

`6.26.2-40-gfa596ef3`

## CodeChecker's output

```
> Traceback (most recent call last):
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_common/cli.py", line 230, in main
> sys.exit(args.func(args))
> ^^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/cli/analyze.py", line 1441, in main
> analyzer.perform_analysis(args, skip_handlers, filter_handlers,
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzer.py", line 169, in perform_analysis
> config_map = analyzer_types.build_config_handlers(args, analyzers)
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzers/analyzer_types.py", line 260, in build_config_handlers
> config_handler = supported_analyzers[ea].construct_config_handler(args)
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzers/clangtidy/analyzer.py", line 722, in construct_config_handler
> checkers = ClangTidy.get_analyzer_checkers()
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzers/clangtidy/analyzer.py", line 335, in get_analyzer_checkers
> get_warnings())
> ^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzers/clangtidy/analyzer.py", line 178, in get_warnings
> environment = analyzer_context.get_context().get_env_for_bin(diagtool_bin)
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> File "/home/ubuntu/.local/share/pipx/venvs/codechecker/lib/python3.12/site-packages/codechecker_analyzer/analyzer_context.py", line 220, in get_env_for_bin
> bin_path = Path(binary).resolve()
> ^^^^^^^^^^^^ 
> File "/usr/lib/python3.12/pathlib.py", line 1164, in init
> super().init(*args)
> File "/usr/lib/python3.12/pathlib.py", line 373, in init
> raise TypeError(
> TypeError: argument should be a str or an os.PathLike object where fspath returns a str, not 'NoneType'
```