### PR TITLE
[gui] Show the selected source component filter mode in toolbar

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/ReportFilterModeSelector.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/ReportFilterModeSelector.vue
@@ -6,6 +6,12 @@
     <v-radio value="end">
       <template v-slot:label>
         <span>
+          <v-icon
+            start
+            class="mr-1"
+          >
+            {{ filterIcon["end"] }}
+          </v-icon>
           End of report path
           <TooltipHelpIcon>
             Filters reports with final error location within the
@@ -17,6 +23,12 @@
     <v-radio value="anywhere">
       <template v-slot:label>
         <span>
+          <v-icon
+            start
+            class="mr-1"
+          >
+            {{ filterIcon["anywhere"] }}
+          </v-icon>
           Anywhere on report path
           <TooltipHelpIcon>
             Filters reports that have any bug path element within the
@@ -28,6 +40,12 @@
     <v-radio value="single-origin">
       <template v-slot:label>
         <span>
+          <v-icon
+            start
+            class="mr-1"
+          >
+            {{ filterIcon["single-origin"] }}
+          </v-icon>
           Single origin
           <TooltipHelpIcon>
             Filters reports with the full bug path contained within the
@@ -46,6 +64,10 @@ defineProps({
   value: {
     type: String,
     default: ""
+  },
+  filterIcon: {
+    type: Object,
+    required: true
   }
 });
 

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
@@ -3,7 +3,7 @@
     v-model="isDialogOpen"
   >
     <select-option
-      :id="id.value"
+      :id="id"
       title="Source component"
       :bus="baseSelectOptionFilter.bus"
       :fetch-items="fetchItems"
@@ -15,9 +15,18 @@
       @input="baseSelectOptionFilter.setSelectedItems"
     >
       <template v-slot:append-toolbar>
-        <ReportFilterModeSelector v-model="reportFilterMode" />
+        <ReportFilterModeSelector
+          v-model="reportFilterMode"
+          :filter-icon="filterIconNames"
+        />
       </template>
       <template v-slot:prepend-toolbar-items>
+        <v-icon
+          start
+          class="mr-1"
+        >
+          {{ filterIconNames[reportFilterMode] }}
+        </v-icon>
         <v-btn
           v-if="administrating"
           class="manage-components-btn"
@@ -74,13 +83,19 @@ const props = defineProps({
 
 const emit = defineEmits([ "update:url" ]);
 
-const id = ref("source-component");
+const id = "source-component";
 const anywhereId = ref("anywhere-sourcecomponent");
 const sameOriginId = ref("sameorigin-sourcecomponent");
 const isDialogOpen = ref(false);
 const reportFilterMode = ref(null);
 const isAnywhere = ref(false);
 const isSameOrigin = ref(false);
+
+const filterIconNames = ref({
+  "end": "mdi-ray-end",
+  "anywhere": "mdi-ray-start-vertex-end",
+  "single-origin": "mdi-ray-vertex"
+});
 
 const baseSelectOptionFilter =
   useBaseSelectOptionFilter(toRef(props, "namespace"));
@@ -150,7 +165,7 @@ function getUrlState() {
     );
 
   return {
-    [id.value]: _state.length ? _state : undefined,
+    [id]: _state.length ? _state : undefined,
     [anywhereId.value]: isAnywhere.value || undefined,
     [sameOriginId.value]: isSameOrigin.value || undefined
   };


### PR DESCRIPTION
This change makes it easier to see which component filter mode is currently active by showing it on the toolbar.