### PR TITLE
Fix: Handle empty stdin gracefully in fixit command

### DIFF
--- a/analyzer/codechecker_analyzer/cli/fixit.py
+++ b/analyzer/codechecker_analyzer/cli/fixit.py
@@ -377,11 +377,15 @@ def main(args):
                   "arriving from standard input.")
         sys.exit(1)
 
-    try:
-        reports = None if sys.stdin.isatty() else json.loads(sys.stdin.read())
-    except json.decoder.JSONDecodeError as ex:
-        LOG.error("JSON format error on standard input: %s", ex)
-        sys.exit(1)
+    reports = None
+    if not sys.stdin.isatty():
+        stdin_data = sys.stdin.read().strip()
+        if stdin_data:
+            try:
+                reports = json.loads(stdin_data)
+            except json.decoder.JSONDecodeError as ex:
+                LOG.error("JSON format error on standard input: %s", ex)
+                sys.exit(1)
 
     # "CodeChecker fixit" can be applied on the output of
     # "CodeChecker cmd diff" command. Earlier this was a simple list of


### PR DESCRIPTION
## Problem

When stdin is not a TTY (e.g., in CI environments like GitHub Actions), `CodeChecker fixit` attempts to read and parse JSON from stdin for report filtering. If stdin is empty (which is common in CI), this fails with:

```
[ERROR] - JSON format error on standard input: Expecting value: line 1 column 1 (char 0)
```

This forces users to use workarounds like:
- `script -q -c 'CodeChecker fixit ...' /dev/null`

## Solution

This change reads stdin first and only attempts JSON parsing if there is actual content. Empty stdin is now treated as 'no report filter' (`reports = None`), which is the same behavior as when stdin is a TTY.

## Changes

- Read stdin content before attempting JSON parse
- Only parse if content is non-empty after stripping whitespace
- Empty stdin now behaves like TTY stdin (no filtering)

## Testing

- Tested locally with empty stdin in non-TTY context
- Verified that piped JSON input still works correctly

## Complaint

This JSON feature does not seem to be mentioned in docs, it was strange to stumble into problems it introduced.