### PR TITLE
[fix] Eliminate silent query limits

### DIFF
--- a/scripts/test/func_template/template_test.py
+++ b/scripts/test/func_template/template_test.py
@@ -26,6 +26,8 @@ from libtest import codechecker
 from libtest import env
 from libtest import project
 
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
+
 
 # This is a test skeleton. The unused variables will be used probably in the
 # actual tests.
@@ -158,7 +160,7 @@ class TestSkeleton(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
     def test_skel(self):

--- a/scripts/thrift/client.py
+++ b/scripts/thrift/client.py
@@ -148,7 +148,7 @@ Python client to communicate with a CodeChecker server.""",
         args, ReportAPI_v6, "CodeCheckerService", "Default", token)
 
     run_filter = None
-    limit = 0
+    limit = ReportAPI_v6.constants.MAX_QUERY_SIZE
     offset = 0
     sort_mode = None
     try:

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -132,8 +132,8 @@ def get_run_tag(client, run_ids: List[int], tag_name: str):
     """Return run tag information for the given tag name in the given runs."""
     run_history_filter = ttypes.RunHistoryFilter()
     run_history_filter.tagNames = [tag_name]
-    run_histories = client.getRunHistory(run_ids, None, None,
-                                         run_history_filter)
+    run_histories = client.getRunHistory(
+        run_ids, constants.MAX_QUERY_SIZE, None, run_history_filter)
 
     return run_histories[0] if run_histories else None
 
@@ -385,13 +385,13 @@ def check_deprecated_arg_usage(args):
                     'help.')
 
 
-def get_run_data(client, run_filter, sort_mode=None,
-                 limit=constants.MAX_QUERY_SIZE):
+def get_run_data(client, run_filter, sort_mode=None):
     """Get all runs based on the given run filter."""
 
     all_runs = []
 
     offset = 0
+    limit = constants.MAX_QUERY_SIZE
     while True:
         runs = runs = client.getRunData(run_filter, limit, offset, sort_mode)
         all_runs.extend(runs)
@@ -522,8 +522,8 @@ def parse_report_filter(client, args):
         # Handle tags (requires API call to resolve tag names to IDs)
         if 'tag' in args:
             run_history_filter = ttypes.RunHistoryFilter(tagNames=args.tag)
-            run_histories = client.getRunHistory(None, None, None,
-                                                 run_history_filter)
+            run_histories = client.getRunHistory(
+                None, constants.MAX_QUERY_SIZE, None, run_history_filter)
             if run_histories:
                 report_filter.runTag = [t.id for t in run_histories]
 
@@ -1555,7 +1555,7 @@ def handle_list_result_types(args):
         checkers = client.getCheckerCounts(run_ids,
                                            report_filter,
                                            None,
-                                           None,
+                                           constants.MAX_QUERY_SIZE,
                                            0)
 
         return dict((res.name, res.count) for res in checkers)
@@ -1588,7 +1588,7 @@ def handle_list_result_types(args):
     all_checkers = client.getCheckerCounts(run_ids,
                                            all_checkers_report_filter,
                                            None,
-                                           None,
+                                           constants.MAX_QUERY_SIZE,
                                            0)
     all_checkers_dict = dict((res.name, res) for res in all_checkers)
 
@@ -1846,7 +1846,8 @@ def handle_list_run_histories(args):
         runs = get_run_data(client, run_filter)
         run_ids = [r.runId for r in runs]
 
-    run_history = client.getRunHistory(run_ids, None, None, None)
+    run_history = client.getRunHistory(
+        run_ids, constants.MAX_QUERY_SIZE, None, None)
 
     if args.output_format == 'json':
         print(CmdLineOutputEncoder().encode(run_history))

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -121,6 +121,13 @@ def verify_limit_range(limit):
 
     Query limit should not be larger than the max allowed value.
     Max is returned if the value is larger than max.
+
+    TODO: It would be nice in the long terms to raise an error when the limit
+    parameter is too big, otherwise the clients aren't notified about capping
+    the results.
+    The client implementation is providing a limit from CodeChecker 6.29. This
+    behavior could be strictly enforced when this version becomes quite
+    outdated.
     """
     max_query_limit = constants.MAX_QUERY_SIZE
     if not limit:

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/FilePathFilter.vue
@@ -148,7 +148,7 @@
 
 <script setup>
 import { ccService, handleThriftError } from "@cc-api";
-import { ReportFilter } from "@cc/report-server-types";
+import { MAX_QUERY_SIZE, ReportFilter } from "@cc/report-server-types";
 import { computed, ref, watch } from "vue";
 
 import {
@@ -309,12 +309,12 @@ function fetchAllFileCounts() {
     const fetchPage = offset => {
       ccService.getClient().getFileCounts(
         baseSelectOptionFilter.runIds.value, reportFilter,
-        baseSelectOptionFilter.cmpData.value, 500, offset,
+        baseSelectOptionFilter.cmpData.value, MAX_QUERY_SIZE, offset,
         handleThriftError(res => {
           const keys = Object.keys(res || {});
           keys.forEach(fp => { allCounts[fp] = res[fp]; });
-          if (keys.length >= 500) {
-            fetchPage(offset + 500);
+          if (keys.length >= MAX_QUERY_SIZE) {
+            fetchPage(offset + MAX_QUERY_SIZE);
           } else {
             allFileCounts.value = Object.assign({}, allCounts);
             resolve();
@@ -437,7 +437,7 @@ function fetchItems(opt={}) {
       _reportFilter,
       baseSelectOptionFilter.cmpData.value,
       _limit,
-      _offset, 
+      _offset,
       handleThriftError(res => {
       // Order the results alphabetically.
         resolve(Object.keys(res).sort((a, b) => {

--- a/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
+++ b/web/server/vue-cli/src/components/Report/ReportInfo/ReportInfo.vue
@@ -220,7 +220,7 @@ import { useReviewStatus } from "@/composables/useReviewStatus";
 import { useSeverity } from "@/composables/useSeverity";
 import { ccService, handleThriftError } from "@cc-api";
 import ReportInfoItem from "@/components/Report/ReportInfo/ReportInfoItem";
-import { Checker } from "@cc/report-server-types";
+import { Checker, RunFilter } from "@cc/report-server-types";
 
 const props = defineProps({
   value: { type: Object, default: null }
@@ -273,8 +273,10 @@ onMounted(function() {
 });
 
 async function fetchRunName() {
-  const runs = await ccService.getRuns([ props.value.runId ]);
-  runName.value = runs[0].name;
+  const runFilter = new RunFilter({ ids: [ props.value.runId ] });
+  ccService.getClient().getRunData(runFilter, 1).then(runs => {
+    runName.value = runs[0].name;
+  });
 }
 
 function formatLabel(key) {

--- a/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatistics.vue
@@ -69,7 +69,6 @@ import { useToCSV } from "@/composables/useToCSV";
 import { ccService, handleThriftError } from "@cc-api";
 import {
   Checker,
-  MAX_QUERY_SIZE,
   ReportFilter,
   RunFilter
 } from "@cc/report-server-types";
@@ -97,7 +96,6 @@ const showRuns = ref({
 });
 const statistics = ref([]);
 const type = ref(null);
-
 
 watch(checker_stat, function(_stat) {
   statistics.value = Object.keys(_stat).map(_checker_id => {
@@ -146,44 +144,14 @@ function downloadCSV() {
   csv.toCSV(_data, "codechecker_checker_coverage_statistics.csv");
 }
 
-async function getRunData() {
-  const _limit = MAX_QUERY_SIZE;
-  let _offset = 0;
-
-  const _filter = new RunFilter({
-    ids: baseStats.runIds.value
-  });
-
-  const _runCount = await new Promise(_resolve => {
-    ccService.getClient().getRunCount(
-      _filter, handleThriftError(_runCnt => {
-        _resolve(_runCnt.toNumber());
-      }));
-  });
-
-  const _runs = [];
-
-  for ( _offset; _offset <= _runCount; _offset+=_limit ) {
-    const _limitedRuns = await new Promise(_resolve => {
-      ccService.getClient().getRunData(
-        _filter, _limit, _offset, null, handleThriftError(_runDataList => {
-          _resolve(_runDataList.map(_runData => ({
-            runId: _runData.runId,
-            runName: _runData.name,
-            codeCheckerVersion: _runData.codeCheckerVersion
-          })));
-        }));
-    });
-    _runs.push(..._limitedRuns);
-  }
-
-  return _runs;
-}
-
 async function fetchStatistics() {
   loading.value = true;
 
-  await fetchRuns();
+  const _run_filter = new RunFilter({
+    ids: baseStats.runIds.value
+  });
+
+  runs.value = await ccService.getRuns(_run_filter);
 
   const _filter = new ReportFilter(baseStats.reportFilter.value);
 
@@ -239,14 +207,6 @@ async function fetchStatistics() {
   }
 
   checker_stat.value = _checker_stat;
-  loading.value = false;
-}
-
-async function fetchRuns() {
-  loading.value = true;
-
-  const _runs = await getRunData();
-  runs.value = _runs;
   loading.value = false;
 }
 

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -100,7 +100,6 @@ import { ccService, handleThriftError } from "@cc-api";
 import {
   Checker,
   Guideline,
-  MAX_QUERY_SIZE,
   ReportFilter,
   RunFilter
 } from "@cc/report-server-types";
@@ -310,49 +309,14 @@ async function getAllGuidelineRules() {
   });
 }
 
-async function getRunData() {
+async function fetchStatistics() {
+  loading.value = true;
+
   const _filter = new RunFilter({
     ids: baseStatistics.runIds.value
   });
 
-  const _runCount = await new Promise(resolve => {
-    ccService.getClient().getRunCount(
-      _filter,
-      handleThriftError(runCnt => {
-        resolve(runCnt.toNumber());
-      })
-    );
-  });
-
-  const _runs = [];
-  const _limit = MAX_QUERY_SIZE;
-  for (let _offset = 0; _offset <= _runCount; _offset+=_limit) {
-    const _limitedRuns = await new Promise(resolve => {
-      ccService.getClient().getRunData(
-        _filter,
-        _limit,
-        _offset,
-        null,
-        handleThriftError(runDataList => {
-          resolve(
-            runDataList.map(runData => ({
-              runId: runData.runId,
-              runName: runData.name,
-              codeCheckerVersion: runData.codeCheckerVersion
-            }))
-          );
-        })
-      );
-    });
-    _runs.push(..._limitedRuns);
-  }
-
-  return _runs;
-}
-
-async function fetchStatistics() {
-  loading.value = true;
-  await fetchRuns();
+  runs.value = await ccService.getRuns(_filter);
 
   await getAllGuidelineRules();
 
@@ -369,13 +333,6 @@ async function fetchStatistics() {
 
   checker_stats.value = checker_stat_result;
   checker_stat(checker_stat_result);
-  loading.value = false;
-}
-
-async function fetchRuns() {
-  loading.value = true;
-  const _runs = await getRunData();
-  runs.value = _runs;
   loading.value = false;
 }
 

--- a/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/Overview.vue
@@ -132,6 +132,7 @@ import { useRoute, useRouter } from "vue-router";
 import TooltipHelpIcon from "@/components/TooltipHelpIcon";
 import { useBaseStatistics } from "@/composables/useBaseStatistics";
 import { ccService, handleThriftError } from "@cc-api";
+import { MAX_QUERY_SIZE } from "@cc/report-server-types";
 
 import FailedFilesDialog from "./FailedFilesDialog";
 import OutstandingReportsChart from "./OutstandingReportsChart";
@@ -231,7 +232,7 @@ function getNumberOfActiveCheckers() {
     reportFilter: _reportFilter,
     cmpData: _cmpData
   } = baseStats.getStatisticsFilters();
-  const _limit = null;
+  const _limit = MAX_QUERY_SIZE;
   const _offset = 0;
 
   return new Promise(_resolve => {

--- a/web/server/vue-cli/src/components/Statistics/StatisticsHelper.js
+++ b/web/server/vue-cli/src/components/Statistics/StatisticsHelper.js
@@ -1,5 +1,6 @@
 import { ccService, handleThriftError } from "@cc-api";
 import {
+  MAX_QUERY_SIZE,
   ReportFilter,
   ReviewStatus,
 } from "@cc/report-server-types";
@@ -32,7 +33,7 @@ function initDiffField(count) {
 }
 
 function getCheckerStatistics(runIds, reportFilter, cmpData) {
-  const limit = null;
+  const limit = MAX_QUERY_SIZE;
   const offset = null;
 
   const queries = reviewStatusVariations.map(q => {

--- a/web/server/vue-cli/src/composables/useAnalysisInfo.js
+++ b/web/server/vue-cli/src/composables/useAnalysisInfo.js
@@ -39,14 +39,13 @@ function decideNegativeCheckerStatusAvailability(
     const filter = new RunFilter({
       ids: [ runId ]
     });
-    ccService.getClient().getRunData(filter, null, null, null,
-      handleThriftError(runDataList => {
-        if (runDataList.length !== 1) return;
+    ccService.getClient().getRunData(filter, 1).then(runDataList => {
+      if (runDataList.length !== 1) return;
 
-        setCheckerStatusUnavailableDueToVersion(
-          analysisInfo,
-          runDataList[0].codeCheckerVersion);
-      }));
+      setCheckerStatusUnavailableDueToVersion(
+        analysisInfo,
+        runDataList[0].codeCheckerVersion);
+    });
   } else if (runId && runHistoryId) {
     const filter = new RunHistoryFilter({
       tagNames: [],

--- a/web/server/vue-cli/src/services/api/cc.service.js
+++ b/web/server/vue-cli/src/services/api/cc.service.js
@@ -30,6 +30,10 @@ class CodeCheckerService extends BaseService {
     super("CodeCheckerService", ServiceClient);
   }
 
+  /**
+   * This function returns the first MAX_QUERY_SIZE number of reports with the
+   * given bug hash.
+   */
   getSameReports(bugHash) {
     const reportFilter = new ReportFilter({ reportHash: [ bugHash ] });
 
@@ -42,8 +46,10 @@ class CodeCheckerService extends BaseService {
       this.getClient().getRunResults(null, MAX_QUERY_SIZE, 0,
         [ sortMode ], reportFilter, null, false,
         handleThriftError(reports => {
-          const runIds = reports.map(report => report.runId);
-          this.getRuns(runIds).then(runs => {
+          const runFilter = new RunFilter({
+            ids: reports.map(report => report.runId)
+          });
+          this.getClient().getRunData(runFilter, MAX_QUERY_SIZE).then(runs => {
             resolve(reports.map(report => {
               const run =
                 runs.find(run => run.runId.equals(report.runId)) || {};
@@ -58,33 +64,38 @@ class CodeCheckerService extends BaseService {
     });
   }
 
-  getRuns(runIds) {
-    const runFilter = new RunFilter({ ids: runIds });
+  async getRuns(runFilter, sortMode) {
+    const runs = [];
+    let offset = 0;
 
-    return new Promise(resolve => {
-      this.getClient().getRunData(runFilter, null, 0, null,
-        handleThriftError(res => {
-          resolve(res);
-        }));
-    });
+    while (true) {
+      const r = await new Promise(resolve => {
+        this.getClient().getRunData(
+          runFilter, MAX_QUERY_SIZE, offset, sortMode,
+          handleThriftError(res => {
+            resolve(res);
+          }));
+      });
+
+      runs.push(...r);
+
+      if (r.length < MAX_QUERY_SIZE)
+        break;
+
+      offset += MAX_QUERY_SIZE;
+    }
+
+    return runs;
   }
 
-  getRunIds(runName) {
+  async getRunIds(runName) {
     const runFilter = new RunFilter({ names: [ runName ] });
-    const limit = null;
-    const offset = null;
-    const sortMode = null;
-
-    return new Promise(resolve => {
-      this.getClient().getRunData(runFilter, limit, offset, sortMode,
-        handleThriftError(runs => {
-          resolve(runs.map(run => run.runId.toNumber() ));
-        }));
-    });
+    const runs = await this.getRuns(runFilter);
+    return runs.map(run => run.runId.toNumber());
   }
 
   async getTags(runIds, tagIds, tagNames, stored) {
-    const limit = null;
+    const limit = MAX_QUERY_SIZE;
     const offset = 0;
 
     const runHistoryFilter = new RunHistoryFilter({

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -429,6 +429,7 @@ import { Pane, Splitpanes } from "splitpanes";
 import { ccService, handleThriftError } from "@cc-api";
 import {
   Checker,
+  MAX_QUERY_SIZE,
   Order,
   ReviewStatus,
   Severity,
@@ -806,7 +807,7 @@ function i64ToNum(val) {
 }
 
 function fetchFileSeverities() {
-  const PAGE = 500;
+  const PAGE = MAX_QUERY_SIZE;
   const allStats = {};
 
   const fetchPage = offset => {

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -197,7 +197,7 @@ body {
 }
 
 .splitpanes__pane {
-  overflow-y: auto;
+  overflow-y: hidden;
   height: 100%;
 }
 

--- a/web/tests/functional/blame/test_blame_info.py
+++ b/web/tests/functional/blame/test_blame_info.py
@@ -20,6 +20,7 @@ import uuid
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Order, \
   ReportFilter, RunFilter, RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 from libtest.thrift_client_to_db import get_all_run_results
 
 from libtest import codechecker
@@ -129,7 +130,8 @@ class TestBlameInfo(unittest.TestCase):
         self.assertIsNotNone(self._cc_client)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        self.test_runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        self.test_runs = \
+            self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
     def test_update_blame_info(self):
         with tempfile.TemporaryDirectory() as proj_dir:
@@ -160,7 +162,8 @@ class TestBlameInfo(unittest.TestCase):
                 self._codechecker_cfg, run_name, proj_dir)
 
             run_filter = RunFilter(names=[run_name], exactMatch=True)
-            runs = self._cc_client.getRunData(run_filter, None, 0, None)
+            runs = self._cc_client.getRunData(
+                run_filter, MAX_QUERY_SIZE, 0, None)
             run_id = runs[0].runId
 
             report_filter = ReportFilter(
@@ -258,7 +261,8 @@ class TestBlameInfo(unittest.TestCase):
             os.chdir(old_pwd)
 
             run_filter = RunFilter(names=[run_name], exactMatch=True)
-            runs = self._cc_client.getRunData(run_filter, None, 0, None)
+            runs = self._cc_client.getRunData(
+                run_filter, MAX_QUERY_SIZE, 0, None)
             run_id = runs[0].runId
 
             report_filter = ReportFilter(

--- a/web/tests/functional/comment/test_comment.py
+++ b/web/tests/functional/comment/test_comment.py
@@ -22,6 +22,7 @@ import unittest
 from codechecker_api_shared.ttypes import RequestFailed
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import CommentData, \
     CommentKind
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -162,7 +163,7 @@ class TestComment(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         self._test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/component/test_component.py
+++ b/web/tests/functional/component/test_component.py
@@ -20,6 +20,7 @@ import uuid
 from codechecker_api_shared.ttypes import Permission
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportFilter
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -156,7 +157,7 @@ class TestComponent(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -246,17 +247,16 @@ class TestComponent(unittest.TestCase):
         the component.
         """
         all_results = self._cc_client.getRunResults(
-            None, 500, 0, None, ReportFilter(), None, False)
+            None, MAX_QUERY_SIZE, 0, None, ReportFilter(), None, False)
 
         r_filter = ReportFilter(componentNames=[c['name'] for c in components])
-        component_results = self._cc_client.getRunResults(None, 500, 0, None,
-                                                          r_filter, None,
-                                                          False)
+        component_results = self._cc_client.getRunResults(
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertNotEqual(len(component_results), 0)
 
         r_filter = ReportFilter(componentNames=[GEN_OTHER_COMPONENT_NAME])
-        other_results = self._cc_client.getRunResults(None, 500, 0, None,
-                                                      r_filter, None, False)
+        other_results = self._cc_client.getRunResults(
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertNotEqual(len(other_results), 0)
 
         self.assertEqual(len(all_results),
@@ -309,7 +309,7 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=[test_component['name']])
         run_results = self._cc_client.getRunResults(None,
-                                                    500,
+                                                    MAX_QUERY_SIZE,
                                                     0,
                                                     None,
                                                     r_filter,
@@ -350,7 +350,7 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=[test_component['name']])
         run_results = self._cc_client.getRunResults(None,
-                                                    500,
+                                                    MAX_QUERY_SIZE,
                                                     0,
                                                     None,
                                                     r_filter,
@@ -404,7 +404,7 @@ class TestComponent(unittest.TestCase):
                                                 test_component2['name']])
 
         run_results = self._cc_client.getRunResults(None,
-                                                    500,
+                                                    MAX_QUERY_SIZE,
                                                     0,
                                                     None,
                                                     r_filter,
@@ -445,7 +445,7 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=[test_component['name']])
         run_results = self._cc_client.getRunResults(None,
-                                                    500,
+                                                    MAX_QUERY_SIZE,
                                                     0,
                                                     None,
                                                     r_filter,
@@ -474,12 +474,12 @@ class TestComponent(unittest.TestCase):
         self.assertEqual(len(components), 0)
 
         all_results = self._cc_client.getRunResults(
-            None, 500, 0, None, ReportFilter(), None, False)
+            None, MAX_QUERY_SIZE, 0, None, ReportFilter(), None, False)
         self.assertIsNotNone(all_results)
 
         r_filter = ReportFilter(componentNames=[GEN_OTHER_COMPONENT_NAME])
-        other_results = self._cc_client.getRunResults(None, 500, 0, None,
-                                                      r_filter, None, False)
+        other_results = self._cc_client.getRunResults(
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
 
         self.assertEqual(len(all_results), len(other_results))
 
@@ -566,7 +566,7 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=['peh'])
         component_results = self._cc_client.getRunResults(
-            None, 500, 0, None, r_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
 
         self.assertEqual(len(component_results), 3)
         self.assertTrue(
@@ -575,14 +575,14 @@ class TestComponent(unittest.TestCase):
 
         r_filter = ReportFilter(componentNames=['pb1cpp'])
         component_results = self._cc_client.getRunResults(
-            None, 500, 0, None, r_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertEqual(len(component_results), 0)
 
         r_filter = ReportFilter(
             componentNames=['pb1cpp'],
             componentMatchesAnyPoint=True)
         component_results = self._cc_client.getRunResults(
-            None, 500, 0, None, r_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertEqual(len(component_results), 1)
         self.assertTrue(
             component_results[0].checkedFile.endswith('path_end.h'))
@@ -614,7 +614,7 @@ class TestComponent(unittest.TestCase):
             fullReportPathInComponent=False
         )
         component_results = self._cc_client.getRunResults(
-            None, 500, 0, None, r_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertEqual(len(component_results), 2)
         self.assertEqual(component_results[0].checkerId, 'core.DivideZero')
         self.assertEqual(component_results[1].checkerId,
@@ -624,7 +624,7 @@ class TestComponent(unittest.TestCase):
             componentNames=['calculate'],
             fullReportPathInComponent=True)
         component_results = self._cc_client.getRunResults(
-            None, 500, 0, None, r_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, r_filter, None, False)
         self.assertEqual(len(component_results), 1)
         self.assertEqual(component_results[0].checkerId,
                          'misc-definitions-in-headers')

--- a/web/tests/functional/db_cleanup/test_db_cleanup.py
+++ b/web/tests/functional/db_cleanup/test_db_cleanup.py
@@ -19,6 +19,7 @@ from shutil import copytree, rmtree
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import CommentData, \
     ReportFilter, ReviewStatus, RunFilter, Severity
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 from codechecker_common.checker_labels import CheckerLabels
 
 from libtest import codechecker
@@ -151,7 +152,7 @@ int f(int x) { return 1 / x; }
         run_filter.names = [run_name]
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         return runs[0].runId
 
     def __get_files_in_report(self, run_name):
@@ -187,7 +188,7 @@ int f(int x) { return 1 / x; }
         run_filter.names = [run_name]
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         run_id = runs[0].runId
 
         reports = self._cc_client.getRunResults(

--- a/web/tests/functional/delete_runs/test_delete_runs.py
+++ b/web/tests/functional/delete_runs/test_delete_runs.py
@@ -26,6 +26,8 @@ from libtest import codechecker
 from libtest import env
 from libtest import project
 
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
+
 
 def run_cmd(cmd, environ):
     proc = subprocess.Popen(
@@ -176,14 +178,16 @@ class TestCmdLineDeletion(unittest.TestCase):
         """
 
         def all_exists(runs):
-            run_names = [run.name for run in
-                         self._cc_client.getRunData(None, None, 0, None)]
+            run_names = [
+                run.name for run in
+                self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)]
             print(run_names)
             return set(runs) <= set(run_names)
 
         def none_exists(runs):
-            run_names = [run.name for run in
-                         self._cc_client.getRunData(None, None, 0, None)]
+            run_names = [
+                run.name for run in
+                self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)]
             return not bool(set(runs).intersection(run_names))
 
         # The config database caches the number of runs in a product. We also
@@ -243,7 +247,7 @@ class TestCmdLineDeletion(unittest.TestCase):
         # Get runs before run 2 by run date.
         run2 = [run for run in self._cc_client.getRunData(
                     None,
-                    None,
+                    MAX_QUERY_SIZE,
                     0,
                     None) if run.name == run2_name][0]
 

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -16,6 +16,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import DetectionStatus, \
     Encoding, ReportFilter
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -97,7 +98,7 @@ class TestDetectionStatus(unittest.TestCase):
         self.assertIsNotNone(self._cc_client)
 
         # Remove all runs before the test cases.
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         if runs:
             run_id = max(map(lambda run: run.runId, runs))
             self._cc_client.removeRun(run_id, None)
@@ -199,7 +200,7 @@ int main()
         self._create_source_file(0)
         self._check_source_file(self._codechecker_cfg)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         run_id = max(run.runId for run in runs)
 
         reports = self._cc_client.getRunResults([run_id],
@@ -358,7 +359,7 @@ int main()
 
         codechecker.store(self._codechecker_cfg, 'hello')
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         run_id = max(run.runId for run in runs)
 
         reports = self._cc_client.getRunResults([run_id],

--- a/web/tests/functional/diff_cmdline/test_diff_cmdline.py
+++ b/web/tests/functional/diff_cmdline/test_diff_cmdline.py
@@ -18,6 +18,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import \
         ReviewStatus, DiffType, ReportFilter, DetectionStatus
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_client.cmd_line_client import \
     get_diff_local_dirs, get_diff_remote_run_local_dir, \
@@ -102,7 +103,8 @@ class TestDiffFromCmdLine(unittest.TestCase):
     # ===-----------------------------------------------------------------=== #
 
     def __remove_all_runs(self):
-        for run_data in self._cc_client.getRunData(None, None, 0, None):
+        for run_data in self._cc_client.getRunData(
+                None, MAX_QUERY_SIZE, 0, None):
             ret = self._cc_client.removeRun(run_data.runId, None)
             self.assertTrue(ret)
             print(f"Successfully removed run '{run_data.name}'.")

--- a/web/tests/functional/diff_local_remote_suppress/__init__.py
+++ b/web/tests/functional/diff_local_remote_suppress/__init__.py
@@ -19,6 +19,8 @@ from libtest import codechecker
 from libtest import env
 from libtest import project
 
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
+
 
 def setup_class_common(workspace_name):
     """
@@ -100,7 +102,7 @@ def setup_class_common(workspace_name):
 
     env.export_test_cfg(test_workspace, test_config)
     cc_client = env.setup_viewer_client(test_workspace)
-    for run_data in cc_client.getRunData(None, None, 0, None):
+    for run_data in cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None):
         cc_client.removeRun(run_data.runId, None)
 
     # Copy "cpp" test project 3 times to different directories.

--- a/web/tests/functional/diff_local_remote_suppress/test_diff_local_remote_suppress_rule.py
+++ b/web/tests/functional/diff_local_remote_suppress/test_diff_local_remote_suppress_rule.py
@@ -20,6 +20,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportFilter, \
     RunFilter, ReviewStatus
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import env
 from libtest.codechecker import get_diff_results
@@ -82,12 +83,13 @@ class DiffLocalRemoteSuppressRule(unittest.TestCase):
         project_orig_run_name = \
             self._test_cfg['codechecker_cfg']['run_names']['test_project_orig']
         run_filter = RunFilter(names=[project_orig_run_name])
-        project_orig_run = \
-            self._cc_client.getRunData(run_filter, None, None, None)[0]
+        project_orig_run = self._cc_client.getRunData(
+            run_filter, MAX_QUERY_SIZE, None, None)[0]
 
         report_filter = ReportFilter(checkerName=[checker_name])
         reports = self._cc_client.getRunResults(
-            [project_orig_run.runId], 500, 0, None, report_filter, None, False)
+            [project_orig_run.runId], MAX_QUERY_SIZE, 0, None, report_filter,
+            None, False)
 
         for report in reports:
             self._cc_client.addReviewStatusRule(

--- a/web/tests/functional/diff_remote/test_diff_remote.py
+++ b/web/tests/functional/diff_remote/test_diff_remote.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import CompareData, \
     DiffType, Order, ReportFilter, ReviewStatus, RunHistoryFilter, \
     RunSortMode, RunSortType, Severity
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_report_converter.report import InvalidFileContentMsg
 
@@ -315,7 +316,7 @@ class DiffRemote(unittest.TestCase):
         run_names = env.get_run_names(self.test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
         self._test_runs = [run for run in runs if run.name in run_names]
 
         # There should be at least two runs for this test.
@@ -345,7 +346,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     ReportFilter(),
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -366,7 +367,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     report_filter,
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -401,7 +402,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.NEW)
 
         diff_res = self._cc_client.getRunResults([base_run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  ReportFilter(),
@@ -421,7 +422,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.RESOLVED)
 
         diff_res = self._cc_client.getRunResults([base_run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  ReportFilter(),
@@ -443,7 +444,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     report_filter,
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -462,7 +463,7 @@ class DiffRemote(unittest.TestCase):
                                diffType=DiffType.UNRESOLVED)
 
         diff_res = self._cc_client.getRunResults([base_run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  ReportFilter(),
@@ -483,7 +484,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     report_filter,
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -564,7 +565,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     ReportFilter(),
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -675,7 +676,7 @@ class DiffRemote(unittest.TestCase):
         diff_res = self._cc_client.getCheckerCounts([base_run_id],
                                                     ReportFilter(),
                                                     cmp_data,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -697,7 +698,7 @@ class DiffRemote(unittest.TestCase):
             self._cc_client.getCheckerCounts([base_run_id],
                                              ReportFilter(),
                                              cmp_data,
-                                             None,
+                                             MAX_QUERY_SIZE,
                                              0)
         diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -727,7 +728,7 @@ class DiffRemote(unittest.TestCase):
                     self._cc_client.getCheckerCounts([base_run_id],
                                                      checker_filter,
                                                      cmp_data,
-                                                     None,
+                                                     MAX_QUERY_SIZE,
                                                      0)
                 diff_dict = dict((res.name, res.count) for res in diff_res)
 
@@ -817,8 +818,8 @@ class DiffRemote(unittest.TestCase):
 
         def get_run_tags(tag_name):
             run_history_filter = RunHistoryFilter(tagNames=[tag_name])
-            return self._cc_client.getRunHistory([run_id], None, None,
-                                                 run_history_filter)
+            return self._cc_client.getRunHistory(
+                [run_id], MAX_QUERY_SIZE, None, run_history_filter)
 
         get_all_tags = get_run_tags('t*')
         self.assertEqual(len(get_all_tags), 3)
@@ -837,7 +838,7 @@ class DiffRemote(unittest.TestCase):
                                runTag=[new_tag_id])
 
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,
@@ -850,7 +851,7 @@ class DiffRemote(unittest.TestCase):
 
         cmp_data.diffType = DiffType.RESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,
@@ -863,7 +864,7 @@ class DiffRemote(unittest.TestCase):
 
         cmp_data.diffType = DiffType.UNRESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,
@@ -877,8 +878,8 @@ class DiffRemote(unittest.TestCase):
         """
         d = datetime(1992, 1, 1)
         tag_filter = ReportFilter(openReportsDate=int(d.timestamp()))
-        res = self._cc_client.getRunResults(None, 500, 0, [], tag_filter,
-                                            None, False)
+        res = self._cc_client.getRunResults(
+            None, MAX_QUERY_SIZE, 0, [], tag_filter, None, False)
 
         self.assertEqual(len(res), 0)
 
@@ -888,8 +889,8 @@ class DiffRemote(unittest.TestCase):
 
         def get_run_tags(tag_name):
             run_history_filter = RunHistoryFilter(tagNames=[tag_name])
-            return self._cc_client.getRunHistory([run_id], None, None,
-                                                 run_history_filter)
+            return self._cc_client.getRunHistory(
+                [run_id], MAX_QUERY_SIZE, None, run_history_filter)
 
         get_all_tags = get_run_tags('t*')
         self.assertEqual(len(get_all_tags), 3)
@@ -910,7 +911,7 @@ class DiffRemote(unittest.TestCase):
                                openReportsDate=new_tag_timestamp)
 
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,
@@ -923,7 +924,7 @@ class DiffRemote(unittest.TestCase):
 
         cmp_data.diffType = DiffType.RESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,
@@ -936,7 +937,7 @@ class DiffRemote(unittest.TestCase):
 
         cmp_data.diffType = DiffType.UNRESOLVED
         diff_res = self._cc_client.getRunResults([run_id],
-                                                 500,
+                                                 MAX_QUERY_SIZE,
                                                  0,
                                                  [],
                                                  tag_filter,

--- a/web/tests/functional/dynamic_results/test_dynamic_results.py
+++ b/web/tests/functional/dynamic_results/test_dynamic_results.py
@@ -23,6 +23,7 @@ from libtest import project
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import \
     Order, Pair, ReportFilter, SortMode, SortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 
 class DynamicResults(unittest.TestCase):
@@ -100,14 +101,15 @@ class DynamicResults(unittest.TestCase):
         Test if the reports can be sorted by their "timestamp" attribute.
         """
         results = self._cc_client.getRunResults(
-            None, 500, 0, None, ReportFilter(), None, False)
+            None, MAX_QUERY_SIZE, 0, None, ReportFilter(), None, False)
 
         self.assertEqual(len(results), 6)
 
         sort_timestamp = SortMode(SortType.TIMESTAMP, Order.ASC)
 
         results = self._cc_client.getRunResults(
-            None, 500, 0, [sort_timestamp], ReportFilter(), None, False)
+            None, MAX_QUERY_SIZE, 0, [sort_timestamp], ReportFilter(),
+            None, False)
 
         # At least one report has a timestamp.
         # Needed for the next sorting test.
@@ -132,7 +134,7 @@ class DynamicResults(unittest.TestCase):
             second='TC-1')])
 
         results = self._cc_client.getRunResults(
-            None, 500, 0, None, testcase_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, testcase_filter, None, False)
 
         self.assertEqual(len(results), 3)
 
@@ -145,7 +147,7 @@ class DynamicResults(unittest.TestCase):
             second='TC-*')])
 
         results = self._cc_client.getRunResults(
-            None, 500, 0, None, testcase_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, None, testcase_filter, None, False)
 
         self.assertEqual(len(results), 5)
 
@@ -175,7 +177,7 @@ class DynamicResults(unittest.TestCase):
         """Test that the unique path hash is calculated when two reports differ
         only in their annotations."""
         results = self._cc_client.getRunResults(
-            None, 500, 0, None, ReportFilter(), None, False)
+            None, MAX_QUERY_SIZE, 0, None, ReportFilter(), None, False)
 
         # The main.c_lang-tidy<blabla>.plist test file contains three
         # bugprone-sizeof-expression reports. Two of them differ in their

--- a/web/tests/functional/export_import/test_export_import.py
+++ b/web/tests/functional/export_import/test_export_import.py
@@ -22,6 +22,7 @@ import tempfile
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import CommentData, \
     ReviewStatus, CommentKind, RunFilter
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -162,7 +163,7 @@ class TestExport(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         self.test_runs = [run for run in runs if run.name in run_names]
 
     def test_export_import(self):

--- a/web/tests/functional/extended_report_data/test_extended_report_data.py
+++ b/web/tests/functional/extended_report_data/test_extended_report_data.py
@@ -22,6 +22,7 @@ from libtest import project
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReportFilter, \
     RunFilter, ExtendedReportDataType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 
 class TestExtendedReportData(unittest.TestCase):
@@ -113,7 +114,7 @@ class TestExtendedReportData(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -128,11 +129,11 @@ class TestExtendedReportData(unittest.TestCase):
         run_filter.names = [run_name]
         run_filter.exactMatch = True
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         run_id = runs[0].runId
 
         return self._cc_client.getRunResults(
-            [run_id], None, 0, [], ReportFilter(), None, False)
+            [run_id], MAX_QUERY_SIZE, 0, [], ReportFilter(), None, False)
 
     def test_notes(self):
         """

--- a/web/tests/functional/products/test_config_db_share.py
+++ b/web/tests/functional/products/test_config_db_share.py
@@ -25,6 +25,7 @@ from codechecker_api_shared.ttypes import RequestFailed
 
 from codechecker_api.ProductManagement_v6.ttypes import ProductConfiguration
 from codechecker_api.ProductManagement_v6.ttypes import DatabaseConnection
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_web.shared import convert
 
@@ -101,7 +102,7 @@ class TestProductConfigShare(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace_main)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -209,13 +210,16 @@ class TestProductConfigShare(unittest.TestCase):
         self.assertEqual(store_res, 0, "Storing the test project failed.")
 
         cc_client_2 = env.setup_viewer_client(self.test_workspace_secondary)
-        self.assertEqual(len(cc_client_2.getRunData(None, None, 0, None)), 1,
-                         "There should be a run present in the new server.")
+        self.assertEqual(
+            len(cc_client_2.getRunData(None, MAX_QUERY_SIZE, 0, None)),
+            1,
+            "There should be a run present in the new server.")
 
-        self.assertEqual(len(self._cc_client.getRunData(None, None, 0, None)),
-                         1,
-                         "There should be a run present in the database when "
-                         "connected through the main server.")
+        self.assertEqual(
+            len(self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)),
+            1,
+            "There should be a run present in the database when "
+            "connected through the main server.")
 
         # Remove the product through the main server.
         p_id = self._root_client.getProducts('producttest_second', None)[0].id

--- a/web/tests/functional/products/test_products.py
+++ b/web/tests/functional/products/test_products.py
@@ -21,6 +21,7 @@ from codechecker_api_shared.ttypes import DBStatus
 from codechecker_api.ProductManagement_v6.ttypes import ProductConfiguration
 from codechecker_api.ProductManagement_v6.ttypes import DatabaseConnection
 from codechecker_api.ProductManagement_v6.ttypes import Confidentiality
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_web.shared import convert
 
@@ -74,7 +75,7 @@ class TestProducts(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         test_runs = [run for run in runs if run.name in run_names]
 
         self.assertEqual(len(test_runs), 1,
@@ -320,7 +321,7 @@ class TestProducts(unittest.TestCase):
         # There is no schema initialization if the product database
         # was changed. The inital schema needs to be created manually
         # for the new database.
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         self.assertIsNone(runs)
 
         # Connect back to the old database.
@@ -333,7 +334,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old database name.")
 
         # The old database should have its data available again.
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")
@@ -369,7 +370,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save new endpoint.")
 
         # The old product is gone. Thus, connection should NOT happen.
-        res = self._cc_client.getRunData(None, None, 0, None)
+        res = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         self.assertIsNone(res)
 
         # The new product should connect and have the data.
@@ -381,8 +382,9 @@ class TestProducts(unittest.TestCase):
             product=new_endpoint,  # Use the new product URL.
             endpoint='/CodeCheckerService',
             session_token=token)
-        self.assertEqual(len(new_client.getRunData(None, None, 0, None)), 1,
-                         "The new product did not serve the stored data.")
+        self.assertEqual(
+            len(new_client.getRunData(None, MAX_QUERY_SIZE, 0, None)), 1,
+            "The new product did not serve the stored data.")
 
         # Set back to the old endpoint.
         config.endpoint = old_endpoint
@@ -394,7 +396,7 @@ class TestProducts(unittest.TestCase):
                          "Server didn't save back to old endpoint.")
 
         # The old product should have its data available again.
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
         self.assertEqual(
             len(runs), 1,
             "We connected to old database but the run was missing.")

--- a/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
+++ b/web/tests/functional/report_viewer_api/test_get_lines_in_file.py
@@ -19,6 +19,7 @@ from libtest import env
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Encoding, \
     LinesInFilesRequested, Order, ReportFilter, RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_web.shared import convert
 
@@ -51,7 +52,7 @@ class TestGetLinesInFile(unittest.TestCase):
         run_names = env.get_run_names(test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/report_viewer_api/test_get_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_get_run_results.py
@@ -24,6 +24,7 @@ import codecs
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Encoding, Checker, \
     Guideline, Order, ReportFilter, SortMode, SortType, RunFilter, \
     RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from codechecker_web.shared import convert
 
@@ -62,7 +63,7 @@ class RunResults(unittest.TestCase):
         run_names = env.get_run_names(test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -538,7 +539,8 @@ class RunResults(unittest.TestCase):
             self.assertEqual(ret, 0)
 
             run_filter = RunFilter(names=[run_name], exactMatch=True)
-            runs = self._cc_client.getRunData(run_filter, None, 0, None)
+            runs = self._cc_client.getRunData(
+                run_filter, MAX_QUERY_SIZE, 0, None)
             self.assertEqual(len(runs), 1)
             run_id = runs[0].runId
 

--- a/web/tests/functional/report_viewer_api/test_hash_clash.py
+++ b/web/tests/functional/report_viewer_api/test_hash_clash.py
@@ -25,6 +25,7 @@ from libtest import codechecker
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Encoding, \
     RunFilter, ReportFilter
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from . import setup_class_common, teardown_class_common
 
@@ -93,14 +94,14 @@ class HashClash(unittest.TestCase):
         Remove the run which was stored by this test case.
         """
         run_filter = RunFilter(names=[self._run_name], exactMatch=True)
-        runs = self._report.getRunData(run_filter, None, 0, None)
+        runs = self._report.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         run_id = runs[0].runId
 
         # Remove the run.
         self._report.removeRun(run_id, None)
 
     def _reports_for_latest_run(self):
-        runs = self._report.getRunData(None, None, 0, None)
+        runs = self._report.getRunData(None, MAX_QUERY_SIZE, 0, None)
         max_run_id = max(run.runId for run in runs)
         return self._report.getRunResults([max_run_id],
                                           100,

--- a/web/tests/functional/report_viewer_api/test_remove_run_results.py
+++ b/web/tests/functional/report_viewer_api/test_remove_run_results.py
@@ -18,6 +18,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Order, \
     ReportFilter, RunFilter, RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -56,7 +57,7 @@ class RemoveRunResults(unittest.TestCase):
         run_names = env.get_run_names(test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -78,7 +79,8 @@ class RemoveRunResults(unittest.TestCase):
 
         run_filter = RunFilter(names=['remove_run_results'], exactMatch=True)
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(run_filter, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(
+            run_filter, MAX_QUERY_SIZE, 0, sort_mode)
         self.assertEqual(len(runs), 1)
 
         run_id = runs[0].runId

--- a/web/tests/functional/report_viewer_api/test_report_counting.py
+++ b/web/tests/functional/report_viewer_api/test_report_counting.py
@@ -18,6 +18,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import DetectionStatus, \
     ReportFilter, ReviewStatus, Severity, RunSortMode, RunSortType, Order
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import env
 
@@ -60,7 +61,7 @@ class TestReportFilter(unittest.TestCase):
         run_names = env.get_run_names(test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         self._test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in self._test_runs]
@@ -142,7 +143,7 @@ class TestReportFilter(unittest.TestCase):
         checker_counts = self._cc_client.getCheckerCounts([runid],
                                                           ReportFilter(),
                                                           None,
-                                                          None,
+                                                          MAX_QUERY_SIZE,
                                                           0)
         checkers_dict = dict((res.name, res.count) for res in checker_counts)
 
@@ -158,7 +159,7 @@ class TestReportFilter(unittest.TestCase):
         checker_counts = self._cc_client.getCheckerCounts([runid],
                                                           core_filter,
                                                           None,
-                                                          None,
+                                                          MAX_QUERY_SIZE,
                                                           0)
         checkers_dict = dict((res.name, res.count) for res in checker_counts)
 
@@ -176,7 +177,7 @@ class TestReportFilter(unittest.TestCase):
         checker_counts = self._cc_client.getCheckerCounts([runid],
                                                           ReportFilter(),
                                                           None,
-                                                          None,
+                                                          MAX_QUERY_SIZE,
                                                           0)
         checkers_dict = dict((res.name, res.count) for res in checker_counts)
 
@@ -190,7 +191,7 @@ class TestReportFilter(unittest.TestCase):
         checker_counts = self._cc_client.getCheckerCounts(self._runids,
                                                           ReportFilter(),
                                                           None,
-                                                          None,
+                                                          MAX_QUERY_SIZE,
                                                           0)
         checkers_dict = dict((res.name, res.count) for res in checker_counts)
 
@@ -209,7 +210,7 @@ class TestReportFilter(unittest.TestCase):
         checker_counts = self._cc_client.getCheckerCounts(self._runids,
                                                           core_filter,
                                                           None,
-                                                          None,
+                                                          MAX_QUERY_SIZE,
                                                           0)
         checkers_dict = dict((res.name, res.count) for res in checker_counts)
 
@@ -273,7 +274,7 @@ class TestReportFilter(unittest.TestCase):
         """
         runid = self._runids[0]
         file_counts = self._cc_client.getFileCounts([runid], ReportFilter(),
-                                                    None, None, 0)
+                                                    None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_counts.items()}
 
         print(res)
@@ -286,7 +287,7 @@ class TestReportFilter(unittest.TestCase):
         """
         runid = self._runids[1]
         file_counts = self._cc_client.getFileCounts([runid], ReportFilter(),
-                                                    None, None, 0)
+                                                    None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_counts.items()}
 
         print(res)
@@ -300,7 +301,7 @@ class TestReportFilter(unittest.TestCase):
         file_counts = self._cc_client.getFileCounts(self._runids,
                                                     ReportFilter(),
                                                     None,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
         res = {get_filename(k): v for k, v in file_counts.items()}
 
@@ -322,7 +323,7 @@ class TestReportFilter(unittest.TestCase):
         file_counts = self._cc_client.getFileCounts(self._runids,
                                                     null_stack_filter,
                                                     None,
-                                                    None,
+                                                    MAX_QUERY_SIZE,
                                                     0)
 
         res = {get_filename(k): v for k, v in file_counts.items()}
@@ -351,7 +352,7 @@ class TestReportFilter(unittest.TestCase):
         """
         runid = self._runids[0]
         file_summary = self._cc_client.getFileCountsSummary(
-            [runid], ReportFilter(), None, None, 0)
+            [runid], ReportFilter(), None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_summary.items()}
 
         self.assertEqual(len(res), len(self.run1_files))
@@ -365,7 +366,7 @@ class TestReportFilter(unittest.TestCase):
         """
         runid = self._runids[1]
         file_summary = self._cc_client.getFileCountsSummary(
-            [runid], ReportFilter(), None, None, 0)
+            [runid], ReportFilter(), None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_summary.items()}
 
         self.assertEqual(len(res), len(self.run2_files))
@@ -378,7 +379,7 @@ class TestReportFilter(unittest.TestCase):
         Get all the file count summaries for run1 and run2.
         """
         file_summary = self._cc_client.getFileCountsSummary(
-            self._runids, ReportFilter(), None, None, 0)
+            self._runids, ReportFilter(), None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_summary.items()}
 
         r1_count = Counter(self.run1_files)
@@ -397,7 +398,7 @@ class TestReportFilter(unittest.TestCase):
         """
         runid = self._runids[0]
         file_summary = self._cc_client.getFileCountsSummary(
-            [runid], ReportFilter(), None, None, 0)
+            [runid], ReportFilter(), None, MAX_QUERY_SIZE, 0)
 
         severity_totals = defaultdict(int)
         for summary in file_summary.values():
@@ -417,7 +418,7 @@ class TestReportFilter(unittest.TestCase):
             filepath=["*null_dereference.cpp", "*stack_address_escape.cpp"])
 
         file_summary = self._cc_client.getFileCountsSummary(
-            self._runids, null_stack_filter, None, None, 0)
+            self._runids, null_stack_filter, None, MAX_QUERY_SIZE, 0)
         res = {get_filename(k): v for k, v in file_summary.items()}
 
         null_r1 = {k: v for k, v in self.run1_files.items()
@@ -447,19 +448,19 @@ class TestReportFilter(unittest.TestCase):
         run1_msgs = self._cc_client.getCheckerMsgCounts([self._runids[0]],
                                                         ReportFilter(),
                                                         None,
-                                                        None,
+                                                        MAX_QUERY_SIZE,
                                                         0)
 
         run2_msgs = self._cc_client.getCheckerMsgCounts([self._runids[1]],
                                                         ReportFilter(),
                                                         None,
-                                                        None,
+                                                        MAX_QUERY_SIZE,
                                                         0)
 
         run1_run2_msgs = self._cc_client.getCheckerMsgCounts(self._runids,
                                                              ReportFilter(),
                                                              None,
-                                                             None,
+                                                             MAX_QUERY_SIZE,
                                                              0)
 
         r1_checker_msg = Counter(run1_msgs)
@@ -632,7 +633,7 @@ class TestReportFilter(unittest.TestCase):
         new_reports = self._cc_client.getCheckerCounts([runid],
                                                        new_filter,
                                                        None,
-                                                       None,
+                                                       MAX_QUERY_SIZE,
                                                        0)
         checkers_dict = dict((res.name, res.count) for res in new_reports)
 
@@ -659,7 +660,7 @@ class TestReportFilter(unittest.TestCase):
         resolved_reports = self._cc_client.getCheckerCounts([runid],
                                                             resolved_filter,
                                                             None,
-                                                            None,
+                                                            MAX_QUERY_SIZE,
                                                             0)
         checkers_dict = dict((res.name, res.count) for res in resolved_reports)
 
@@ -677,7 +678,7 @@ class TestReportFilter(unittest.TestCase):
             self._cc_client.getCheckerCounts([runid],
                                              unresolved_filter,
                                              None,
-                                             None,
+                                             MAX_QUERY_SIZE,
                                              0)
         checkers_dict = dict((res.name, res.count)
                              for res in unresolved_reports)
@@ -695,7 +696,7 @@ class TestReportFilter(unittest.TestCase):
         reopened_reports = self._cc_client.getCheckerCounts([runid],
                                                             reopen_filter,
                                                             None,
-                                                            None,
+                                                            MAX_QUERY_SIZE,
                                                             0)
         checkers_dict = dict((res.name, res.count) for res in reopened_reports)
         self.assertDictEqual({}, checkers_dict)
@@ -707,19 +708,19 @@ class TestReportFilter(unittest.TestCase):
         Run name is randomly generated for all of the test runs.
         """
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         separate_report_counts = 0
         for run in runs:
             run_report_count = self._cc_client.getRunReportCounts(
-                [run.runId], ReportFilter(), None, 0)
+                [run.runId], ReportFilter(), MAX_QUERY_SIZE, 0)
             # Should return the count for only one run.
             self.assertEqual(len(run_report_count), 1)
             separate_report_counts += run_report_count[0].reportCount
 
         all_report_counts = 0
-        report_counts = \
-            self._cc_client.getRunReportCounts([], ReportFilter(), None, 0)
+        report_counts = self._cc_client.getRunReportCounts(
+            [], ReportFilter(), MAX_QUERY_SIZE, 0)
 
         for rc in report_counts:
             all_report_counts += rc.reportCount

--- a/web/tests/functional/report_viewer_api/test_report_filter.py
+++ b/web/tests/functional/report_viewer_api/test_report_filter.py
@@ -19,6 +19,7 @@ import unittest
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import BugPathLengthRange, \
     DateInterval, DetectionStatus, ReportFilter, ReviewStatus, Severity, \
     ReportDate, RunSortMode, RunSortType, Order
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import env
 
@@ -61,7 +62,7 @@ class TestReportFilter(unittest.TestCase):
         run_names = env.get_run_names(test_workspace)
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         test_runs = [run for run in runs if run.name in run_names]
         self._runids = [r.runId for r in test_runs]
@@ -119,10 +120,8 @@ class TestReportFilter(unittest.TestCase):
             sev = get_severity_level(severity)
             sev_f = ReportFilter(severity=[sev])
 
-            run_result_count = self._cc_client.getRunResultCount(
-                [runid], sev_f, None)
             run_results = self._cc_client.getRunResults(
-                [runid], run_result_count, 0, sort_types, sev_f, None,
+                [runid], MAX_QUERY_SIZE, 0, sort_types, sev_f, None,
                 False)
             self.assertIsNotNone(run_results)
             self.assertEqual(test_result_count, len(run_results))
@@ -142,7 +141,7 @@ class TestReportFilter(unittest.TestCase):
                 cid_f = ReportFilter(checkerName=[checker_id_filter])
 
                 run_results = self._cc_client.getRunResults([runid],
-                                                            500,
+                                                            MAX_QUERY_SIZE,
                                                             0,
                                                             sort_types,
                                                             cid_f,
@@ -267,7 +266,7 @@ class TestReportFilter(unittest.TestCase):
                     [runid], s_f, None)
 
                 run_results = self._cc_client.getRunResults([runid],
-                                                            run_result_count,
+                                                            MAX_QUERY_SIZE,
                                                             0,
                                                             sort_types,
                                                             s_f,
@@ -288,14 +287,14 @@ class TestReportFilter(unittest.TestCase):
 
         # Get unique results.
         run_results = self._cc_client.getRunResults(
-            None, 500, 0, sort_types, unique_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, sort_types, unique_filter, None, False)
         unique_result_count = self._cc_client.getRunResultCount(
             None, unique_filter, None)
         unique_bughash = set(res.bugHash for res in run_results)
 
         # Get simple results.
         run_results = self._cc_client.getRunResults(
-            None, 500, 0, sort_types, simple_filter, None, False)
+            None, MAX_QUERY_SIZE, 0, sort_types, simple_filter, None, False)
         simple_result_count = self._cc_client.getRunResultCount(
             None, simple_filter, None)
         simple_bughash = set(res.bugHash for res in run_results)
@@ -341,7 +340,7 @@ class TestReportFilter(unittest.TestCase):
             f = ReportFilter(bugPathLength=bug_path_len_filter)
 
             run_results = self._cc_client.getRunResults(self._runids,
-                                                        None,
+                                                        MAX_QUERY_SIZE,
                                                         0,
                                                         sort_types,
                                                         f,
@@ -372,16 +371,15 @@ class TestReportFilter(unittest.TestCase):
         detected = DateInterval(before=int(before), after=int(after))
         report_filter = ReportFilter(date=ReportDate(detected=detected))
 
-        run_results = self._cc_client.getRunResults(self._runids, None, 0,
-                                                    None, report_filter, None,
-                                                    False)
+        run_results = self._cc_client.getRunResults(
+            self._runids, MAX_QUERY_SIZE, 0, None, report_filter, None, False)
         self.assertEqual(len(run_results), 47)
 
     def test_fix_date_filters(self):
         """ Filter by fix dates. """
         report_filter = ReportFilter(
             detectionStatus=[DetectionStatus.OFF])
-        run_results = self._cc_client.getRunResults(None, None, 0,
+        run_results = self._cc_client.getRunResults(None, MAX_QUERY_SIZE, 0,
                                                     None, report_filter, None,
                                                     False)
         self.assertNotEqual(len(run_results), 0)
@@ -395,7 +393,7 @@ class TestReportFilter(unittest.TestCase):
         fixed = DateInterval(before=int(before), after=int(after))
         report_filter = ReportFilter(date=ReportDate(fixed=fixed))
 
-        run_results = self._cc_client.getRunResults(None, None, 0,
+        run_results = self._cc_client.getRunResults(None, MAX_QUERY_SIZE, 0,
                                                     None, report_filter, None,
                                                     False)
         self.assertNotEqual(len(run_results), 0)
@@ -416,7 +414,7 @@ class TestReportFilter(unittest.TestCase):
                 an_f = ReportFilter(analyzerNames=[analyzer_name_filter])
 
                 run_results = self._cc_client.getRunResults([runid],
-                                                            500,
+                                                            MAX_QUERY_SIZE,
                                                             0,
                                                             sort_types,
                                                             an_f,

--- a/web/tests/functional/report_viewer_api/test_run_data.py
+++ b/web/tests/functional/report_viewer_api/test_run_data.py
@@ -22,6 +22,7 @@ from codechecker_api.codeCheckerDBAccess_v6.ttypes import \
     DetectionStatus, \
     Order, \
     ReportFilter, RunFilter, RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from . import setup_class_common, teardown_class_common
 
@@ -56,7 +57,7 @@ class TestRunData(unittest.TestCase):
         if run_name_filter is not None:
             run_filter.names = [run_name_filter]
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         return [run for run in runs if run.name in self._run_names]
 
     def test_filter_run_names(self):
@@ -126,14 +127,14 @@ class TestRunData(unittest.TestCase):
         """
         # Sort runs in ascending order.
         sort_mode = RunSortMode(RunSortType.DURATION, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         for i in range(len(runs) - 1):
             self.assertTrue(runs[i].duration <= runs[i + 1].duration)
 
         # Sort runs in descending order.
         sort_mode = RunSortMode(RunSortType.DURATION, Order.DESC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         for i in range(len(runs) - 1):
             self.assertTrue(runs[i].duration >= runs[i + 1].duration)
@@ -144,14 +145,14 @@ class TestRunData(unittest.TestCase):
         """
         # Sort runs by number of unresolved reports field.
         sort_mode = RunSortMode(RunSortType.UNRESOLVED_REPORTS, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         for i in range(len(runs) - 1):
             self.assertTrue(runs[i].resultCount <= runs[i + 1].resultCount)
 
         # Sort runs by date field.
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         for i in range(len(runs) - 1):
             date1 = datetime.strptime(runs[i].runDate,
@@ -162,7 +163,7 @@ class TestRunData(unittest.TestCase):
 
         # Sort runs by CodeChecker version field.
         sort_mode = RunSortMode(RunSortType.CC_VERSION, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
         for i in range(len(runs) - 1):
             cc_version1 = runs[i].codeCheckerVersion
@@ -173,7 +174,7 @@ class TestRunData(unittest.TestCase):
         # code because Python and SQL compare strings differently if it
         # contains special characters.
         sort_mode = RunSortMode(RunSortType.NAME, Order.ASC)
-        self._cc_client.getRunData(None, None, 0, sort_mode)
+        self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
 
     def test_analysis_info(self):
         """

--- a/web/tests/functional/review_status/test_review_status.py
+++ b/web/tests/functional/review_status/test_review_status.py
@@ -25,6 +25,7 @@ from codechecker_api.codeCheckerDBAccess_v6.ttypes import CommentKind, \
     DetectionStatus, Order, ReviewStatus, ReviewStatusRule, \
     ReviewStatusRuleFilter, ReviewStatusRuleSortMode, \
     ReviewStatusRuleSortType, RunFilter
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import env, codechecker, plist_test, project
 from libtest.thrift_client_to_db import get_all_run_results
@@ -128,7 +129,7 @@ class TestReviewStatus(unittest.TestCase):
         # get the current run data
         run_filter = RunFilter(names=run_names, exactMatch=True)
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 
@@ -341,7 +342,7 @@ class TestReviewStatus(unittest.TestCase):
         # Run data for the run created by this test case.
         run_filter = RunFilter(names=[test_project_name], exactMatch=True)
 
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         run = runs[0]
         runid = run.runId
         logging.debug('Get all run results from the db for runid: %s',
@@ -534,7 +535,7 @@ class TestReviewStatus(unittest.TestCase):
         # should match the ones in project_info.json.
 
         run_filter = RunFilter(names=[test_project_name1], exactMatch=True)
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         runid1 = next(r.runId for r in runs if r.name == test_project_name1)
 
         reports1 = get_all_run_results(self._cc_client, runid1)
@@ -647,7 +648,7 @@ class TestReviewStatus(unittest.TestCase):
             review_status_rule_after.reviewData.date)
 
         run_filter = RunFilter(names=[test_project_name2], exactMatch=True)
-        runs = self._cc_client.getRunData(run_filter, None, 0, None)
+        runs = self._cc_client.getRunData(run_filter, MAX_QUERY_SIZE, 0, None)
         runid2 = next(r.runId for r in runs if r.name == test_project_name2)
 
         reports2 = get_all_run_results(self._cc_client, runid2)
@@ -802,7 +803,8 @@ int main() {
             """
             run_filter = RunFilter(
                 names=["review_and_detection_status"], exactMatch=True)
-            runs = self._cc_client.getRunData(run_filter, None, 0, None)
+            runs = self._cc_client.getRunData(
+                run_filter, MAX_QUERY_SIZE, 0, None)
             runid = next(
                 r.runId for r in runs
                 if r.name == "review_and_detection_status")

--- a/web/tests/functional/run_tag/test_run_tag.py
+++ b/web/tests/functional/run_tag/test_run_tag.py
@@ -16,6 +16,7 @@ import unittest
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Order, \
     ReportFilter, RunSortMode, RunSortType
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -144,7 +145,7 @@ int main()
         codechecker.check_and_store(self._codechecker_cfg,
                                     run_name, self._test_dir)
 
-    def __get_run_tag_counts(self, run_id, limit=None, offset=0):
+    def __get_run_tag_counts(self, run_id, limit=MAX_QUERY_SIZE, offset=0):
         """
         Get run history tag for the given run.
         """
@@ -201,7 +202,7 @@ int main()
         # Get the run names which belong to this test
 
         sort_mode = RunSortMode(RunSortType.DATE, Order.ASC)
-        runs = self._cc_client.getRunData(None, None, 0, sort_mode)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, sort_mode)
         test_run_ids = [run.runId for run in runs]
 
         self.assertEqual(len(test_run_ids), 2)

--- a/web/tests/functional/skip/test_skip.py
+++ b/web/tests/functional/skip/test_skip.py
@@ -21,10 +21,11 @@ from libtest.debug_printer import print_run_results
 from libtest.thrift_client_to_db import get_all_run_results
 from libtest.result_compare import find_all
 
-
 from libtest import codechecker
 from libtest import env
 from libtest import project
+
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 
 def _generate_skip_list_file(skip_list_file):
@@ -174,7 +175,7 @@ class TestSkip(unittest.TestCase):
         # Get the run names which belong to this test.
         run_names = env.get_run_names(self.test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/suppress/test_suppress_generation.py
+++ b/web/tests/functional/suppress/test_suppress_generation.py
@@ -21,6 +21,7 @@ import unittest
 import uuid
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import ReviewStatus
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 from libtest import codechecker
 from libtest import env
@@ -185,7 +186,7 @@ class TestSuppress(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 

--- a/web/tests/functional/update/test_update_mode.py
+++ b/web/tests/functional/update/test_update_mode.py
@@ -26,6 +26,7 @@ from libtest.debug_printer import print_run_results
 from libtest.thrift_client_to_db import get_all_run_results
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import DetectionStatus
+from codechecker_api.codeCheckerDBAccess_v6.constants import MAX_QUERY_SIZE
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -117,7 +118,7 @@ class TestUpdate(unittest.TestCase):
         # Get the run names which belong to this test
         run_names = env.get_run_names(self._test_workspace)
 
-        runs = self._cc_client.getRunData(None, None, 0, None)
+        runs = self._cc_client.getRunData(None, MAX_QUERY_SIZE, 0, None)
 
         test_runs = [run for run in runs if run.name in run_names]
 


### PR DESCRIPTION
Many report_server API functions have a limit parameter for limiting the number of results. When the parameter is 0 or None, then the MAX_QUERY_SIZE is used which is currently 500.

Silently limiting the results may cause practical problems, too. For example, when we filter on runs with a joker character (e.g. myrun*) then the results from the first 500 runs return only.