### PR TITLE
Fix unbound local variable bug

### DIFF
--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -822,6 +822,7 @@ def handle_list_results(args):
         print(CmdLineOutputEncoder().encode(all_results))
     else:
         rows = []
+        header = []
         max_msg_len = 50
         for res in all_results:
             bug_line = res.line


### PR DESCRIPTION
When running the
CodeChecker cmd results RUN --url URL --checker-msg MSG command,
the following error occurred:

File "codechecker/build/CodeChecker/lib/python3/codechecker_client/cmd_line_client.py", line 881, in handle_list_results
  print(twodim.to_str(args.output_format, header, rows))

UnboundLocalError: cannot access local variable 'header'
where it is not associated with a value

This patch fixes the above issue.