### PR TITLE
Fix clang-apply-replacements flag detection

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -93,8 +93,9 @@ def is_ignore_conflict_supported():
                             .get_env_for_bin(
                                 context.replacer_binary),
                             encoding="utf-8", errors="ignore")
-    out, _ = proc.communicate()
-    return '--ignore-insert-conflict' in out
+    out, err = proc.communicate()
+    help_output = out + err
+    return '--ignore-insert-conflict' in help_output
 
 
 def print_unsupported_analyzers(errored):

--- a/analyzer/tests/unit/test_analyzer_types.py
+++ b/analyzer/tests/unit/test_analyzer_types.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+"""
+Unit tests for analyzer type helper functions.
+"""
+
+from unittest import mock
+
+from codechecker_analyzer.analyzers import analyzer_types
+
+
+class FakeProcess:
+    """Fake subprocess object for clang-apply-replacements --help."""
+
+    def __init__(self, stdout_text, stderr_text):
+        self._stdout_text = stdout_text
+        self._stderr_text = stderr_text
+
+    def communicate(self):
+        return self._stdout_text, self._stderr_text
+
+
+class FakeContext:
+    """Fake analyzer context with a configured replacer binary."""
+
+    replacer_binary = "clang-apply-replacements"
+
+    def get_env_for_bin(self, _binary):
+        return {}
+
+
+def test_ignore_insert_conflict_detected_from_stderr():
+    """The flag should be detected even if help text is printed to stderr."""
+
+    with mock.patch.object(
+        analyzer_types.analyzer_context,
+        "get_context",
+        return_value=FakeContext()
+    ), mock.patch.object(
+        analyzer_types.subprocess,
+        "Popen",
+        return_value=FakeProcess("", "--ignore-insert-conflict")
+    ):
+        assert analyzer_types.is_ignore_conflict_supported()
+
+
+def test_ignore_insert_conflict_detected_from_stdout():
+    """The flag should still be detected from stdout."""
+
+    with mock.patch.object(
+        analyzer_types.analyzer_context,
+        "get_context",
+        return_value=FakeContext()
+    ), mock.patch.object(
+        analyzer_types.subprocess,
+        "Popen",
+        return_value=FakeProcess("--ignore-insert-conflict", "")
+    ):
+        assert analyzer_types.is_ignore_conflict_supported()


### PR DESCRIPTION
Fixes #4768.

CodeChecker detects whether clang-apply-replacements supports --ignore-insert-conflict by parsing the --help output.

Previously only stdout was checked. Some LLVM/Clang versions may emit help output to stderr, so CodeChecker could fail to detect the supported option.

This change checks the combined stdout and stderr output.

Added unit tests for detecting the flag from both stdout and stderr.

Tested with:
REPO_ROOT="$PWD" PYTHONPATH="$PWD/analyzer:$PWD/build/CodeChecker/lib/python3:$PWD" pytest -q analyzer/tests/unit/test_analyzer_types.py