### PR TITLE
Share checker configurations across analysis runs via CheckerSet

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -46,9 +46,9 @@ from ..database import db_cleanup
 from ..database.config_db_model import Product
 from ..database.database import DBSession
 from ..database.run_db_model import \
-    AnalysisInfo, AnalysisInfoChecker, AnalyzerStatistic, \
+    AnalysisInfo, AnalyzerStatistic, \
     BugPathEvent, BugReportPoint, \
-    Checker, \
+    Checker, CheckerSet, CheckerSetItem, \
     ExtendedReportData, \
     File, FileContent, \
     Report as DBReport, ReportAnnotations, ReviewStatus as ReviewStatusRule, \
@@ -62,6 +62,8 @@ from ..session_manager import SessionManager
 from ..task_executors.abstract_task import AbstractTask, TaskCancelHonoured
 from ..task_executors.task_manager import TaskManager
 from .thrift_enum_helper import report_extended_data_type_str
+
+from sqlalchemy.orm import Session as SA_Session
 
 
 LOG = get_logger('server')
@@ -1002,7 +1004,7 @@ class MassStoreRun:
 
     def __store_analysis_info(
         self,
-        session: DBSession,
+        session: SA_Session,
         run_history: RunHistory
     ):
         """ Store analysis info for the given run history. """
@@ -1012,38 +1014,64 @@ class MassStoreRun:
                     analyzer_command.encode("utf-8"),
                     zlib.Z_BEST_COMPRESSION)
 
-                analysis_info_rows = session \
-                    .query(AnalysisInfo) \
-                    .filter(AnalysisInfo.analyzer_command == cmd) \
-                    .all()
+                enabled_checkers: List[int] = []
+                disabled_checkers: List[int] = []
+                for analyzer in mip.analyzers:
+                    q = session \
+                        .query(Checker) \
+                        .filter(Checker.analyzer_name == analyzer)
+                    db_checkers = {r.checker_name: r for r in q.all()}
 
-                if analysis_info_rows:
-                    # It is possible when multiple runs are stored
-                    # simultaneously to the server with the same analysis
-                    # command that multiple entries are stored into the
-                    # database. In this case we will select the first one.
-                    analysis_info = analysis_info_rows[0]
-                else:
-                    analysis_info = AnalysisInfo(analyzer_command=cmd)
+                    for chk, is_enabled in \
+                            mip.checkers.get(analyzer, {}).items():
+                        if is_enabled:
+                            enabled_checkers.append(db_checkers[chk].id)
+                        else:
+                            disabled_checkers.append(db_checkers[chk].id)
 
-                    # Obtain the ID eagerly to be able to use the M-to-N table.
-                    session.add(analysis_info)
-                    session.flush()
-                    session.refresh(analysis_info, ["id"])
+                # Check if the CheckerSet was already used before.
+                checker_set_hash = CheckerSet.compute_hash(enabled_checkers,
+                                                           disabled_checkers)
+                checker_set = session.query(CheckerSet) \
+                    .filter(CheckerSet.hash_digest == checker_set_hash) \
+                    .first()
 
-                    for analyzer in mip.analyzers:
-                        q = session \
-                            .query(Checker) \
-                            .filter(Checker.analyzer_name == analyzer)
-                        db_checkers = {r.checker_name: r for r in q.all()}
+                # If not, create a new CheckerSet and insert to db
+                if not checker_set:
+                    try:
+                        with session.begin_nested():
+                            checker_set = CheckerSet(checker_set_hash)
+                            # Obtain CheckerSet id eagerly.
+                            session.add(checker_set)
+                            session.flush()
+                            session.refresh(checker_set, ["id"])
+                            LOG.info(
+                                "[%s] Created new CheckerSet with hash '%s'",
+                                self._name, checker_set_hash)
 
-                        connection_rows = [AnalysisInfoChecker(
-                            analysis_info, db_checkers[chk], is_enabled)
-                            for chk, is_enabled
-                            in mip.checkers.get(analyzer, {}).items()]
-                        for r in connection_rows:
-                            session.add(r)
+                            # Insert checkers as elements of this newly
+                            # created CheckerSet
+                            for e in enabled_checkers:
+                                session.add(CheckerSetItem(checker_set.id,
+                                                           e, True))
+                            for d in disabled_checkers:
+                                session.add(CheckerSetItem(checker_set.id,
+                                                           d, False))
+                    except Exception:
+                        # Meanwhile, another store operation already
+                        # inserted this CheckerSet, query the existing
+                        # one from db
+                        checker_set = session.query(CheckerSet) \
+                            .filter(
+                                CheckerSet.hash_digest == checker_set_hash) \
+                            .first()
 
+                if not checker_set:
+                    raise RuntimeError(
+                        "Failed to query CheckerSet from database!")
+
+                analysis_info = AnalysisInfo(analyzer_command=cmd,
+                                             checker_set_id=checker_set.id)
                 run_history.analysis_info.append(analysis_info)
                 self.__analysis_info[src_dir_path] = analysis_info
 

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -64,10 +64,10 @@ from ..database import db_cleanup
 from ..database.config_db_model import Product
 from ..database.database import conv, DBSession, escape_like
 from ..database.run_db_model import \
-    AnalysisInfo, AnalysisInfoChecker as DB_AnalysisInfoChecker, \
+    AnalysisInfo, \
     AnalyzerStatistic, \
     BugPathEvent, BugReportPoint, \
-    CleanupPlan, CleanupPlanReportHash, Checker, Comment, \
+    CleanupPlan, CleanupPlanReportHash, Checker, CheckerSetItem, Comment, \
     ExtendedReportData, \
     File, FileContent, \
     Report, ReportAnnotations, ReportAnalysisInfo, ReviewStatus, \
@@ -1949,11 +1949,11 @@ class ThriftRequestHandler:
                     checkers_q = session \
                         .query(Checker.analyzer_name,
                                Checker.checker_name,
-                               DB_AnalysisInfoChecker.enabled) \
-                        .join(Checker, DB_AnalysisInfoChecker.checker_id ==
+                               CheckerSetItem.enabled) \
+                        .join(Checker, CheckerSetItem.checker_id ==
                               Checker.id) \
-                        .filter(DB_AnalysisInfoChecker.
-                                analysis_info_id == cmd.id)
+                        .filter(CheckerSetItem.checker_set_id ==
+                                cmd.checker_set_id)
 
                     checkers: Dict[str, Dict[str, API_AnalysisInfoChecker]] = \
                         defaultdict(dict)
@@ -3383,12 +3383,12 @@ class ThriftRequestHandler:
                 )
                 .join(RunHistory)
                 .join(AnalysisInfo, RunHistory.analysis_info)
-                .join(DB_AnalysisInfoChecker, (
-                    (AnalysisInfo.id ==
-                     DB_AnalysisInfoChecker.analysis_info_id)
-                    & (DB_AnalysisInfoChecker.enabled.is_(True))))
+                .join(CheckerSetItem, (
+                    (AnalysisInfo.checker_set_id ==
+                     CheckerSetItem.checker_set_id)
+                    & (CheckerSetItem.enabled.is_(True))))
                 .join(Checker,
-                      DB_AnalysisInfoChecker.checker_id == Checker.id)
+                      CheckerSetItem.checker_id == Checker.id)
                 .outerjoin(Report, ((Checker.id == Report.checker_id)
                                     & (Run.id == Report.run_id)))
                 .filter(RunHistory.id == max_run_histories.subquery()

--- a/web/server/codechecker_server/database/db_cleanup.py
+++ b/web/server/codechecker_server/database/db_cleanup.py
@@ -23,6 +23,7 @@ from .database import DBSession
 from .run_db_model import \
     AnalysisInfo, \
     BugPathEvent, BugReportPoint, \
+    CheckerSet, \
     Comment, Checker, \
     File, FileContent, \
     Report, ReportAnalysisInfo, RunHistoryAnalysisInfo, RunLock
@@ -42,6 +43,7 @@ def remove_unused_data(product):
     remove_unused_files(product)
     remove_unused_comments(product)
     remove_unused_analysis_info(product)
+    remove_unused_checker_sets(product)
 
 
 def update_contextual_data(product, context):
@@ -216,6 +218,29 @@ def remove_unused_analysis_info(product):
                 add_foreign_keys(session,
                                  ReportAnalysisInfo.name,
                                  rep_ai_foreign_keys)
+
+
+def remove_unused_checker_sets(product):
+    with DBSession(product.session_factory) as session:
+        LOG.debug("[%s] Garbage collection of checker sets started...",
+                  product.endpoint)
+        try:
+            used_checker_sets = session.query(AnalysisInfo.checker_set_id) \
+                .filter(AnalysisInfo.checker_set_id.is_not(None)) \
+                .group_by(AnalysisInfo.checker_set_id)
+
+            session.query(CheckerSet) \
+                .filter(CheckerSet.id.notin_(used_checker_sets)) \
+                .delete(synchronize_session=False)
+
+            session.commit()
+
+            LOG.debug("[%s] Garbage collection of dangling checker sets "
+                      "finished.", product.endpoint)
+        except (sqlalchemy.exc.OperationalError,
+                sqlalchemy.exc.ProgrammingError) as ex:
+            LOG.error("[%s] Failed to remove checker sets: %s",
+                      product.endpoint, str(ex))
 
 
 def upgrade_severity_levels(product, checker_labels):

--- a/web/server/codechecker_server/database/run_db_model.py
+++ b/web/server/codechecker_server/database/run_db_model.py
@@ -11,7 +11,9 @@ SQLAlchemy ORM model for the analysis run storage database.
 from datetime import datetime, timedelta
 from math import ceil
 import os
-from typing import Optional
+import json
+import hashlib
+from typing import Optional, List
 
 from sqlalchemy import BigInteger, Boolean, Column, DateTime, Enum, \
     ForeignKey, Integer, LargeBinary, MetaData, String, UniqueConstraint, \
@@ -54,29 +56,59 @@ class Checker(Base):
         self.severity = severity
 
 
-class AnalysisInfoChecker(Base):
-    __tablename__ = "analysis_info_checkers"
+class CheckerSet(Base):
+    __tablename__ = "checker_set"
 
-    analysis_info_id = Column(Integer,
-                              ForeignKey("analysis_info.id",
-                                         deferrable=True,
-                                         initially="DEFERRED",
-                                         ondelete="CASCADE"),
-                              primary_key=True)
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    hash_digest = Column(String, unique=True, nullable=False)
+
+    def __init__(self, hash_digest: str):
+        self.hash_digest = hash_digest
+
+    # We compute a hash from the enabled_checkers and
+    # disabled_checkers lists to generate a unique identifier
+    # for each CheckerSet.
+    # The goal is to speed up report storage to the server:
+    # when a user stores results to the server, we first compute
+    # this hash and then check if it was already inserted to the database.
+    # If the hash exists in this table, that means the particular CheckerSet
+    # was already used before.
+    @staticmethod
+    def compute_hash(enabled_checkers: List[int],
+                     disabled_checkers: List[int]) -> str:
+        # Sort lists to create identical hashes.
+        enabled_checkers.sort()
+        disabled_checkers.sort()
+
+        checker_set_dict = {"e": enabled_checkers, "d": disabled_checkers}
+        return hashlib.sha256(json.dumps(
+            checker_set_dict, sort_keys=True,
+            separators=(',', ':')).encode()).hexdigest()
+
+
+class CheckerSetItem(Base):
+    __tablename__ = "checker_set_items"
+
+    checker_set_id = Column(Integer,
+                            ForeignKey("checker_set.id",
+                                       deferrable=True,
+                                       initially="DEFERRED",
+                                       ondelete="CASCADE"),
+                            primary_key=True)
     checker_id = Column(Integer,
                         ForeignKey("checkers.id",
                                    deferrable=True,
                                    initially="DEFERRED",
                                    ondelete="RESTRICT"),
                         primary_key=True)
-    enabled = Column(Boolean)
+    enabled = Column(Boolean, nullable=False)
 
     def __init__(self,
-                 analysis_info: "AnalysisInfo",
-                 checker: Checker,
+                 checker_set_id: int,
+                 checker_id: int,
                  is_enabled: bool):
-        self.analysis_info_id = analysis_info.id
-        self.checker_id = checker.id
+        self.checker_set_id = checker_set_id
+        self.checker_id = checker_id
         self.enabled = is_enabled
 
 
@@ -85,10 +117,15 @@ class AnalysisInfo(Base):
 
     id = Column(Integer, autoincrement=True, primary_key=True)
     analyzer_command = Column(LargeBinary)
-    available_checkers = relationship(AnalysisInfoChecker, uselist=True)
+    checker_set_id = Column(Integer,
+                            ForeignKey("checker_set.id",
+                                       deferrable=True,
+                                       initially="DEFERRED",
+                                       ondelete="CASCADE"))
 
-    def __init__(self, analyzer_command: bytes):
+    def __init__(self, analyzer_command: bytes, checker_set_id: int):
         self.analyzer_command = analyzer_command
+        self.checker_set_id = checker_set_id
 
 
 class Run(Base):

--- a/web/server/codechecker_server/migrations/report/versions/b1be74589382_add_checkerset_checkersetitem_tables.py
+++ b/web/server/codechecker_server/migrations/report/versions/b1be74589382_add_checkerset_checkersetitem_tables.py
@@ -1,0 +1,267 @@
+"""
+Add CheckerSet, CheckerSetItem tables
+
+Revision ID: b1be74589382
+Revises:     a7f3c8e21b90
+Create Date: 2026-07-22 14:49:04.765801
+"""
+
+from logging import getLogger
+
+from alembic import op
+import sqlalchemy as sa
+import json
+from codechecker_server.database.run_db_model import CheckerSet
+
+
+# Revision identifiers, used by Alembic.
+revision = 'b1be74589382'
+down_revision = 'a7f3c8e21b90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    LOG = getLogger("migration/report")
+    dialect = op.get_context().dialect.name
+    conn = op.get_bind()
+
+    op.create_table(
+        'checker_set',
+        sa.Column('id', sa.Integer(),
+                  autoincrement=True, nullable=False),
+        sa.Column('hash_digest', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_checker_set')),
+        sa.UniqueConstraint('hash_digest',
+                            name=op.f('uq_checker_set_hash_digest'))
+    )
+    op.create_table(
+        'checker_set_items',
+        sa.Column('checker_set_id', sa.Integer(),
+                  nullable=False),
+        sa.Column('checker_id', sa.Integer(), nullable=False),
+        sa.Column('enabled', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['checker_id'], ['checkers.id'],
+            name=op.f('fk_checker_set_items_checker_id_checkers'),
+            ondelete='RESTRICT', initially='DEFERRED',
+            deferrable=True),
+        sa.ForeignKeyConstraint(
+            ['checker_set_id'], ['checker_set.id'],
+            name=op.f('fk_checker_set_items_checker_set_id_checker_set'),
+            ondelete='CASCADE', initially='DEFERRED', deferrable=True),
+        sa.PrimaryKeyConstraint('checker_set_id', 'checker_id',
+                                name=op.f('pk_checker_set_items'))
+    )
+    op.add_column('analysis_info', sa.Column('checker_set_id',
+                                             sa.Integer(), nullable=True))
+
+    if dialect == "postgresql":
+        op.create_foreign_key(op.f(
+            'fk_analysis_info_checker_set_id_checker_set'),
+            'analysis_info', 'checker_set', ['checker_set_id'],
+            ['id'], ondelete='CASCADE', initially='DEFERRED', deferrable=True)
+    elif dialect == "sqlite":
+        # SQLite does not support adding foreign keys to an existing table,
+        # so the analysis_info table is essentially dropped and recreated
+        # again. For this, we need to disable the foreign key constraints.
+
+        # op.execute("PRAGMA foreign_keys=OFF")
+        # with op.batch_alter_table('analysis_info', schema=None) as batch_op:
+        #     batch_op.create_foreign_key(
+        #         batch_op.f('fk_analysis_info_checker_set_id_checker_set'),
+        #         'checker_set',
+        #         ['checker_set_id'], ['id'],
+        #         ondelete='CASCADE', initially='DEFERRED', deferrable=True
+        #     )
+
+        # The operation above results in an error if executed
+        # as part of a migration chain. Reason:
+        # Foreign key constraints cannot be properly disabled
+        # mid-transaction in case of SQLite.
+        # See comment from other migration (c3dad71f8e6b):
+
+        # It generally appears that the big issue here is the fact that
+        # migration scripts execute as part of a TRANSACTION! As such,
+        # the "PRAGMA foreign_keys=OFF" is useless. See the docs at
+        #     http://sqlite.org/foreignkeys.html (quoted Jan 16, 2024)
+        #
+        # > It is not possible to enable or disable foreign key
+        # > constraints in the middle of a multi-statement transaction
+        # > (when SQLite is not in autocommit mode). Attempting to do
+        # > so does not return an error; it simply has no effect.
+        pass
+    else:
+        raise Exception(f"Dialect {dialect} is not supported!")
+
+    LOG.info("Aggregating all checkers from table "
+             f"analysis_info_checkers (dialect: {dialect}) ...")
+    checker_sets = {}
+
+    if dialect == "postgresql":
+        # Note: For each CheckerSet, we want to generate a unique identifier,
+        # to speed up report storage to the server.
+        # CheckerSet.compute_hash() uses hashing algorithm SHA256
+        # which is significantly slower than MD5.
+        # Therefore, we use Postgresql's built-in md5 hash function to
+        # calculate a hash that can be used to efficiently put checkers
+        # into groups.
+        query = \
+            conn.execute(
+                sa.text(
+                    """SELECT analysis_info_id,
+                       enabled_checkers,
+                       disabled_checkers,
+                       md5(enabled_checkers::text || '-'
+                           || disabled_checkers::text) AS hash
+                       FROM
+                       (SELECT analysis_info_id,
+                       array_agg(checker_id ORDER by checker_id)
+                       FILTER (WHERE enabled) AS enabled_checkers,
+                       array_agg(checker_id ORDER by checker_id)
+                       FILTER (WHERE NOT enabled) AS disabled_checkers
+                       FROM analysis_info_checkers
+                       GROUP BY analysis_info_id)"""))
+        for analysis_info_id, enabled_checkers, \
+                disabled_checkers, md5sum in query:
+            enabled_checkers = enabled_checkers or []
+            disabled_checkers = disabled_checkers or []
+
+            if md5sum not in checker_sets:
+                checker_sets[md5sum] = {}
+                checker_sets[md5sum]["hash_digest"] = \
+                    CheckerSet.compute_hash(enabled_checkers,
+                                            disabled_checkers)
+                checker_sets[md5sum]["enabled_checkers"] = enabled_checkers
+                checker_sets[md5sum]["disabled_checkers"] = disabled_checkers
+                checker_sets[md5sum]["analysis_info_ids"] = [analysis_info_id]
+            else:
+                checker_sets[md5sum]["analysis_info_ids"]. \
+                        append(analysis_info_id)
+    elif dialect == "sqlite":
+        # Note: SQLite does not support an md5 hash function,
+        # therefore we need to compute the hash every time
+        # in Python to determine the checker groups.
+        #
+        # Ordering in json_group_array is not needed in this case,
+        # since no md5sum is computed.
+        # Additionally, CheckerSet.compute_hash() always sorts checker
+        # lists for hash generation.
+        query = conn.execute(
+                sa.text("""SELECT analysis_info_id,
+                           json_group_array(checker_id)
+                           FILTER (WHERE enabled) AS enabled_checkers,
+                           json_group_array(checker_id)
+                           FILTER (WHERE NOT enabled) AS disabled_checkers
+                           FROM analysis_info_checkers
+                           GROUP BY analysis_info_id"""))
+
+        for analysis_info_id, enabled_checkers, disabled_checkers in query:
+            enabled_checkers = json.loads(enabled_checkers) \
+                if enabled_checkers != "[null]" else []
+            disabled_checkers = json.loads(disabled_checkers) \
+                if disabled_checkers != "[null]" else []
+            hash_digest = CheckerSet.compute_hash(enabled_checkers,
+                                                  disabled_checkers)
+
+            if hash_digest not in checker_sets:
+                checker_sets[hash_digest] = {}
+                checker_sets[hash_digest]["hash_digest"] = \
+                    hash_digest
+                checker_sets[hash_digest]["enabled_checkers"] = \
+                    enabled_checkers
+                checker_sets[hash_digest]["disabled_checkers"] = \
+                    disabled_checkers
+                checker_sets[hash_digest]["analysis_info_ids"] = \
+                    [analysis_info_id]
+            else:
+                checker_sets[hash_digest]["analysis_info_ids"]. \
+                        append(analysis_info_id)
+    else:
+        raise Exception(f"Dialect {dialect} is not supported!")
+
+    LOG.info("Inserting new CheckerSets to database ...")
+    for v in checker_sets.values():
+        conn.execute(
+            sa.text("INSERT INTO checker_set (hash_digest) "
+                    "VALUES (:hash_digest)"),
+            {"hash_digest": v["hash_digest"]}
+        )
+
+        # Obtain CheckerSet ID
+        select_q = conn.execute(
+            sa.text("SELECT id from checker_set "
+                    "WHERE hash_digest = :hash_digest"),
+            {"hash_digest": v["hash_digest"]}
+        ).fetchone()
+
+        if not select_q:
+            raise Exception("Failed to insert checker_set "
+                            f"with hash_digest {v['hash_digest']}")
+
+        # Bulk insert checkers
+        if v["enabled_checkers"]:
+            conn.execute(
+                sa.text("INSERT INTO checker_set_items "
+                        "(checker_set_id, checker_id, enabled) "
+                        "VALUES (:checker_set_id, :checker_id, :enabled)"),
+                [{"checker_set_id": select_q.id,
+                  "checker_id": checker_id, "enabled": True}
+                 for checker_id in v["enabled_checkers"]]
+            )
+
+        if v["disabled_checkers"]:
+            conn.execute(
+                sa.text("INSERT INTO checker_set_items "
+                        "(checker_set_id, checker_id, enabled) "
+                        "VALUES (:checker_set_id, :checker_id, :enabled)"),
+                [{"checker_set_id": select_q.id,
+                  "checker_id": checker_id, "enabled": False}
+                 for checker_id in v["disabled_checkers"]]
+            )
+
+        # Update AnalysisInfo table checker_set_id column
+        conn.execute(
+            sa.text(
+                "UPDATE analysis_info SET checker_set_id = :checker_set_id "
+                "WHERE id IN :ids").bindparams(sa.bindparam(
+                    "ids", expanding=True)),
+            [{"checker_set_id": select_q.id, "ids": v["analysis_info_ids"]}]
+        )
+
+    LOG.info("Dropping table analysis_info_checkers ...")
+    op.drop_table('analysis_info_checkers')
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    LOG = getLogger("migration/report")
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_constraint(
+            op.f('fk_analysis_info_checker_set_id_checker_set'),
+            'analysis_info', type_='foreignkey')
+    op.drop_column('analysis_info', 'checker_set_id')
+    op.create_table(
+        'analysis_info_checkers',
+        sa.Column('analysis_info_id', sa.INTEGER(), autoincrement=False,
+                  nullable=False),
+        sa.Column('checker_id', sa.INTEGER(), autoincrement=False,
+                  nullable=False),
+        sa.Column('enabled', sa.BOOLEAN(), autoincrement=False,
+                  nullable=True),
+        sa.ForeignKeyConstraint(
+            ['analysis_info_id'], ['analysis_info.id'],
+            name=op.f(
+                'fk_analysis_info_checkers_analysis_info_id_analysis_info'),
+            ondelete='CASCADE', initially='DEFERRED', deferrable=True),
+        sa.ForeignKeyConstraint(
+            ['checker_id'], ['checkers.id'],
+            name=op.f(
+                'fk_analysis_info_checkers_checker_id_checkers'),
+            ondelete='RESTRICT', initially='DEFERRED', deferrable=True),
+        sa.PrimaryKeyConstraint('analysis_info_id', 'checker_id',
+                                name=op.f('pk_analysis_info_checkers'))
+    )
+    op.drop_table('checker_set_items')
+    op.drop_table('checker_set')
+    # ### end Alembic commands ###


### PR DESCRIPTION
Introduce CheckerSet and CheckerSetItem tables to deduplicate checker configurations across analysis runs. Instead of storing enabled/disabled checkers per AnalysisInfo row, checkers are
now grouped into reusable sets identified by a SHA-256 hash.

This avoids redundant rows when multiple runs share the same checker configuration.