### PR TITLE
[ci] Move CODEOWNERS to .github directory and fix the layout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-# Any CODEOWNERS file modifications must be approved by repository owner.
-/.github/CODEOWNERS @dkrupp
-
 # These owners will be the default owners for everything in the repo.
-*      @bruntib @Vodorok
+* @bruntib
 
 # Documentations.
-/docs @dkrupp
+/docs @bruntib @dkrupp
 
 # Frontend.
-/web/server/vue-cli @gulyasgergely902
+/web/server/vue-cli @bruntib @gulyasgergely902
+
+# Any CODEOWNERS file modifications must be approved by repository owner.
+/.github/CODEOWNERS @dkrupp


### PR DESCRIPTION
CODEOWNERS file should be in .github directory in modern repositories. This change fixes the location and the layout of the file since GitHub reads the file frop top to bottom and applies the ownerships in this fashion. By moving the global rules to the top, it always applies to every PR and going down, it specifies the ownerships based on the modified files.