### PR TITLE
Refactor/replace report filter button icon

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/ClearAllFilters.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ClearAllFilters.vue
@@ -3,7 +3,7 @@
     id="clear-all-filter-btn"
     color="primary"
     variant="outlined"
-    prepend-icon="mdi-delete"
+    prepend-icon="mdi-close-circle"
     @click="clearAllFilters"
   >
     Clear All Filters

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/Layout/FilterToolbar.vue
@@ -31,7 +31,7 @@
           <slot name="prepend-toolbar-items" />
 
           <v-btn
-            icon="mdi-delete"
+            icon="mdi-close-circle"
             size="small"
             variant="plain"
             @click.stop="emit('clear');"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
@@ -6,6 +6,7 @@
     item-title="name"
     item-value="id"
     label="Presets"
+    :menu-props="{ scrim: true, scrollStrategy: 'close' }"
     :hide-details="true"
     :items="presets"
     :loading="loadingList"

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
@@ -2,11 +2,12 @@
   <v-select
     v-model="activePresetId"
     clearable
-    :items="presets"
-    :hide-details="true"
+    clear-icon="mdi-delete"
     item-title="name"
     item-value="id"
     label="Presets"
+    :hide-details="true"
+    :items="presets"
     :loading="loadingList"
     :disabled="saving || settingPreset || deletingId !== null"
     @focus="fetchPresets"
@@ -37,9 +38,9 @@
               </v-icon>
               <v-icon
                 v-else
-                size="small"
+                size="large"
               >
-                mdi-delete
+                mdi-close-circle
               </v-icon>
             </v-btn>
           </v-list-item-action>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/PresetMenu.vue
@@ -2,7 +2,6 @@
   <v-select
     v-model="activePresetId"
     clearable
-    clear-icon="mdi-delete"
     item-title="name"
     item-value="id"
     label="Presets"
@@ -41,7 +40,7 @@
                 v-else
                 size="large"
               >
-                mdi-close-circle
+                mdi-delete
               </v-icon>
             </v-btn>
           </v-list-item-action>


### PR DESCRIPTION
This pull request updates the `PresetMenu` component in the report filter UI to improve the user experience and clarify icon usage. The main changes focus on the appearance and behavior of the preset selection and deletion controls.

UI/UX improvements:

* The clear icon for the `v-select` component is now set to `mdi-delete` for better clarity when clearing a preset.
* The menu dropdown uses a scrim and closes on scroll for improved usability, and the order of some props is adjusted for clarity.

Icon and button updates:

* The delete/cancel icon in the preset list is now larger (`size="large"`) and uses `mdi-close-circle` instead of `mdi-delete` for clearer intent.

Closes #4906 