### PR TITLE
Fix netcat installation in Docker build

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -87,7 +87,7 @@ RUN apt-get update -qq  && \
     # gcc is needed to build psutil.
     gcc \
     # netcat is needed for 'wait-for' script.
-    netcat \
+    netcat-openbsd \
   \
   # Install necessary runtime environment files.
   && pip3 install -r /requirements_py/requirements.txt \


### PR DESCRIPTION
Debian Trixie no longer ships a package named
'netcat', so we install 'netcat-openbsd' instead.