### PR TITLE
[gui] Fix the issue where some report filters being cleared on dismiss event

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SelectOption/SelectOption.vue
@@ -162,6 +162,14 @@ watch(menu, async show => {
   }
 });
 
+watch(
+  () => props.selectedItems,
+  val => {
+    allSelectedItems.value = [ ...val ];
+  },
+  { deep: true }
+);
+
 onMounted(() => {
   props.bus.on("update", () => {
     reloadItems.value = true;


### PR DESCRIPTION
This change fixes the issue where some of the report filters are being cleared when the user clicks outside of the element.