### PR TITLE
Recover highlightselection functionality

### DIFF
--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -302,7 +302,9 @@ import {
   keymap,
   lineNumbers
 } from "@codemirror/view";
-import { findNext, openSearchPanel, searchKeymap } from "@codemirror/search";
+import { findNext, highlightSelectionMatches,
+  openSearchPanel, searchKeymap
+} from "@codemirror/search";
 import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { cpp } from "@codemirror/lang-cpp";
 
@@ -393,7 +395,7 @@ const markField = StateField.define({
       }
 
       if (effect.is(addMarks)) {
-        const decoration = effect.value.map(item => 
+        const decoration = effect.value.map(item =>
           Decoration.mark({
             class: "checker-step",
             attributes: { markerid: item.markerId }
@@ -502,7 +504,7 @@ class AdvancedLineWidget extends WidgetType {
       this.data.index === other.data.index &&
       this.data.id === other.data.id;
   }
-  
+
   toDOM() {
     this.container = document.createElement("div");
     const vnode = h(ReportStepMessage, this.data);
@@ -532,6 +534,7 @@ onMounted(() => {
     parent: editorContainer.value,
     extensions: [
       lineNumbers(),
+      highlightSelectionMatches(),
       EditorState.readOnly.of(true),
       cpp(),
       keymap.of(searchKeymap),

--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -302,8 +302,11 @@ import {
   keymap,
   lineNumbers
 } from "@codemirror/view";
-import { findNext, highlightSelectionMatches,
-  openSearchPanel, searchKeymap
+import {
+  findNext,
+  highlightSelectionMatches,
+  openSearchPanel,
+  searchKeymap
 } from "@codemirror/search";
 import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { cpp } from "@codemirror/lang-cpp";


### PR DESCRIPTION
In the Web GUI the highlight selection
function is reenabled in the code view.
When you select a text range, it will highlight
all other ranges that are matching.
This helps finding variable decalrations etc.