### PR TITLE
[refactor] Remove late setting of database_connection in SessionManager

### DIFF
--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -643,11 +643,15 @@ class CCSimpleHttpServer(HTTPServer):
                  pckg_data,
                  context,
                  check_env,
-                 manager: session_manager.SessionManager,
                  machine_id: str,
                  task_queue: Queue,
                  task_pipes,
-                 server_shutdown_flag: Value):
+                 server_shutdown_flag: Value,
+                 server_cfg_file,
+                 server_secrets_file,
+                 force_auth,
+                 api_handler_processes,
+                 task_worker_processes):
 
         LOG.debug("Initializing HTTP server...")
 
@@ -658,7 +662,6 @@ class CCSimpleHttpServer(HTTPServer):
         self.version = pckg_data['version']
         self.context = context
         self.check_env = check_env
-        self.manager = manager
         self.address, self.port = server_address
         self.__products = {}
 
@@ -666,7 +669,24 @@ class CCSimpleHttpServer(HTTPServer):
         LOG.debug("Creating database engine for CONFIG DATABASE...")
         self.__engine = product_db_sql_server.create_engine()
         self.config_session = sessionmaker(bind=self.__engine)
-        self.manager.set_database_connection(self.config_session)
+
+        try:
+            self.manager = session_manager.SessionManager(
+                self.config_session,
+                server_cfg_file,
+                server_secrets_file,
+                force_auth,
+                api_handler_processes,
+                task_worker_processes)
+
+        except IOError as ioerr:
+            LOG.debug(ioerr)
+            LOG.error("The server's configuration file "
+                      "is missing or can not be read!")
+            sys.exit(1)
+        except ValueError as verr:
+            LOG.error(verr)
+            sys.exit(1)
 
         self.__task_queue = task_queue
         self.task_manager = BackgroundTaskManager(
@@ -1030,23 +1050,6 @@ def start_server(config_directory: str, workspace_directory: str,
 
     server_secrets_file = os.path.join(config_directory, 'server_secrets.json')
 
-    try:
-        manager = session_manager.SessionManager(
-            server_cfg_file,
-            server_secrets_file,
-            force_auth,
-            api_handler_processes,
-            task_worker_processes)
-
-    except IOError as ioerr:
-        LOG.debug(ioerr)
-        LOG.error("The server's configuration file "
-                  "is missing or can not be read!")
-        sys.exit(1)
-    except ValueError as verr:
-        LOG.error(verr)
-        sys.exit(1)
-
     if not skip_db_cleanup:
         all_success, fails = _do_db_cleanups(config_sql_server,
                                              context,
@@ -1061,13 +1064,6 @@ def start_server(config_directory: str, workspace_directory: str,
     else:
         LOG.debug("Skipping db_cleanup, as requested.")
 
-    api_processes: Dict[int, Process] = {}
-    requested_api_threads = cast(int, manager.worker_processes) \
-        or cpu_count()
-
-    bg_processes: Dict[int, Process] = {}
-    requested_bg_threads = cast(int,
-                                manager.background_worker_processes)
     # Note that Queue under the hood uses OS-level primitives such as a socket
     # or a pipe, where the read-write buffers have a **LIMITED** capacity, and
     # are usually **NOT** backed by the full amount of available system memory.
@@ -1121,11 +1117,20 @@ def start_server(config_directory: str, workspace_directory: str,
                                package_data,
                                context,
                                check_env,
-                               manager,
                                machine_id,
                                bg_task_queue,
                                task_pipes,
-                               is_server_shutting_down)
+                               is_server_shutting_down,
+                               server_cfg_file,
+                               server_secrets_file,
+                               force_auth,
+                               api_handler_processes,
+                               task_worker_processes)
+
+    api_processes: Dict[int, Process] = {}
+    bg_processes: Dict[int, Process] = {}
+    requested_api_threads = http_server.manager.worker_processes
+    requested_bg_threads = http_server.manager.background_worker_processes
 
     try:
         instance_manager.register(os.getpid(),
@@ -1345,7 +1350,7 @@ def start_server(config_directory: str, workspace_directory: str,
         signal_log(LOG, "INFO",
                    "Received signal to reload server configuration ...")
 
-        manager.reload_config()
+        http_server.manager.reload_config()
 
         signal_log(LOG, "INFO", "Server configuration reload: Done.")
 

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -18,6 +18,8 @@ from datetime import datetime
 import hashlib
 from typing import Optional
 
+from sqlalchemy.orm import sessionmaker
+
 from codechecker_common.compatibility.multiprocessing import cpu_count
 from codechecker_common.logger import get_logger
 from codechecker_common.util import generate_random_token, load_json
@@ -173,7 +175,8 @@ class SessionManager:
     CodeChecker server.
     """
 
-    def __init__(self, configuration_file, secrets_file, force_auth=False,
+    def __init__(self, config_db_sessionmaker: sessionmaker,
+                 configuration_file, secrets_file, force_auth=False,
                  api_handler_processes: Optional[int] = None,
                  task_worker_processes: Optional[int] = None):
         """
@@ -184,7 +187,7 @@ class SessionManager:
         :param force_auth: If True, the manager will be enabled even if the
             configuration file disables authentication.
         """
-        self.__database_connection = None
+        self.__config_db_sessionmaker = config_db_sessionmaker
         self.__logins_since_prune = 0
         self.__sessions = []
         self.__configuration_file = configuration_file
@@ -560,15 +563,6 @@ class SessionManager:
         """ Get default superuser name. """
         return self.__auth_config['super_user']
 
-    def set_database_connection(self, connection):
-        """
-        Set the instance's database connection to use in fetching
-        database-stored sessions to the given connection.
-
-        Use None as connection's value to unset the database.
-        """
-        self.__database_connection = connection
-
     def __handle_validation(self, auth_string):
         """
         Validate an oncoming authorization request
@@ -602,15 +596,12 @@ class SessionManager:
             self.__auth_config['method_' + method].get('enabled')
 
     def __try_auth_token(self, auth_string):
-        if not self.__database_connection:
-            return None
-
         user_name, token = auth_string.split(':', 1)
 
         transaction = None
         try:
             # Try the database, if it is connected.
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             auth_session = transaction.query(SessionRecord.token) \
                 .filter(SessionRecord.user_name == user_name) \
                 .filter(SessionRecord.token == token) \
@@ -630,15 +621,12 @@ class SessionManager:
         return None
 
     def __try_personal_access_token(self, auth_string):
-        if not self.__database_connection:
-            return None
-
         user_name, token = auth_string.split(':', 1)
         personal_access_token = None
 
         transaction = None
         try:
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             personal_access_token = transaction.query(PersonalAccessToken) \
                 .filter(PersonalAccessToken.user_name == user_name) \
                 .filter(PersonalAccessToken.token == token) \
@@ -762,12 +750,9 @@ class SessionManager:
         """
         Update the groups assigned to a personal access token.
         """
-        if not self.__database_connection:
-            return None
-
         transaction = None
         try:
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             transaction.query(PersonalAccessToken) \
                 .filter(PersonalAccessToken.user_name == user_name) \
                 .update({PersonalAccessToken.groups: ';'.join(groups)})
@@ -787,13 +772,10 @@ class SessionManager:
         """
         Updates group field of the users tokens.
         """
-        if not self.__database_connection:
-            return None
-
         transaction = None
         try:
             # Try the database, if it is connected.
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             transaction.query(SessionRecord) \
                 .filter(SessionRecord.user_name == user_name) \
                 .update({SessionRecord.groups: ';'.join(groups)})
@@ -838,7 +820,7 @@ class SessionManager:
         transaction = None
         try:
             # Try the database, if it is connected.
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             system_permission = transaction.query(SystemPermission) \
                 .filter(SystemPermission.name == user_name) \
                 .filter(SystemPermission.permission == SUPERUSER.name) \
@@ -863,7 +845,7 @@ class SessionManager:
         return _Session(
             token, user_name, groups,
             self.__auth_config['session_lifetime'],
-            self.__refresh_time, is_root, self.__database_connection,
+            self.__refresh_time, is_root, self.__config_db_sessionmaker,
             last_access)
 
     def create_session(self, auth_string):
@@ -903,20 +885,19 @@ class SessionManager:
 
         # Store the session in the database.
         transaction = None
-        if self.__database_connection:
-            try:
-                transaction = self.__database_connection()
-                record = SessionRecord(token, user_name,
-                                       ';'.join(groups))
-                transaction.add(record)
-                transaction.commit()
-            except Exception as e:
-                LOG.error("Couldn't store or update login record in "
-                          "database:")
-                LOG.error(str(e))
-            finally:
-                if transaction:
-                    transaction.close()
+        try:
+            transaction = self.__config_db_sessionmaker()
+            record = SessionRecord(token, user_name,
+                                   ';'.join(groups))
+            transaction.add(record)
+            transaction.commit()
+        except Exception as e:
+            LOG.error("Couldn't store or update login record in "
+                      "database:")
+            LOG.error(str(e))
+        finally:
+            if transaction:
+                transaction.close()
 
         return local_session
 
@@ -974,37 +955,36 @@ class SessionManager:
 
         # Store the session in the database.
         transaction = None
-        if self.__database_connection:
-            try:
-                transaction = self.__database_connection()
+        try:
+            transaction = self.__config_db_sessionmaker()
 
-                # Store the new session.
-                record = SessionRecord(codechecker_session_token,
-                                       user_data.get('username'),
-                                       ';'.join(user_data.get('groups')))
-                transaction.add(record)
-                # Store oauth token data
-                session_id = transaction.query(SessionRecord.id) \
-                    .filter(SessionRecord.user_name ==
-                            user_data.get('username')) \
-                    .first()
+            # Store the new session.
+            record = SessionRecord(codechecker_session_token,
+                                   user_data.get('username'),
+                                   ';'.join(user_data.get('groups')))
+            transaction.add(record)
+            # Store oauth token data
+            session_id = transaction.query(SessionRecord.id) \
+                .filter(SessionRecord.user_name ==
+                        user_data.get('username')) \
+                .first()
 
-                oauth_token_session = OAuthToken(
-                                                 access_token=access_token,
-                                                 expires_at=token_expires_at,
-                                                 refresh_token=refresh_token,
-                                                 auth_session_id=session_id[0]
-                                                 )
-                transaction.add(oauth_token_session)
-                transaction.commit()
+            oauth_token_session = OAuthToken(
+                                             access_token=access_token,
+                                             expires_at=token_expires_at,
+                                             refresh_token=refresh_token,
+                                             auth_session_id=session_id[0]
+                                             )
+            transaction.add(oauth_token_session)
+            transaction.commit()
 
-            except Exception as e:
-                LOG.error("Couldn't store or update login record in "
-                          "database:")
-                LOG.error(str(e))
-            finally:
-                if transaction:
-                    transaction.close()
+        except Exception as e:
+            LOG.error("Couldn't store or update login record in "
+                      "database:")
+            LOG.error(str(e))
+        finally:
+            if transaction:
+                transaction.close()
 
         return local_session
 
@@ -1063,13 +1043,9 @@ class SessionManager:
         Creates a local session if a valid session token can be found in the
         database.
         """
-
-        if not self.__database_connection:
-            return None
-
         transaction = None
         try:
-            transaction = self.__database_connection()
+            transaction = self.__config_db_sessionmaker()
             db_record = transaction.query(SessionRecord) \
                 .filter(SessionRecord.token == token) \
                 .limit(1).one_or_none()
@@ -1145,15 +1121,13 @@ class SessionManager:
         try:
             self.invalidate_local_session(token)
 
-            transaction = self.__database_connection() \
-                if self.__database_connection else None
+            transaction = self.__config_db_sessionmaker()
 
             # Remove sessions from the database.
-            if transaction:
-                transaction.query(SessionRecord) \
-                    .filter(SessionRecord.token == token) \
-                    .delete()
-                transaction.commit()
+            transaction.query(SessionRecord) \
+                .filter(SessionRecord.token == token) \
+                .delete()
+            transaction.commit()
 
             return True
         except Exception as e:


### PR DESCRIPTION
During server initialization, there is a period when SessionManager's __database_connection property is None, and eventually this property is set to a proper sessionmaker object in the __init__ function of the CCSimpleHttpServer class.

Due to this structure, it became a common pattern in the SessionManager class to add "if __database_connection" guards in the beginning of multiple functions to handle the case where the __database_connection property is still None.

In this refactor, the SessionManager object is now constructed properly with a "__database_connection". That field name was also misleading, therefore it was renamed to __config_db_sessionmaker. This change required to now construct the SessionManager object in the __init__ method of the server class, and unfortunately, it increased the number of parameters of its constructor.

Hopefully this makes the further refactoring goal easier to separate server configuration handling from the SessionManager class.