### PR TITLE
[gui] Fix guideline statistics not getting the report filter set

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -445,7 +445,7 @@ async function fetchStatistics() {
 
   await getAllGuidelineRules();
 
-  const filter = new ReportFilter(baseStatistics.reportFilter);
+  const filter = new ReportFilter(baseStatistics.reportFilter.value);
 
   const checker_stat_result = await new Promise(resolve => {
     ccService.getClient().getCheckerStatusVerificationDetails(


### PR DESCRIPTION
This changes fixes a missing .value to set the report filters right