### PR TITLE
fix in debug_tools "failure zip" handling scripts

### DIFF
--- a/scripts/debug_tools/failure_lib.py
+++ b/scripts/debug_tools/failure_lib.py
@@ -36,18 +36,20 @@ def change_paths(string, path_modifier_fun):
     result = []
     i = 0
     while i < len(string):
-        # Everything is a path which starts with a '/' and there is a
-        # whitespace after that.
+        # All strings that start with '/' (or './' or '../') and end with
+        # whitespace are recognized as paths. Additionally any string
+        # immediately after a '-I' option (no whitespace between option and path).
         # Note, this supports only POSIX paths.
-        if string[i] == '/':
+        if string[i] == '/' or string[i:i + 2] == './' or\
+                string[i:i + 3] == '../' or string[i - 3:i] == ' -I':
             path, path_end = find_path_end(string, i)
+            path = path_modifier_fun(path)
             # Make sure that the prospective output folder exists.
             pattern = re.compile(r'[\s\S]*-o *\Z')
             if pattern.match(string[:i]):
-                out_dir = "./sources-root" + os.path.dirname(path)
+                out_dir = os.path.dirname(path)
                 if not os.path.isdir(out_dir):
                     os.makedirs(out_dir)
-            path = path_modifier_fun(path)
             result += path
             i = path_end - 1
         else:
@@ -57,10 +59,17 @@ def change_paths(string, path_modifier_fun):
 
 
 class IncludePathModifier:
-    def __init__(self, sources_root):
+    def __init__(self, sources_root, working_dir = '.'):
         self.sources_root = sources_root
+        self.working_dir = working_dir
 
     def __call__(self, path):
+        if not os.path.isabs(path):
+            return os.path.normpath(
+                os.path.join(
+                    self.sources_root,
+                    self.working_dir.lstrip(os.path.sep),
+                    path))
         return os.path.join(
             self.sources_root,
             os.path.normpath(

--- a/scripts/debug_tools/prepare_compile_cmd.py
+++ b/scripts/debug_tools/prepare_compile_cmd.py
@@ -46,8 +46,9 @@ def prepare(compile_command_json, sources_root):
         if not exists_in_source_root(entry, sources_root):
             continue
 
+        working_dir = entry['directory']
         entry['directory'] =\
-            lib.change_paths(entry['directory'],
+            lib.change_paths(working_dir,
                              lib.IncludePathModifier(sources_root_abs))
 
         try:
@@ -62,11 +63,11 @@ def prepare(compile_command_json, sources_root):
         compiler, compiler_end = lib.find_path_end(cmd.lstrip(), 0)
         entry['command'] = compiler +\
             lib.change_paths(cmd[compiler_end:],
-                             lib.IncludePathModifier(sources_root_abs))
+                             lib.IncludePathModifier(sources_root_abs, working_dir))
 
         entry['file'] =\
             lib.change_paths(entry['file'],
-                             lib.IncludePathModifier(sources_root_abs))
+                             lib.IncludePathModifier(sources_root_abs, working_dir))
 
         result_json.append(entry)
     return result_json


### PR DESCRIPTION
Include paths in commands were not detected correctly in all cases. This fixes problems with non-absolute paths and paths after '-I' option (which can start with any character).