### PR TITLE
Log full OS error message when the connection fails

### DIFF
--- a/web/client/codechecker_client/thrift_call.py
+++ b/web/client/codechecker_client/thrift_call.py
@@ -117,7 +117,7 @@ def thrift_client_call(function):
             sys.exit(1)
         except OSError as oserr:
             LOG.error("Connection failed.")
-            LOG.error(oserr.strerror)
+            LOG.error("OS Error: %s", str(oserr))
             LOG.error("Check if your CodeChecker server is running.")
             sys.exit(1)
         finally:


### PR DESCRIPTION
It can sometimes happen that an `OSError` object's `strerror` attribute is `None` instead of a proper error message.
Example of this behavior:

```
[INFO] - Get missing file content hashes from the server...
[ERROR] - Connection failed.
[ERROR] - None
[ERROR] - Check if your CodeChecker server is running.
```
Instead of printing `strerror`, we should log the full error message.