### PR TITLE
[analyzer] Remove -analyzer-opt-analyze-headers flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/statistics.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/statistics.py
@@ -40,9 +40,6 @@ def build_stat_coll_cmd(action, config, source):
                     "-Xclang", "-load",
                     "-Xclang", plugin])
 
-    cmd.extend(['-Xclang',
-                '-analyzer-opt-analyze-headers'])
-
     cmd.extend(config.analyzer_extra_arguments)
     cmd.extend(action.analyzer_options)
 


### PR DESCRIPTION
Statistical analysis of C++20 headers seems to cause memory exhaustion with this analyzer option on. The results of two analysis runs that only differ in the passing or the omission of this flag on 4 open source C and C++ projects shows no difference.