### PR TITLE
Enhancement: Add confirmation dialog for deleting FilterPresets

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
@@ -27,7 +27,7 @@
             <v-btn
               v-if="canSeeActions"
               variant="text"
-              @click.stop="deletePreset(item.value)"
+              @click.stop="promptDelete(item.value)"
             >
               <v-icon
                 v-if="deletingId === item.value"
@@ -47,11 +47,26 @@
       </v-list-item>
     </template>
   </v-select>
+
+  <ConfirmDialog
+    v-model="showDeleteConfirmDialog"
+    max-width="400px"
+    cancel-btn-color="primary"
+    confirm-btn-label="Delete"
+    confirm-btn-color="error"
+    title="Delete Preset"
+    @confirm="confirmDelete"
+  >
+    <template v-slot:content>
+      Delete "<b>{{ pendingDeleteName }}</b>"? This action cannot be undone.
+    </template>
+  </ConfirmDialog>
 </template>
 
 <script setup>
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 import isEqual from "lodash/isEqual";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import {
   authService,
   ccService,
@@ -73,6 +88,13 @@ const isAdminOfAnyProduct = ref(false);
 const activePresetId = ref(null);
 const querySnapshot = ref(null);
 const isModified = ref(false);
+const showDeleteConfirmDialog = ref(false);
+const pendingDeleteId = ref(null);
+
+const pendingDeleteName = computed(() => {
+  const preset = presets.value.find(p => p.id === pendingDeleteId.value);
+  return preset?.name || "";
+});
 
 const route = useRoute();
 
@@ -187,6 +209,19 @@ function clearPresetState() {
   activePresetId.value = null;
   querySnapshot.value = null;
   isModified.value = false;
+}
+
+function promptDelete(id) {
+  pendingDeleteId.value = id;
+  showDeleteConfirmDialog.value = true;
+}
+
+async function confirmDelete() {
+  showDeleteConfirmDialog.value = false;
+  if (pendingDeleteId.value !== null) {
+    await deletePreset(pendingDeleteId.value);
+    pendingDeleteId.value = null;
+  }
 }
 
 async function deletePreset(id) {


### PR DESCRIPTION
This pull request enhances the user experience for deleting presets in the `PresetMenu.vue` component by introducing a confirmation dialog before deletion. Instead of immediately deleting a preset when the delete button is clicked, users are now prompted to confirm their action, reducing the risk of accidental deletions.

**User experience improvements:**

* Added a `ConfirmDialog` component that appears when a user attempts to delete a preset, requiring explicit confirmation before the action proceeds.
* Introduced new state variables (`showDeleteConfirmDialog`, `pendingDeleteId`, and `pendingDeleteName`) to manage the dialog's visibility and display the name of the preset pending deletion.
* Replaced the direct call to `deletePreset` in the delete button's click handler with a new `promptDelete` method that triggers the confirmation dialog.
* Added `promptDelete` and `confirmDelete` methods to handle the confirmation workflow before actually deleting the preset.