### PR TITLE
Remove store_time.log

### DIFF
--- a/codechecker_common/logger.py
+++ b/codechecker_common/logger.py
@@ -11,7 +11,6 @@ import datetime
 import json
 import logging
 from logging import config
-from pathlib import Path
 import os
 import sys
 from typing import Optional
@@ -162,10 +161,10 @@ class LogCfgServer:
     'CC_LOG_CONFIG_PORT' environment variable is set.
     """
 
-    def __init__(self, log_level='INFO', workspace=None):
+    def __init__(self, log_level='INFO'):
 
         # Configure the logging with the default config.
-        setup_logger(log_level, workspace=workspace)
+        setup_logger(log_level)
 
         self.log_server = None
 
@@ -184,7 +183,7 @@ class LogCfgServer:
             self.log_server.join()
 
 
-def setup_logger(log_level=None, stream=None, workspace=None):
+def setup_logger(log_level=None, stream=None):
     """
     Modifies the log configuration.
     Overwrites the log levels for the loggers and handlers in the
@@ -218,27 +217,5 @@ def setup_logger(log_level=None, stream=None, workspace=None):
             handler = log_config['handlers'][k]
             if 'stream' in handler:
                 handler['stream'] = stream
-
-    # If workspace is set, we will log to a file in the workspace.
-    # This is added dynamically because the declarative config
-    # (config/logger.conf) is not flexible enough, and will always
-    # create a log file in weird locations, before we can initialize
-    # the filename attribute, to the workspace directories.
-    if workspace:
-        # Add file_handler to store_time logger,
-        # and add the handler to the config
-        loggers = log_config.get("loggers", {})
-        loggers["store_time"]["handlers"].append('store_time_file_handler')
-
-        handlers = log_config.get("handlers", {})
-        log_path = Path(workspace, "store_time.log")
-        handlers["store_time_file_handler"] = {}
-        store_time_handler = {
-            'backupCount': 8,
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            "filename": log_path,
-            'formatter': 'store_time_formatter',
-            'interval': 7}
-        handlers["store_time_file_handler"] = store_time_handler
 
     config.dictConfig(log_config)

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -2,9 +2,6 @@
   "version": 1,
   "disable_existing_loggers": true,
   "formatters": {
-    "store_time_formatter": {
-      "format": "[%(levelname)s] - %(message)s"
-    },
     "brief": {
       "format": "[%(levelname)s %(asctime)s] - %(message)s",
       "datefmt": "%Y-%m-%d %H:%M"
@@ -40,10 +37,6 @@
       "handlers": ["console"]
     },
     "server": {
-      "level": "INFO",
-      "handlers": ["console"]
-    },
-    "store_time": {
       "level": "INFO",
       "handlers": ["console"]
     },

--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -63,7 +63,6 @@ from .thrift_enum_helper import report_extended_data_type_str
 
 
 LOG = get_logger('server')
-STORE_TIME_LOG = get_logger('store_time')
 
 
 class StepLog:
@@ -1705,24 +1704,14 @@ class MassStoreRun:
                     time_spent_on_task_preparation
                 zip_size_kib: float = original_zip_size / 1024
 
-                LOG.info("'%s' stored results (decompressed size: %.2f KiB) "
-                         "to run '%s' (ID: %d%s) in %.2f seconds.",
-                         self._user_name, zip_size_kib, self._name, run_id,
-                         f", under tag '{self._tag}'" if self._tag else "",
-                         run_time)
-
-                iso_start_time = datetime.fromtimestamp(start_time) \
-                    .isoformat()
-
-                log_msg = f"{iso_start_time}, " \
-                          f"{round(run_time, 2)}s, " \
-                          f'"{self.__product.name}", ' \
-                          f'"{self._name}", ' \
-                          f"{round(zip_size_kib)}KiB, " \
-                          f"{self.__report_count}, " \
-                          f"{run_id}"
-
-                STORE_TIME_LOG.info(log_msg)
+                LOG.info("User '%s' stored results "
+                         "to product '%s', run '%s' in %.2f seconds "
+                         "(run id: %d%s, report count: %d, "
+                         "decompressed size: %.2f KiB).",
+                         self._user_name, self.__product.name, self._name,
+                         run_time, run_id,
+                         f", under tag: '{self._tag}'" if self._tag else "",
+                         self.__report_count, zip_size_kib)
             except (sqlalchemy.exc.OperationalError,
                     sqlalchemy.exc.ProgrammingError) as ex:
                 LOG.error("Database error! Storing reports to the "

--- a/web/server/codechecker_server/cli/server.py
+++ b/web/server/codechecker_server/cli/server.py
@@ -1077,7 +1077,7 @@ def main(args):
             os.makedirs(args.config_directory)
 
     with logger.LogCfgServer(
-        args.verbose if "verbose" in args else None, workspace=workspace
+        args.verbose if "verbose" in args else None
     ):
         try:
             cmd_config.check_config_file(args)


### PR DESCRIPTION
With the introduction of the async store feature, it is no longer necessary to log store times in the workspace directory, as this information is now saved in the database.