### PR TITLE
[fix] Fix fnmatch regex generation assert

### DIFF
--- a/tools/report-converter/codechecker_report_converter/util.py
+++ b/tools/report-converter/codechecker_report_converter/util.py
@@ -78,8 +78,9 @@ def trim_path_prefixes(path: str, prefixes: Optional[List[str]]) -> str:
             prefix += '/'
 
         regex_str = fnmatch.translate(prefix)
-        assert regex_str[-2:] == '\\Z', \
-               r'fnmatch.translate should leave \\Z at the end of the matcher!'
+        assert regex_str[-2:] in ('\\Z', '\\z'), \
+               r'fnmatch.translate should leave \\Z or \\z ' \
+               r'at the end of the matcher!'
 
         prefix_matcher = re.compile(regex_str[:-2])
 


### PR DESCRIPTION
In some environments fnmatch.translate() returns a string that ends with \z instead of \Z. Their meaining is the same.

Fixes #4737