### PR TITLE
[doc] Replace year and owner placeholders in LICENSE

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/analyzer/tools/merge_clang_extdef_mappings/LICENSE.txt
+++ b/analyzer/tools/merge_clang_extdef_mappings/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/analyzer/tools/statistics_collector/LICENSE.txt
+++ b/analyzer/tools/statistics_collector/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/bazel/LICENSE.txt
+++ b/tools/bazel/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/report-converter/LICENSE.txt
+++ b/tools/report-converter/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/tu_collector/LICENSE.txt
+++ b/tools/tu_collector/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/web/api/js/codechecker-api-node/LICENSE
+++ b/web/api/js/codechecker-api-node/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/web/api/py/codechecker_api/LICENSE
+++ b/web/api/py/codechecker_api/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/web/api/py/codechecker_api_shared/LICENSE
+++ b/web/api/py/codechecker_api_shared/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 CodeChecker Team (Ericsson)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace the default [yyyy] [name of copyright owner] placeholder texts with real data.