### PR TITLE
Check the different API version usages

### DIFF
--- a/web/codechecker_web/shared/version.py
+++ b/web/codechecker_web/shared/version.py
@@ -8,6 +8,34 @@
 """
 This module stores constants that are shared between the CodeChecker server
 and client, related to API and other version-specific information.
+
+API Versioning Strategy
+-----------------------
+CodeChecker uses a two-level versioning scheme for its Thrift API:
+**MAJOR.MINOR** (e.g. ``6.72``).
+
+- **MAJOR version** identifies the protocol generation. All current endpoints
+  share the same major version (v6). A major bump would indicate a
+  fundamentally incompatible protocol change.
+- **MINOR version** is incremented when new Thrift methods are added or
+  existing method signatures are extended. The server accepts any client
+  whose minor version is <= the server's supported minor version for that
+  major, ensuring backward compatibility.
+
+The npm and PyPI packages use a three-part semver (``6.72.0``) because those
+ecosystems require it. The **patch component is always 0** and is never used
+in version negotiation — it is stripped before constructing API URLs or
+performing compatibility checks.
+
+Version flow through the system:
+1. The client constructs a URL with ``/v<MAJOR.MINOR>/`` from CLIENT_API.
+2. ``routing.py`` parses the version tag, validates major.minor against
+   SUPPORTED_VERSIONS, and returns a ``(major, minor)`` tuple.
+3. ``server.py`` dispatches to the appropriate handler based on the major
+   version (currently only v6 exists).
+4. Individual handlers (e.g. ``report_server.py``) may branch on the full
+   ``(major, minor)`` tuple for backward-compatible behavioral changes
+   introduced at a specific minor version.
 """
 
 
@@ -24,7 +52,7 @@ SUPPORTED_VERSIONS = {
 }
 
 # Used by the client to automatically identify the latest major and minor
-# version.
+# version. This string is used in API URL paths (e.g. "/v6.72/Tasks").
 CLIENT_API = \
     f'{max(SUPPORTED_VERSIONS.keys())}.' \
     f'{SUPPORTED_VERSIONS[max(SUPPORTED_VERSIONS.keys())]}'

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -2080,7 +2080,14 @@ class ThriftRequestHandler:
         # based on the client's version. We are having access to the Thrift
         # API version here. The behavior change happend in Thrift API version
         # 6.50.
-        client_version = tuple(map(int, self.__client_version.split('.')))
+        #
+        # The client version string comes from the URL path (e.g. "6.72")
+        # as parsed by routing.split_client_POST_request(). It is always in
+        # MAJOR.MINOR format (see versioning strategy in
+        # codechecker_web.shared.version). We parse it into a tuple for
+        # lexicographic comparison against the threshold version (6, 50).
+        version_parts = self.__client_version.split('.')
+        client_version = (int(version_parts[0]), int(version_parts[1]))
 
         if not skip_detection_statuses:
             skip_detection_statuses = [ttypes.DetectionStatus.RESOLVED,

--- a/web/server/codechecker_server/routing.py
+++ b/web/server/codechecker_server/routing.py
@@ -71,13 +71,20 @@ def is_supported_version(version):
     server.
 
     If supported, returns the major and minor version as a tuple.
+
+    Only the first two version components (major.minor) are considered.
+    Any additional components (e.g. a patch number from semver-formatted
+    package versions) are ignored. See the versioning strategy documentation
+    in ``codechecker_web.shared.version`` for details.
     """
     version = version.lstrip('v')
     version_parts = version.split('.')
     if len(version_parts) < 2:
         return False
 
-    # We don't care if accidentally the version tag contains a revision number.
+    # Only major and minor are meaningful for API compatibility; any trailing
+    # components (e.g. patch from npm semver "6.72.0") are intentionally
+    # discarded here.
     major, minor = int(version_parts[0]), int(version_parts[1])
     if major in SUPPORTED_VERSIONS and minor <= SUPPORTED_VERSIONS[major]:
         return major, minor

--- a/web/server/vue-cli/config/webpack.common.js
+++ b/web/server/vue-cli/config/webpack.common.js
@@ -7,6 +7,10 @@ const ESLintPlugin = require("eslint-webpack-plugin");
 const { join } = require("path");
 
 const codeCheckerApi = require("codechecker-api/package.json");
+// The npm package uses a 3-part semver (e.g. "6.72.0") because npm requires
+// it, but the CodeChecker API versioning scheme only uses MAJOR.MINOR.
+// The patch component is always 0 and is never part of API URL paths.
+// See: web/codechecker_web/shared/version.py for the full versioning strategy.
 const apiVersion = codeCheckerApi.version.split(".").slice(0, 2).join(".");
 
 const helpers = require("./helpers");


### PR DESCRIPTION
## Addresses #3276: Check the different API version usages

Adds inline documentation explaining the MAJOR.MINOR versioning strategy used across the codebase, and standardizes the one place where version parsing was not explicitly constrained to two components.

### Changes

- **`web/codechecker_web/shared/version.py`** — Added module docstring documenting the versioning scheme and how version flows through the system.
- **`web/server/codechecker_server/routing.py`** — Clarified `is_supported_version()` docstring re: why trailing version components are discarded.
- **`web/server/codechecker_server/api/report_server.py`** — Documented the backward-compat branching logic; changed version parsing to explicitly take only major.minor (prevents accidental 3-part tuple comparisons).
- **`web/server/vue-cli/config/webpack.common.js`** — Added comment explaining why the npm semver patch is stripped.