### PR TITLE
Introduce Personal Access Token creation date column

### DIFF
--- a/web/server/codechecker_server/database/config_db_model.py
+++ b/web/server/codechecker_server/database/config_db_model.py
@@ -155,6 +155,7 @@ class PersonalAccessToken(Base):
     # List of group names separated by semicolons.
     groups = Column(String)
 
+    creation_date = Column(DateTime, nullable=False)
     last_access = Column(DateTime, nullable=False)
     expiration = Column(DateTime)
 
@@ -176,7 +177,8 @@ class PersonalAccessToken(Base):
         self.token = token
         self.description = description
         self.groups = groups
-        self.last_access = datetime.now()
+        self.creation_date = datetime.now()
+        self.last_access = self.creation_date
         self.expiration = self.last_access + timedelta(days=expiration)
 
 
@@ -277,7 +279,7 @@ class BackgroundTask(Base):
         # The job never started, or its execution was terminated due to a
         # system-level reason (such as the server's foced shutdown).
         "dropped",
-        ),
+        name="background_task_statuses"),
                     nullable=False,
                     default="enqueued",
                     index=True)

--- a/web/server/codechecker_server/migrations/config/versions/511b1b37de2e_add_pat_creation_date_column.py
+++ b/web/server/codechecker_server/migrations/config/versions/511b1b37de2e_add_pat_creation_date_column.py
@@ -1,0 +1,48 @@
+"""
+Add PAT creation date column
+
+Revision ID: 511b1b37de2e
+Revises:     5e1501dfd333
+Create Date: 2026-07-20 15:35:59.392866
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision = '511b1b37de2e'
+down_revision = '5e1501dfd333'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    dialect = op.get_context().dialect.name
+
+    op.add_column('personal_access_tokens',
+                  sa.Column('creation_date', sa.DateTime(), nullable=True))
+
+    # Due to a bug, previously the last_access column stored the
+    # Personal Access Token's creation date.
+    op.execute("UPDATE personal_access_tokens SET creation_date = last_access")
+
+    # Finally, mark the column as NOT nullable.
+    if dialect == 'sqlite':
+        with op.batch_alter_table('personal_access_tokens') as batch_op:
+            batch_op.alter_column('creation_date',
+                                  existing_type=sa.DateTime(),
+                                  nullable=False)
+    else:
+        op.alter_column('personal_access_tokens', 'creation_date',
+                        existing_type=sa.DateTime(), nullable=False)
+
+
+def downgrade():
+    dialect = op.get_context().dialect.name
+
+    if dialect == 'sqlite':
+        with op.batch_alter_table('personal_access_tokens') as batch_op:
+            batch_op.drop_column('creation_date')
+    else:
+        op.drop_column('personal_access_tokens', 'creation_date')

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -643,28 +643,38 @@ class SessionManager:
                 .filter(PersonalAccessToken.user_name == user_name) \
                 .filter(PersonalAccessToken.token == token) \
                 .limit(1).one_or_none()
+
+            if not personal_access_token:
+                return False
+
+            if personal_access_token.expiration < datetime.now():
+                LOG.info("User '%s' tried to login with an expired "
+                         "Personal Access Token.",
+                         personal_access_token.user_name)
+                raise codechecker_api_shared.ttypes.RequestFailed(
+                    codechecker_api_shared.ttypes.ErrorCode.AUTH_DENIED,
+                    "Personal Access Token is expired!")
+
+            result = {
+                'username': personal_access_token.user_name,
+                'groups': str(personal_access_token.groups).split(";")
+            }
+
+            # Update the timestamp in the database for the
+            # Personal Access Token's last access.
+            personal_access_token.last_access = datetime.now()
+            transaction.commit()
+
+            return result
+        except codechecker_api_shared.ttypes.RequestFailed:
+            raise
         except Exception as e:
             LOG.error("Couldn't check login in the database:")
             LOG.error(str(e))
+            return False
         finally:
             if transaction:
                 transaction.close()
-
-        if not personal_access_token:
-            return False
-
-        if personal_access_token.expiration < datetime.now():
-            LOG.info("User '%s' tried to login with an expired "
-                     "Personal Access Token.",
-                     personal_access_token.user_name)
-            raise codechecker_api_shared.ttypes.RequestFailed(
-                codechecker_api_shared.ttypes.ErrorCode.AUTH_DENIED,
-                "Personal Access Token is expired!")
-
-        return {
-            'username': personal_access_token.user_name,
-            'groups': str(personal_access_token.groups).split(";")
-        }
 
     def __try_auth_dictionary(self, auth_string):
         """


### PR DESCRIPTION
Previously, the personal_access_tokens table's
last_access column was not updated after the token's creation and therefore it reflected its creation date.
With this change, last_access column is now updated after each login, and a new column is added to save the creation date of the Personal Access Token.

The previous schema migration could not finish because the BackgroundTasks status Enum was missing a name, also added that in this patch.