### PR TITLE
[gui] Restore Vuetify 2 spacing for CodeChecker web UI

### DIFF
--- a/web/server/vue-cli/src/components/CopyBtn.vue
+++ b/web/server/vue-cli/src/components/CopyBtn.vue
@@ -6,8 +6,8 @@
   >
     <template v-slot:activator="{}">
       <v-btn
-        icon
-        size="x-small"
+        size="small"
+        variant="text"
         @click="copy"
       >
         <v-icon v-if="copyInProgress" color="green">
@@ -15,7 +15,7 @@
         </v-icon>
 
         <v-icon v-else>
-          mdi-content-paste
+          mdi-content-copy
         </v-icon>    
       </v-btn>
     </template>

--- a/web/server/vue-cli/src/components/Icons/DetectionStatusIcon.vue
+++ b/web/server/vue-cli/src/components/Icons/DetectionStatusIcon.vue
@@ -61,7 +61,7 @@ import { computed } from "vue";
 
 const props = defineProps({
   status: { type: Number, required: true },
-  size: { type: String, default: undefined },
+  size: { type: Number, default: undefined },
   title: { type: String, default: null }
 });
 

--- a/web/server/vue-cli/src/components/Icons/ReportStepEnumIcon.vue
+++ b/web/server/vue-cli/src/components/Icons/ReportStepEnumIcon.vue
@@ -11,7 +11,7 @@
   <v-avatar
     v-else
     :color="color"
-    size="24"
+    :size="size"
   >
     <span class="text-caption text-white">{{ index }}</span>
   </v-avatar>
@@ -21,7 +21,8 @@
 import { computed } from "vue";
 const props = defineProps({
   type: { type: String, default: null },
-  index: { type: [ Number, String ], default: null }
+  index: { type: [ Number, String ], default: null },
+  size: { type: Number, default: 24 }
 });
 
 const color = computed(() => {

--- a/web/server/vue-cli/src/components/Layout/TheHeader.vue
+++ b/web/server/vue-cli/src/components/Layout/TheHeader.vue
@@ -10,10 +10,14 @@
     >
       <div
         class="d-flex justify-center align-center w-100"
-        style="background-color: #ff9800; height: 24px; color: black;"
+        style="background-color: #ff9800; height: 24px; color: #573300;"
       >
-        <v-icon>mdi-bullhorn-outline</v-icon>
-        <span class="font-weight-semibold ml-2">
+        <v-icon
+          size="x-small"
+        >
+          mdi-bullhorn-outline
+        </v-icon>
+        <span class="font-weight-semibold ml-1 text-caption">
           {{ announcement }}
         </span>
       </div>

--- a/web/server/vue-cli/src/components/Product/ProductNameColumn.vue
+++ b/web/server/vue-cli/src/components/Product/ProductNameColumn.vue
@@ -1,22 +1,29 @@
 <template>
   <v-list-item
-    class="py-2"
+    class="pt-2"
     two-line
+    density="compact"
   >
     <template v-slot:prepend>
       <v-avatar
         :color="strToColor(product.endpoint)"
-        size="48"
+        size="42"
         class="my-1"
       >
-        <span class="white--text headline">
+        <span class="text-white headline">
           {{ getProductIconName(product.endpoint) }}
         </span>
       </v-avatar>
     </template>
 
-    <v-list-item-title>
-      <confidentiality-icon :value="product.confidentiality" small />
+    <v-list-item-title
+      class="text-body-2"
+    >
+      <confidentiality-icon
+        class="mr-1"
+        :value="product.confidentiality"
+        small
+      />
 
       <span
         v-if="product.databaseStatus !== DBStatus.OK || !product.accessible"
@@ -63,30 +70,37 @@
     <v-list-item-subtitle
       v-if="product.databaseStatus === DBStatus.OK && product.accessible"
     >
-      <span
-        v-for="link in links"
-        :key="link.name"
+      <v-btn-group
+        class="overflow-visible"
+        density="compact"
       >
-        <v-btn
-          :to="{
-            name: link.name,
-            params: { endpoint: product.endpoint },
-            query: link.query || {}
-          }"
-          :title="link.title"
-          :color="link.color"
-          size="small"
-          variant="text"
-          :icon="link.icon"
-        />
+        <template
+          v-for="link in links"
+          :key="link.name"
+        >
+          <v-btn
+            class="pa-0"
+            :min-width="0"
+            :to="{
+              name: link.name,
+              params: { endpoint: product.endpoint },
+              query: link.query || {}
+            }"
+            :title="link.title"
+            :color="link.color"
+            :icon="link.icon"
+            size="small"
+            variant="text"
+          />
 
-        <v-divider
-          v-if="link.divider"
-          class="mx-2 d-inline"
-          inset
-          vertical
-        />
-      </span>
+          <v-divider
+            v-if="link.divider"
+            class="mx-2 d-inline"
+            inset
+            vertical
+          />
+        </template>
+      </v-btn-group>
     </v-list-item-subtitle>
   </v-list-item>
 </template>

--- a/web/server/vue-cli/src/components/Report/Report.vue
+++ b/web/server/vue-cli/src/components/Report/Report.vue
@@ -122,7 +122,14 @@
             >
               <v-checkbox
                 v-model="showArrows"
-                class="show-arrows mx-2 my-0 align-center justify-center"
+                class="
+                  show-arrows
+                  mx-2
+                  my-0
+                  align-center
+                  justify-center
+                  text-caption
+                "
                 label="Show arrows"
                 density="compact"
                 hide-details
@@ -196,7 +203,7 @@
                     <span
                       v-if="sourceFile"
                       :title="`Tracking branch: ${trackingBranch}`"
-                      class="text-grey text-darken-3"
+                      class="text-grey text-darken-3 text-body-2"
                     >
                       <v-icon class="mr-0" small>mdi-source-branch</v-icon>
                       ({{ truncate(trackingBranch, 20) }})
@@ -219,10 +226,13 @@
                     class="file-path py-0 pl-1"
                     align-self="center"
                   >
-                    <copy-btn v-if="sourceFile" :value="sourceFile.filePath" />
+                    <copy-btn
+                      v-if="sourceFile"
+                      :value="sourceFile.filePath"
+                    />
                     <span
                       v-if="sourceFile"
-                      class="file-path"
+                      class="file-path text-body-2"
                       :title="`\u200E${sourceFile.filePath}`"
                     >
                       {{ sourceFile.filePath }}
@@ -449,6 +459,17 @@ const reviewData = computed(() =>
   report.value?.reviewData || new ReviewData()
 );
 
+const compactTheme = EditorView.theme({
+  "&": {
+    fontSize: "12px",
+  },
+  ".cm-gutterElement": {
+    fontSize: "12px",
+    paddingLeft: "4px",
+    paddingRight: "4px"
+  }
+});
+
 watch(enableBlameView, async () => {
   if (enableBlameView.value) {
     await gitBlame.loadBlameView();
@@ -543,7 +564,8 @@ onMounted(() => {
       }),
       markField,
       lineWidgetField(parentAppContext),
-      gitBlame.blameCompartment.of([])
+      gitBlame.blameCompartment.of([]),
+      compactTheme
     ]
   });
 
@@ -1082,5 +1104,38 @@ function truncate(text, length) {
 .blame-gutter {
   width: 400px;
   background-color: #f7f7f7;
+}
+</style>
+
+<style lang="scss" scoped>
+:deep(.show-arrows .v-input__control .v-selection-control) {
+  min-height: 0;
+  max-height: 30px;
+}
+
+:deep(.select-review-status .v-input__control .v-field) {
+  min-height: 0;
+  max-height: 30px;
+}
+
+:deep(
+  .select-review-status
+  .v-input__control
+  .v-field
+  .v-field__field
+  .v-field__input
+  ) {
+  min-height: 0;
+  max-height: 30px;
+}
+
+:deep(.select-review-status .v-input__control .v-field .v-field__input) {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+:deep(.select-review-status .v-input__control .v-field .v-field__append-inner) {
+  min-height: 0;
+  max-height: 30px;
 }
 </style>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
@@ -1,6 +1,7 @@
 <template>
   <v-expansion-panels
     v-model="panelOpen"
+    flat
   >
     <v-expansion-panel
       eager

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/UniqueFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/UniqueFilter.vue
@@ -2,6 +2,7 @@
   <v-checkbox
     v-model="isUniqueModel"
     :hide-details="true"
+    density="compact"
   >
     <template v-slot:label>
       Unique reports

--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -59,7 +59,9 @@
           font-weight-semibold
           mr-2
           text-truncate"
-      >Filter Preset</span>
+      >
+        Filter Preset
+      </span>
       <tooltip-help-icon
         class="mr-2"
       >
@@ -186,7 +188,7 @@
                 @update:url="updateUrl"
               />
 
-              <v-divider class="mt-2" />
+              <v-divider />
 
               <baseline-open-reports-date-filter
                 :ref="setFilterRef"
@@ -233,7 +235,7 @@
                 @update:url="updateUrl"
               />
 
-              <v-divider class="mt-2" />
+              <v-divider />
 
               <compared-to-open-reports-date-filter
                 :ref="setFilterRef"
@@ -241,7 +243,7 @@
                 @update:url="updateUrl"
               />
 
-              <v-divider v-if="showDiffType" class="mt-2" />
+              <v-divider v-if="showDiffType" />
 
               <compared-to-diff-type-filter
                 v-if="showDiffType"
@@ -1143,11 +1145,12 @@ async function clearToolbarSilently() {
 
 .v-expansion-panel--active > .v-expansion-panel-title,
 .v-expansion-panel-title {
-  min-height: 40px;
+  min-height: 40px !important;
+  font-size: 0.875rem !important;
 }
 
-.v-expansion-panel-text > .v-expansion-panel-text__wrap {
-  padding: 0 4px 0 6px;
+.v-expansion-panel-text > .v-expansion-panel-text__wrapper {
+  padding: 0 4px 0 6px !important;
 }
 
 #baseline-filters,
@@ -1158,11 +1161,6 @@ async function clearToolbarSilently() {
 
 #compare-to-filters {
   border-top: 0;
-}
-
-.v-expansion-panel-title {
-  min-height: 48px !important;
-  font-size: 0.875rem !important;
 }
 
 .v-expansion-panel-title__icon {

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportStepIcon.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportStepIcon.vue
@@ -2,6 +2,7 @@
   <v-icon
     v-if="value === ReportStepIconType.DEFAULT"
     color="#000000"
+    :size="size"
   >
     mdi-console-line
   </v-icon>
@@ -9,6 +10,7 @@
   <v-icon
     v-else-if="value === ReportStepIconType.CALLING"
     color="#1855B6"
+    :size="size"
   >
     mdi-phone-in-talk
   </v-icon>
@@ -16,6 +18,7 @@
   <v-icon
     v-else-if="value === ReportStepIconType.ENTERED_CALL"
     color="#316ecf"
+    :size="size"
   >
     mdi-subdirectory-arrow-right
   </v-icon>
@@ -23,6 +26,7 @@
   <v-icon
     v-else-if="value === ReportStepIconType.RETURNING"
     color="#61a2ff"
+    :size="size"
   >
     mdi-keyboard-return
   </v-icon>
@@ -30,6 +34,7 @@
   <v-icon
     v-else-if="value === ReportStepIconType.ASSUMING"
     color="#ff5c11"
+    :size="size"
   >
     mdi-exclamation-thick
   </v-icon>
@@ -37,6 +42,7 @@
   <v-icon
     v-else-if="value === ReportStepIconType.ASSUMING_CONDITION"
     color="#7f410c"
+    :size="size"
   >
     mdi-swap-horizontal-bold
   </v-icon>
@@ -44,18 +50,21 @@
   <v-icon
     v-else-if="value === ReportStepIconType.ENTERING_LOOP_BODY"
     color="#000000"
+    :size="size"
   >
     mdi-refresh
   </v-icon>
   <v-icon
     v-else-if="value === ReportStepIconType.LOOP_BODY_EXECUTED"
     color="#000000"
+    :size="size"
   >
     mdi-sync
   </v-icon>
   <v-icon
     v-else-if="value === ReportStepIconType.LOOP_BACK"
     color="#000000"
+    :size="size"
   >
     mdi-undo
   </v-icon>
@@ -68,6 +77,10 @@ defineProps({
   value: {
     required: true,
     validator: v => typeof v === "number" || v === null
+  },
+  size: {
+    type: Number,
+    default: undefined
   }
 });
 </script>

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTree.vue
@@ -10,6 +10,8 @@
     item-value="id"
     open-on-click
     density="compact"
+    slim
+    fluid
     @update:activated="onClick"
   >
     <template v-slot:prepend="{ item }">
@@ -22,11 +24,15 @@
         &nbsp;
       </span>
 
-      <report-tree-icon :item="item" />
+      <report-tree-icon
+        :item="item"
+        size="22"
+      />
 
       <review-status-icon
         v-if="item.kind === ReportTreeKind.REPORT"
         :status="parseInt(item.report.reviewData.status)"
+        size="22"
       />
     </template>
 
@@ -284,11 +290,7 @@ function isTheReportFileChanged() {
 </script>
 
 <style lang="scss" scoped>
-:deep(.v-treeview-item) {
-  min-height: 25px;
-}
-
-:deep(.v-treeview-item__level) {
-  width: 18px;
+:deep(.v-list-item) {
+  min-height: 20px !important;
 }
 </style>

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeIcon.vue
@@ -4,55 +4,65 @@
   >
     <report-step-icon
       :value="item.icon"
+      :size="size"
     />
 
     <report-step-enum-icon
       :type="item.reportStepIcon.type"
       :index="item.reportStepIcon.index"
+      :size="size"
     />
   </span>
 
   <severity-icon
     v-else-if="item.kind === ReportTreeKind.SEVERITY_LEVEL"
     :status="item.severity"
+    :size="size"
   />
 
   <detection-status-icon
     v-else-if="item.kind === ReportTreeKind.DETECTION_STATUS"
     :status="DetectionStatus.RESOLVED"
+    :size="size"
   />
 
   <detection-status-icon
     v-else-if="item.kind === ReportTreeKind.REPORT"
     :status="item.report.detectionStatus"
+    :size="size"
   />
 
   <v-icon
     v-else-if="item.kind === ReportTreeKind.BUG"
+    :size="size"
   >
     mdi-message-processing
   </v-icon>
 
   <v-icon
     v-else-if="item.kind === ReportTreeKind.MACRO_EXPANSION"
+    :size="size"
   >
     mdi-arrow-expand-all
   </v-icon>
 
   <v-icon
     v-else-if="item.kind === ReportTreeKind.MACRO_EXPANSION_ITEM"
+    :size="size"
   >
     mdi-arrow-expand
   </v-icon>
 
   <v-icon
     v-else-if="item.kind === ReportTreeKind.NOTE"
+    :size="size"
   >
     mdi-note
   </v-icon>
 
   <v-icon
     v-else-if="item.kind === ReportTreeKind.NOTE_ITEM"
+    :size="size"
   >
     mdi-note-outline
   </v-icon>
@@ -63,6 +73,7 @@
 (review status is unreviewed or confirmed and
 detection status is new, unresolved or reopened)"
     color="primary"
+    :size="size"
   >
     mdi-folder-lock-open
   </v-icon>
@@ -73,11 +84,15 @@ detection status is new, unresolved or reopened)"
 (false positive, intentional) or whose detection status is resolved,
 off or unavailable."
     color="primary"
+    :size="size"
   >
     mdi-folder-lock
   </v-icon>
 
-  <v-icon v-else>
+  <v-icon
+    v-else
+    :size="size"
+  >
     {{ item.open ? "mdi-folder-open" : "mdi-folder" }}
   </v-icon>
 </template>
@@ -95,6 +110,7 @@ import ReportStepIcon from "./ReportStepIcon";
 import ReportTreeKind from "./ReportTreeKind";
 
 defineProps({
-  item: { type: Object, required: true }
+  item: { type: Object, required: true },
+  size: { type: Number, default: null }
 });
 </script>

--- a/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeLabel.vue
+++ b/web/server/vue-cli/src/components/Report/ReportTree/ReportTreeLabel.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :data-id="item.id">
+  <span :data-id="item.id" class="text-caption">
     <span v-if="item.kind === ReportTreeKind.REPORT">
       L{{ item.report.line }} &ndash; {{ item.report.checkerId }}
       [{{ item.report.bugPathLength }}]

--- a/web/server/vue-cli/src/components/Report/SelectReviewStatus.vue
+++ b/web/server/vue-cli/src/components/Report/SelectReviewStatus.vue
@@ -16,7 +16,7 @@
         <v-row>
           <v-col
             cols="auto"
-            class="pa-0 mx-4"
+            class="pa-0 mx-2"
           >
             <v-select
               :model-value="value.status"
@@ -24,7 +24,6 @@
               :hide-details="true"
               :menu-props="{ contentClass: 'select-review-status-menu' }"
               :disabled="isReviewStatusDisabled"
-              label="Set review status"
               item-title="label"
               item-value="id"
               class="select-review-status small"

--- a/web/server/vue-cli/src/components/Report/SelectSameReport.vue
+++ b/web/server/vue-cli/src/components/Report/SelectSameReport.vue
@@ -4,7 +4,6 @@
     :items="items"
     :hide-details="true"
     class="select-same-report small"
-    label="Found in"
     item-title="label"
     item-value="id"
     height="0"

--- a/web/server/vue-cli/src/components/Run/RunNameColumn.vue
+++ b/web/server/vue-cli/src/components/Run/RunNameColumn.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-list-item two-line>
+  <v-list-item
+    two-line
+    density="compact"
+  >
     <v-list-item-title>
       <router-link
         :to="{ name: 'reports',
@@ -8,7 +11,7 @@
                  ...reportFilterQuery
                }
         }"
-        class="name mr-2"
+        class="name mr-2 text-body-2"
       >
         <span>{{ name }}</span>
       </router-link>
@@ -25,45 +28,52 @@
     </v-list-item-title>
 
     <v-list-item-subtitle>
-      <show-statistics-btn
-        :extra-queries="statisticsFilterQuery"
-      />
-
-      <v-divider
-        class="mx-2 d-inline"
-        inset
-        vertical
-      />
-
-      <analysis-info-dialog
-        :run-id="runId"
-        :icon-only="true"
-        icon-size="default"
-      />
-
-      <v-divider
-        class="mx-2 d-inline"
-        inset
-        vertical
-      />
-
-      <v-btn
-        v-for="(value, status) in detectionStatusCount"
-        :key="status"
-        :to="{ name: 'reports', query: {
-          run: name,
-          'detection-status': detectionStatusFromCodeToString(status)
-        }}"
-        class="detection-status-count"
-        variant="text"
+      <v-btn-group
+        class="overflow-visible"
+        density="compact"
       >
-        <detection-status-icon
-          class="mr-1"
-          :status="parseInt(status)"
-          size="small"
+        <show-statistics-btn
+          :extra-queries="statisticsFilterQuery"
         />
-        ({{ value }})
-      </v-btn>
+
+        <v-divider
+          class="mx-2 d-inline"
+          length="20"
+          inset
+          vertical
+        />
+
+        <analysis-info-dialog
+          :run-id="runId"
+          :icon-only="true"
+          icon-size="default"
+        />
+
+        <v-divider
+          class="mx-2 d-inline"
+          length="20"
+          inset
+          vertical
+        />
+
+        <v-btn
+          v-for="(value, status) in detectionStatusCount"
+          :key="status"
+          :to="{ name: 'reports', query: {
+            run: name,
+            'detection-status': detectionStatusFromCodeToString(status)
+          }}"
+          class="detection-status-count"
+          variant="text"
+        >
+          <detection-status-icon
+            class="mr-1"
+            :status="parseInt(status)"
+            size="small"
+          />
+          ({{ value }})
+        </v-btn>
+      </v-btn-group>
     </v-list-item-subtitle>
   </v-list-item>
 </template>

--- a/web/server/vue-cli/src/components/Run/RunNameColumn.vue
+++ b/web/server/vue-cli/src/components/Run/RunNameColumn.vue
@@ -69,7 +69,7 @@
           <detection-status-icon
             class="mr-1"
             :status="parseInt(status)"
-            size="small"
+            :size="16"
           />
           ({{ value }})
         </v-btn>

--- a/web/server/vue-cli/src/main.js
+++ b/web/server/vue-cli/src/main.js
@@ -143,6 +143,17 @@ const vuetify = createVuetify({
         }
       }
     }
+  },
+  defaults: {
+    VCard: {
+      density: "comfortable",
+    },
+    VTable: {
+      density: "compact",
+    },
+    VDataTableServer: {
+      density: "compact",
+    }
   }
 });
 

--- a/web/server/vue-cli/src/views/ReportDetail.vue
+++ b/web/server/vue-cli/src/views/ReportDetail.vue
@@ -1,36 +1,35 @@
 <template>
   <v-container
     v-if="reportNotFound"
-    class="text-center"
+    class="d-flex align-center justify-center"
+    fluid
     fill-height
   >
-    <v-row align="center" justify="center">
-      <v-col class="error--text" cols="6">
-        <h1 class="display-2">
-          404 - Report not found!
-        </h1>
+    <v-col class="text-error text-center" cols="6">
+      <h1 class="display-2">
+        404 - Report not found!
+      </h1>
 
-        <v-alert
-          class="mt-4"
-          type="error"
-          density="compact"
-          variant="outlined"
-        >
-          The report (
-          report ID: <i>{{ route.query["report-id"] }}</i>,
-          report hash: <i>{{ route.query["report-hash"] }}</i>,
-          file path:
-          <i>"{{ route.query["report-filepath"] }}"</i>
-          ) was removed from the database.
+      <v-alert
+        class="mt-4"
+        type="error"
+        density="compact"
+        variant="outlined"
+      >
+        The report (
+        report ID: <i>{{ route.query["report-id"] }}</i>,
+        report hash: <i>{{ route.query["report-hash"] }}</i>,
+        file path:
+        <i>"{{ route.query["report-filepath"] }}"</i>
+        ) was removed from the database.
 
-          <span v-if="!route.query['report-hash']">
-            Unfortunately, your hyperlink was copied from an older version of
-            CodeChecker and the request does not contain the <i>report-hash</i>
-            parameter which could be used as a fallback mechanism.
-          </span>
-        </v-alert>
-      </v-col>
-    </v-row>
+        <span v-if="!route.query['report-hash']">
+          Unfortunately, your hyperlink was copied from an older version of
+          CodeChecker and the request does not contain the <i>report-hash</i>
+          parameter which could be used as a fallback mechanism.
+        </span>
+      </v-alert>
+    </v-col>
   </v-container>
 
   <splitpanes

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -14,12 +14,12 @@
         v-model="checkerDocDialog"
         :checker="selectedChecker"
       />
-      <div class="d-flex align-center mb-2">
+      <div class="d-flex align-center w-100">
         <span class="mr-2 text-body-2">View</span>
         <v-btn-toggle
           v-model="viewMode"
           mandatory
-          density="compact"
+          style="height: 28px;"
           variant="outlined"
         >
           <v-btn
@@ -37,6 +37,11 @@
             File Tree
           </v-btn>
         </v-btn-toggle>
+        <v-spacer />
+        <set-cleanup-plan-btn
+          v-if="viewMode === 'table'"
+          :selected-reports="selected"
+        />
       </div>
 
       <v-data-table-server
@@ -46,6 +51,7 @@
         v-model:items-per-page="itemsPerPage"
         v-model:sort-by="sortBy"
         v-model:expanded="expanded"
+        class="text-caption"
         :items-per-page-options="itemsPerPageOptions"
         :items-length="totalItems"
         :headers="tableHeaders"
@@ -57,21 +63,9 @@
         :mobile-breakpoint="1100"
         item-value="id"
         return-object
+        density="compact"
         @update:expanded="itemExpanded"
       >
-        <template v-slot:top>
-          <v-toolbar
-            flat
-            class="report-filter-toolbar"
-            density="compact"
-            color="transparent"
-          >
-            <div class="d-flex justify-end w-100">
-              <set-cleanup-plan-btn :selected-reports="selected" />
-            </div>
-          </v-toolbar>
-        </template>
-
         <template v-slot:expanded-row="{ item }">
           <td
             class="pa-0"
@@ -141,7 +135,7 @@
               'report-filepath': reportFilter.isUnique
                 ? `*${item.checkedFile}` : item.checkedFile
             }}"
-            class="file-name"
+            class="file-name text-body-small text-primary"
           >
             {{ item.checkedFile }}
             <span v-if="item.line">@&nbsp;Line&nbsp;{{ item.line }}</span>
@@ -150,7 +144,7 @@
 
         <template #item.checkerId="{ item }">
           <span
-            class="checker-name primary--text"
+            class="checker-name text-primary"
             @click="openCheckerDocDialog(item.checkerId, item.analyzerName)"
           >
             {{ item.checkerId }}


### PR DESCRIPTION
Vuetify 3 introduced new spacing values which creates a more spacious feel for the users. This is not ideal for CodeChecker since it allows less data to be present and users have to scroll and resize the page to view any info.

This change aims to restore the old Vuetify 2 spacings in some form to be able to display more information.