### PR TITLE
[analyzer] Completely remove -analyzer-opt-analyze-headers

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -507,8 +507,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
 
             analyzer_mode = 'plist-multi-file'
             analyzer_cmd.extend(['-Xclang',
-                                 '-analyzer-opt-analyze-headers',
-                                 '-Xclang',
                                  '-analyzer-output=' + analyzer_mode,
                                  '-o', analyzer_output_file])
 

--- a/analyzer/tests/unit/test_analyzer_command.py
+++ b/analyzer/tests/unit/test_analyzer_command.py
@@ -63,3 +63,13 @@ class AnalyzerCommandClangSATest(unittest.TestCase):
         result_handler = create_result_handler(analyzer)
         cmd = analyzer.construct_analyzer_cmd(result_handler)
         self.assertIn('-idirafter', cmd)
+
+    def test_no_analyze_headers(self):
+        """
+        Test that the -analyzer-opt-analyze-headers flag is NOT present in the
+        analyzer command.
+        """
+        analyzer = create_analyzer_sa()
+        result_handler = create_result_handler(analyzer)
+        cmd = analyzer.construct_analyzer_cmd(result_handler)
+        self.assertNotIn('-analyzer-opt-analyze-headers', cmd)


### PR DESCRIPTION
This option is an undocumented, off-by default flag in upstream Clang. We have measured that disabling this lead to an overall ~24% decrease in analysis time with some loss and shifting around of the result set on open source projects, and concluded that it worth disabling. Users still should have the possiblity of enabling this via configuring the analyzer with analyzer options, but not the other way around: there is no flag to disable this functionality once it is enabled.