### PR TITLE
Fix login not redirecting after successful login

### DIFF
--- a/web/server/vue-cli/src/store/modules/auth.js
+++ b/web/server/vue-cli/src/store/modules/auth.js
@@ -27,9 +27,9 @@ const getters = {
   token() {
     return authService.getToken();
   },
-  isAuthenticated() {
-    // Check token existence dynamically to avoid initialization issues
-    return !!authService.getToken();
+  isAuthenticated(state) {
+    state.isAuthenticated = !!authService.getToken();
+    return state.isAuthenticated;
   },
   authParams(state) {
     return state.authParams;

--- a/web/server/vue-cli/src/store/modules/auth.js
+++ b/web/server/vue-cli/src/store/modules/auth.js
@@ -24,9 +24,6 @@ const getters = {
   currentUser(state) {
     return state.currentUser;
   },
-  token() {
-    return authService.getToken();
-  },
   isAuthenticated(state) {
     state.isAuthenticated = !!authService.getToken();
     return state.isAuthenticated;


### PR DESCRIPTION
Login does not redirect the user if logged in successfully which is
caused by a missing state argument from the store getters function.
By missing this argument out, vuex does not recognize this as a
valid getter function and not invokes it as it should.

This change fixes this minor mistake and makes login working.