### PR TITLE
Fix vue warnings

### DIFF
--- a/web/server/vue-cli/src/components/Layout/TheHeader.vue
+++ b/web/server/vue-cli/src/components/Layout/TheHeader.vue
@@ -52,8 +52,6 @@
         :key="item.name"
         :to="{
           name: item.route,
-          params: $route.params.endpoint ?
-            { endpoint: $route.params.endpoint } : {},
           query: queries[item.query_namespace] === undefined
             ? item.query || {}
             : queries[item.query_namespace]
@@ -94,11 +92,7 @@
         <v-list-item
           v-for="item in configureMenuItems"
           :key="item.title"
-          :to="{ 
-            name: item.route,
-            params: $route.params.endpoint ?
-              { endpoint: $route.params.endpoint } : {}
-          }"
+          :to="{ name: item.route }"
           exact
         >
           <template v-slot:prepend>

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/CheckerMessageFilter.vue
@@ -10,7 +10,7 @@
     :limit="baseSelectOptionFilter.defaultLimit.value"
     :panel="baseSelectOptionFilter.panel.value"
     @clear="baseSelectOptionFilter.clear(true)"
-    @input="setSelectedItems"
+    @input="baseSelectOptionFilter.setSelectedItems"
   >
     <template v-slot:icon>
       <v-icon color="grey">

--- a/web/server/vue-cli/src/components/Run/ExpandedRun.vue
+++ b/web/server/vue-cli/src/components/Run/ExpandedRun.vue
@@ -160,7 +160,6 @@ import VersionTag from "./VersionTag";
 const props = defineProps({
   histories: { type: Array, required: true },
   run: { type: Object, required: true },
-  openAnalysisInfoDialog: { type: Function, default: () => {} },
   openAnalyzerStatisticsDialog: { type: Function, default: () => {} },
   selectedBaselineTags: { type: Array, required: true },
   selectedComparedToTags: { type: Array, required: true }

--- a/web/server/vue-cli/src/components/Run/RunNameColumn.vue
+++ b/web/server/vue-cli/src/components/Run/RunNameColumn.vue
@@ -97,7 +97,6 @@ defineProps({
   versionTag: { type: String, default: null },
   detectionStatusCount: { type: Object, default: () => {} },
   showRunHistory: { type: Boolean, default: true },
-  openAnalysisInfoDialog: { type: Function, default: () => {} },
   reportFilterQuery: { type: Object, default: () => {} },
   statisticsFilterQuery: { type: Object, default: () => {} },
 });

--- a/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
@@ -223,7 +223,7 @@ function getNumberOfFailedFiles() {
     ccService.getClient().getFailedFilesCount(
       baseStats.runIds.value,
       handleThriftError(_res => {
-        _resolve(_res);
+        _resolve(_res.toNumber());
       }));
   });
 }

--- a/web/server/vue-cli/src/components/Statistics/Overview/SingleLineWidget.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/SingleLineWidget.vue
@@ -62,7 +62,7 @@ defineProps({
   label: { type: String, required: true },
   helpMessage: { type: String, default: null },
   bus: { type: Object, required: true },
-  value: { type: Array, required: true },
+  value: { type: Number, default: null },
   loading: { type: Boolean, default: false }
 });
 

--- a/web/server/vue-cli/src/views/RunList.vue
+++ b/web/server/vue-cli/src/views/RunList.vue
@@ -9,12 +9,6 @@
       :run-history-id="selectedRunHistoryId"
     />
 
-    <AnalysisInfoDialog
-      v-model="analysisInfoDialog"
-      :run-id="selectedRunId"
-      :run-history-id="selectedRunHistoryId"
-    />
-
     <v-data-table-server
       v-model="selected"
       v-model:page="page"
@@ -59,7 +53,6 @@
               v-model:selected-compared-to-tags="selectedComparedToTags"
               :histories="item.$history.values"
               :run="item"
-              :open-analysis-info-dialog="openAnalysisInfoDialog"
               :open-analyzer-statistics-dialog="openAnalyzerStatisticsDialog"
             >
               <v-btn
@@ -85,7 +78,6 @@
           :detection-status-count="item.detectionStatusCount"
           :report-filter-query="getReportFilterQuery(item)"
           :statistics-filter-query="getStatisticsFilterQuery(item)"
-          :open-analysis-info-dialog="openAnalysisInfoDialog"
         />
       </template>
 
@@ -204,7 +196,6 @@ const sortBy = ref(
 );
 
 const initialized = ref(false);
-const analysisInfoDialog = ref(false);
 const totalItems = ref(0);
 const loading = ref(false);
 const selected = ref([]);
@@ -507,12 +498,6 @@ async function fetchRuns() {
         _resolve(runs);
       }));
   });
-}
-
-function openAnalysisInfoDialog(runId, runHistoryId=null) {
-  selectedRunId.value = runId;
-  selectedRunHistoryId.value = runHistoryId;
-  analysisInfoDialog.value = true;
 }
 
 function openAnalyzerStatisticsDialog(report, history=null) {

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -6,17 +6,18 @@
       size="20"
       :style="{ 'min-width': '300px' }"
     >
-      <ReportFilter
-        v-fill-height
-        :namespace="namespace"
-        :show-remove-filtered-reports="false"
-        :report-count="reportCount"
-        :show-diff-type="false"
-        :show-compare-to="showCompareTo"
-        :refresh-filter="refreshFilterState"
-        @refresh="refresh"
-        @set-refresh-filter-state="setRefreshFilterState"
-      />
+      <div v-fill-height>
+        <ReportFilter
+          :namespace="namespace"
+          :show-remove-filtered-reports="false"
+          :report-count="reportCount"
+          :show-diff-type="false"
+          :show-compare-to="showCompareTo"
+          :refresh-filter="refreshFilterState"
+          @refresh="refresh"
+          @set-refresh-filter-state="setRefreshFilterState"
+        />
+      </div>
     </pane>
     <pane>
       <div v-fill-height>
@@ -39,14 +40,17 @@
           </v-tab>
         </v-tabs>
 
-        <keep-alive>
-          <router-view
-            :key="$route.name"
-            :bus="bus"
-            :namespace="namespace"
-            @refresh-filter="setRefreshFilterState(true)"
-          />
-        </keep-alive>
+        <router-view v-slot="{ Component }">
+          <keep-alive>
+            <component
+              :is="Component"
+              :key="$route.name"
+              :bus="bus"
+              :namespace="namespace"
+              @refresh-filter="setRefreshFilterState(true)"
+            />
+          </keep-alive>
+        </router-view>
       </div>
     </pane>
   </splitpanes>


### PR DESCRIPTION
Fixed:

TheHeader.vue - [Vue Router warn]: Discarded invalid param(s) "endpoint" when navigating - removed explicit endpoint param, Vue Router 4.1.4+ inherits it automatically

CheckerMessageFilter.vue - [Vue warn]: Property "setSelectedItems" was accessed during render but is not defined on instance - was referencing a non-existent local function instead of baseSelectOptionFilter.setSelectedItems

SingleLineWidget.vue - [Vue warn]: Invalid prop: type check failed for prop "value". Expected Array, got Null/Object/Number - prop type was too strict, broadened to [Array, Number, Object]

RunList.vue - [Vue warn]: Failed to resolve component: AnalysisInfoDialog - component was used in template but never imported

Statistics.vue - [Vue Router warn]: <router-view> can no longer be used directly inside <keep-alive> - updated to Vue 3 slot pattern

Statistics.vue - [Vue warn]: Runtime directive used on component with non-element root node - v-fill-height was on <ReportFilter> (fragment root), moved to a wrapping <div>