### PR TITLE
[add] add severity for sarif

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
@@ -63,7 +63,7 @@ class Parser(BaseParser):
 
         for run in data.runs:
             rules = self._get_rules(run.run_data)
-            analyzer_name = self._get_analyzer_name(run.run_data).lower()
+            analyzer_name = self._get_analyzer_name(run.run_data)
             # $3.14.14
             self.original_uri_base_ids = None
             if "originalUriBaseIds" in run.run_data:


### PR DESCRIPTION
Normalize analyzer names to lowercase to match the default lowercase naming in the configuration that maps rule_id to severity, and fix severity propagation for SARIF reports so that issue severity is displayed correctly in the Web UI.

Example:
<img width="1146" height="338" alt="изображение" src="https://github.com/user-attachments/assets/806442d7-b3cd-45f3-8f52-174167a0cca4" />

Fixes: #4348
