### PR TITLE
Remove OAuth groups source requirements

### DIFF
--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -441,9 +441,7 @@ class ThriftAuthHandler:
                     morePages = True
                     while morePages:
                         for group in response["value"]:
-                            if group.get("onPremisesSyncEnabled") and \
-                                    group.get("securityEnabled"):
-                                groups.append(group["displayName"])
+                            groups.append(group["displayName"])
                         # paging of groups
                         morePages = "@odata.nextLink" in response
                         if morePages:


### PR DESCRIPTION
These two were a needless restriction on where groups can come from, and it prevents CodeChecker from parsing some native Entra groups.