### PR TITLE
docker: add container HEALTHCHECK

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -139,6 +139,9 @@ RUN chmod 755 /usr/local/bin/wait-for
 
 EXPOSE 8001
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/live', timeout=3).read()" || exit 1
+
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint.sh"]
 
 CMD ["CodeChecker", "server", "--workspace", "/workspace", "--not-host-only"]


### PR DESCRIPTION
Fixes #4564 

Adds a Docker HEALTHCHECK to the CodeChecker web container. The healthcheck probes the built-in liveness endpoint (/live) on port 8001. Implementation uses Python's standard library instead of curl to avoid adding extra dependencies and increasing image size.
