### PR TITLE
[fix] Crash on non-existing variable

### DIFF
--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -623,6 +623,7 @@ class SessionManager:
             return None
 
         user_name, token = auth_string.split(':', 1)
+        personal_access_token = None
 
         transaction = None
         try:


### PR DESCRIPTION
If personal access token can't be queried due to some DB issue, then it crashes on reading an unset variable.