### PR TITLE
Add rollback to remove_unused_analysis_info()

### DIFF
--- a/web/server/codechecker_server/database/db_cleanup.py
+++ b/web/server/codechecker_server/database/db_cleanup.py
@@ -206,6 +206,7 @@ def remove_unused_analysis_info(product):
                 sqlalchemy.exc.ProgrammingError) as ex:
             LOG.error("[%s] Failed to remove dangling analysis info: %s",
                       product.endpoint, str(ex))
+            session.rollback()  # Reset transaction state
         finally:
             # Re-enable foreign key constraints
             if session.bind.dialect.name == "postgresql":


### PR DESCRIPTION
In function remove_unused_analysis_info(), the
try block may fail with a database exception and
the transaction is not rolled back.

This means subsequent queries in the finally block will also fail with an exception because the
transaction is currently in a failed state.