### PR TITLE
Dump compiler_info.json

### DIFF
--- a/analyzer/codechecker_analyzer/cli/check.py
+++ b/analyzer/codechecker_analyzer/cli/check.py
@@ -129,6 +129,25 @@ def add_arguments_to_parser(parser):
                              "analyzers' output will not be printed to the "
                              "standard output.")
 
+    parser.add_argument('--compiler-info-file',
+                        dest="compiler_info_file",
+                        required=False,
+                        default=argparse.SUPPRESS,
+                        help="Read the compiler includes and target from the "
+                             "specified file rather than invoke the compiler "
+                             "executable.")
+
+    parser.add_argument('--dump-compiler-info-file',
+                        dest="dump_compiler_info_file",
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help="Dump implicit gcc compiler info to a json file "
+                             "that can be used for fine-tuning analysis later."
+                             "These are information like the implicit include "
+                             "paths of standard headers, the default language "
+                             "version and the default target architecture.")
+
     parser.add_argument('--keep-gcc-include-fixed',
                         dest="keep_gcc_include_fixed",
                         required=False,
@@ -980,6 +999,8 @@ def main(args):
                           'compile_uniqueing',
                           'report_hash',
                           'add_gcc_include_dirs_with_isystem',
+                          'compiler_info_file',
+                          'dump_compiler_info_file',
                           'enable_z3',
                           'enable_z3_refutation']
         for key in args_to_update:

--- a/analyzer/codechecker_analyzer/pre_analysis_manager.py
+++ b/analyzer/codechecker_analyzer/pre_analysis_manager.py
@@ -43,8 +43,7 @@ def collect_statistics(action, source, clangsa_config, statistics_data):
         LOG.debug('Can not collect statistical data.')
         return None
 
-    # TODO: shlex.join() will be more convenient in Python 3.8.
-    LOG.debug_analyzer(' '.join(map(shlex.quote, cmd)))
+    LOG.debug_analyzer(shlex.join(cmd))
 
     ret_code, analyzer_out, analyzer_err = \
         analyzer_base.SourceAnalyzer.run_proc(cmd)

--- a/analyzer/tests/unit/test_buildcmd_escaping.py
+++ b/analyzer/tests/unit/test_buildcmd_escaping.py
@@ -88,7 +88,7 @@ class BuildCmdTest(unittest.TestCase):
             ' -DDEBUG \'-DMYPATH="/this/some/path/"\''
 
         comp_actions, _ = log_parser.\
-            parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
+            parse_unique_log(self.__get_cmp_json(compile_cmd))
 
         for comp_action in comp_actions:
             cmd = [self.compiler]
@@ -114,7 +114,7 @@ class BuildCmdTest(unittest.TestCase):
         """
         compile_cmd = self.compiler + ''' '-DMYPATH=\"/some/other/path\"' '''
         comp_actions, _ = log_parser.\
-            parse_unique_log(self.__get_cmp_json(compile_cmd), self.tmp_dir)
+            parse_unique_log(self.__get_cmp_json(compile_cmd))
 
         for comp_action in comp_actions:
             cmd = [self.compiler]

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -75,8 +75,7 @@ class LogParserTest(unittest.TestCase):
         # option_parser, so here we aim for a non-failing stalemate of the
         # define being considered a file and ignored, for now.
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -95,8 +94,7 @@ class LogParserTest(unittest.TestCase):
         # Logfile contains -DVARIABLE="some value"
         # and --target=x86_64-linux-gnu.
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -108,8 +106,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "ldlogger-new-space.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a b.cpp')
@@ -118,8 +115,7 @@ class LogParserTest(unittest.TestCase):
         # Test @ sign in variable definition.
         logfile = os.path.join(self.__test_files, "ldlogger-new-at.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -132,8 +128,7 @@ class LogParserTest(unittest.TestCase):
         # Make it relative to the response file.
         logjson[0]['directory'] = self.__test_files
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(logjson, self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(logjson)
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 2)
@@ -152,8 +147,7 @@ class LogParserTest(unittest.TestCase):
         # -DVARIABLE=\"some value\" and --target=x86_64-linux-gnu
         logfile = os.path.join(self.__test_files, "intercept-old.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -167,8 +161,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-old-space.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
@@ -189,8 +182,7 @@ class LogParserTest(unittest.TestCase):
         #
         # The define is passed to the analyzer properly.
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
@@ -202,8 +194,7 @@ class LogParserTest(unittest.TestCase):
         # Test source file with spaces.
         logfile = os.path.join(self.__test_files, "intercept-new-space.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(build_action.source, '/tmp/a b.cpp')
@@ -234,8 +225,7 @@ class LogParserTest(unittest.TestCase):
              "file": "/tmp/a.cpp"}]
 
         build_actions, _ = \
-            log_parser.parse_unique_log(preprocessor_actions,
-                                        self.__this_dir)
+            log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-M' not in build_actions[0].original_command)
         self.assertTrue('-E' not in build_actions[0].original_command)
@@ -250,8 +240,7 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions,
-                                                       self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 1)
         self.assertTrue('-MD' in build_actions[0].original_command)
 
@@ -266,8 +255,7 @@ class LogParserTest(unittest.TestCase):
              "command": "g++ /tmp/a.cpp -E -MD /tmp/a.cpp",
              "file": "/tmp/a.cpp"}]
 
-        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions,
-                                                       self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(preprocessor_actions)
         self.assertEqual(len(build_actions), 0)
 
     def test_include_rel_to_abs(self):
@@ -276,8 +264,7 @@ class LogParserTest(unittest.TestCase):
         """
         logfile = os.path.join(self.__test_files, "include.json")
 
-        build_actions, _ = log_parser.\
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 4)
@@ -328,7 +315,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              pre_analysis_skip_handlers=pre_analysis_skip)
 
@@ -359,7 +346,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              pre_analysis_skip_handlers=pre_analysis_skip)
 
@@ -394,7 +381,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              pre_analysis_skip_handlers=pre_analysis_skip)
 
@@ -426,7 +413,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler(pre_skip_list)])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              pre_analysis_skip_handlers=pre_analysis_skip)
 
@@ -456,7 +443,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler("")])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              ctu_or_stats_enabled=True,
                              pre_analysis_skip_handlers=pre_analysis_skip)
@@ -483,7 +470,7 @@ class LogParserTest(unittest.TestCase):
         pre_analysis_skip = SkipListHandlers([SkipListHandler(skip_list)])
 
         build_actions, _ = log_parser.\
-            parse_unique_log(cmp_cmd_json, self.__this_dir,
+            parse_unique_log(cmp_cmd_json,
                              analysis_skip_handlers=analysis_skip,
                              pre_analysis_skip_handlers=pre_analysis_skip)
 
@@ -508,8 +495,7 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_actions, _ = log_parser. \
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
         self.assertEqual(len(build_action.analyzer_options), 1)
         self.assertEqual(build_action.analyzer_options[0],
@@ -533,8 +519,7 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_actions, _ = log_parser. \
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
         build_action = build_actions[0]
 
         self.assertEqual(len(build_action.analyzer_options), 1)
@@ -572,8 +557,7 @@ class LogParserTest(unittest.TestCase):
 
         logfile = os.path.join(self.compile_command_file_path)
 
-        build_actions, _ = log_parser. \
-            parse_unique_log(load_json(logfile), self.__this_dir)
+        build_actions, _ = log_parser.parse_unique_log(load_json(logfile))
 
         self.assertEqual(len(build_actions), 2)
 
@@ -608,7 +592,7 @@ class LogParserTest(unittest.TestCase):
                 }]))
 
         build_actions, _ = log_parser.parse_unique_log(load_json(
-            self.compile_command_file_path), self.__this_dir)
+            self.compile_command_file_path))
 
         self.assertEqual(len(build_actions), 1)
 
@@ -656,7 +640,6 @@ class LogParserTest(unittest.TestCase):
              "file": file_b_sym}]
 
         build_actions, _ = log_parser.parse_unique_log(compilation_cmd,
-                                                       self.__this_dir,
                                                        "symlink")
         build_action = build_actions[2]
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -1058,6 +1058,12 @@ optional arguments:
                         Read the compiler includes and target from the
                         specified file rather than invoke the compiler
                         executable.
+  --dump-compiler-info-file
+                        Dump implicit gcc compiler info to a json file that can
+                        be used for fine-tuning analysis later.These are
+                        information like the implicit include paths of standard
+                        headers, the default language version and the default
+                        target architecture. (default: False)
   --keep-gcc-include-fixed
                         There are some implicit include paths which
                         are only used by GCC (include-fixed). This flag


### PR DESCRIPTION
A new flag is added to "CodeChecker analyze": --dump-compiler-info-file. This flag is given a filename as parameter. This filename will be created in the output folder. The file contains implicit include paths and some other gcc-specific data that can be used to finetune analysis later. When this flag is used, then analysis doesn't run.

The compiler_info.json was generated in the output directory by default. Due to some bug, this file is empty in recent CodeChecker versions. The reason is that parsing compile_commands.json is done in parallel with a process pool. The dict object that collects this data must be handled by multiprocessing.SyncManager() so it can be used in a process pool.