### PR TITLE
[perf] Improve analyze file filter for header

### DIFF
--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -1012,7 +1012,8 @@ def is_checker_config_valid(
 
 def get_affected_file_paths(
     file_filters: List[str],
-    compile_commands: tu_collector.CompilationDB
+    compile_commands: tu_collector.CompilationDB,
+    jobs: int
 ) -> List[str]:
     """
     Returns a list of source files for existing header file otherwise returns
@@ -1028,7 +1029,7 @@ def get_affected_file_paths(
                 file_filter.endswith(header_file_extensions):
             LOG.info("Get dependent source files for '%s'...", file_filter)
             dependent_sources = tu_collector.get_dependent_sources(
-                compile_commands, file_filter, dependencies)
+                compile_commands, file_filter, dependencies, jobs)
 
             LOG.info("Get dependent source files for '%s' done.", file_filter)
             LOG.debug("Dependent source files: %s",
@@ -1047,7 +1048,7 @@ def __get_skip_handlers(args, compile_commands) -> SkipListHandlers:
     skip_handlers = SkipListHandlers()
     if 'files' in args:
         source_file_paths = get_affected_file_paths(
-            args.files, compile_commands)
+            args.files, compile_commands, args.jobs)
 
         # Creates a skip file where all source files will be skipped except
         # the given source files and all the header files.

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -1019,6 +1019,7 @@ def get_affected_file_paths(
     with the same file path expression.
     """
     file_paths = []  # Use list to keep the order of the file paths.
+    dependencies: tu_collector.Dependencies = collections.defaultdict(set)
     for file_filter in file_filters:
         file_paths.append(str(Path(file_filter).resolve())
                           if '*' not in file_filter else file_filter)
@@ -1027,7 +1028,7 @@ def get_affected_file_paths(
                 file_filter.endswith(header_file_extensions):
             LOG.info("Get dependent source files for '%s'...", file_filter)
             dependent_sources = tu_collector.get_dependent_sources(
-                compile_commands, file_filter)
+                compile_commands, file_filter, dependencies)
 
             LOG.info("Get dependent source files for '%s' done.", file_filter)
             LOG.debug("Dependent source files: %s",

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -1001,28 +1001,35 @@ def is_checker_config_valid(
 
 def get_affected_file_paths(
     file_filters: List[str],
-    compile_commands: tu_collector.CompilationDB
+    compile_commands: tu_collector.CompilationDB,
+    jobs: int
 ) -> List[str]:
     """
     Returns a list of source files for existing header file otherwise returns
     with the same file path expression.
     """
     file_paths = []  # Use list to keep the order of the file paths.
+    header_files: List[str] = []
     for file_filter in file_filters:
         file_paths.append(str(Path(file_filter).resolve())
                           if '*' not in file_filter else file_filter)
 
         if os.path.exists(file_filter) and \
                 file_filter.endswith(header_file_extensions):
-            LOG.info("Get dependent source files for '%s'...", file_filter)
-            dependent_sources = tu_collector.get_dependent_sources(
-                compile_commands, file_filter)
+            header_files.append(file_filter)
 
-            LOG.info("Get dependent source files for '%s' done.", file_filter)
-            LOG.debug("Dependent source files: %s",
-                      ', '.join(dependent_sources))
+    if not header_files:
+        return file_paths
 
-            file_paths.extend(dependent_sources)
+    LOG.info("Get dependent source files for '%s'...", ', '.join(header_files))
+    dependent_sources = tu_collector.get_dependent_sources(
+        compile_commands, header_files, jobs)
+    LOG.info("Get dependent source files for '%s' done.",
+             ', '.join(header_files))
+    LOG.debug("Dependent source files: %s",
+              ', '.join(dependent_sources))
+
+    file_paths.extend(dependent_sources)
 
     return file_paths
 
@@ -1035,7 +1042,7 @@ def __get_skip_handlers(args, compile_commands) -> SkipListHandlers:
     skip_handlers = SkipListHandlers()
     if 'files' in args:
         source_file_paths = get_affected_file_paths(
-            args.files, compile_commands)
+            args.files, compile_commands, args.jobs)
 
         # Creates a skip file where all source files will be skipped except
         # the given source files and all the header files.

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -31,7 +31,7 @@ import zipfile
 from shutil import which
 
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict  # pylint: disable=no-name-in-module
@@ -56,6 +56,7 @@ class CompileAction(TypedDict):
 
 
 CompilationDB = List[CompileAction]
+Dependencies = Dict[str, Set[str]]
 
 
 def __random_string(length: int) -> str:
@@ -474,19 +475,22 @@ def zip_tu_files(
 
 def get_dependent_sources(
     compilation_db: CompilationDB,
-    header_path: Optional[str] = None
+    header_path: Optional[str] = None,
+    dependencies: Optional[Dependencies] = None,
 ) -> Set[str]:
     """ Get dependencies for each files in each translation unit. """
-    dependencies = collections.defaultdict(set)
-    for build_action in compilation_db:
-        files, _ = get_dependent_headers(
-            build_action['command'],
-            build_action['directory'])
+    if dependencies is None:
+        dependencies = collections.defaultdict(set)
+    if not dependencies:
+        for build_action in compilation_db:
+            files, _ = get_dependent_headers(
+                build_action['command'],
+                build_action['directory'])
 
-        source_file = os.path.join(build_action['directory'],
-                                   build_action['file'])
-        for f in files:
-            dependencies[f].add(source_file)
+            source_file = os.path.join(build_action['directory'],
+                                       build_action['file'])
+            for f in files:
+                dependencies[f].add(source_file)
 
     pattern = None
     if header_path:

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -28,6 +28,7 @@ import string
 import subprocess
 import sys
 import zipfile
+from multiprocessing import Pool
 from shutil import which
 
 from pathlib import Path
@@ -473,22 +474,34 @@ def zip_tu_files(
                          json.dumps(compilation_database, indent=2))
 
 
+def __get_dependent_headers_for_build_action(build_action: CompileAction
+                                             ) -> Tuple[str, Set[str]]:
+    """ Return the source file and dependent headers for a build action. """
+    files, _ = get_dependent_headers(
+        build_action['command'],
+        build_action['directory'])
+
+    source_file = os.path.join(build_action['directory'],
+                               build_action['file'])
+    return source_file, files
+
+
 def get_dependent_sources(
     compilation_db: CompilationDB,
     header_path: Optional[str] = None,
     dependencies: Optional[Dependencies] = None,
+    jobs: Optional[int] = None
 ) -> Set[str]:
     """ Get dependencies for each files in each translation unit. """
     if dependencies is None:
         dependencies = collections.defaultdict(set)
+    if jobs is None:
+        jobs = 1
     if not dependencies:
-        for build_action in compilation_db:
-            files, _ = get_dependent_headers(
-                build_action['command'],
-                build_action['directory'])
-
-            source_file = os.path.join(build_action['directory'],
-                                       build_action['file'])
+        with Pool(jobs) as p:
+            results = list(p.map(__get_dependent_headers_for_build_action,
+                                 compilation_db))
+        for source_file, files in results:
             for f in files:
                 dependencies[f].add(source_file)
 

--- a/tools/tu_collector/tu_collector/tu_collector.py
+++ b/tools/tu_collector/tu_collector/tu_collector.py
@@ -28,6 +28,7 @@ import string
 import subprocess
 import sys
 import zipfile
+from multiprocessing import Pool
 from shutil import which
 
 from pathlib import Path
@@ -472,31 +473,45 @@ def zip_tu_files(
                          json.dumps(compilation_database, indent=2))
 
 
+def __get_dependent_headers_for_build_action(build_action: CompileAction
+                                             ) -> Tuple[str, Set[str]]:
+    """ Return the source file and dependent headers for a build action. """
+    files, _ = get_dependent_headers(
+        build_action['command'],
+        build_action['directory'])
+
+    source_file = os.path.join(build_action['directory'],
+                               build_action['file'])
+    return source_file, files
+
+
 def get_dependent_sources(
     compilation_db: CompilationDB,
-    header_path: Optional[str] = None
+    header_paths: Optional[List[str]] = None,
+    jobs: int = 1
 ) -> Set[str]:
     """ Get dependencies for each files in each translation unit. """
-    dependencies = collections.defaultdict(set)
-    for build_action in compilation_db:
-        files, _ = get_dependent_headers(
-            build_action['command'],
-            build_action['directory'])
+    if not header_paths:
+        return set()
 
-        source_file = os.path.join(build_action['directory'],
-                                   build_action['file'])
+    deps = set()
+    dependencies = collections.defaultdict(set)
+    with Pool(jobs) as p:
+        results = list(p.map(__get_dependent_headers_for_build_action,
+                             compilation_db))
+    for source_file, files in results:
         for f in files:
             dependencies[f].add(source_file)
 
-    pattern = None
-    if header_path:
-        norm_header_path = os.path.normpath(header_path.strip())
-        pattern = re.compile(fnmatch.translate(norm_header_path))
+    for header_path in header_paths:
+        pattern = None
+        if header_path:
+            norm_header_path = os.path.normpath(header_path.strip())
+            pattern = re.compile(fnmatch.translate(norm_header_path))
 
-    deps = set()
-    for header, source_files in dependencies.items():
-        if not pattern or pattern.match(header):
-            deps.update(source_files)
+        for header, source_files in dependencies.items():
+            if not pattern or pattern.match(header):
+                deps.update(source_files)
 
     return deps
 
@@ -603,7 +618,7 @@ used to generate a log file on the fly.""")
                      ctu_deps_dir=args.ctu_deps_dir)
         LOG.info("Done.")
     else:
-        deps = get_dependent_sources(compilation_db, args.filter)
+        deps = get_dependent_sources(compilation_db, [args.filter])
 
         if deps:
             print("\n".join(deps))


### PR DESCRIPTION
In this PR:

 - Compute dependencies of each source file of the compilation database only once for all header provided
 - Parse the compilation database in parallel

Close #4949 