### PR TITLE
[gui] Fix the issue where source components were removed from the url

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/SourceComponentFilter.vue
@@ -83,7 +83,14 @@ const props = defineProps({
 
 const emit = defineEmits([ "update:url" ]);
 
+const baseSelectOptionFilter =
+  useBaseSelectOptionFilter(toRef(props, "namespace"));
+baseSelectOptionFilter.fetchItems.value = fetchItems;
+baseSelectOptionFilter.updateReportFilter.value = updateReportFilter;
+
 const id = "source-component";
+baseSelectOptionFilter.id.value = id;
+
 const anywhereId = ref("anywhere-sourcecomponent");
 const sameOriginId = ref("sameorigin-sourcecomponent");
 const isDialogOpen = ref(false);
@@ -96,11 +103,6 @@ const filterIconNames = ref({
   "anywhere": "mdi-ray-start-vertex-end",
   "single-origin": "mdi-ray-vertex"
 });
-
-const baseSelectOptionFilter =
-  useBaseSelectOptionFilter(toRef(props, "namespace"));
-baseSelectOptionFilter.fetchItems.value = fetchItems;
-baseSelectOptionFilter.updateReportFilter.value = updateReportFilter;
 
 const search = ref({
   placeHolder : "Search for source components...",


### PR DESCRIPTION
This change fixes an issue where the source component report filter was removed from the url after loading the page from the link. The issue was caused by the report filter id not getting passed to the report filter store on initialization.