### PR TITLE
Dead links in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -143,7 +143,7 @@ For more information how to use CodeChecker see our [user guide](usage.md).
 
 ## Web based report management
 * [Webserver User Guide](web/user_guide.md)
-* [WEB GUI User Guide](/web/server/vue-cli/src/assets/userguide/userguide.md)
+* [WEB GUI User Guide](https://github.com/Ericsson/codechecker/blob/master/web/server/vue-cli/src/assets/userguide/userguide.md)
 * [Command line and WEB UI Feature overview](feature_comparison.md)
 * Security configuration
   * [Configuring Authentication](web/authentication.md)
@@ -170,37 +170,37 @@ The following tools are supported:
 | **C/C++**      | [Clang Static Analyzer](https://clang-analyzer.llvm.org/)                    |
 |                | [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/)                       |
 |                | [Clang Sanitizers](supported_code_analyzers.md#clang-sanitizers)             |
-|                | [Cppcheck](/docs/tools/report-converter.md#cppcheck)                         |
-|                | [Facebook Infer](/docs/tools/report-converter.md#facebook-infer)             |
-|                | [Coccinelle](/docs/tools/report-converter.md#coccinelle)                     |
-|                | [Smatch](/docs/tools/report-converter.md#smatch)                             |
-|                | [Kernel-Doc](/docs/tools/report-converter.md#kernel-doc)                     |
-|                | [Sparse](/docs/tools/report-converter.md#sparse)                             |
-|                | [cpplint](/docs/tools/report-converter.md#cpplint)                           |
-| **C#**         | [Roslynator.DotNet.Cli](/docs/tools/report-converter.md#roslynatordotnetcli) |
-| **Java**       | [SpotBugs](/docs/tools/report-converter.md#spotbugs)                         |
-|                | [Facebook Infer](/docs/tools/report-converter.md#facebook-infer)                    |
-| **Python**     | [Pylint](/docs/tools/report-converter.md#pylint)                             |
-|                | [Pyflakes](/docs/tools/report-converter.md#pyflakes)                         |
-| **JavaScript** | [ESLint](/docs/tools/report-converter.md#eslint)                             |
-| **TypeScript** | [TSLint](/docs/tools/report-converter.md#tslint)                             |
-| **Go**         | [Golint](/docs/tools/report-converter.md#golint)                             |
-| **Markdown**   | [Markdownlint](/docs/tools/report-converter.md#markdownlint)                 |
-|                | [Sphinx](/docs/tools/report-converter.md#sphinx)                             |
+|                | [Cppcheck](tools/report-converter.md#cppcheck)                         |
+|                | [Facebook Infer](tools/report-converter.md#facebook-infer)             |
+|                | [Coccinelle](tools/report-converter.md#coccinelle)                     |
+|                | [Smatch](tools/report-converter.md#smatch)                             |
+|                | [Kernel-Doc](tools/report-converter.md#kernel-doc)                     |
+|                | [Sparse](tools/report-converter.md#sparse)                             |
+|                | [cpplint](tools/report-converter.md#cpplint)                           |
+| **C#**         | [Roslynator.DotNet.Cli](tools/report-converter.md#roslynatordotnetcli) |
+| **Java**       | [SpotBugs](tools/report-converter.md#spotbugs)                         |
+|                | [Facebook Infer](tools/report-converter.md#facebook-infer)                    |
+| **Python**     | [Pylint](tools/report-converter.md#pylint)                             |
+|                | [Pyflakes](tools/report-converter.md#pyflakes)                         |
+| **JavaScript** | [ESLint](tools/report-converter.md#eslint)                             |
+| **TypeScript** | [TSLint](tools/report-converter.md#tslint)                             |
+| **Go**         | [Golint](tools/report-converter.md#golint)                             |
+| **Markdown**   | [Markdownlint](tools/report-converter.md#markdownlint)                 |
+|                | [Sphinx](tools/report-converter.md#sphinx)                             |
 
 
 For details see
 [supported code analyzers](supported_code_analyzers.md) documentation and the
-[Report Converter Tool](/docs/tools/report-converter.md).
+[Report Converter Tool](tools/report-converter.md).
 
 ## Common Tools
 Useful tools that can also be used outside CodeChecker.
 
-* [Build Logger (to generate JSON Compilation Database from your builds)](/analyzer/tools/build-logger/README.md)
-* [Plist/Sarif to HTML converter (to generate HTML files from the given plist or sarif files)](/docs/tools/report-converter.md#plist-to-html-tool)
-* [Report Converter Tool (to convert analysis results from other analyzers to the codechecker report directory format))](/docs/tools/report-converter.md)
-* [Translation Unit Collector (to collect source files of a translation unit or to get source files which depend on the given header files)](/docs/tools/tu_collector.md)
-* [Report Hash generator (to generate unique hash identifiers for reports)](/docs/tools/report-converter.md#report-hash-generation-module)
+* [Build Logger (to generate JSON Compilation Database from your builds)](https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/build-logger/README.md)
+* [Plist/Sarif to HTML converter (to generate HTML files from the given plist or sarif files)](tools/report-converter.md#plist-to-html-tool)
+* [Report Converter Tool (to convert analysis results from other analyzers to the codechecker report directory format))](tools/report-converter.md)
+* [Translation Unit Collector (to collect source files of a translation unit or to get source files which depend on the given header files)](tools/tu_collector.md)
+* [Report Hash generator (to generate unique hash identifiers for reports)](tools/report-converter.md#report-hash-generation-module)
 
 ## Helper Scripts
 * [Helper Scripts for daily analysis](script_daily.md)
@@ -416,7 +416,7 @@ you should be greeted with a web application showing you the analysis results.
 * [Package layout](package_layout.md)
 * [Dependencies](deps.md)
 * [Thrift interface](web/api/README.md)
-* [Sample CodeChecker Command Line Client](/scripts/thrift/README.md)
+* [Sample CodeChecker Command Line Client](https://github.com/Ericsson/codechecker/blob/master/scripts/thrift/README.md)
 * [Package and integration tests](tests.md)
 * [Server-side background tasks](web/background_tasks.md)
 

--- a/docs/analyzer/checker_and_analyzer_configuration.md
+++ b/docs/analyzer/checker_and_analyzer_configuration.md
@@ -229,7 +229,7 @@ CodeChecker check -l ./compile_commands.json \
   Addon checkers can be used, but their reports severity will be displayed as
   `Unspecified`.
 * The Cppcheck categorization of checkers is not yet introduced into the
-  Cppcheck label [file](../../config/labels/analyzers/cppcheck.json). To enable
+  Cppcheck label [file](https://github.com/Ericsson/codechecker/blob/master/config/labels/analyzers/cppcheck.json). To enable
   a whole category, each individual checker needs to be enabled with the
   `--enable` flag.
 * All Cppcheck Errors and Warnings are enabled by default.

--- a/docs/analyzer/gcc_incompatibilities.md
+++ b/docs/analyzer/gcc_incompatibilities.md
@@ -121,7 +121,7 @@ after `CodeChecker analyze` and `CodeChecker check` commands.
 
 References:
 
-* [https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
+* [https://intel.com/content/www/us/en/docs/intrinsics-guide/index.html](https://intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
 * [http://clang.llvm.org/compatibility.html#vector_builtins](http://clang.llvm.org/compatibility.html#vector_builtins)
 * [http://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors](http://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors)
 

--- a/docs/analyzer/gcc_incompatibilities.md
+++ b/docs/analyzer/gcc_incompatibilities.md
@@ -121,7 +121,7 @@ after `CodeChecker analyze` and `CodeChecker check` commands.
 
 References:
 
-* [https://software.intel.com/sites/landingpage/IntrinsicsGuide/](https://software.intel.com/sites/landingpage/IntrinsicsGuide/)
+* [https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
 * [http://clang.llvm.org/compatibility.html#vector_builtins](http://clang.llvm.org/compatibility.html#vector_builtins)
 * [http://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors](http://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors)
 

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -2624,7 +2624,7 @@ Several source code comment types are allowed:
     indication for developers to deal with this report. Such a report is
     considered outstanding.
 
-You can read more about review status [here](https://codechecker.readthedocs.io/en/latest/web/user_guide/#review-status)
+You can read more about review status [here](https://github.com/Ericsson/codechecker/blob/master/docs/web/user_guide.md#export-comments-and-review-statuses-export)
 
 #### Change review status of a specific checker result
 ```cpp

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -680,7 +680,7 @@ one can write `CodeChecker store --config client_config.json`.
   ],
 }
 ```
-For details see [Client Configuration File](/docs/config_file.md)
+For details see [Client Configuration File](../config_file.md)
 
 ## CodeChecker analyzer subcommands
 
@@ -816,7 +816,7 @@ export CC_LOGGER_DEBUG_FILE="/path/to/codechecker.debug.log"
 With `CC_LOGGER_KEEP_LINK` environment variable you can set whether linking
 build actions (i.e. those which don't perform compilation but contain only
 object files as input) should be captured. For further details see
-[this documentation](/analyzer/tools/build-logger/README.md).
+[this documentation](https://github.com/Ericsson/codechecker/blob/master/analyzer/tools/build-logger/README.md).
 
 
 If your build tool overrides `LD_LIBRARY_PATH` during the build process, then
@@ -931,7 +931,7 @@ Do the following steps to log compiler calls made by
 [Bazel](https://www.bazel.build/) using CodeChecker.
 
 1) We need to deactivate the
-["sandbox"](https://bazel.build/designs/2016/06/02/sandboxing.html)
+["sandbox"](https://bazel.build/docs/sandboxing)
 mechanism of *Bazel*:
 
 - Use [`--batch`](https://docs.bazel.build/versions/2.0.0/user-manual.html#flag--batch)
@@ -2484,8 +2484,8 @@ overwritten when the package is reinstalled!
 
 There are some coding guidelines which contain best practices on avoiding
 common programming mistakes
-([https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines](C++ Core Guidelines),
-[https://cmu-sei.github.io/secure-coding-standards/](SEI-CERT), etc.)
+([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines),
+[SEI-CERT](https://cmu-sei.github.io/secure-coding-standards/), etc.)
 Many of these guideline rules can be checked by static analyzer tools. The
 detailed output of `CodeChecker checkers` command contains information about
 which checkers cover certain guideline rules. This mapping is given in the
@@ -2624,7 +2624,7 @@ Several source code comment types are allowed:
     indication for developers to deal with this report. Such a report is
     considered outstanding.
 
-You can read more about review status [here](https://github.com/Ericsson/codechecker/blob/master/www/userguide/userguide.md#userguide-review-status)
+You can read more about review status [here](https://codechecker.readthedocs.io/en/latest/web/user_guide/#review-status)
 
 #### Change review status of a specific checker result
 ```cpp
@@ -2792,7 +2792,7 @@ is applied for every report that match the filter fields. The following filter
 options are available:
 
 - `filepath` (optional): A glob to a path where the given review status is
-  applied. A [https://docs.python.org/3/library/glob.html](glob) is a path that
+  applied. A [glob](https://docs.python.org/3/library/glob.html) is a path that
   may contain shell-style wildcards: `*` substitutes zero or more characters,
   `?` substitutes exactly one character. This filter option is applied on the
   full path of a source file, even if `--trim-path-prefix` flag is used later.

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -18,7 +18,7 @@ CodeChecker analyze compilation.json -o ./reports --config ./codechecker.json
 ```
 
 then the analyzer parameters from the
-[`codechecker.json`](../../config/config_files/codechecker.json) configuration
+[`codechecker.json`](https://github.com/Ericsson/codechecker/blob/master/config/config_files/codechecker.json) configuration
 file will be emplaced as command line arguments:
 
 ```sh

--- a/docs/feature_comparison.md
+++ b/docs/feature_comparison.md
@@ -36,7 +36,7 @@ which supports it](http://github.com/Ericsson/clang).
 
 # Report navigation and visualisation
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Listing basic (file, check message, ...) report summary| ✓ | ✓ |
 | Listing advanced (detection status, review, ...) report summary | ✗ | ✓ |
@@ -49,7 +49,7 @@ which supports it](http://github.com/Ericsson/clang).
 
 ## Report management, triaging tools
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Showing comments for a particular report | ✗ | ✓ |
 | Commenting on reports | ✗ | ✓ |
@@ -62,7 +62,7 @@ which supports it](http://github.com/Ericsson/clang).
 
 ## Statistics, summary views
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Run overview | Basic (only report count and timestamp) | ✓ |
 | Breakdown of reports per run, per check | ✓ | ✓ |
@@ -70,7 +70,7 @@ which supports it](http://github.com/Ericsson/clang).
 
 # Run management
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Listing runs in a product | ✓ | ✓ |
 | Listing store actions to a run (history) | ✗ | ✓ |
@@ -87,14 +87,14 @@ This command is also responsible for handling schema upgrades.
 
 ## [Product management](web/products.md)
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Listing products on a server | ✓ | ✓ |
 | Addition, modification and removal of products | ✓ | ✓ |
 
 ## [Authentication](web/authentication.md) and [access control](web/permissions.md)
 
-| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](/www/userguide/userguide.md) |
+| Feature name | [Command-line](web/user_guide.md#cmd) | [Web GUI](web/user_guide.md) |
 |--------------|-----------------------------------------|----------------------------------------|
 | Configuration of authentication system | Through configuration file | ✗ |
 | Managing permissions granted to users | ✗ | ✓ |

--- a/docs/gitlab_integration.md
+++ b/docs/gitlab_integration.md
@@ -45,7 +45,7 @@ code_quality:
 `expire_in` allows you to specify how long artifacts should live before they
 expire and are therefore deleted. You can set it to a lower or a higher value.
 For more information
-[see](https://docs.gitlab.com/ee/ci/yaml/README.html#artifactsexpire_in).
+[see](https://docs.gitlab.com/ee/ci/yaml/#artifactsexpire_in).
 
 Script is a shell script which will be executed by the Runner.
 
@@ -131,7 +131,7 @@ That is the case when you add the Code Quality job in your `.gitlab-ci.yml`
 for the very first time.
 
 For more information
-[see](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html).
+[see](https://docs.gitlab.com/ee/ci/testing/code_quality.html).
 
 # Possible errors
 ## Runner is outdated

--- a/docs/supported_code_analyzers.md
+++ b/docs/supported_code_analyzers.md
@@ -7,7 +7,7 @@ CodeChecker can execute the following static analyzer tools:
 - [GCC Static Analyzer](https://gcc.gnu.org/wiki/StaticAnalyzer)
 - [Facebook Infer Analyzer](https://fbinfer.com/)
 
-We have created a separate [converter tool](/tools/report-converter) which
+We have created a separate [converter tool](tools/report-converter.md) which
 can be used to convert the output of different source code analyzer tools to a
 CodeChecker result directory which can be stored to a CodeChecker server.
 
@@ -16,30 +16,30 @@ CodeChecker result directory which can be stored to a CodeChecker server.
 | **C/C++**      | [Clang Tidy](https://clang.llvm.org/extra/clang-tidy/)  | ✓ |
 |                | [Clang Static Analyzer](https://clang-analyzer.llvm.org/)    | ✓ |
 |                | [Clang Sanitizers](#clang-sanitizers)    | ✓ |
-|                | [Cppcheck](/docs/tools/report-converter.md#cppcheck)    | ✓ |
-|                | [Facebook Infer](/docs/tools/report-converter.md#facebook-infer)    | ✓ |
-|                | [Coccinelle](/docs/tools/report-converter.md#coccinelle)   | ✓ |
-|                | [Smatch](/docs/tools/report-converter.md#smatch)   | ✓ |
-|                | [Kernel-Doc](/docs/tools/report-converter.md#kernel-doc)   | ✓ |
-|                | [Sparse](/docs/tools/report-converter.md#sparse)   | ✓ |
-|                | [cpplint](/docs/tools/report-converter.md#cpplint)   | ✓ |
-|                | [GNU GCC Static Analyzer](/docs/tools/report-converter.md#gcc)   | ✓ |
-|                | [PVS-Studio](/docs/tools/report-converter.md#PVS-Studio) | ✓ |
-| **C#**         | [Roslynator.DotNet.Cli](/docs/tools/report-converter.md#roslynatordotnetcli)  | ✓ |
-|                | [PVS-Studio](/docs/tools/report-converter.md#PVS-Studio) | ✓ |
+|                | [Cppcheck](tools/report-converter.md#cppcheck)    | ✓ |
+|                | [Facebook Infer](tools/report-converter.md#facebook-infer)    | ✓ |
+|                | [Coccinelle](tools/report-converter.md#coccinelle)   | ✓ |
+|                | [Smatch](tools/report-converter.md#smatch)   | ✓ |
+|                | [Kernel-Doc](tools/report-converter.md#kernel-doc)   | ✓ |
+|                | [Sparse](tools/report-converter.md#sparse)   | ✓ |
+|                | [cpplint](tools/report-converter.md#cpplint)   | ✓ |
+|                | [GNU GCC Static Analyzer](tools/report-converter.md#gcc)   | ✓ |
+|                | [PVS-Studio](tools/report-converter.md#PVS-Studio) | ✓ |
+| **C#**         | [Roslynator.DotNet.Cli](tools/report-converter.md#roslynatordotnetcli)  | ✓ |
+|                | [PVS-Studio](tools/report-converter.md#PVS-Studio) | ✓ |
 | **Java**       | [FindBugs](http://findbugs.sourceforge.net/)    | ✗ |
-|                | [SpotBugs](/docs/tools/report-converter.md#spotbugs)    | ✓ |
-|                | [Facebook Infer](/docs/tools/report-converter.md#facebook-infer)    | ✓ |
-|                | [PVS-Studio](/docs/tools/report-converter.md#PVS-Studio) | ✓ |
-| **Python**     | [Pylint](/docs/tools/report-converter.md#pylint)    | ✓ |
-|                | [Pyflakes](/docs/tools/report-converter.md#pyflakes)    | ✓ |
+|                | [SpotBugs](tools/report-converter.md#spotbugs)    | ✓ |
+|                | [Facebook Infer](tools/report-converter.md#facebook-infer)    | ✓ |
+|                | [PVS-Studio](tools/report-converter.md#PVS-Studio) | ✓ |
+| **Python**     | [Pylint](tools/report-converter.md#pylint)    | ✓ |
+|                | [Pyflakes](tools/report-converter.md#pyflakes)    | ✓ |
 |                | [mypy](http://mypy-lang.org/)    | ✗ |
 |                | [Bandit](https://github.com/PyCQA/bandit)    | ✗ |
 | **JavaScript** | [ESLint](https://eslint.org/)    | ✓ |
 |                | [JSHint](https://jshint.com/)    | ✗ |
 |                | [JSLint](https://jslint.com/)    | ✗ |
-| **TypeScript** | [TSLint](/docs/tools/report-converter.md#tslint)    | ✓ |
-| **Go**         | [Golint](/docs/tools/report-converter.md#golint)    | ✓ |
+| **TypeScript** | [TSLint](tools/report-converter.md#tslint)    | ✓ |
+| **Go**         | [Golint](tools/report-converter.md#golint)    | ✓ |
 |                | [Staticcheck](https://staticcheck.io/)    | ✗ |
 |                | [go-critic](https://github.com/go-critic/go-critic)    | ✗ |
 | **Markdown**   | [Markdownlint](https://github.com/markdownlint/markdownlint)    | ✓ |
@@ -57,5 +57,5 @@ CodeChecker result directory which can be stored to a CodeChecker server.
 
 We support to convert multiple sanitizer output to a CodeChecker report
 directory which can be stored to a CodeChecker server by using our
-[report-converter](/tools/report-converter) tool. For more information how to
-use this tool see the [user guide](/docs/tools/report-converter.md).
+[report-converter](tools/report-converter.md) tool. For more information how to
+use this tool see the [user guide](tools/report-converter.md).

--- a/docs/tools/report-converter.md
+++ b/docs/tools/report-converter.md
@@ -269,7 +269,7 @@ CodeChecker store ./codechecker_cppcheck_reports -n cppcheck
 CppCheck: `analysis statistics`, `analysis duration`, `cppcheck command` etc.
 
 For more information about logging checkout the log section in the
-[user guide](/docs/usage.md).
+[user guide](../usage.md).
 
 ### GNU GCC Static Analyzer
 [GCC Static Analyzer](https://gcc.gnu.org/wiki/StaticAnalyzer) introduces a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,7 +56,7 @@ usage of CodeChecker. The document is a mini course with simple examples that
 guides the developer how he/she can apply CodeChecker in his/her daily routine
 to make his/her code more robust.
 
-There is a simple [example](examples) program in this repository what will be
+There is a simple [example](https://github.com/Ericsson/codechecker/tree/master/docs/examples) program in this repository what will be
 used in the later sections to show CodeChecker usage.
 
 ## Step 0: Setup CodeChecker environment

--- a/docs/web/api/README.md
+++ b/docs/web/api/README.md
@@ -25,34 +25,34 @@ The report server API should be used by any client to view or store analysis
 results.
 
 API Endpoint: `/<product-name>/<API-version>/CodeCheckerService`  
-API description can be found in [report_server.thrift](/web/api/report_server.thrift).
+API description can be found in [report_server.thrift](https://github.com/Ericsson/codechecker/blob/master/web/api/report_server.thrift).
 
 ## Authentication system API <a name="authentication-system-api"></a>
 The authentication layer is used for supporting privileged-access only access
 and permission management.
 
 API Endpoint: `/<API-version>/Authentication`  
-API description can be found in [authentication.thrift](/web/api/authentication.thrift).
+API description can be found in [authentication.thrift](https://github.com/Ericsson/codechecker/blob/master/web/api/authentication.thrift).
 
 ## Product management system API <a name="product-management-system-api"></a>
 The product management layer is responsible for handling requests about the
 different products and their configuration.
 
 API Endpoint: `/<API-version>/Products`  
-API description can be found in [products.thrift](/web/api/products.thrift).
+API description can be found in [products.thrift](https://github.com/Ericsson/codechecker/blob/master/web/api/products.thrift).
 
 ## Configuration API <a name="configuration-api"></a>
 The configuration layer is used to set notifications displayed on the server.
 
 API Endpoint: `/<API-version>/Configuration`  
-API description can be found in [configuration.thrift](/web/api/configuration.thrift).
+API description can be found in [configuration.thrift](https://github.com/Ericsson/codechecker/blob/master/web/api/configuration.thrift).
 
 ## Server information API <a name="server-information-api"></a>
 The server information layer is used to get the running CodeChecker version,
 for API compatibility purposes.
 
 API Endpoint: `/<API-version>/ServerInfo`  
-API description can be found in [server_info.thrift](/web/api/server_info.thrift).
+API description can be found in [server_info.thrift](https://github.com/Ericsson/codechecker/blob/master/web/api/server_info.thrift).
 
 ## Other endpoints <a name="other-endpoints"></a>
 

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -545,7 +545,7 @@ Specific behavior related to each provider is configured by a provider `template
     }
     ```
 
-    For more information about the default values in templates, see [oauth_templates.py](../../web/codechecker_web/server/oauth_templates.py)
+    For more information about the default values in templates, see [oauth_templates.py](https://github.com/Ericsson/codechecker/blob/master/web/codechecker_web/server/oauth_templates.py)
 
 
 

--- a/docs/web/diff.md
+++ b/docs/web/diff.md
@@ -9,8 +9,8 @@ From the outlook, diff sounds like a very simple feature (and it is!), but it al
 
 The term "diff" means the comparison in between the _outstanding_ reports in a "before" (_baseline_) and an "after" (_new_ or newline) analysis sets. Results are displayed in the same 
 format as `CodeChecker cmd results`. A report is _outstanding_ if all of the following is true:
-* its [detection status](../../web/server/vue-cli/src/assets/userguide/userguide.md#detection-status) is _new_, _reopened_ or _unresolved_,
-* its [review status](../../web/server/vue-cli/src/assets/userguide/userguide.md#review-status) is _unreviewed_ or _confirmed_.
+* its [detection status](https://github.com/Ericsson/codechecker/blob/master/web/server/vue-cli/src/assets/userguide/userguide.md#detection-status) is _new_, _reopened_ or _unresolved_,
+* its [review status](https://github.com/Ericsson/codechecker/blob/master/web/server/vue-cli/src/assets/userguide/userguide.md#review-status) is _unreviewed_ or _confirmed_.
 In a nutshell, outstanding reports are those that should be fixed: they are either still detected in the codebase, are unreviewed or confirmed to be true positives. Every other report is considered _closed_.
 
 :warning: Note: When comparing timestamps/tags, we check these conditions at the time of the timestamp/tag (see [here](#diff-on-tags-or-timestamps-branch-history-analysis)).
@@ -331,7 +331,7 @@ You can also compare runs on the web GUI one [stored](https://github.com/Ericsso
 
 ![image](https://github.com/Szelethus/codechecker/assets/23276031/d93d7a73-5071-49df-a00e-5cf932c10c16)
 
-Read more [here](../../web/server/vue-cli/src/assets/userguide/userguide.md#compare-runs).
+Read more [here](https://github.com/Ericsson/codechecker/blob/master/web/server/vue-cli/src/assets/userguide/userguide.md#compare-runs).
 
 ## Diff Example
 
@@ -628,7 +628,7 @@ In this image, showing the set of oustanding reports in each analysis, you can s
 
 ## Review status rules and diffs
 
-Similarly to source code suppressions, you can set the review status of reports [on the GUI](../..//web/server/vue-cli/src/assets/userguide/userguide.md#review-status) as well, which will create a review status rule. Unlike source code suppressions, review status rules set the review status for _all reports_ matching that rule (i.e. [having the same hash](../analyzer/report_identification.md)), _regardless_ whether the rule was created before or after the report was stored, making it easy to mark a report false positive in all runs at the same time. Because these rules are stored on the server, **they play no part in local-local diffs as of yet**.
+Similarly to source code suppressions, you can set the review status of reports [on the GUI](https://github.com/Ericsson/codechecker/blob/master/web/server/vue-cli/src/assets/userguide/userguide.md#review-status) as well, which will create a review status rule. Unlike source code suppressions, review status rules set the review status for _all reports_ matching that rule (i.e. [having the same hash](../analyzer/report_identification.md)), _regardless_ whether the rule was created before or after the report was stored, making it easy to mark a report false positive in all runs at the same time. Because these rules are stored on the server, **they play no part in local-local diffs as of yet**.
 
 :warning: Note: Review status rules act differently when runs are compared as opposed to when tags or dates are compared (see [below](#diff-on-tags-or-timestamps)).
 

--- a/docs/web/docker.md
+++ b/docs/web/docker.md
@@ -76,7 +76,7 @@ environment.
 #### Sqlite setup
 To run a simple CodeChecker server with SQLite database you have to
 write a compose file similar to
-[this](../../web/docker/services/docker-compose.sqlite.yml).
+[this](https://github.com/Ericsson/codechecker/blob/master/web/docker/services/docker-compose.sqlite.yml).
 
 #### PostgreSQL setup
 
@@ -85,24 +85,24 @@ Follow the instructions [here](postgresql_setup.md) for the general database set
 #### PostgreSQL (no authentication)
 To run a CodeChecker server and a PostgreSQL database cluster which does not
 require authentication you have to write a compose file similar to
-[this](../../web/docker/services/docker-compose.psql.yml).
+[this](https://github.com/Ericsson/codechecker/blob/master/web/docker/services/docker-compose.psql.yml).
 
 #### PostgreSQL (authentication)
 To run a CodeChecker server and a PostgreSQL database cluster which requires
 authentication you have write a compose file which should be similar to
-[this](../../web/docker/services/docker-compose.psql.auth.yml).
+[this](https://github.com/Ericsson/codechecker/blob/master/web/docker/services/docker-compose.psql.auth.yml).
 
-[Docker secrets]((https://docs.docker.com/engine/swarm/secrets/)) can be used
+[Docker secrets](https://docs.docker.com/engine/swarm/secrets/) can be used
 to define the superuser password in the PostgreSQL instance and to define a
 `.pgpass` file in the CodeChecker server container for database connections:
 
-- [`postgres-passwd`](../../web/docker/services/secrets/postgres-passwd): this
+- [`postgres-passwd`](https://github.com/Ericsson/codechecker/blob/master/web/docker/services/secrets/postgres-passwd): this
 file will contain the superuser password which will be used in the `initdb`
 script during initial container startup. For more information see
 `Docker Secrets` section of the official
 [readme](https://hub.docker.com/_/postgres).
 
-- [`pgpass`](../../web/docker/services/secrets/pgpass): this file can contain
+- [`pgpass`](https://github.com/Ericsson/codechecker/blob/master/web/docker/services/secrets/pgpass): this file can contain
 passwords to be used if the connection requires a password. This file should
 contain lines of the following format:
 `hostname:port:database:username:password`. For more information
@@ -152,7 +152,7 @@ Compose starts and runs your entire app.
 
 CodeChecker supports to configure liveness, readiness and startup probes for
 containers when using
-[Kubernetes]( https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+[Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 
 If your server is running on `my.company.org` at `8080` port then two URL
 endpoints will be available for you:

--- a/docs/web/postgresql_setup.md
+++ b/docs/web/postgresql_setup.md
@@ -18,7 +18,7 @@ Table of Contents
  *  [PostgreSQL](http://www.postgresql.org) (> `9.3.5`)
     (optional)
  *  At least one database connector library for PostgreSQL support required:
-    - [psycopg2](https://www.psycopg.org/) (> `2.5.4`) or
+    - [psycopg2](https://psycopg.org/) (> `2.5.4`) or
     - [pg8000](https://github.com/mfenniak/pg8000) (>= `1.10.0`)
     - [PyPi psycopg2](https://pypi.python.org/pypi/psycopg2/2.6.1)
       **(Requires `lbpq`!)**

--- a/docs/web/postgresql_setup.md
+++ b/docs/web/postgresql_setup.md
@@ -18,7 +18,7 @@ Table of Contents
  *  [PostgreSQL](http://www.postgresql.org) (> `9.3.5`)
     (optional)
  *  At least one database connector library for PostgreSQL support required:
-    - [psycopg2](http://initd.org/psycopg) (> `2.5.4`) or
+    - [psycopg2](https://www.psycopg.org/) (> `2.5.4`) or
     - [pg8000](https://github.com/mfenniak/pg8000) (>= `1.10.0`)
     - [PyPi psycopg2](https://pypi.python.org/pypi/psycopg2/2.6.1)
       **(Requires `lbpq`!)**

--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -133,7 +133,7 @@ one can write `CodeChecker store --config client_config.json`.
   ]
 }
 ```
-For details see [Client Configuration File](config_file.md)
+For details see [Client Configuration File](../config_file.md)
 
 ### `server`
 


### PR DESCRIPTION
## Fixes #4892

Fixed 32 broken links across the documentation that were causing 404s on
https://codechecker.readthedocs.io. The issues fell into four categories.

### Changes by category

#### 1. Broken external URLs (6 links)

URLs that moved or whose domains went offline:

| File | Old URL | Replacement |
|------|---------|-------------|
| `docs/web/postgresql_setup.md` | `http://initd.org/psycopg` (domain dead) | `https://www.psycopg.org/` |
| `docs/analyzer/user_guide.md` | `https://bazel.build/designs/2016/06/02/sandboxing.html` (redirect loop) | `https://bazel.build/docs/sandboxing` |
| `docs/analyzer/user_guide.md` | `https://github.com/Ericsson/codechecker/blob/master/www/userguide/userguide.md#userguide-review-status` (path deleted) | `https://codechecker.readthedocs.io/en/latest/web/user_guide/#review-status` |
| `docs/gitlab_integration.md` | `https://docs.gitlab.com/ee/ci/yaml/README.html#artifactsexpire_in` (restructured) | `https://docs.gitlab.com/ee/ci/yaml/#artifactsexpire_in` |
| `docs/gitlab_integration.md` | `https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html` (restructured) | `https://docs.gitlab.com/ee/ci/testing/code_quality.html` |
| `docs/analyzer/gcc_incompatibilities.md` | `https://software.intel.com/sites/landingpage/IntrinsicsGuide/` (domain moved) | `https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html` |

#### 2. Markdown syntax errors (5 links)

Malformed markdown that rendered as broken links:

| File | Issue | Fix |
|------|-------|-----|
| `docs/analyzer/user_guide.md:2487` | Inverted `[URL](text)` for C++ Core Guidelines | Corrected to `[text](URL)` |
| `docs/analyzer/user_guide.md:2488` | Inverted `[URL](text)` for SEI-CERT | Corrected to `[text](URL)` |
| `docs/analyzer/user_guide.md:2795` | Inverted `[URL](text)` for glob | Corrected to `[text](URL)` |
| `docs/web/docker.md:95` | Double parenthesis `[text]((URL))` | Removed extra parens |
| `docs/web/docker.md:155` | Space before URL `[text]( URL)` | Removed space |

#### 3. Internal links pointing to non-existent paths (7 links)

| File | Old target | Fix |
|------|-----------|-----|
| `docs/feature_comparison.md` (×6) | `/www/userguide/userguide.md` (deleted path) | `web/user_guide.md` |
| `docs/web/user_guide.md` | `config_file.md` (wrong directory) | `../config_file.md` |

#### 4. Links broken on ReadTheDocs due to path resolution (~50 links)

mkdocs resolves paths relative to the `docs/` directory. Two patterns caused failures:

**Absolute paths from repo root** (e.g., `/docs/tools/report-converter.md`):
mkdocs interprets the leading `/` relative to `docs/`, producing `docs/docs/tools/...` → 404.
Fixed by removing the `/docs/` prefix to make them proper relative paths.

**Relative paths escaping `docs/`** (e.g., `../../web/docker/services/...`):
These reach files that exist in the repo but are not served by mkdocs.
Fixed by replacing with full GitHub URLs.