### PR TITLE
[fix] Fix crash when analyzer_command is null

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1891,7 +1891,7 @@ class ThriftRequestHandler:
 
                 for cmd in analysis_info_query:
                     command = zlib.decompress(cmd.analyzer_command) \
-                        .decode("utf-8")
+                        .decode("utf-8") if cmd.analyzer_command else ""
 
                     checkers_q = session \
                         .query(Checker.analyzer_name,


### PR DESCRIPTION
Old CodeChecker versions didn't store the analyzer command. In this case `null` value was written to the analyzer_command column. Decompressing it with zlib results an error.