### PR TITLE
Remove clang-diagnostics-default-const-init-var-unsafe from the defau…

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -2178,8 +2178,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-default-const-init-var": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wdefault-const-init-var",
-      "profile:default",
+      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wdefault-const-init-var",      
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM"


### PR DESCRIPTION
…lt profile

The warning is a portability checker (between C and C++) and hence should not be placed in the default profile.