### PR TITLE
Fix fnmatch.translate() in skiplist handler

### DIFF
--- a/codechecker_common/skiplist_handler.py
+++ b/codechecker_common/skiplist_handler.py
@@ -60,7 +60,7 @@ class SkipListHandler:
             # Note: normalization removes '/' from the end, see:
             # https://docs.python.org/3/library/os.path.html#os.path.normpath
             translated_glob = fnmatch.translate(norm_skip_path)
-            if translated_glob.endswith(r"\Z"):
+            if translated_glob.endswith((r"\Z", r"\z")):
                 translated_glob = translated_glob[:-2]
             rexpr = re.compile(
                 translated_glob + fr"(?:\{os.path.sep}.*)?$")


### PR DESCRIPTION
In some environments fnmatch.translate() returns a string that ends with \z instead of \Z.