### PR TITLE
[gui] Fix statistics table coloring

### DIFF
--- a/web/server/vue-cli/package-lock.json
+++ b/web/server/vue-cli/package-lock.json
@@ -168,6 +168,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2186,6 +2187,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2209,6 +2211,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5253,6 +5256,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
       "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.25",
@@ -5620,6 +5624,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5664,6 +5669,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6106,6 +6112,7 @@
       "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^28.1.3",
         "@types/babel__core": "^7.1.14",
@@ -6744,6 +6751,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -6997,6 +7005,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7246,6 +7255,7 @@
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
       "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -7524,6 +7534,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8541,6 +8552,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8699,6 +8711,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11325,6 +11338,7 @@
       "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^28.1.3",
         "@jest/types": "^28.1.3",
@@ -14506,6 +14520,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15871,6 +15886,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -17846,6 +17862,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17977,7 +17994,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -18289,6 +18307,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",
@@ -18337,6 +18356,7 @@
       "integrity": "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -18539,6 +18559,7 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.8.tgz",
       "integrity": "sha512-gvmOWeLd6CG7LVh2Qonft5YrIb7MpbKZglRjg0ItEloSbu6hfUII2RZmRSVxGKYdiXTf7J1hI3BRSHr8J9LkxA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -18679,6 +18700,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
       "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -18845,6 +18867,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18929,6 +18952,7 @@
       "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18987,6 +19011,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19090,6 +19115,7 @@
       "resolved": "https://registry.npmjs.org/webpack-plugin-vuetify/-/webpack-plugin-vuetify-3.1.3.tgz",
       "integrity": "sha512-0o3H+UEgeZh47vjgLeHbbFl+oZUpnRadRUyk6xCMXSZQR1Jh0ZnfzYC79+fO83OWlMpv2AqHbJkEXwDKnCafYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.2",
         "decache": "^4.6.0",
@@ -19237,6 +19263,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
@@ -1,6 +1,7 @@
 <template>
   <v-data-table
     v-bind="{ ...$props }"
+    :row-props="getRowProps"
     :disable-pagination="true"
     :hide-default-footer="true"
     :custom-sort="customSort"
@@ -529,7 +530,7 @@
     </template>
 
     <template v-if="necessaryTotal" v-slot:body.append>
-      <tr>
+      <tr class="total-row">
         <td class="text-center" :colspan="colspan">
           <strong>Total</strong>
         </td>
@@ -581,7 +582,8 @@ const props = defineProps({
     default: () => [ "unreviewed", "confirmed", "outstanding",
       "falsePositive", "intentional", "suppressed","reports" ]
   },
-  necessaryTotal: { type: Boolean, default: false }
+  necessaryTotal: { type: Boolean, default: false },
+  itemClass: { type: Function, default: null }
 });
 
 defineEmits([ "enabled-click" ]);
@@ -590,6 +592,12 @@ const route = useRoute();
 const reportStatus = useReportStatus();
 const reviewStatus = useReviewStatus();
 const severity = useSeverity();
+
+function getRowProps({ item }) {
+  if (!props.itemClass) return {};
+  const className = props.itemClass(item);
+  return className ? { class: className } : {};
+}
 
 const severityFromCodeToString = computed(function() {
   return severity.severityFromCodeToString;

--- a/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Checker/CheckerStatisticsTable.vue
@@ -69,7 +69,7 @@ const headers = [
 </script>
 
 <style lang="scss">
-@use "@/components/Statistics/style.scss" with (
+@use "@/components/Statistics/colored-columns" with (
   $class-name: ".checker-statistics"
 );
 </style>

--- a/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/CheckerCoverage/CheckerCoverageStatisticsTable.vue
@@ -8,6 +8,8 @@
     loading-text="Loading checker statistics..."
     item-key="checker"
     :sort-by="[{ key: 'severity', order: 'desc' }]"
+    :item-class="getRowClass"
+    no-data-text="No checker coverage statistics available"
     @enabled-click="enabledClick"
   />
 </template>
@@ -56,10 +58,14 @@ const headers = [
 function enabledClick(_type, _checker_name) {
   emit("enabled-click", _type, _checker_name);
 }
+
+function getRowClass(item) {
+  return item.outstanding > 0 ? "highlight-row" : "";
+}
 </script>
 
 <style lang="scss">
-@use "@/components/Statistics/style.scss" with (
+@use "@/components/Statistics/highlight-rows" with (
   $class-name: ".analysis-statistics"
 );
 </style>

--- a/web/server/vue-cli/src/components/Statistics/Component/ComponentStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Component/ComponentStatisticsTable.vue
@@ -123,7 +123,7 @@ async function itemExpanded(expandedItem) {
 </script>
 
 <style lang="scss">
-@use "@/components/Statistics/style.scss" with (
+@use "@/components/Statistics/colored-columns" with (
   $class-name: ".component-statistics"
 );
 </style>

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatisticsTable.vue
@@ -143,7 +143,7 @@ function getRowClass(item) {
 </script>
 
 <style lang="scss">
-@use "@/components/Statistics/style.scss" with (
+@use "@/components/Statistics/highlight-rows" with (
   $class-name: ".guideline-statistics-table"
 );
 </style>

--- a/web/server/vue-cli/src/components/Statistics/Severity/ComponentSeverityStatistics/ComponentSeverityStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Severity/ComponentSeverityStatistics/ComponentSeverityStatisticsTable.vue
@@ -1,7 +1,7 @@
 <template>
   <base-statistics-table
     v-model:expanded="expanded"
-    class="component-statistics"
+    class="component-severity-statistics"
     :headers="headers"
     :items="items"
     :loading="loading"
@@ -125,6 +125,8 @@ async function itemExpanded(expandedItem) {
 }
 </script>
 
-<style lang="scss" scoped>
-// This section is needed to override the default inherited style.
+<style lang="scss">
+@use "@/components/Statistics/base-table" with (
+  $class-name: ".component-severity-statistics"
+);
 </style>

--- a/web/server/vue-cli/src/components/Statistics/Severity/SeverityStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Severity/SeverityStatisticsTable.vue
@@ -66,7 +66,7 @@ const headers = [
 </script>
 
 <style lang="scss">
-@use "@/components/Statistics/style.scss" with (
+@use "@/components/Statistics/colored-columns" with (
   $class-name: ".severity-statistics",
   $unreviewed_col: 2,
   $colspan: 0

--- a/web/server/vue-cli/src/components/Statistics/_base-table.scss
+++ b/web/server/vue-cli/src/components/Statistics/_base-table.scss
@@ -1,0 +1,10 @@
+$class-name: "" !default;
+
+$tr: "tr:not(.v-data-table__expanded__content)";
+
+#{$class-name} > table {
+  & > thead > #{$tr}:not(:last-child) > th:not(.v-data-table__mobile-row),
+  & > tbody > #{$tr}:not(:last-child) > td:not(.v-data-table__mobile-row) {
+    border-bottom: thin solid rgba(0, 0, 0, 0.12);
+  }
+}

--- a/web/server/vue-cli/src/components/Statistics/_colored-columns.scss
+++ b/web/server/vue-cli/src/components/Statistics/_colored-columns.scss
@@ -1,4 +1,4 @@
-$class-name: '' !default;
+$class-name: "" !default;
 $unreviewed_col: 3 !default;
 $colspan: 1 !default;
 
@@ -13,39 +13,50 @@ $border_before: (
   $suppressed_reports_col + 1
 ) !default;
 
+// The total row uses colspan to merge the leading columns into one cell,
+// so nth-child indices are shifted by (colspan - 1).
+$total-row-offset: $unreviewed_col - 2;
+
 $outstanding-bg-color: #fef5f6;
 $suppressed-bg-color: #f2f6eb;
 $darken: 2;
 
-$tr: 'tr:not(.v-data-table__expanded__content)';
+$tr: "tr:not(.v-data-table__expanded__content):not(.total-row)";
 
 @mixin set-cells-color($cols...) {
   #{$class-name} table {
     @each $col in $cols {
       th:nth-child(#{$col}),
-      td:nth-child(#{$col}) {
+      tbody #{$tr} td:nth-child(#{$col}) {
         @content;
       }
     }
   }
 }
 
-@mixin set-rows-color() {
-  #{$class-name} > table {
-    & > tbody > #{$tr} {
-      @content;
+@mixin set-total-row-color($cols...) {
+  #{$class-name} table tbody tr.total-row {
+    @each $col in $cols {
+      td:nth-child(#{$col - $total-row-offset}) {
+        @content;
+      }
     }
   }
 }
 
 @mixin set-bg-color($bg-color, $cols...) {
-  // Base color
+  // Header and regular body rows
   @include set-cells-color($cols...) {
     background-color: $bg-color;
   }
 
-  // Hover state
-  #{$class-name} table tbody tr:hover {
+  // Total row (shifted indices due to colspan)
+  @include set-total-row-color($cols...) {
+    background-color: $bg-color;
+  }
+
+  // Hover state for regular rows
+  #{$class-name} table tbody #{$tr}:hover {
     @each $col in $cols {
       td:nth-child(#{$col}) {
         background-color: darken($bg-color, 5%);
@@ -54,14 +65,14 @@ $tr: 'tr:not(.v-data-table__expanded__content)';
   }
 }
 
-// Set background color of outstanding report columns.
+// Set background color of outstanding report columns (red).
 @for $i from $unreviewed_col through $outstanding_reports_col {
   @include set-bg-color($outstanding-bg-color, $i);
 }
 
 @include set-bg-color(darken($outstanding-bg-color, $darken), $outstanding_reports_col);
 
-// Set background color of suppressed report columns.
+// Set background color of suppressed report columns (green).
 @for $i from $false_positive_col through $suppressed_reports_col {
   @include set-bg-color($suppressed-bg-color, $i);
 }
@@ -76,12 +87,8 @@ $tr: 'tr:not(.v-data-table__expanded__content)';
 }
 
 #{$class-name} > table {
-  & > thead > #{$tr}:not(:last-child) > th:not(.v-data-table__mobile-row),
-  & > tbody > #{$tr}:not(:last-child) > td:not(.v-data-table__mobile-row) {
+  & > thead > tr:not(:last-child) > th:not(.v-data-table__mobile-row),
+  & > tbody > tr:not(:last-child) > td:not(.v-data-table__mobile-row) {
     border-bottom: thin solid rgba(0, 0, 0, 0.12);
   }
-}
-
-#{$class-name} .highlight-row {
-  background-color: $outstanding-bg-color !important;
 }

--- a/web/server/vue-cli/src/components/Statistics/_highlight-rows.scss
+++ b/web/server/vue-cli/src/components/Statistics/_highlight-rows.scss
@@ -1,0 +1,16 @@
+$class-name: "" !default;
+
+$outstanding-bg-color: #ffebee;
+
+$tr: "tr:not(.v-data-table__expanded__content)";
+
+#{$class-name} tr.highlight-row td {
+  background-color: $outstanding-bg-color !important;
+}
+
+#{$class-name} > table {
+  & > thead > #{$tr}:not(:last-child) > th:not(.v-data-table__mobile-row),
+  & > tbody > #{$tr}:not(:last-child) > td:not(.v-data-table__mobile-row) {
+    border-bottom: thin solid rgba(0, 0, 0, 0.12);
+  }
+}


### PR DESCRIPTION
This change fixes the coloring issues of the statistics tables. All tables are now colored as it was before the update without the shifted "Total" row. The guideline statistics table highlights the rows only with outstanding reports greater than 0.