### PR TITLE
Remove deprecated --tidy-config flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -699,16 +699,6 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                         'key': f"{cfg.checker}.{cfg.option}",
                         'value': cfg.value})
             analyzer_config['CheckOptions'] = check_options
-        else:
-            try:
-                with open(args.tidy_config, 'r',
-                          encoding='utf-8', errors='ignore') as tidy_config:
-                    handler.checker_config = tidy_config.read()
-            except IOError as ioerr:
-                LOG.debug(ioerr)
-            except AttributeError as aerr:
-                # No clang tidy config file was given in the command line.
-                LOG.debug(aerr)
 
         handler.analyzer_config = analyzer_config
 

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -461,17 +461,6 @@ def add_arguments_to_parser(parser):
                                     "clang-tidy:cc-verbatim-args-file="
                                     "<filepath>")
 
-    analyzer_opts.add_argument('--tidy-config',
-                               dest='tidy_config',
-                               required=False,
-                               default=argparse.SUPPRESS,
-                               help="DEPRECATED. "
-                                    "A file in YAML format containing the "
-                                    "configuration of clang-tidy checkers. "
-                                    "The file can be dumped by "
-                                    "'CodeChecker analyzers --dump-config "
-                                    "clang-tidy' command.")
-
     analyzer_opts.add_argument('--analyzer-config',
                                type=analyzer_config,
                                dest='analyzer_config',
@@ -1285,11 +1274,6 @@ def main(args):
                  "errors relating to unknown analyzer/checker configs, "
                  "consider using the option '--no-missing-checker-error'")
         sys.exit(1)
-
-    if 'tidy_config' in args:
-        LOG.warning(
-            "--tidy-config is deprecated and will be removed in the next "
-            "release. Use --analyzer-config or --checker-config instead.")
 
     # CTU loading mode is only meaningful if CTU itself is enabled.
     if 'ctu_ast_mode' in args and 'ctu_phases' not in args:

--- a/analyzer/codechecker_analyzer/cli/check.py
+++ b/analyzer/codechecker_analyzer/cli/check.py
@@ -418,17 +418,6 @@ used to generate a log file on the fly.""")
                                     "clang-tidy:cc-verbatim-args-file="
                                     "<filepath>")
 
-    analyzer_opts.add_argument('--tidy-config',
-                               dest='tidy_config',
-                               required=False,
-                               default=argparse.SUPPRESS,
-                               help="DEPRECATED. "
-                                    "A file in YAML format containing the "
-                                    "configuration of clang-tidy checkers. "
-                                    "The file can be dumped by "
-                                    "'CodeChecker analyzers --dump-config "
-                                    "clang-tidy' command.")
-
     analyzer_opts.add_argument('--analyzer-config',
                                type=analyzer_config,
                                dest='analyzer_config',


### PR DESCRIPTION
The --tidy-config flag was marked as deprecated in a previous release. Now it is completely removed.