### PR TITLE
[docs] Update required Node.js version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -253,7 +253,7 @@ sudo apt-get install libpq-dev
 # Install nodejs dependency for web. In case of Debian/Ubuntu you can use the
 # following commands. For more information see the official docs:
 # https://nodejs.org/en/download/package-manager/
-curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Check out CodeChecker source code.


### PR DESCRIPTION
The latest webgui build now requires Node
version 20 or later.