### PR TITLE
[fix][report-converter] Honour trim-path-prefix in sarif export

### DIFF
--- a/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
+++ b/tools/report-converter/codechecker_report_converter/report/parser/sarif.py
@@ -349,7 +349,7 @@ class Parser(BaseParser):
             "locations": [{
                 "physicalLocation": {
                     "artifactLocation": {
-                        "uri": f"file://{report.file.original_path}"
+                        "uri": f"file://{report.file.path}"
                     },
                     "region": {
                         "startLine": report.line,
@@ -432,7 +432,7 @@ class Parser(BaseParser):
             "location": {
                 "physicalLocation": {
                     "artifactLocation": {
-                        "uri": f"file://{pos.file.original_path}"
+                        "uri": f"file://{pos.file.path}"
                     },
                     "region": region
                 }

--- a/tools/report-converter/tests/unit/parser/sarif/test_sarif_parser.py
+++ b/tools/report-converter/tests/unit/parser/sarif/test_sarif_parser.py
@@ -14,7 +14,9 @@ Test the parsing of the sarif files.
 import os
 import unittest
 
-from codechecker_report_converter.report import report_file
+from codechecker_report_converter.report import BugPathEvent, File, Report, \
+    report_file
+from codechecker_report_converter.report.parser import sarif
 
 
 gen_sarif_dir_path = os.path.join(
@@ -41,3 +43,25 @@ class SarifParserTestCase(unittest.TestCase):
                 abs_filename = os.path.join(root, filename)
                 # We test for no crashes.
                 report_file.get_reports(abs_filename)
+
+    def test_trim_path_prefix_in_artifact_location(self):
+        """Exported sarif URIs must honour trim-path-prefix."""
+        report = Report(
+            file=File('/home/user/project/src/main.c'),
+            line=3, column=5, message='divide by zero',
+            checker_name='core.DivideZero',
+            bug_path_events=[BugPathEvent(
+                'assuming zero', File('/home/user/project/src/util.c'), 7, 2)])
+        report.trim_path_prefixes(['/home/user/project'])
+
+        data = sarif.Parser().convert([report])
+        result = data['runs'][0]['results'][0]
+
+        self.assertEqual(
+            result['locations'][0]['physicalLocation']
+            ['artifactLocation']['uri'],
+            'file://src/main.c')
+        self.assertEqual(
+            result['codeFlows'][0]['threadFlows'][0]['locations'][0]
+            ['location']['physicalLocation']['artifactLocation']['uri'],
+            'file://src/util.c')


### PR DESCRIPTION
Closes #4659

The sarif exporter built `artifactLocation` URIs from `report.file.original_path`, which always holds the untrimmed path, so `CodeChecker parse --trim-path-prefix ... --export sarif` still emitted absolute paths. Using `report.file.path` returns the trimmed path once `Report.trim_path_prefixes()` has run and the original path otherwise — the same fix applied to the HTML export in #4387.

Added a regression test covering both the primary result location and the code flow locations; it fails on master with `file:///home/user/project/src/main.c` and passes with the change.
