### PR TITLE
Copy review_status_config instead of creating a symlink

### DIFF
--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -1091,7 +1091,7 @@ def __update_review_status_config(args):
     if 'review_status_config' in args:
         LOG.debug("Copying review status config file %s to %s",
                   args.review_status_config, rs_config_to_send)
-        os.symlink(args.review_status_config, rs_config_to_send)
+        shutil.copyfile(args.review_status_config, rs_config_to_send)
 
 
 def __update_analysis_config_files(args):


### PR DESCRIPTION
The current implementation creates a symbolic link for review_status_config to the report directory. This causes failures in Bazel and other sandboxed build systems because the symlink points outside the output tree and is treated as a dangling symbolic link during validation. This patch fixes the issue by copying the file instead.

Closes https://github.com/Ericsson/codechecker/issues/4863