### PR TITLE
Use proper Boolean values in DB migration scripts

### DIFF
--- a/web/server/codechecker_server/migrations/config/versions/4964142b58d2_authentication_session_tokens.py
+++ b/web/server/codechecker_server/migrations/config/versions/4964142b58d2_authentication_session_tokens.py
@@ -28,7 +28,7 @@ def upgrade():
         sa.Column('description', sa.String(), nullable=True),
         sa.Column('can_expire',
                   sa.Boolean(),
-                  server_default=sa.text('true'),
+                  server_default=sa.true(),
                   nullable=True),
         sa.PrimaryKeyConstraint('id', name=op.f('pk_auth_sessions')),
         sa.UniqueConstraint('token', name=op.f('uq_auth_sessions_token')))

--- a/web/server/codechecker_server/migrations/config/versions/7ed50f8b3fb8_new_table_for_personal_access_tokens.py
+++ b/web/server/codechecker_server/migrations/config/versions/7ed50f8b3fb8_new_table_for_personal_access_tokens.py
@@ -81,7 +81,7 @@ def downgrade():
         'auth_sessions',
         sa.Column('can_expire',
                   sa.Boolean(),
-                  server_default=sa.text('true'),
+                  server_default=sa.true(),
                   nullable=True))
 
     op.drop_table('personal_access_tokens')

--- a/web/server/codechecker_server/migrations/report/versions/75ae226b5d88_review_status_for_each_report.py
+++ b/web/server/codechecker_server/migrations/report/versions/75ae226b5d88_review_status_for_each_report.py
@@ -42,7 +42,7 @@ def upgrade():
         'review_status_date', sa.DateTime(), nullable=True)
     col_rs_is_in_source = sa.Column(
         'review_status_is_in_source',
-        sa.Boolean(), server_default='0', nullable=True)
+        sa.Boolean(), server_default=sa.false(), nullable=True)
     col_rs_message = sa.Column(
         'review_status_message', sa.LargeBinary(), nullable=True)
 

--- a/web/server/codechecker_server/migrations/report/versions/82ca43f05c10_initial_schema.py
+++ b/web/server/codechecker_server/migrations/report/versions/82ca43f05c10_initial_schema.py
@@ -67,7 +67,7 @@ def upgrade():
         sa.Column('name', sa.String(), nullable=True),
         sa.Column('version', sa.String(), nullable=True),
         sa.Column('command', sa.String(), nullable=True),
-        sa.Column('can_delete', sa.Boolean(), server_default=sa.text('true'),
+        sa.Column('can_delete', sa.Boolean(), server_default=sa.true(),
                   nullable=False),
         sa.PrimaryKeyConstraint('id', name=op.f('pk_runs')),
         sa.UniqueConstraint('name', name=op.f('uq_runs_name'))


### PR DESCRIPTION
Using sa.true() and sa.false() are a better alternative especially for SQLite, where setting false/true as string instead of 0/1 values may lead to bugs.

Fixes #1874