### PR TITLE
[fix] semver.Version doesn't have strip()

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/cppcheck/analyzer.py
@@ -410,7 +410,7 @@ class Cppcheck(analyzer_base.SourceAnalyzer):
             return None
 
         return "CppCheck binary found is too old at " \
-               f"v{str(analyzer_version).strip()}; minimum version is 1.80"
+               f"v{analyzer_version}; minimum version is 1.80"
 
     def construct_result_handler(self, buildaction, report_output,
                                  skiplist_handler):

--- a/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/gcc/analyzer.py
@@ -196,7 +196,7 @@ class Gcc(analyzer_base.SourceAnalyzer):
         if analyzer_version and analyzer_version >= Version(13, 0, 0):
             return None
 
-        return f"GCC binary found is too old at v{analyzer_version.strip()}; "\
+        return f"GCC binary found is too old at v{analyzer_version}; "\
                "minimum version is 13.0.0."
 
     def construct_result_handler(self, buildaction, report_output,


### PR DESCRIPTION
The `get_binary_version()` now returns `semver.Version` instead of `str`. However, at two places the changes were not properly adatped, where we still assumed a string.