### PR TITLE
Bugfix: OAuth login redirect not working

### DIFF
--- a/web/server/vue-cli/src/router/index.js
+++ b/web/server/vue-cli/src/router/index.js
@@ -19,7 +19,7 @@ const router = createRouter({
       component: () => import("@/views/Login")
     },
     {
-      path: "/login/oAuthlogin/:provider",
+      path: "/login/OAuthLogin/:provider",
       name: "oauthlogin",
       component: () => import("@/views/OAuthLogin")
     },

--- a/web/server/vue-cli/src/views/Login.vue
+++ b/web/server/vue-cli/src/views/Login.vue
@@ -272,7 +272,7 @@ function oauth(provider) {
       success.value = false;
       error.value = false;
 
-      router.push({ path: url });
+      window.location.href = url;
     } else {
       errorMsg.value = `Server returned an invalid URL: ${url}`;
       error.value = true;


### PR DESCRIPTION
This PR fixes the OAuth login flow which was broken when redirecting to external authorization URLs.

## The bug
`router.push({ path: url })`  is intended for client-side navigation within the SPA. When passed an external URL (such as the OAuth provider's authorization endpoint), Vue Router attempts to match it against the defined routes, fails, and falls through to the 404 handler instead of redirecting the browser. window.location.href is the correct API for navigating to external URLs.

Reproduction: attempt to log in via GitHub OAuth, observe the error in the console:
`OAuth createLink failed: 'scope'`

## The fix
* `Login.vue`: replaced `router.push({ path: url })` with `window.location.href = url`, the correct API for navigating to external URLs.
* `index.js`: corrected the casing of the OAuth login route path from `/login/oAuthlogin/:provider` to `/login/OAuthLogin/:provider` for consistency.

## Testing
Tested locally by logging in via GitHub OAuth. The redirect to the provider now works correctly.