### PR TITLE
Fix report converter log message for non-plist exports

### DIFF
--- a/tools/report-converter/codechecker_report_converter/analyzers/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/analyzer_result.py
@@ -164,7 +164,8 @@ class AnalyzerResultBase(metaclass=ABCMeta):
             out_file_name = f"{out_file_name}.{export_type}"
             out_file_path = os.path.join(output_dir, out_file_name)
 
-            LOG.info("Create/modify plist file: '%s'.", out_file_path)
+            LOG.info("Create/modify %s file: '%s'.",
+                     export_type, out_file_path)
             LOG.debug(file_reports)
 
             data = parser.convert(file_reports, analyzer_info)


### PR DESCRIPTION
Use the actual export type in the analyzer result log message instead of
always referring to the output as a plist file.