### PR TITLE
[gui] Fix report filter expansion panel open state handling

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-expansion-panels
-    v-model="value"
+    v-model="panelOpen"
   >
     <v-expansion-panel
       eager
@@ -53,15 +53,15 @@ import { ref, watch } from "vue";
 
 const props = defineProps({
   title: { type: String, required: true },
-  panel: { type: Boolean, default: false }
+  panelActive: { type: Boolean, default: false }
 });
 
 const emit = defineEmits([ "clear" ]);
 
-const value = ref(null);
+const panelOpen = ref(undefined);
 
-watch(() => props.panel, newPanel => {
-  value.value = newPanel ? 0 : null;
+watch(() => props.panelActive, active => {
+  panelOpen.value = active ? 0 : undefined;
 }, { immediate: true });
 </script>
 

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
@@ -1,7 +1,7 @@
 <template>
   <FilterToolbar
     :title="title"
-    :panel="panel"
+    :panel-active="panel"
     @clear="emit('clear')"
   >
     <template v-slot:append-toolbar-title>


### PR DESCRIPTION
Report filter expansion panels handles openness state wrong. This commit it and makes them open or closed based on whether its value is set or not.