### PR TITLE
Fix return_to being ignored after OAuth login

### DIFF
--- a/web/server/vue-cli/src/store/modules/auth.js
+++ b/web/server/vue-cli/src/store/modules/auth.js
@@ -66,7 +66,7 @@ const actions = {
           "oauth", credentials.provider + "@" + credentials.url,
           handleThriftError(token => {
             context.commit(SET_AUTH, {
-              userName: "OAuth @" + credentials.provider,
+              userName: null,
               token: token
             });
             resolve(token);

--- a/web/server/vue-cli/src/views/Login.vue
+++ b/web/server/vue-cli/src/views/Login.vue
@@ -264,6 +264,10 @@ function getProviders() {
 }
 
 function oauth(provider) {
+  const returnTo = route.query["return_to"];
+  if (returnTo) {
+    localStorage.setItem("return_to", returnTo);
+  }
   new Promise(resolve => {
     localStorage.setItem("oauth_provider", provider);
     authService.getClient().createLink(provider,

--- a/web/server/vue-cli/src/views/OAuthLogin.vue
+++ b/web/server/vue-cli/src/views/OAuthLogin.vue
@@ -61,8 +61,9 @@ function detectCallback() {
         success.value = true;
         error.value = false;
 
-        const _w = window.location;
-        window.location.href = _w.origin + _w.pathname;
+        const returnTo = localStorage.getItem("return_to");
+        localStorage.removeItem("return_to");
+        router.replace(returnTo || { name: "products" });
       }).catch(_err => {
         errorMsg.value = `Failed to log in! ${_err.message}`;
         error.value = true;


### PR DESCRIPTION
Persist the return_to query parameter in localStorage before redirecting to the OAuth provider, since the browser navigation loses query params. After successful OAuth callback, read it back and navigate accordingly instead of always redirecting to the app root.

Also set userName to null on OAuth login so the actual username is fetched from the server via getLoggedInUser instead of using a placeholder string.