### PR TITLE
Rework guidelines selector component

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -64,8 +64,11 @@
                 item-value="value"
                 label="Select guidelines"
                 variant="outlined"
-                multiple
                 density="comfortable"
+                multiple
+                clearable
+                chips
+                closable-chips
               >
                 <template v-slot:selection="{ item }">
                   <div class="selection-item">


### PR DESCRIPTION
This PR makes the Guidelines selector be smaller by adding `chips` tag to component, making them individually and collectively clearable. 

New look:
<img width="949" height="139" alt="image" src="https://github.com/user-attachments/assets/6f3aa262-96c1-4cc1-a6b0-08e34a82b315" />
Old look:
<img width="949" height="139" alt="image" src="https://github.com/user-attachments/assets/f64baa1b-1894-4600-93d2-782774107115" />
