### PR TITLE
Simplify Docker build process

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: ./web/docker/
+          context: .
           file: ./web/docker/Dockerfile
           tags: |
             codechecker/codechecker-web:latest

--- a/docs/web/docker.md
+++ b/docs/web/docker.md
@@ -23,19 +23,13 @@ sections.
 
 ## Build Docker image
 You can create a Docker image by running the following command in the root
-directory of this repository:
+directory of the CodeChecker repository:
 ```bash
-docker build -t codechecker-web:latest web/docker
+docker build -t codechecker-web:latest -f web/docker/Dockerfile .
 ```
 
 Multiple build-time variables can be specified:
 
-- `CC_REPO` (default: *https://github.com/Ericsson/CodeChecker.git*):
-repository which will be cloned from Git. Use it when you would like to build
-an image from a custom CodeChecker repository.
-- `CC_VERSION` (default: *master*): branch or tag version which will be cloned
-from Git. Use `master` if you would like to build an image from the latest
-CodeChecker.
 - `CC_UID` (default: *950*): id of the *codechecker* user which will be created
 during the image build and which will be used to start CodeChecker server.
 - `CC_GID` (default: *950*): id of the *codechecker* group which will be
@@ -52,7 +46,7 @@ Example:
 docker build \
   --build-arg INSTALL_AUTH=yes \
   --build-arg INSTALL_PSYCOPG2=yes \
-  --tag codechecker-web:latest web/docker
+  --tag codechecker-web:latest -f web/docker/Dockerfile .
 ```
 
 

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -4,13 +4,7 @@
 
 FROM python:3.10.16-slim-bullseye as builder
 
-ARG CC_REPO=https://github.com/Ericsson/CodeChecker.git
-ENV CC_REPO ${CC_REPO}
-
-ARG CC_VERSION=master
-ENV CC_VERSION ${CC_VERSION}
-
-COPY hooks/ /hooks
+COPY web/docker/hooks/ /hooks
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN set -x && apt-get update -qq \
@@ -22,10 +16,9 @@ RUN set -x && apt-get update -qq \
     && curl -sL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs
 
-# Download CodeChecker release.
-RUN git clone ${CC_REPO} /codechecker
+# Copy CodeChecker source code.
+COPY . /codechecker
 WORKDIR /codechecker
-RUN git checkout ${CC_VERSION}
 
 # Run script before the package generation.
 RUN chmod a+x /hooks/before_build.sh && sync && /hooks/before_build.sh
@@ -127,7 +120,7 @@ RUN chown codechecker:codechecker /codechecker
 
 ENV PATH="/codechecker/bin:$PATH"
 
-COPY ./entrypoint.sh /usr/local/bin/
+COPY web/docker/entrypoint.sh /usr/local/bin/
 RUN chmod a+x /usr/local/bin/entrypoint.sh \
   && chown codechecker:codechecker /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
Instead of cloning the repository again, the docker build process now simply copies the source code from the local git repository.