### PR TITLE
Fix autoincrement warning in report ID BIGINT migration

### DIFF
--- a/web/server/codechecker_server/migrations/report/versions/a7f3c8e21b90_report_id_bigint.py
+++ b/web/server/codechecker_server/migrations/report/versions/a7f3c8e21b90_report_id_bigint.py
@@ -168,8 +168,7 @@ def upgrade():
             'id',
             existing_type=sa.Integer(),
             type_=sa.BigInteger(),
-            existing_nullable=False,
-            autoincrement=True)
+            existing_nullable=False)
         op.execute(sa.text('ALTER SEQUENCE reports_id_seq AS BIGINT'))
         _tighten_association_tables_postgresql()
     elif dialect == 'sqlite':
@@ -189,8 +188,7 @@ def downgrade():
             'id',
             existing_type=sa.BigInteger(),
             type_=sa.Integer(),
-            existing_nullable=False,
-            autoincrement=True)
+            existing_nullable=False)
         op.execute(sa.text('ALTER SEQUENCE reports_id_seq AS INTEGER'))
     elif dialect == 'sqlite':
         _relax_association_tables_sqlite()


### PR DESCRIPTION
Removed the redundant autoincrement=True argument from the op.alter_column('reports', 'id', ...) calls in upgrade() and downgrade(). It is a no-op on PostgreSQL and triggered a warning during schema migration.