### PR TITLE
[nfc] Remove redundant session.revalidate()

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -72,6 +72,8 @@ from .task_executors.main import executor as background_task_executor
 from .task_executors.task_manager import \
     TaskManager as BackgroundTaskManager
 
+from .session_manager import _Session
+
 
 LOG = get_logger('server')
 
@@ -85,6 +87,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
     Handle thrift and browser requests
     Simply modified and extended version of SimpleHTTPRequestHandler
     """
+    server: "CCSimpleHttpServer"
     auth_session = None
 
     def __init__(self, request, client_address, server):
@@ -114,7 +117,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(result)
 
-    def __check_session_header(self):
+    def __check_session_header(self) -> Optional[_Session]:
         """
         Check the CodeChecker privileged access cookie in the request headers.
 
@@ -147,10 +150,6 @@ class RequestHandler(SimpleHTTPRequestHandler):
                     session = self.server.manager.get_session(values[1])
 
         if session and session.is_alive:
-            # If a valid bearer token was found and it can still be used,
-            # mark that the user's last access to the server was the
-            # request that resulted in the execution of this function.
-            session.revalidate()
             return session
         else:
             # If the user's token is no longer usable (invalid),

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -847,7 +847,7 @@ class SessionManager:
         return False
 
     def __create_local_session(self, token, user_name, groups, is_root,
-                               last_access=None):
+                               last_access=None) -> _Session:
         """
         Returns a new local session object initalized by the given parameters.
         """
@@ -1051,7 +1051,7 @@ class SessionManager:
         """ Get keepalive max probe count. """
         return self.__keepalive_config.get('max_probe')
 
-    def __get_local_session_from_db(self, token):
+    def __get_local_session_from_db(self, token) -> Optional[_Session]:
         """
         Creates a local session if a valid session token can be found in the
         database.
@@ -1087,7 +1087,7 @@ class SessionManager:
 
         return None
 
-    def get_session(self, token):
+    def get_session(self, token) -> Optional[_Session]:
         """
         Retrieves the session for the given session cookie token from the
         server's memory backend, if such session exists or creates and returns


### PR DESCRIPTION
session.revalidate() is already handled in function get_session().

Also added type annotations to a few session handler functions.