### PR TITLE
[gui] Fix bug path length filter

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BugPathLengthFilter.vue
@@ -27,10 +27,10 @@
           >
             <v-text-field
               :id="minId"
-              :value="minBugPathLength"
+              :model-value="minBugPathLength"
               :rules="rules.bugPathLength"
               label="Min..."
-              @input="setMinBugPathLength"
+              @update:model-value="setMinBugPathLength"
             />
           </v-col>
 
@@ -42,10 +42,10 @@
           >
             <v-text-field
               :id="maxId"
-              :value="maxBugPathLength"
+              :model-value="maxBugPathLength"
               :rules="rules.bugPathLength"
               label="Max..."
-              @input="setMaxBugPathLength"
+              @update:model-value="setMaxBugPathLength"
             />
           </v-col>
         </v-row>


### PR DESCRIPTION
Bug path length filter sets the wrong values got from the input fields when updating. This change fixes the update to the Vue 3 version which was left out in the migration.