### PR TITLE
[gui] Fix source component edit modal will not fix the component data

### DIFF
--- a/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
+++ b/web/server/vue-cli/src/components/Report/SourceComponent/EditSourceComponentDialog.vue
@@ -83,7 +83,7 @@
 
 <script setup>
 import { ccService, handleThriftError } from "@cc-api";
-import { computed, onMounted, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -142,8 +142,8 @@ const dialog = computed({
   }
 });
 
-onMounted(() => {
-  if (props.sourceComponent) {
+watch(dialog, opened => {
+  if (opened && props.sourceComponent) {
     nameInput.value = props.sourceComponent.name;
     componentInput.value = props.sourceComponent.value;
     descriptionInput.value = props.sourceComponent.description;


### PR DESCRIPTION
This change fixes an issue where the source component edit modal is not populated on open. The issue is onMounted will only fire when the component is mounted. V-dialog is only mounted once and will stay mounted until refresh. A watcher fixes this issue.