### PR TITLE
Extend SEI Cert guideline mapping for cppcheck and gcc analyzers

### DIFF
--- a/analyzer/tests/functional/cmdline/test_cmdline.py
+++ b/analyzer/tests/functional/cmdline/test_cmdline.py
@@ -211,7 +211,9 @@ class TestCmdline(unittest.TestCase):
                                       'Malloc',
                                       'MallocSizeof',
                                       'clang-diagnostic-format-overflow',
-                                      'overflow-non-kprintf']))
+                                      'overflow-non-kprintf',
+                                      'gcc-allocation-size',
+                                      'gcc-out-of-bounds']))
 
         checkers_cmd = [env.codechecker_cmd(), 'checkers', '--guideline']
         _, out, _ = run_cmd(checkers_cmd)

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -21,7 +21,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:fio39-c"
     ],
     "cppcheck-StlMissingComparison": [
       "profile:default",
@@ -58,7 +59,8 @@
       "memory-safety:cwe-121",
       "memory-safety:cwe-122",
       "memory-safety:cwe-126",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:arr30-c"
     ],
     "cppcheck-arrayIndexOutOfBoundsCond": [
       "profile:default",
@@ -100,7 +102,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:dcl30-c"
     ],
     "cppcheck-autovarInvalidDeallocation": [
       "guideline:memory-safety",
@@ -108,7 +111,8 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-590",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem34-c"
     ],
     "cppcheck-badBitmaskCheck": [
       "profile:default",
@@ -132,7 +136,9 @@
       "profile:sensitive",
       "memory-safety:cwe-121",
       "memory-safety:cwe-122",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp33-c",
+      "sei-cert-c:str38-c"
     ],
     "cppcheck-catchExceptionByValue": [
       "severity:STYLE"
@@ -187,6 +193,10 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH"
+    ],
+    "cppcheck-subtractPointers": [
+      "severity:MEDIUM",
+      "sei-cert-c:arr336-c"
     ],
     "cppcheck-compareValueOutOfTypeRangeError": [
       "severity:STYLE"
@@ -246,7 +256,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:str53-cpp"
     ],
     "cppcheck-copyCtorAndEqOperator": [
       "profile:default",
@@ -284,7 +295,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:dcl-30-c"
     ],
     "cppcheck-danglingReference": [
       "profile:default",
@@ -299,7 +311,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem50-cpp"
     ],
     "cppcheck-deallocDealloc": [
       "profile:default",
@@ -319,7 +332,9 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-416",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem30-c",
+      "sei-cert-c:mem50-cpp"
     ],
     "cppcheck-derefInvalidIterator": [
       "profile:default",
@@ -339,7 +354,9 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-415",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem36-c",
+      "sei-cert-c:mem56-cpp"
     ],
     "cppcheck-duplInheritedMember": [
       "profile:default",
@@ -397,6 +414,14 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM"
+    ],
+    "cppcheck-throwInEntryPoint": [
+      "severity:MEDIUM",
+      "sei-cert-c:con56-cpp",
+      "sei-cert-c:err55-cpp",
+      "sei-cert-c:err57-cpp",
+      "sei-cert-c:mem53-cpp",
+      "sei-cert-c:msc53-cpp"
     ],
     "cppcheck-fflushOnInputStream": [
       "severity:LOW"
@@ -507,7 +532,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:str52-cpp"
     ],
     "cppcheck-invalidContainerLoop": [
       "severity:HIGH"
@@ -522,7 +548,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:flp32-c"
     ],
     "cppcheck-invalidFunctionArgBool": [
       "profile:default",
@@ -552,7 +579,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem50-cpp"
     ],
     "cppcheck-invalidPointerCast": [
       "severity:LOW"
@@ -701,8 +729,12 @@
     "cppcheck-legacyUninitvar": [
       "guideline:sei-cert-c",
       "profile:security",
+      "severity:HIGH",
       "sei-cert-c:exp33-c",
-      "severity:HIGH"
+      "sei-cert-c:exp53-cpp",
+      "sei-cert-c:exp54-cpp",
+      "sei-cert-c:msc33-c",
+      "sei-cert-c:oop57-cpp"
     ],
     "cppcheck-literalWithCharPtrCompare": [
       "profile:default",
@@ -732,19 +764,23 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem31-c",
+      "sei-cert-c:mem34-c"
     ],
     "cppcheck-memleakOnRealloc": [
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:err33-c"
     ],
     "cppcheck-memsetClass": [
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp62-cpp"
     ],
     "cppcheck-memsetClassFloat": [
       "severity:LOW"
@@ -776,7 +812,8 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-762",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem51-cpp"
     ],
     "cppcheck-mismatchSize": [
       "profile:default",
@@ -821,7 +858,10 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:con35-c",
+      "sei-cert-c:msc37-c",
+      "sei-cert-c:msc52-cpp"
     ],
     "cppcheck-moduloAlwaysTrueFalse": [
       "profile:default",
@@ -854,7 +894,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:ctr50-cpp"
     ],
     "cppcheck-negativeIndex": [
       "guideline:memory-safety",
@@ -902,7 +943,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp34-c"
     ],
     "cppcheck-nullPointerArithmetic": [
       "profile:default",
@@ -920,17 +962,29 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:err33-c"
+    ],
+    "cppcheck-nullPointerArithmeticOutOfMemory": [
+      "severity:MEDIUM",
+      "sei-cert-c:arr30-c",
+      "sei-cert-c:err33-c"
     ],
     "cppcheck-nullPointerOutOfMemory": [
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:exp33-c",
+      "sei-cert-c:exp34-c",
+      "sei-cert-c:mem30-c",
+      "sei-cert-c:mem33-c",
+      "sei-cert-c:sig30-c"
     ],
     "cppcheck-nullPointerOutOfResources": [
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:err33-c"
     ],
     "cppcheck-nullPointerRedundantCheck": [
       "profile:default",
@@ -1111,7 +1165,9 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:err30-c",
+      "sei-cert-c:fio42-c"
     ],
     "cppcheck-rethrowNoCurrentException": [
       "profile:default",
@@ -1140,7 +1196,10 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-562",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:dcl30-c",
+      "sei-cert-c:exp54-cpp",
+      "sei-cert-c:exp61-cpp"
     ],
     "cppcheck-returnLocalVariable": [
       "profile:default",
@@ -1200,7 +1259,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int34-c"
     ],
     "cppcheck-shiftNegativeLHS": [
       "severity:LOW"
@@ -1209,7 +1269,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int34-c"
     ],
     "cppcheck-shiftTooManyBitsSigned": [
       "profile:default",
@@ -1344,7 +1405,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:str30-c"
     ],
     "cppcheck-suspiciousCase": [
       "profile:default",
@@ -1362,7 +1424,8 @@
       "severity:MEDIUM"
     ],
     "cppcheck-syntaxError": [
-      "severity:CRITICAL"
+      "severity:CRITICAL",
+      "sei-cert-c:pre32-c"
     ],
     "cppcheck-thisSubtraction": [
       "profile:default",
@@ -1428,7 +1491,9 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp53-cpp",
+      "sei-cert-c:mem53-cpp"
     ],
     "cppcheck-uninitstring": [
       "profile:default",
@@ -1442,13 +1507,18 @@
       "profile:extreme",
       "profile:sensitive",
       "memory-safety:cwe-457",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:ctr53-cpp",
+      "sei-cert-c:exp33-c",
+      "sei-cert-c:exp62-cpp"
     ],
     "cppcheck-unknownEvaluationOrder": [
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp30-c",
+      "sei-cert-c:exp50-cpp"
     ],
     "cppcheck-unknownMacro": [
       "severity:CRITICAL"
@@ -1580,7 +1650,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp58-cpp"
     ],
     "cppcheck-va_start_subsequentCalls": [
       "profile:default",
@@ -1610,7 +1681,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:oop52-cpp"
     ],
     "cppcheck-writeReadOnlyFile": [
       "profile:default",
@@ -1646,7 +1718,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int33-c"
     ],
     "cppcheck-zerodivcond": [
       "profile:default",

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -137,8 +137,7 @@
       "memory-safety:cwe-121",
       "memory-safety:cwe-122",
       "severity:HIGH",
-      "sei-cert-c:exp33-c",
-      "sei-cert-c:str38-c"
+      "sei-cert-c:arr30-c"
     ],
     "cppcheck-catchExceptionByValue": [
       "severity:STYLE"
@@ -196,7 +195,7 @@
     ],
     "cppcheck-subtractPointers": [
       "severity:MEDIUM",
-      "sei-cert-c:arr336-c"
+      "sei-cert-c:arr36-c"
     ],
     "cppcheck-compareValueOutOfTypeRangeError": [
       "severity:STYLE"
@@ -257,6 +256,7 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
+      "sei-cert-c:ctr50-cpp",
       "sei-cert-c:str53-cpp"
     ],
     "cppcheck-copyCtorAndEqOperator": [
@@ -296,7 +296,7 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
-      "sei-cert-c:dcl-30-c"
+      "sei-cert-c:dcl30-c"
     ],
     "cppcheck-danglingReference": [
       "profile:default",
@@ -312,6 +312,7 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
+      "sei-cert-c:exp54-cpp",
       "sei-cert-c:mem50-cpp"
     ],
     "cppcheck-deallocDealloc": [
@@ -417,11 +418,7 @@
     ],
     "cppcheck-throwInEntryPoint": [
       "severity:MEDIUM",
-      "sei-cert-c:con56-cpp",
-      "sei-cert-c:err55-cpp",
-      "sei-cert-c:err57-cpp",
-      "sei-cert-c:mem53-cpp",
-      "sei-cert-c:msc53-cpp"
+      "sei-cert-c:err55-cpp"
     ],
     "cppcheck-fflushOnInputStream": [
       "severity:LOW"
@@ -520,7 +517,8 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int32-c"
     ],
     "cppcheck-internalAstError": [
       "severity:CRITICAL"
@@ -731,10 +729,7 @@
       "profile:security",
       "severity:HIGH",
       "sei-cert-c:exp33-c",
-      "sei-cert-c:exp53-cpp",
-      "sei-cert-c:exp54-cpp",
-      "sei-cert-c:msc33-c",
-      "sei-cert-c:oop57-cpp"
+      "sei-cert-c:exp53-cpp"
     ],
     "cppcheck-literalWithCharPtrCompare": [
       "profile:default",
@@ -765,8 +760,7 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
-      "sei-cert-c:mem31-c",
-      "sei-cert-c:mem34-c"
+      "sei-cert-c:mem31-c"
     ],
     "cppcheck-memleakOnRealloc": [
       "profile:default",
@@ -859,7 +853,6 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
-      "sei-cert-c:con35-c",
       "sei-cert-c:msc37-c",
       "sei-cert-c:msc52-cpp"
     ],
@@ -967,18 +960,15 @@
     ],
     "cppcheck-nullPointerArithmeticOutOfMemory": [
       "severity:MEDIUM",
-      "sei-cert-c:arr30-c",
       "sei-cert-c:err33-c"
     ],
     "cppcheck-nullPointerOutOfMemory": [
       "profile:extreme",
       "profile:sensitive",
       "severity:MEDIUM",
-      "sei-cert-c:exp33-c",
+      "sei-cert-c:err33-c",
       "sei-cert-c:exp34-c",
-      "sei-cert-c:mem30-c",
-      "sei-cert-c:mem33-c",
-      "sei-cert-c:sig30-c"
+      "sei-cert-c:mem52-cpp"
     ],
     "cppcheck-nullPointerOutOfResources": [
       "profile:extreme",
@@ -1166,7 +1156,6 @@
       "profile:extreme",
       "profile:sensitive",
       "severity:HIGH",
-      "sei-cert-c:err30-c",
       "sei-cert-c:fio42-c"
     ],
     "cppcheck-rethrowNoCurrentException": [
@@ -1508,9 +1497,7 @@
       "profile:sensitive",
       "memory-safety:cwe-457",
       "severity:HIGH",
-      "sei-cert-c:ctr53-cpp",
-      "sei-cert-c:exp33-c",
-      "sei-cert-c:exp62-cpp"
+      "sei-cert-c:exp33-c"
     ],
     "cppcheck-unknownEvaluationOrder": [
       "profile:default",

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -194,7 +194,7 @@
       "severity:HIGH"
     ],
     "cppcheck-subtractPointers": [
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:arr36-c"
     ],
     "cppcheck-compareValueOutOfTypeRangeError": [
@@ -341,7 +341,7 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:HIGH"
     ],
     "cppcheck-divideSizeof": [
       "profile:default",
@@ -417,11 +417,11 @@
       "severity:MEDIUM"
     ],
     "cppcheck-throwInEntryPoint": [
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:err55-cpp"
     ],
     "cppcheck-fflushOnInputStream": [
-      "severity:LOW"
+      "severity:MEDIUM"
     ],
     "cppcheck-floatConversionOverflow": [
       "profile:default",
@@ -581,7 +581,7 @@
       "sei-cert-c:mem50-cpp"
     ],
     "cppcheck-invalidPointerCast": [
-      "severity:LOW"
+      "severity:MEDIUM"
     ],
     "cppcheck-invalidPrintfArgType_float": [
       "profile:default",
@@ -1058,10 +1058,10 @@
       "severity:STYLE"
     ],
     "cppcheck-pointerOutOfBounds": [
-      "severity:LOW"
+      "severity:MEDIUM"
     ],
     "cppcheck-pointerOutOfBoundsCond": [
-      "severity:LOW"
+      "severity:MEDIUM"
     ],
     "cppcheck-pointerPositive": [
       "severity:STYLE"
@@ -1076,7 +1076,7 @@
       "severity:LOW"
     ],
     "cppcheck-preprocessorErrorDirective": [
-      "severity:HIGH"
+      "severity:CRITICAL"
     ],
     "cppcheck-publicAllocationError": [
       "profile:default",
@@ -1088,7 +1088,7 @@
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
-      "severity:MEDIUM"
+      "severity:HIGH"
     ],
     "cppcheck-purgedConfiguration": [
       "severity:LOW"
@@ -1252,7 +1252,7 @@
       "sei-cert-c:int34-c"
     ],
     "cppcheck-shiftNegativeLHS": [
-      "severity:LOW"
+      "severity:MEDIUM"
     ],
     "cppcheck-shiftTooManyBits": [
       "profile:default",
@@ -1423,7 +1423,7 @@
       "severity:MEDIUM"
     ],
     "cppcheck-thisUseAfterFree": [
-      "severity:MEDIUM"
+      "severity:HIGH"
     ],
     "cppcheck-throwInNoexceptFunction": [
       "profile:default",

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -4,12 +4,16 @@
     "gcc-allocation-size": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-allocation-size",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp36-c",
+      "sei-cert-c:mem35-c",
+      "sei-cert-c:mem54-cpp"
     ],
     "gcc-deref-before-check": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-deref-before-check",
       "profile:extreme",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:exp34-c"
     ],
     "gcc-double-fclose": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-fclose",
@@ -46,7 +50,9 @@
     "gcc-fd-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-leak",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:pos35-c",
+      "sei-cert-c:pos38-c"
     ],
     "gcc-fd-phase-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-phase-mismatch",
@@ -66,19 +72,24 @@
     "gcc-fd-use-without-check": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-without-check",
       "profile:extreme",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:pos35-c",
+      "sei-cert-c:pos38-c"
     ],
     "gcc-file-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-file-leak",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:fio42-c"
     ],
     "gcc-free-of-non-heap": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-free-of-non-heap",
       "guideline:memory-safety",
       "profile:extreme",
       "memory-safety:cwe-590",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem34-c",
+      "sei-cert-c:mem51-cpp"
     ],
     "gcc-imprecise-fp-arithmetic": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-imprecise-fp-arithmetic",
@@ -93,7 +104,8 @@
     "gcc-jump-through-null": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-jump-through-null",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:oop55-cpp"
     ],
     "gcc-malloc-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-malloc-leak",
@@ -101,26 +113,38 @@
       "profile:extreme",
       "memory-safety:cwe-401",
       "memory-safety:cwe-761",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:err57-cpp",
+      "sei-cert-c:fio41-c",
+      "sei-cert-c:fio42-c",
+      "sei-cert-c:mem53-cpp",
+      "sei-cert-c:mem56-cpp"
     ],
     "gcc-mismatching-deallocation": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-mismatching-deallocation",
       "guideline:memory-safety",
       "profile:extreme",
       "memory-safety:cwe-762",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp51-cpp",
+      "sei-cert-c:mem51-cpp",
+      "sei-cert-c:mem57-cpp"
     ],
     "gcc-null-argument": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-argument",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:err33-c",
+      "sei-cert-c:exp34-c"
     ],
     "gcc-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-dereference",
       "guideline:memory-safety",
       "profile:extreme",
       "memory-safety:cwe-476",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:ctr50-cpp",
+      "sei-cert-c:exp33-c"
     ],
     "gcc-out-of-bounds": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-out-of-bounds",
@@ -132,22 +156,37 @@
       "memory-safety:cwe-126",
       "memory-safety:cwe-127",
       "memory-safety:cwe-843",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:arr30-c",
+      "sei-cert-c:arr38-c",
+      "sei-cert-c:arr39-c",
+      "sei-cert-c:exp36-c",
+      "sei-cert-c:int10-c",
+      "sei-cert-c:mem33-c",
+      "sei-cert-c:mem35-c",
+      "sei-cert-c:mem50-cpp",
+      "sei-cert-c:mem54-cpp",
+      "sei-cert-c:oop55-cpp"
     ],
     "gcc-possible-null-argument": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-argument",
       "profile:extreme",
-      "severity:LOW"
+      "severity:LOW",
+      "sei-cert-c:fio41-c",
+      "sei-cert-c:pos54-c"
     ],
     "gcc-possible-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-dereference",
       "profile:extreme",
-      "severity:LOW"
+      "severity:LOW",
+      "sei-cert-c:exp33-c",
+      "sei-cert-c:exp34-c"
     ],
     "gcc-putenv-of-auto-var": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-putenv-of-auto-var",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:pos34-c"
     ],
     "gcc-shift-count-negative": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-negative",
@@ -157,7 +196,8 @@
     "gcc-shift-count-overflow": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-overflow",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int34-c"
     ],
     "gcc-stale-setjmp-buffer": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-stale-setjmp-buffer",
@@ -197,39 +237,57 @@
     "gcc-unsafe-call-within-signal-handler": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-unsafe-call-within-signal-handler",
       "profile:extreme",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:sig30-c"
     ],
     "gcc-use-after-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-after-free",
       "guideline:memory-safety",
       "profile:extreme",
       "memory-safety:cwe-416",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem30-c",
+      "sei-cert-c:mem51-cpp"
     ],
     "gcc-use-of-pointer-in-stale-stack-frame": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-of-pointer-in-stale-stack-frame",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:dcl30-c",
+      "sei-cert-c:exp61-cpp"
     ],
     "gcc-use-of-uninitialized-value": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-of-uninitialized-value",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:arr38-c",
+      "sei-cert-c:dcl41-c",
+      "sei-cert-c:err56-cpp",
+      "sei-cert-c:exp33-c",
+      "sei-cert-c:exp53-cpp",
+      "sei-cert-c:mem30-c",
+      "sei-cert-c:mem50-cpp",
+      "sei-cert-c:oop53-cpp",
+      "sei-cert-c:oop54-cpp"
     ],
     "gcc-va-arg-type-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-arg-type-mismatch",
       "profile:extreme",
-      "severity:MEDIUM"
+      "severity:MEDIUM",
+      "sei-cert-c:msc39-c"
     ],
     "gcc-va-list-exhausted": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-exhausted",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:dcl50-cpp",
+      "sei-cert-c:exp47-c"
     ],
     "gcc-va-list-leak": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-leak",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:exp58-cpp"
     ],
     "gcc-va-list-use-after-va-end": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-list-use-after-va-end",
@@ -244,7 +302,106 @@
     "gcc-write-to-string-literal": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-write-to-string-literal",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:str30-c"
+    ],
+    "gcc-stringop-overread": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overread",
+      "severity:MEDIUM",
+      "sei-cert-c:arr38-c"
+    ],
+    "gcc-stringop-overflow=": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow",
+      "severity:MEDIUM",
+      "sei-cert-c:arr39-c"
+    ],
+    "gcc-return-local-addr": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-return-local-addr",
+      "severity:LOW",
+      "sei-cert-c:dcl30-c",
+      "sei-cert-c:exp54-cpp"
+    ],
+    "gcc-switch-unreachable": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-unreachable",
+      "severity:LOW",
+      "sei-cert-c:dcl41-c"
+    ],
+    "gcc-literal-suffix": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wliteral-suffix",
+      "severity:STYLE",
+      "sei-cert-c:dcl51-cpp"
+    ],
+    "gcc-vexing-parse": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wvexing-parse",
+      "severity:STYLE",
+      "sei-cert-c:dcl53-cpp"
+    ],
+    "gcc-exceptions": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wexceptions",
+      "severity:LOW",
+      "sei-cert-c:dcl54-cpp"
+    ],
+    "gcc-format-overflow=": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-overflow",
+      "severity:MEDIUM",
+      "sei-cert-c:exp33-c"
+    ],
+    "gcc-analyzer-overlapping-buffers": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-overlapping-buffers",
+      "severity:MEDIUM",
+      "sei-cert-c:exp43-c"
+    ],
+    "gcc-analyzer-infinite-loop": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-infinite-loop",
+      "severity:MEDIUM",
+      "sei-cert-c:exp45-c",
+      "sei-cert-c:sig30-c"
+    ],
+    "gcc-delete-incomplete": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wdelete-incomplete",
+      "severity:MEDIUM",
+      "sei-cert-c:exp57-cpp"
+    ],
+    "gcc-invalid-offsetof": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wno-invalid-offsetof",
+      "severity:LOW",
+      "sei-cert-c:exp59-cpp"
+    ],
+    "gcc-unused-result": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wunused-result",
+      "severity:MEDIUM",
+      "sei-cert-c:exp63-cpp"
+    ],
+    "gcc-format-security": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security",
+      "severity:HIGH",
+      "sei-cert-c:fio30-c"
+    ],
+    "gcc-pointer-to-int-cast": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-pointer-to-int-cast",
+      "severity:MEDIUM",
+      "sei-cert-c:int36-c"
+    ],
+    "gcc-int-to-pointer-cast": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-int-to-pointer-cast",
+      "severity:MEDIUM",
+      "sei-cert-c:int36-c"
+    ],
+    "gcc-free-nonheap-object": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wfree-nonheap-object",
+      "severity:HIGH",
+      "sei-cert-c:mem34-c",
+      "sei-cert-c:mem51-cpp"
+    ],
+    "gcc-placement-new=": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wplacement-new",
+      "severity:HIGH",
+      "sei-cert-c:mem54-cpp"
+    ],
+    "gcc-return-type": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type",
+      "severity:MEDIUM",
+      "sei-cert-c:msc52-cpp"
     ]
   }
 }

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -42,7 +42,7 @@
     "gcc-fd-access-mode-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-access-mode-mismatch",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:MEDIUM"
     ],
     "gcc-fd-double-close": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-double-close",
@@ -59,12 +59,12 @@
     "gcc-fd-phase-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-phase-mismatch",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:MEDIUM"
     ],
     "gcc-fd-type-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-type-mismatch",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:MEDIUM"
     ],
     "gcc-fd-use-after-close": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-after-close",
@@ -170,14 +170,14 @@
     "gcc-possible-null-argument": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-argument",
       "profile:extreme",
-      "severity:LOW",
+      "severity:MEDIUM",
       "sei-cert-c:pos54-c",
       "sei-cert-c:err33-c"
     ],
     "gcc-possible-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-dereference",
       "profile:extreme",
-      "severity:LOW",
+      "severity:MEDIUM",
       "sei-cert-c:exp34-c",
       "sei-cert-c:err33-c"
     ],
@@ -237,7 +237,7 @@
     "gcc-unsafe-call-within-signal-handler": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-unsafe-call-within-signal-handler",
       "profile:extreme",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:sig30-c"
     ],
     "gcc-use-after-free": [
@@ -270,7 +270,7 @@
     "gcc-va-arg-type-mismatch": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-va-arg-type-mismatch",
       "profile:extreme",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:msc39-c"
     ],
     "gcc-va-list-exhausted": [
@@ -305,23 +305,23 @@
     ],
     "gcc-stringop-overread": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overread",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:arr38-c"
     ],
     "gcc-stringop-overflow=": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:arr39-c"
     ],
     "gcc-return-local-addr": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-return-local-addr",
-      "severity:LOW",
+      "severity:HIGH",
       "sei-cert-c:dcl30-c",
       "sei-cert-c:exp54-cpp"
     ],
     "gcc-switch-unreachable": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-unreachable",
-      "severity:LOW",
+      "severity:MEDIUM",
       "sei-cert-c:dcl41-c"
     ],
     "gcc-literal-suffix": [
@@ -336,31 +336,31 @@
     ],
     "gcc-exceptions": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wexceptions",
-      "severity:LOW",
+      "severity:MEDIUM",
       "sei-cert-c:err54-cpp"
     ],
     "gcc-format-overflow=": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-overflow",
-      "severity:MEDIUM"
+      "severity:HIGH"
     ],
     "gcc-analyzer-overlapping-buffers": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-overlapping-buffers",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:exp43-c"
     ],
     "gcc-analyzer-infinite-loop": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-infinite-loop",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:exp45-c"
     ],
     "gcc-delete-incomplete": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wdelete-incomplete",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:exp57-cpp"
     ],
     "gcc-invalid-offsetof": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wno-invalid-offsetof",
-      "severity:LOW",
+      "severity:MEDIUM",
       "sei-cert-c:exp59-cpp"
     ],
     "gcc-unused-result": [
@@ -396,7 +396,7 @@
     ],
     "gcc-return-type": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type",
-      "severity:MEDIUM",
+      "severity:HIGH",
       "sei-cert-c:msc52-cpp",
       "sei-cert-c:msc37-c"
     ]

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -18,14 +18,16 @@
     "gcc-double-fclose": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-fclose",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:fio42-c"
     ],
     "gcc-double-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-double-free",
       "guideline:memory-safety",
       "profile:extreme",
       "memory-safety:cwe-415",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:mem30-c"
     ],
     "gcc-exposure-through-output-file": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-exposure-through-output-file",
@@ -67,7 +69,8 @@
     "gcc-fd-use-after-close": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-after-close",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:pos35-c"
     ],
     "gcc-fd-use-without-check": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-fd-use-without-check",
@@ -115,10 +118,8 @@
       "memory-safety:cwe-761",
       "severity:HIGH",
       "sei-cert-c:err57-cpp",
-      "sei-cert-c:fio41-c",
       "sei-cert-c:fio42-c",
-      "sei-cert-c:mem53-cpp",
-      "sei-cert-c:mem56-cpp"
+      "sei-cert-c:mem31-c"
     ],
     "gcc-mismatching-deallocation": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-mismatching-deallocation",
@@ -143,8 +144,7 @@
       "profile:extreme",
       "memory-safety:cwe-476",
       "severity:HIGH",
-      "sei-cert-c:ctr50-cpp",
-      "sei-cert-c:exp33-c"
+      "sei-cert-c:exp34-c"
     ],
     "gcc-out-of-bounds": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-out-of-bounds",
@@ -164,7 +164,6 @@
       "sei-cert-c:int10-c",
       "sei-cert-c:mem33-c",
       "sei-cert-c:mem35-c",
-      "sei-cert-c:mem50-cpp",
       "sei-cert-c:mem54-cpp",
       "sei-cert-c:oop55-cpp"
     ],
@@ -172,15 +171,15 @@
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-argument",
       "profile:extreme",
       "severity:LOW",
-      "sei-cert-c:fio41-c",
-      "sei-cert-c:pos54-c"
+      "sei-cert-c:pos54-c",
+      "sei-cert-c:err33-c"
     ],
     "gcc-possible-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-possible-null-dereference",
       "profile:extreme",
       "severity:LOW",
-      "sei-cert-c:exp33-c",
-      "sei-cert-c:exp34-c"
+      "sei-cert-c:exp34-c",
+      "sei-cert-c:err33-c"
     ],
     "gcc-putenv-of-auto-var": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-putenv-of-auto-var",
@@ -191,7 +190,8 @@
     "gcc-shift-count-negative": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-negative",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:int34-c"
     ],
     "gcc-shift-count-overflow": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-shift-count-overflow",
@@ -246,8 +246,7 @@
       "profile:extreme",
       "memory-safety:cwe-416",
       "severity:HIGH",
-      "sei-cert-c:mem30-c",
-      "sei-cert-c:mem51-cpp"
+      "sei-cert-c:mem30-c"
     ],
     "gcc-use-of-pointer-in-stale-stack-frame": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-of-pointer-in-stale-stack-frame",
@@ -265,8 +264,6 @@
       "sei-cert-c:err56-cpp",
       "sei-cert-c:exp33-c",
       "sei-cert-c:exp53-cpp",
-      "sei-cert-c:mem30-c",
-      "sei-cert-c:mem50-cpp",
       "sei-cert-c:oop53-cpp",
       "sei-cert-c:oop54-cpp"
     ],
@@ -297,7 +294,8 @@
     "gcc-write-to-const": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-write-to-const",
       "profile:extreme",
-      "severity:HIGH"
+      "severity:HIGH",
+      "sei-cert-c:str30-c"
     ],
     "gcc-write-to-string-literal": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-write-to-string-literal",
@@ -339,12 +337,11 @@
     "gcc-exceptions": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wexceptions",
       "severity:LOW",
-      "sei-cert-c:dcl54-cpp"
+      "sei-cert-c:err54-cpp"
     ],
     "gcc-format-overflow=": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-overflow",
-      "severity:MEDIUM",
-      "sei-cert-c:exp33-c"
+      "severity:MEDIUM"
     ],
     "gcc-analyzer-overlapping-buffers": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-overlapping-buffers",
@@ -354,8 +351,7 @@
     "gcc-analyzer-infinite-loop": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-infinite-loop",
       "severity:MEDIUM",
-      "sei-cert-c:exp45-c",
-      "sei-cert-c:sig30-c"
+      "sei-cert-c:exp45-c"
     ],
     "gcc-delete-incomplete": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wdelete-incomplete",
@@ -401,7 +397,8 @@
     "gcc-return-type": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type",
       "severity:MEDIUM",
-      "sei-cert-c:msc52-cpp"
+      "sei-cert-c:msc52-cpp",
+      "sei-cert-c:msc37-c"
     ]
   }
 }

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -303,102 +303,44 @@
       "severity:HIGH",
       "sei-cert-c:str30-c"
     ],
-    "gcc-stringop-overread": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overread",
-      "severity:HIGH",
-      "sei-cert-c:arr38-c"
-    ],
-    "gcc-stringop-overflow=": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow",
-      "severity:HIGH",
-      "sei-cert-c:arr39-c"
-    ],
-    "gcc-return-local-addr": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-return-local-addr",
-      "severity:HIGH",
-      "sei-cert-c:dcl30-c",
-      "sei-cert-c:exp54-cpp"
-    ],
-    "gcc-switch-unreachable": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-unreachable",
-      "severity:MEDIUM",
-      "sei-cert-c:dcl41-c"
-    ],
-    "gcc-literal-suffix": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wliteral-suffix",
-      "severity:STYLE",
-      "sei-cert-c:dcl51-cpp"
-    ],
-    "gcc-vexing-parse": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wvexing-parse",
-      "severity:STYLE",
-      "sei-cert-c:dcl53-cpp"
-    ],
-    "gcc-exceptions": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wexceptions",
-      "severity:MEDIUM",
-      "sei-cert-c:err54-cpp"
-    ],
-    "gcc-format-overflow=": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-overflow",
-      "severity:HIGH"
-    ],
-    "gcc-analyzer-overlapping-buffers": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-overlapping-buffers",
-      "severity:HIGH",
-      "sei-cert-c:exp43-c"
-    ],
-    "gcc-analyzer-infinite-loop": [
+    "gcc-infinite-loop": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-infinite-loop",
+      "profile:extreme",
       "severity:HIGH",
       "sei-cert-c:exp45-c"
     ],
-    "gcc-delete-incomplete": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wdelete-incomplete",
+    "gcc-overlapping-buffers": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-overlapping-buffers",
+      "profile:extreme",
       "severity:HIGH",
-      "sei-cert-c:exp57-cpp"
+      "sei-cert-c:exp43-c"
     ],
-    "gcc-invalid-offsetof": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wno-invalid-offsetof",
-      "severity:MEDIUM",
-      "sei-cert-c:exp59-cpp"
+    "gcc-symbol-too-complex": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-symbol-too-complex",
+      "profile:extreme",
+      "severity:LOW"
     ],
-    "gcc-unused-result": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wunused-result",
-      "severity:MEDIUM",
-      "sei-cert-c:exp63-cpp"
-    ],
-    "gcc-format-security": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security",
+    "gcc-throw-of-unexpected-type": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-throw-of-unexpected-type",
+      "profile:extreme",
       "severity:HIGH",
-      "sei-cert-c:fio30-c"
+      "sei-cert-c:err55-cpp"
     ],
-    "gcc-pointer-to-int-cast": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-pointer-to-int-cast",
-      "severity:MEDIUM",
-      "sei-cert-c:int36-c"
+    "gcc-too-complex": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-too-complex",
+      "profile:extreme",
+      "severity:LOW"
     ],
-    "gcc-int-to-pointer-cast": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-int-to-pointer-cast",
-      "severity:MEDIUM",
-      "sei-cert-c:int36-c"
-    ],
-    "gcc-free-nonheap-object": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wfree-nonheap-object",
+    "gcc-undefined-behavior-ptrdiff": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-undefined-behavior-ptrdiff",
+      "profile:extreme",
       "severity:HIGH",
-      "sei-cert-c:mem34-c",
-      "sei-cert-c:mem51-cpp"
+      "sei-cert-c:arr36-c"
     ],
-    "gcc-placement-new=": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wplacement-new",
-      "severity:HIGH",
-      "sei-cert-c:mem54-cpp"
-    ],
-    "gcc-return-type": [
-      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type",
-      "severity:HIGH",
-      "sei-cert-c:msc52-cpp",
-      "sei-cert-c:msc37-c"
+    "gcc-undefined-behavior-strtok": [
+      "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-undefined-behavior-strtok",
+      "profile:extreme",
+      "severity:HIGH"
     ]
   }
 }


### PR DESCRIPTION
In this change, the mapping for the existing sei cert guidelines for clang was extended to have the analyzers cppcheck and gcc as well.

The label files for cppcheck and gcc now contains all the found sei cert guidelines.