### PR TITLE
[gui] Display a none character if no bug path length is available

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
+++ b/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
@@ -41,7 +41,8 @@
             v-else-if="key === 'bugPathLength'"
             :color="bugPathLenColor.getBugPathLenColor(value[key])"
           >
-            {{ value[key] }}
+            <span v-if="value[key]">{{ value[key] }}</span>
+            <span v-else>-</span>
           </v-chip>
 
           <span v-else>


### PR DESCRIPTION
This change adds a "-" char to the v-chip if bug path length is not available.