### PR TITLE
Remove default report filter values which only adds Detection status and Review status filters which does not required here.

### DIFF
--- a/web/server/vue-cli/src/components/Run/ExpandedRun.vue
+++ b/web/server/vue-cli/src/components/Run/ExpandedRun.vue
@@ -34,7 +34,6 @@
             <router-link
               :to="{ name: 'reports',
                      query: {
-                       ...defaultReportFilterValues,
                        run: history.runName,
                        'run-tag': history.id
                      }
@@ -139,7 +138,6 @@
 
 <script>
 import { format, parse } from "date-fns";
-import { defaultReportFilterValues } from "@/components/Report/ReportFilter";
 import AnalysisInfoBtn from "./AnalysisInfoBtn";
 import AnalyzerStatisticsBtn from "./AnalyzerStatisticsBtn";
 import ShowStatisticsBtn from "./ShowStatisticsBtn";
@@ -160,11 +158,6 @@ export default {
     openAnalyzerStatisticsDialog: { type: Function, default: () => {} },
     selectedBaselineTags: { type: Array, required: true },
     selectedComparedToTags: { type: Array, required: true }
-  },
-  data() {
-    return {
-      defaultReportFilterValues
-    };
   },
   computed: {
     baselineTags: {


### PR DESCRIPTION
This change removes the default report filter from link on the expanded runs page which links to the reports. This way Detection Status and Review Status filters are not getting applied to the resulting reports list.