### PR TITLE
[fix] SQLAlchemy warning on subquery in IN clause

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -3535,8 +3535,6 @@ class ThriftRequestHandler:
                 tag_run_ids = tag_run_ids.filter(
                     RunHistory.run_id.in_(run_ids))
 
-            tag_run_ids = tag_run_ids.subquery()
-
             report_cnt_q = session.query(Report.run_id,
                                          Report.bug_id,
                                          Report.detected_at,


### PR DESCRIPTION
The follow warning message suggests that the IN clause should be given the query instead of the subquery object:

codechecker_server/api/report_server.py:3554: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly