### PR TITLE
Updated linting profile

### DIFF
--- a/web/server/vue-cli/eslint.config.mjs
+++ b/web/server/vue-cli/eslint.config.mjs
@@ -52,24 +52,23 @@ export default defineConfig([
         "multiline": 1
       }],
       "vue/v-slot-style": "off",
-      "vue/valid-v-slot": "off",
+      "vue/valid-v-slot": ["error", { "allowModifiers": true }],
       "vue/multi-word-component-names": "off",
-      "vue/no-mutating-props": "error",
-      "vue/valid-next-tick": "off",
+      "vue/valid-next-tick": "error",
       "quotes": ["error", "double", {
         "avoidEscape": true
       }],
-      "vue/component-api-style": ["warn", ["script-setup"]], // TODO: error
-      "vue/block-order": ["warn", { // TODO: error
+      "vue/component-api-style": ["error", ["script-setup"]],
+      "vue/block-order": ["error", {
         "order": ["template", "script", "style"]
       }],
-      "vue/define-macros-order": ["warn", { // TODO: error
+      "vue/define-macros-order": ["error", {
         "order": ["defineProps", "defineEmits", "defineExpose"]
       }],
       "vue/no-ref-object-reactivity-loss": "warn",
       "vue/no-setup-props-reactivity-loss": "warn",
       "vue/prefer-define-options": "warn",
-      "vue/require-macro-variable-name": ["warn", { // TODO: error
+      "vue/require-macro-variable-name": ["error", {
         "defineProps": "props",
         "defineEmits": "emit",
         "defineSlots": "slots",


### PR DESCRIPTION
vue/component-api-style - "warn" to "error"
vue/block-order - "warn" to "error"
vue/define-macros-order - "warn" to "error"
vue/require-macro-variable-name - "warn" to "error"
vue/valid-v-slot - "off" to ["error", { "allowModifiers": true }]
vue/valid-next-tick - "off" to "error"
vue/no-mutating-props - removed entirely

package.json
test:lint script - removed obsolete --ext .js,.vue flag (not supported in ESLint v9, file extensions are handled by the files array in eslint.config.mjs)