### PR TITLE
Fix the issue where the ReportTree component remains in a loading state when the result exceeds MAX_QUERY_SIZE

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
@@ -147,7 +147,7 @@ export default {
       // in the given file.
       ccService.getClient().getRunResults(runIds, limit, offset, sortType,
         reportFilter, cmpData, getDetails, handleThriftError(reports => {
-          if (reports.length === MAX_QUERY_SIZE) {
+          if (reports.length === MAX_QUERY_SIZE.toNumber()) {
             const currentReport =
               reports.find(r => r.reportId.equals(this.report.reportId));
             if (!currentReport) {


### PR DESCRIPTION
The MAX_QUERY_SIZE constant is defined in the report_server.thrift file as const i64 MAX_QUERY_SIZE = 500. After being compiled into a JavaScript package, Thrift i64 constants are not of type number in JavaScript and therefore cannot be used directly.