### PR TITLE
Fix post-login redirect dropping URL query parameters

### DIFF
--- a/web/server/vue-cli/src/views/Login.vue
+++ b/web/server/vue-cli/src/views/Login.vue
@@ -237,7 +237,7 @@ function login() {
     error.value = false;
 
     const returnTo = route.query["return_to"];
-    router.replace(returnTo ? { path: returnTo } : { name: "products" });
+    router.replace(returnTo || { name: "products" });
   }).catch(err => {
     errorMsg.value = `Failed to log in! ${err.message}`;
     error.value = true;


### PR DESCRIPTION
Use router.replace() with a string path instead of { path: returnTo } so Vue Router correctly preserves the full query string.