### PR TITLE
[web] Fix timing issue in run filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -183,6 +183,8 @@ const selectTagMenu = ref(false);
 const selectTagForRun = ref(null);
 const prevSelectedRuns = ref([]);
 const prevSelectedTagItems = ref([]);
+const selectedRunIds = ref([]);
+const selectedTagIds = ref([]);
 const search = ref({
   placeHolder: "Search for run names (e.g.: myrun*)...",
   regexLabel: "Filter by wildcard pattern (e.g.: myrun*)",
@@ -313,6 +315,7 @@ async function initByUrl() {
   if (_runs.length || _tags.length) {
     let _selectedTags = [];
     if (_tags.length) {
+      selectedTagIds.value = _tags;
       _selectedTags = await getSelectedTagItems(_tags);
 
       // Add runs related to tags.
@@ -322,6 +325,7 @@ async function initByUrl() {
       _runs = [ ...new Set(_runs) ];
     }
 
+    selectedRunIds.value = _runs;
     const _selectedRuns = await getSelectedRunItems(_runs);
     prevSelectedRuns.value = _selectedRuns;
     prevSelectedTagItems.value = _selectedTags;
@@ -351,6 +355,8 @@ function applyTagSelection(selected) {
 }
 
 async function clear(updateUrl) {
+  selectedRunIds.value = [];
+  selectedTagIds.value = [];
   await setSelectedItems([], [], updateUrl);
 }
 
@@ -359,17 +365,27 @@ function selectRunTags(selectedItems) {
 }
 
 function getUrlState() {
-  const _runState = baseSelectOptionFilter.selectedItems.value.map(
+  let _runState = selectedRunIds.value;
+  const _newRunState = baseSelectOptionFilter.selectedItems.value.map(
     item => baseSelectOptionFilter.encodeValue.value(item.id)
   );
 
-  const _tagState = runFilter.selectedTagItems.value.map(item => item.id);
+  if (_newRunState.length) {
+    _runState = _newRunState;
+  }
+
+  let _tagState = selectedTagIds.value;
+  const _newTagState = runFilter.selectedTagItems.value.map(item => item.id);
+
+  if (_newTagState.length) {
+    _tagState = _newTagState;
+  }
 
   return {
     [id]: _runState.length ? _runState : undefined,
     [runTagId.value]: _tagState.length ? _tagState : undefined
   };
-}
+};
 
 async function setSelectedItems(runItems, tagItems, updateUrl=true) {
   baseSelectOptionFilter.selectedItems.value = runItems;


### PR DESCRIPTION
Run filter was getting the run name and tag from the global store which made it lose sync and not getting a valid result before setting the URL. This change returns the run id and tag to the update URL function without the need for global store to return the data in time.