### PR TITLE
Increase healthcheck retries from 3 to 10

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -132,7 +132,7 @@ RUN chmod 755 /usr/local/bin/wait-for
 
 EXPOSE 8001
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=10 \
   CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/live', timeout=3).read()" || exit 1
 
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Allow more consecutive failures before marking the container as unhealthy to tolerate slow startups.