### PR TITLE
web: Remove "All" option from items-per-page in data tables

### DIFF
--- a/web/server/vue-cli/src/components/Report/CleanupPlan/ListCleanupPlansTable.vue
+++ b/web/server/vue-cli/src/components/Report/CleanupPlan/ListCleanupPlansTable.vue
@@ -2,6 +2,8 @@
   <v-data-table
     :headers="headers"
     :items="items"
+    :items-per-page="25"
+    :items-per-page-options="itemsPerPageOptions"
     :loading="loading"
     loading-text="Loading cleanup plans..."
     no-data-text="There aren't any cleanup plan that match."
@@ -84,6 +86,12 @@ const props = defineProps({
 });
 
 const emit = defineEmits([ "remove", "close", "reopen", "edit" ]);
+
+const itemsPerPageOptions = [
+  { value: 25, title: "25" },
+  { value: 50, title: "50" },
+  { value: 100, title: "100" }
+];
 
 const headers = computed(() => [
   {

--- a/web/server/vue-cli/src/components/Report/SourceComponent/ListSourceComponents.vue
+++ b/web/server/vue-cli/src/components/Report/SourceComponent/ListSourceComponents.vue
@@ -2,6 +2,8 @@
   <v-data-table
     :headers="headers"
     :items="processedComponents"
+    :items-per-page="25"
+    :items-per-page-options="itemsPerPageOptions"
     :loading="loading"
   >
     <template v-slot:top>
@@ -89,6 +91,12 @@ const components = ref([]);
 const loading = ref(false);
 const selectedComponent = ref(null);
 const editDialog = ref(false);
+
+const itemsPerPageOptions = [
+  { value: 25, title: "25" },
+  { value: 50, title: "50" },
+  { value: 100, title: "100" }
+];
 
 const headers = [
   {

--- a/web/server/vue-cli/src/components/ReviewStatus/ListReviewStatusRules.vue
+++ b/web/server/vue-cli/src/components/ReviewStatus/ListReviewStatusRules.vue
@@ -7,7 +7,7 @@
     :loading="loading"
     :mobile-breakpoint="1000"
     loading-text="Loading review status rules..."
-    :footer-props="footerProps"
+    :items-per-page-options="itemsPerPageOptions"
     item-key="reportHash"
   >
     <template v-slot:top>
@@ -177,8 +177,7 @@ const reviewStatus = useReviewStatus();
 const itemsPerPageOptions = [
   { value: 25, title: "25" },
   { value: 50, title: "50" },
-  { value: 100, title: "100" },
-  { value: -1, title: "$vuetify.dataFooter.itemsPerPageAll" }
+  { value: 100, title: "100" }
 ];
 
 const page = ref(parseInt(route.query["page"]) || 1);
@@ -188,19 +187,16 @@ const itemsPerPage = ref(
 );
 
 const sortBy = ref(
-  route.query["sort-by"] 
-    ? [ { 
-      key: route.query["sort-by"], 
-      order: route.query["sort-desc"] === "true" ? "desc" : "asc" 
+  route.query["sort-by"]
+    ? [ {
+      key: route.query["sort-by"],
+      order: route.query["sort-desc"] === "true" ? "desc" : "asc"
     } ]
     : [ { key: "name", order: "asc" } ]
 );
 
 const initialized = ref(false);
 
-const footerProps = {
-  itemsPerPageOptions: itemsPerPageOptions
-};
 const totalItems = ref(0);
 const rules = ref([]);
 const filter = ref(null);

--- a/web/server/vue-cli/src/views/Products.vue
+++ b/web/server/vue-cli/src/views/Products.vue
@@ -4,7 +4,7 @@
       :headers="headers"
       :items="products"
       :loading="loading"
-      :footer-props="footerProps"
+      :items-per-page-options="itemsPerPageOptions"
       loading-text="Loading products..."
       item-key="endpoint"
       :items-per-page="25"
@@ -156,7 +156,12 @@ import {
   ProductNameColumn
 } from "@/components/Product/";
 
-const itemsPerPageOptions = ref([ 25 ]);
+const itemsPerPageOptions = [
+  { value: 25, title: "25" },
+  { value: 50, title: "50" },
+  { value: 100, title: "100" }
+];
+
 const sortBy = ref(null);
 const sortDesc = ref(null);
 const page = ref(null);
@@ -169,10 +174,6 @@ const isAdminOfAnyProduct = ref(false);
 const pagination = computed(() => ({
   sortBy: sortBy.value ? [ sortBy.value ] : [ ],
   sortDesc: sortDesc.value !== undefined ? [ !!sortDesc.value ] : [ ]
-}));
-
-const footerProps = computed(() => ({
-  itemsPerPageOptions: itemsPerPageOptions.value
 }));
 
 watch(pagination, () => {

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -318,8 +318,7 @@ const detectionStatus = useDetectionStatus();
 const itemsPerPageOptions = [
   { value: 25, title: "25" },
   { value: 50, title: "50" },
-  { value: 100, title: "100" },
-  { value: -1, title: "$vuetify.dataFooter.itemsPerPageAll" }
+  { value: 100, title: "100" }
 ];
 const page = ref(parseInt(route.query["page"]) || 1);
 const itemsPerPage = ref(

--- a/web/server/vue-cli/src/views/RunList.vue
+++ b/web/server/vue-cli/src/views/RunList.vue
@@ -187,8 +187,7 @@ const store = useStore();
 const itemsPerPageOptions = [
   { value: 25, title: "25" },
   { value: 50, title: "50" },
-  { value: 100, title: "100" },
-  { value: -1, title: "$vuetify.dataFooter.itemsPerPageAll" }
+  { value: 100, title: "100" }
 ];
 const page = ref(parseInt(route.query["page"]) || 1);
 const itemsPerPage = ref(
@@ -196,10 +195,10 @@ const itemsPerPage = ref(
   itemsPerPageOptions[0].value
 );
 const sortBy = ref(
-  route.query["sort-by"] 
-    ? [ { 
-      key: route.query["sort-by"], 
-      order: route.query["sort-desc"] === "true" ? "desc" : "asc" 
+  route.query["sort-by"]
+    ? [ {
+      key: route.query["sort-by"],
+      order: route.query["sort-desc"] === "true" ? "desc" : "asc"
     } ]
     : [ { key: "name", order: "asc" } ]
 );


### PR DESCRIPTION
Replace Vuetify 2 footer-props pattern with Vuetify 3 items-per-page-options prop. Limit page size choices to 25, 50, and 100 across all data tables.