### PR TITLE
Fix unclosed database session in add_product

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -861,9 +861,10 @@ class CCSimpleHttpServer(HTTPServer):
         # More on this:
         # https://github.com/Ericsson/codechecker/pull/3733#issuecomment-1235304179
         # https://github.com/PyCQA/pylint/issues/6005
-        orm_product.num_of_runs = \
-            prod.session_factory().query(func.count(Run.id)).one_or_none()[0] \
-            # pylint: disable=not-callable
+        with DBSession(prod.session_factory) as session:
+            orm_product.num_of_runs = \
+                session.query(func.count(Run.id)).one_or_none()[0] \
+                # pylint: disable=not-callable
 
         self.__products[prod.endpoint] = prod
 


### PR DESCRIPTION
prod.session_factory() creates an SQLAlchemy session which is not closed explicitly.
As a solution, we use DBSession which closes the
session automatically on exit.