### PR TITLE
[gui] Fix new features timeline alignment

### DIFF
--- a/web/server/vue-cli/src/views/NewFeatures.vue
+++ b/web/server/vue-cli/src/views/NewFeatures.vue
@@ -5,6 +5,7 @@
   >
     <v-timeline
       align="start"
+      class="centered-timeline"
     >
       <v-timeline-item
         dot-color="green-lighten-1"
@@ -3059,3 +3060,12 @@ analyzer:
 <script setup>
 import { NewFeatureItem, NewReleaseItem } from "@/components/NewFeatures";
 </script>
+
+<style scoped>
+.centered-timeline :deep(.v-timeline-item__body),
+.centered-timeline :deep(.v-timeline-item__opposite) {
+  flex: 1 1 0% !important;
+  width: 100% !important;
+  min-width: 0 !important;
+}
+</style>


### PR DESCRIPTION
New features timeline is misaligned in the new Vue 3 rework. This change fixes it by forcing all timeline item to be the same size disregarding its content.