### PR TITLE
Fix flakyness of the GuidelineStatistics Page

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -157,7 +157,7 @@ import {
   ReportFilter,
   RunFilter
 } from "@cc/report-server-types";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import StatisticsDialog from "../StatisticsDialog";
 import GuidelineStatisticsTable from "./GuidelineStatisticsTable";
@@ -247,10 +247,6 @@ watch(() => baseStatistics.runIds, async () => {
 
 watch(selectedGuidelines, async () => {
   await fetchStatistics();
-});
-
-onMounted(() => {
-  fetchStatistics();
 });
 
 function checker_stat(stat) {
@@ -439,7 +435,6 @@ async function getRunData() {
 
 async function fetchStatistics() {
   loading.value = true;
-
   await fetchProblematicRuns();
 
   await getAllGuidelineRules();
@@ -448,7 +443,7 @@ async function fetchStatistics() {
 
   const checker_stat_result = await new Promise(resolve => {
     ccService.getClient().getCheckerStatusVerificationDetails(
-      baseStatistics.runIds,
+      baseStatistics.runIds.value,
       filter,
       handleThriftError(res => {
         resolve(res);


### PR DESCRIPTION
Calling the onMounted() callback needs to be removed, because it is too early and by that time the filters are not ready.

1. Statistics.vue has a <ReportFilter> that emits @refresh="refresh".
2. refresh() in Statistics.vue calls refreshCurrentTab() which does bus.emit("refresh").
3. Each statistics child (like CheckerStatistics.vue) calls baseStats.setupRefreshListener(fetchStatistics) which registers bus.on("refresh", fetchStatistics) during onActivated.

So this way the fetchStatistics will be called after the filter has been initialized.