### PR TITLE
[doc] Fix sei-cert guideline references to sei-cert-c/sei-cert-cpp

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/config_handler.py
+++ b/analyzer/codechecker_analyzer/analyzers/config_handler.py
@@ -191,7 +191,8 @@ class AnalyzerConfigHandler(metaclass=ABCMeta):
         for identifier, enabled in cmdline_enable:
             labels = checker_labels.labels() \
                 if callable(getattr(checker_labels, 'labels', None)) \
-                else ["guideline", "profile", "severity", "sei-cert"]
+                else ["guideline", "profile", "severity",
+                      "sei-cert-c", "sei-cert-cpp"]
 
             all_namespaces = ["checker", "prefix"] + labels
 

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -761,12 +761,12 @@ CodeChecker recognizes several third party coding guidelines, such as
 CppCoreGuidelines, SEI-CERT, or MISRA. These are collections of best
 programming practices to avoid common programming errors. Some checkers cover
 the rules of these guidelines. CodeChecker assigns the 'guideline' label to
-these checkers, such as 'guideline:sei-cert'. This way you can list and enable
-those checkers which check the fulfillment of certain guideline rules. See the
-output of "CodeChecker checkers --guideline" command.
+these checkers, such as 'guideline:sei-cert-c'. This way you can list and
+enable those checkers which check the fulfillment of certain guideline rules.
+See the output of "CodeChecker checkers --guideline" command.
 
 Guidelines are labels themselves, and can be used as a label:
-'-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+'-e guideline:<value>', e.g. '-e guideline:sei-cert-c'.
 
 Note: The 'guideline' label is mandatory when there is ambiguity between the
 name of a guideline and a checker prefix group or a checker profile. This

--- a/analyzer/codechecker_analyzer/cli/check.py
+++ b/analyzer/codechecker_analyzer/cli/check.py
@@ -728,12 +728,12 @@ CodeChecker recognizes several third party coding guidelines, such as
 CppCoreGuidelines, SEI-CERT, or MISRA. These are collections of best
 programming practices to avoid common programming errors. Some checkers cover
 the rules of these guidelines. CodeChecker assigns the 'guideline' label to
-these checkers, such as 'guideline:sei-cert'. This way you can list and enable
-those checkers which check the fulfillment of certain guideline rules. See the
-output of "CodeChecker checkers --guideline" command.
+these checkers, such as 'guideline:sei-cert-c'. This way you can list and
+enable those checkers which check the fulfillment of certain guideline rules.
+See the output of "CodeChecker checkers --guideline" command.
 
 Guidelines are labels themselves, and can be used as a label:
-'-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+'-e guideline:<value>', e.g. '-e guideline:sei-cert-c'.
 
 Note: The 'guideline' label is mandatory when there is ambiguity between the
 name of a guideline and a checker prefix group or a checker profile. This

--- a/analyzer/codechecker_analyzer/cli/checkers.py
+++ b/analyzer/codechecker_analyzer/cli/checkers.py
@@ -63,12 +63,12 @@ List checkers in "HIGH" severity:
     CodeChecker checkers --severity HIGH
 
 List checkers covering str34-c SEI-CERT rule:
-    CodeChecker checkers --label sei-cert:str-34-c
-    CodeChecker checkers --guideline sei-cert:str34-c
+    CodeChecker checkers --label sei-cert-c:str34-c
+    CodeChecker checkers --guideline sei-cert-c:str34-c
 
-List checkers covering all SEI-CERT rules:
-    CodeChecker checkers --label guideline:sei-cert
-    CodeChecker checkers --guideline sei-cert
+List checkers covering all SEI-CERT C rules:
+    CodeChecker checkers --label guideline:sei-cert-c
+    CodeChecker checkers --guideline sei-cert-c
 
 List available profiles, guidelines and severities:
     CodeChecker checkers --profile
@@ -195,9 +195,9 @@ def __guideline_to_label(
 ) -> str:
     """
     Transforms --guideline parameter as if they were given through --label.
-    For example "--guideline sei-cert" is equivalent with
-    "--label guideline:sei-cert" and "--guideline sei-cert:str38-c" is the same
-    as "--label sei-cert:str38-c".
+    For example "--guideline sei-cert-c" is equivalent with
+    "--label guideline:sei-cert-c" and "--guideline sei-cert-c:str38-c" is the
+    same as "--label sei-cert-c:str38-c".
     """
     guidelines = []
     for analyzer in args.analyzers:

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -52,7 +52,7 @@ class MockClangsaCheckerLabels:
             return ['alpha.core.BoolAssignment',
                     'alpha.core.TestAfterDivZero']
 
-        if labels[0] == 'guideline:sei-cert':
+        if labels[0] == 'guideline:sei-cert-c':
             return ['alpha.core.CastSize', 'alpha.core.CastToStruct']
 
         if labels[0] == 'severity:LOW':
@@ -73,8 +73,8 @@ class MockClangsaCheckerLabels:
 
     def occurring_values(self, label):
         if label == 'guideline':
-            return ['sei-cert']
-        elif label == 'sei-cert':
+            return ['sei-cert-c']
+        elif label == 'sei-cert-c':
             return ['rule1', 'rule2']
         elif label == 'profile':
             return ['default',
@@ -197,7 +197,7 @@ class CheckerHandlingClangSATest(unittest.TestCase):
                 'security.FloatLoopCounter',
                 'deadcode.DeadStores']
 
-        # Checkers covering some "sei-cert" rules.
+        # Checkers covering some "sei-cert-c" rules.
         cert_guideline = [
                 'alpha.core.CastSize',
                 'alpha.core.CastToStruct']
@@ -310,34 +310,35 @@ class CheckerHandlingClangSATest(unittest.TestCase):
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), default_profile))
 
-        # Enable "sei-cert" guideline checkers with the "guideline:" label.
+        # Enable "sei-cert-c" guideline checkers with the "guideline:" label.
         # Using the "guideline" label is optional in this case, because the
-        # guideline name "sei-cert" does not conflict with any checker
+        # guideline name "sei-cert-c" does not conflict with any checker
         # prefix group names.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
-                                        [('guideline:sei-cert', True)])
+                                        [('guideline:sei-cert-c', True)])
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), cert_guideline))
 
-        # Enable "sei-cert" guideline checkers without the "guideline:" label.
+        # Enable "sei-cert-c" guideline checkers without the "guideline:"
+        # label.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
-                                        [('sei-cert', True)])
+                                        [('sei-cert-c', True)])
         self.assertTrue(all_with_status(CheckerState.ENABLED)
                         (cfg_handler.checks(), cert_guideline))
 
-        # Disable "sei-cert" guideline checkers.
+        # Disable "sei-cert-c" guideline checkers.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
-                                        [('guideline:sei-cert', False)])
+                                        [('guideline:sei-cert-c', False)])
         self.assertTrue(all_with_status(CheckerState.DISABLED)
                         (cfg_handler.checks(), cert_guideline))
 
-        # Disable "sei-cert" guideline checkers.
+        # Disable "sei-cert-c" guideline checkers.
         cfg_handler = ClangSA.construct_config_handler(args)
         cfg_handler.initialize_checkers(checkers,
-                                        [('sei-cert', False)])
+                                        [('sei-cert-c', False)])
         self.assertTrue(all_with_status(CheckerState.DISABLED)
                         (cfg_handler.checks(), cert_guideline))
 
@@ -423,8 +424,8 @@ class MockClangTidyCheckerLabels:
 
     def occurring_values(self, label):
         if label == 'guideline':
-            return ['sei-cert']
-        elif label == 'sei-cert':
+            return ['sei-cert-c']
+        elif label == 'sei-cert-c':
             return ['rule1', 'rule2']
         elif label == 'profile':
             return ['default',
@@ -817,8 +818,8 @@ class MockCppcheckCheckerLabels:
 
     def occurring_values(self, label):
         if label == 'guideline':
-            return ['sei-cert']
-        elif label == 'sei-cert':
+            return ['sei-cert-c']
+        elif label == 'sei-cert-c':
             return ['rule1', 'rule2']
         elif label == 'profile':
             return ['default',

--- a/analyzer/tests/unit/test_checker_labels.py
+++ b/analyzer/tests/unit/test_checker_labels.py
@@ -39,7 +39,7 @@ class TestCheckerLabels(unittest.TestCase):
               "UNSPECIFIED": "Unspecified documentation"
           },
           "guideline": {
-              "sei-cert": "SEI-CERT documentation"
+              "sei-cert-c": "SEI-CERT C documentation"
           }
         }
 
@@ -101,8 +101,8 @@ class TestCheckerLabels(unittest.TestCase):
                     "profile:sensitive",
                     "profile:security",
                     "profile:extreme",
-                    "guideline:sei-cert",
-                    "sei-cert:err34-c",
+                    "guideline:sei-cert-c",
+                    "sei-cert-c:err34-c",
                     "severity:LOW"
                 ]
             }
@@ -182,7 +182,7 @@ class TestCheckerLabels(unittest.TestCase):
 
         self.assertEqual(
             sorted(cl.labels()),
-            sorted(['guideline', 'profile', 'sei-cert', 'severity']))
+            sorted(['guideline', 'profile', 'sei-cert-c', 'severity']))
 
         self.assertEqual(
             sorted(cl.occurring_values('profile')),

--- a/analyzer/tests/unit/test_guidelines.py
+++ b/analyzer/tests/unit/test_guidelines.py
@@ -27,8 +27,8 @@ class TestGuidelines(unittest.TestCase):
 
     def initialize_guidelines_dir(self):
         guidelines = {
-            "guideline": "sei-cert",
-            "guideline_title": "SEI CERT Coding Standard",
+            "guideline": "sei-cert-cpp",
+            "guideline_title": "SEI CERT C++ Coding Standard",
             "rules": [
                 {
                     "rule_id": "con50-cpp",
@@ -61,21 +61,21 @@ class TestGuidelines(unittest.TestCase):
             ]
         }
 
-        with open(os.path.join(self.guidelines_dir.name, 'sei-cert.yaml'),
+        with open(os.path.join(self.guidelines_dir.name, 'sei-cert-cpp.yaml'),
                   'w', encoding='utf-8') as fp:
             yaml.safe_dump(guidelines, fp, default_flow_style=False)
 
     def test_guidelines(self):
         g = Guidelines(self.guidelines_dir.name)
 
-        self.assertNotEqual(len(g.rules_of_guideline("sei-cert")), 0)
+        self.assertNotEqual(len(g.rules_of_guideline("sei-cert-cpp")), 0)
 
         self.assertEqual(
-            sorted(g.rules_of_guideline("sei-cert").keys()),
+            sorted(g.rules_of_guideline("sei-cert-cpp").keys()),
             ["con50-cpp", "con51-cpp", "con52-cpp", "con53-cpp"])
 
         self.assertEqual(
-            g.rules_of_guideline("sei-cert"),
+            g.rules_of_guideline("sei-cert-cpp"),
             {
                 "con50-cpp": {
                     "rule_url": "https://wiki.sei.cmu.edu/confluence/display"

--- a/config/config.md
+++ b/config/config.md
@@ -11,7 +11,7 @@ Current labels are:
 |-------|-------------|
 | profile | A grouping of checker that can be used after `--enable`/`--disable` flags during analysis. |
 | guideline | A coding guideline which contains a coding rule covered by the given checker. |
-| sei-cert | Rules of SEI-CERT coding guideline that the given checker covers. |
+| sei-cert-c, sei-cert-cpp | Rules of SEI-CERT coding guideline that the given checker covers. |
 | severity | Indicates how severe a bug described by the given checker is when it occurs. |
 
 As for severities, the following levels are defined:

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -439,12 +439,14 @@ checker configuration:
   CppCoreGuidelines, SEI-CERT, or MISRA. These are collections of best
   programming practices to avoid common programming errors. Some checkers cover
   the rules of these guidelines. CodeChecker assigns the 'guideline' label to
-  these checkers, such as 'guideline:sei-cert'. This way you can list and enable
-  those checkers which check the fulfillment of certain guideline rules. See the
-  output of "CodeChecker checkers --guideline" command.
+  these checkers, such as 'guideline:sei-cert-c' or 'guideline:sei-cert-cpp'.
+  This way you can list and enable those checkers which check the fulfillment
+  of certain guideline rules. See the output of
+  "CodeChecker checkers --guideline" command.
 
   Guidelines are labels themselves, and can be used as a label:
-  '-e guideline:<value>', e.g. '-e guideline:sei-cert'.
+  '-e guideline:<value>', e.g. '-e guideline:sei-cert-c' or
+  '-e guideline:sei-cert-cpp'.
 
   Note: The 'guideline' label is mandatory when there is ambiguity between the
   name of a guideline and a checker prefix group or a checker profile. This
@@ -2451,12 +2453,12 @@ List checkers in "HIGH" severity:
     CodeChecker checkers --severity HIGH
 
 List checkers covering str34-c SEI-CERT rule:
-    CodeChecker checkers --label sei-cert:str-34-c
-    CodeChecker checkers --guideline sei-cert:str34-c
+    CodeChecker checkers --label sei-cert-c:str34-c
+    CodeChecker checkers --guideline sei-cert-c:str34-c
 
-List checkers covering all SEI-CERT rules:
-    CodeChecker checkers --label guideline:sei-cert
-    CodeChecker checkers --guideline sei-cert
+List checkers covering all SEI-CERT C rules:
+    CodeChecker checkers --label guideline:sei-cert-c
+    CodeChecker checkers --guideline sei-cert-c
 
 List available profiles, guidelines and severities:
     CodeChecker checkers --profile


### PR DESCRIPTION
The bare 'sei-cert' guideline label does not exist. The actual labels are 'sei-cert-c' and 'sei-cert-cpp'.