### PR TITLE
Fix: recognize --std=/--stdlib= double-dash compiler flags (#4926)

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -594,13 +594,14 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                     self.buildaction.arch != "":
                 analyzer_cmd.extend(["-arch", self.buildaction.arch])
 
-            if not has_flag('-std', analyzer_cmd) and \
-                    self.buildaction.compiler_standard != "":
-                analyzer_cmd.append(self.buildaction.compiler_standard)
-
             analyzer_cmd.extend(config.analyzer_extra_arguments)
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
+
+            if not has_flag('-std', analyzer_cmd) and \
+                    not has_flag('--std', analyzer_cmd) and \
+                    self.buildaction.compiler_standard != "":
+                analyzer_cmd.append(self.buildaction.compiler_standard)
 
             analyzer_cmd.extend(prepend_all(
                 '-isystem' if config.add_gcc_include_dirs_with_isystem else

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -224,8 +224,8 @@ COMPILE_OPTIONS_LIST = [
     '-pedantic',
     '-O[1-3]',
     '-Os',
-    '-std=',
-    '-stdlib=',
+    '-{1,2}std=',
+    '-{1,2}stdlib=',
     '-f',
     '-m',
     '-Wno-',
@@ -293,7 +293,8 @@ def filter_compiler_includes_extra_args(compiler_flags):
     # If these options are present in the original build command, they must
     # be forwarded to get_compiler_includes and get_compiler_defines so the
     # resulting includes point to the target that was used in the build.
-    pattern = re.compile('-m(32|64)|-std=|-stdlib=|-nostdinc|--driver-mode=')
+    pattern = re.compile(
+        '-m(32|64)|-{1,2}std=|-{1,2}stdlib=|-nostdinc|--driver-mode=')
     extra_opts = list(filter(pattern.match, compiler_flags))
 
     pos = next((pos for pos, val in enumerate(compiler_flags)

--- a/analyzer/tests/unit/test_analyzer_command.py
+++ b/analyzer/tests/unit/test_analyzer_command.py
@@ -14,7 +14,7 @@ from codechecker_analyzer.cli import analyze
 from libtest.cmd_line import create_analyze_argparse
 
 
-def create_analyzer_sa(args=None):
+def create_analyzer_sa(args=None, command="g++ -o main main.cpp"):
     parser = argparse.ArgumentParser()
     analyze.add_arguments_to_parser(parser)
     cfg_handler = ClangSA.construct_config_handler(
@@ -22,7 +22,7 @@ def create_analyzer_sa(args=None):
 
     action = {
         'file': 'main.cpp',
-        'command': "g++ -o main main.cpp",
+        'command': command,
         'directory': '/'}
     build_action = log_parser.parse_options(action)
 
@@ -73,3 +73,35 @@ class AnalyzerCommandClangSATest(unittest.TestCase):
         result_handler = create_result_handler(analyzer)
         cmd = analyzer.construct_analyzer_cmd(result_handler)
         self.assertNotIn('-analyzer-opt-analyze-headers', cmd)
+
+    def test_no_duplicate_std_flag_double_dash(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/4926
+
+        When the original build command already specifies a standard
+        version with the double-dash spelling (--std=...), the implicit
+        default standard must not also be appended - the analyzer command
+        should contain the user's flag exactly once, with no implicit
+        '-std=...' added alongside it.
+        """
+        analyzer = create_analyzer_sa(
+            command="g++ --std=c++23 -o main main.cpp")
+        result_handler = create_result_handler(analyzer)
+        cmd = analyzer.construct_analyzer_cmd(result_handler)
+
+        std_flags = [x for x in cmd if x.startswith(('-std=', '--std='))]
+        self.assertEqual(std_flags, ['--std=c++23'])
+
+    def test_implicit_std_flag_still_added_when_missing(self):
+        """
+        Sanity check accompanying the regression test above: when the
+        original build command has no standard-version flag at all, the
+        implicit default standard should still be added exactly once.
+        """
+        analyzer = create_analyzer_sa(command="g++ -o main main.cpp")
+        result_handler = create_result_handler(analyzer)
+        cmd = analyzer.construct_analyzer_cmd(result_handler)
+
+        std_flags = [x for x in cmd if x.startswith(('-std=', '--std='))]
+        self.assertEqual(len(std_flags), 1)

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -287,6 +287,38 @@ class LogParserTest(unittest.TestCase):
         filtered = log_parser.filter_compiler_includes_extra_args(flags)
         self.assertEqual(filtered, ["-m64", "-stdlib=libc++", "-std=c++17"])
 
+    def test_compiler_implicit_include_flags_double_dash_std(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/4926
+
+        GCC accepts both '-std=' and '--std=' (and likewise '-stdlib='/
+        '--stdlib=') as equivalent spellings. Previously only the
+        single-dash form was recognized, so '--std=' was silently dropped
+        instead of being forwarded to the analyzer.
+        """
+
+        flags = ["-I", "/usr/include", "-m64", "--stdlib=libc++",
+                 "--std=c++23"]
+        filtered = log_parser.filter_compiler_includes_extra_args(flags)
+        self.assertEqual(filtered, ["-m64", "--stdlib=libc++", "--std=c++23"])
+
+    def test_compile_options_matches_double_dash_std(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/4926
+
+        The COMPILE_OPTIONS pattern (used to decide which flags get
+        forwarded from the original build command to the analyzer
+        invocation) must recognize '--std=' and '--stdlib=', not just the
+        single-dash forms.
+        """
+
+        self.assertTrue(log_parser.COMPILE_OPTIONS.match("--std=c++23"))
+        self.assertTrue(log_parser.COMPILE_OPTIONS.match("-std=c++23"))
+        self.assertTrue(log_parser.COMPILE_OPTIONS.match("--stdlib=libc++"))
+        self.assertTrue(log_parser.COMPILE_OPTIONS.match("-stdlib=libc++"))
+
     def test_compiler_implicit_include_flags_sysroot(self):
         """sysroot flags should be kept."""
 


### PR DESCRIPTION
Fixes #4926

## Problem
`CodeChecker log` + `CodeChecker analyze` fail when a build command uses
the double-dash spelling of the standard flag, e.g. `g++ --std=c++23`.
GCC accepts both `-std=` and `--std=` as equivalent, but CodeChecker's
flag-recognition regex only matched the single-dash form. As a result,
`--std=c++23` was silently dropped while translating the build command
into the analyzer invocation, and CodeChecker fell back to querying the
compiler's own default standard (e.g. `gnu++17`), causing spurious
"not found" errors for anything newer.

## Root cause
In `analyzer/codechecker_analyzer/buildlog/log_parser.py`:
- `COMPILE_OPTIONS_LIST` included `'-std='` / `'-stdlib='`, matched via
  `re.match()`, which anchors at the start of the string — so
  `--std=c++23` (starting with `--s`, not `-s`) never matched.
- The same anchoring issue existed in the separate pattern used inside
  `filter_compiler_includes_extra_args()`.

Verified with `--verbose debug_analyzer`: the assembled clangsa
invocation contained `-std=gnu++17` with no trace of the user's
`--std=c++23` at all (not duplicated, just dropped).

## Fix
Made both patterns tolerant of one or two leading dashes:
`-std=` → `-{1,2}std=`, `-stdlib=` → `-{1,2}stdlib=`.

## Testing
- Added two regression tests in `test_log_parser.py` covering both the
  `COMPILE_OPTIONS` match and `filter_compiler_includes_extra_args()`.
- Ran the full `test_log_parser.py` suite (25 tests) — all pass, no
  regressions.
- Reproduced the original bug end-to-end with a minimal project using
  `g++ --std=c++23` and `<print>`, confirmed it fails before the fix
  and `clangsa analyzed main.cpp successfully` after the fix.