### PR TITLE
Added flags to set server processes

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -186,6 +186,14 @@ optional arguments:
                         subsequent executions of the "same" server is achieved
                         in distinct environments, e.g., if the server
                         otherwise is running in a container.
+  --api-handler-processes API_HANDLER_PROCESSES
+                        Number of API request handler processes the server should start.
+                        This setting overrides the server config file values.
+  --task-worker-processes TASK_WORKER_PROCESSES
+                        Number of task worker processes the server should start.
+                        These handle report storage tasks (massStoreRun,
+                        massStoreRunAsynchronous).
+                        This setting overrides the server config file values.
   --host LISTEN_ADDRESS
                         The IP address or hostname of the server on which it
                         should listen for connections. For IPv6 listening,
@@ -256,6 +264,9 @@ By default, the running server can only be accessed from the same machine
 (`localhost`) where it is running. This can be overridden by specifying
 `--host ""`, instructing the server to listen on all available interfaces.
 
+The server spawns additional Python processes to handle incoming API requests
+and to process report storing tasks. The process counts can be changed using
+the `--api-handler-processes` and `--task-worker-processes` flags, respectively.
 
 #### Run CodeChecker server in Docker
 To run CodeChecker server in Docker see the [Docker](docker.md) documentation.

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -48,6 +48,8 @@ from codechecker_api.codeCheckerDBAccess_v6.ttypes import \
     SourceComponentData, SourceFileData, SortMode, SortType, \
     SubmittedRunOptions
 
+from codechecker_api_shared.ttypes import ErrorCode, RequestFailed
+
 from codechecker_common import util
 from codechecker_common.logger import get_logger
 
@@ -3998,6 +4000,10 @@ class ThriftRequestHandler:
         self.__require_store()
         if not store_opts.runName:
             raise ValueError("A run name is needed to know where to store!")
+
+        if self._manager.background_worker_processes == 0:
+            raise RequestFailed(ErrorCode.GENERAL,
+                                "No task worker process is available!")
 
         from .mass_store_run import MassStoreRunInputHandler, MassStoreRunTask
         ih = MassStoreRunInputHandler(self._manager,

--- a/web/server/codechecker_server/cli/server.py
+++ b/web/server/codechecker_server/cli/server.py
@@ -115,6 +115,25 @@ executions of the "same" server is achieved in distinct environments, e.g.,
 if the server otherwise is running in a container.
 """)
 
+    parser.add_argument("--api-handler-processes",
+                        type=int,
+                        dest="api_handler_processes",
+                        required=False,
+                        help="""
+Number of API request handler processes the server should start.
+This setting overrides the server config file values.
+""")
+
+    parser.add_argument("--task-worker-processes",
+                        type=int,
+                        dest="task_worker_processes",
+                        required=False,
+                        help="""
+Number of task worker processes the server should start.
+These handle report storage tasks (massStoreRun, massStoreRunAsynchronous).
+This setting overrides the server config file values.
+""")
+
     parser.add_argument('--host',
                         type=str,
                         dest="listen_address",
@@ -1043,7 +1062,9 @@ def server_init_start(args):
                                    args.skip_db_cleanup,
                                    context,
                                    environ,
-                                   machine_id)
+                                   machine_id,
+                                   args.api_handler_processes,
+                                   args.task_worker_processes)
     except socket.error as err:
         if err.errno == errno.EADDRINUSE:
             LOG.error("Server can't be started, maybe port number (%s) is "

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -171,7 +171,9 @@ class SessionManager:
     CodeChecker server.
     """
 
-    def __init__(self, configuration_file, secrets_file, force_auth=False):
+    def __init__(self, configuration_file, secrets_file, force_auth=False,
+                 api_handler_processes: Optional[int] = None,
+                 task_worker_processes: Optional[int] = None):
         """
         Initialise a new Session Manager on the server.
 
@@ -194,6 +196,13 @@ class SessionManager:
         # instantiate SessionManager with the found configuration.
         self.__worker_processes, self.__background_worker_processes = \
             get_worker_processes(self.scfg_dict)
+
+        if api_handler_processes is not None:
+            self.__worker_processes = api_handler_processes
+
+        if task_worker_processes is not None:
+            self.__background_worker_processes = task_worker_processes
+
         self.__max_run_count = self.scfg_dict.get('max_run_count', None)
         self.__store_config = self.scfg_dict.get('store', {})
         self.__keepalive_config = self.scfg_dict.get('keepalive', {})


### PR DESCRIPTION
Added `--api-handler-processes` and `--task-worker-processes` server CLI flags. Using these flags overrides the corresponding values in the server config file.