### PR TITLE
Add report-converter --example flag and EXAMPLE_CMD interface (#4992)

### DIFF
--- a/docs/tools/report-converter.md
+++ b/docs/tools/report-converter.md
@@ -22,6 +22,7 @@ a CodeChecker server.
   * [TSLint](#tslint)
   * [Golint](#golint)
   * [Pyflakes](#pyflakes)
+  * [Ruff](#ruff)
   * [PVS-Studio](#PVS-Studio)
   * [Markdownlint](#markdownlint)
   * [Coccinelle](#coccinelle)
@@ -132,6 +133,13 @@ Supported analyzers:
 </details>
 
 ## Supported analyzer outputs
+For an always up-to-date usage example for a given analyzer straight from
+the source, run:
+```sh
+report-converter --example <TYPE>
+# e.g. report-converter --example ruff
+```
+
 ### Sanitizers
 #### Undefined Behaviour Sanitizer
 [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
@@ -407,6 +415,28 @@ report-converter -t pyflakes -o ./codechecker_pyflakes_reports ./pyflakes_report
 
 # Store the Pyflakes reports with CodeChecker.
 CodeChecker store ./codechecker_pyflakes_reports -n pyflakes
+```
+
+### Ruff
+[Ruff](https://docs.astral.sh/ruff/) is an extremely fast static analysis
+tool (linter) for `Python` code.
+
+report-converter only accepts a `json` output file from Ruff, so you must
+generate one.
+
+The following example shows you how to run Ruff and store the results
+found by Ruff to the CodeChecker database.
+
+```sh
+# Run ruff and generate a json output file.
+ruff check --output-format json /path/to/my/project > ./ruff_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of ruff.
+report-converter -t ruff -o ./codechecker_ruff_reports ./ruff_reports.json
+
+# Store the ruff reports with CodeChecker.
+CodeChecker store ./codechecker_ruff_reports -n ruff
 ```
 
 ### PVS-Studio

--- a/docs/tools/report-converter.md
+++ b/docs/tools/report-converter.md
@@ -22,6 +22,7 @@ a CodeChecker server.
   * [TSLint](#tslint)
   * [Golint](#golint)
   * [Pyflakes](#pyflakes)
+  * [Ruff](#ruff)
   * [PVS-Studio](#PVS-Studio)
   * [Markdownlint](#markdownlint)
   * [Coccinelle](#coccinelle)
@@ -132,6 +133,13 @@ Supported analyzers:
 </details>
 
 ## Supported analyzer outputs
+The list below can go out of sync with the actual code. For an always
+up-to-date usage example for a given analyzer straight from the source, run:
+```sh
+report-converter --example <TYPE>
+# e.g. report-converter --example ruff
+```
+
 ### Sanitizers
 #### Undefined Behaviour Sanitizer
 [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
@@ -407,6 +415,27 @@ report-converter -t pyflakes -o ./codechecker_pyflakes_reports ./pyflakes_report
 
 # Store the Pyflakes reports with CodeChecker.
 CodeChecker store ./codechecker_pyflakes_reports -n pyflakes
+```
+
+### Ruff
+[Ruff](https://docs.astral.sh/ruff/) is an extremely fast static analysis
+tool (linter) for `Python` code.
+
+The recommended way of running Ruff is to generate a `json` output file.
+
+The following example shows you how to run Ruff and store the results
+found by Ruff to the CodeChecker database.
+
+```sh
+# Run ruff and generate a json output file.
+ruff check --output-format json /path/to/my/project > ./ruff_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of ruff.
+report-converter -t ruff -o ./codechecker_ruff_reports ./ruff_reports.json
+
+# Store the ruff reports with CodeChecker.
+CodeChecker store ./codechecker_ruff_reports -n ruff
 ```
 
 ### PVS-Studio

--- a/tools/report-converter/codechecker_report_converter/analyzers/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/analyzer_result.py
@@ -35,6 +35,15 @@ class AnalyzerResultBase(metaclass=ABCMeta):
     # Link to the official analyzer website.
     URL: str = ''
 
+    # An example shell command (or short sequence of commands) showing how
+    # to produce an analyzer result file that this parser can consume, and
+    # how to feed it to 'report-converter'. Every new parser MUST provide
+    # this so that usage instructions live next to the code and can't
+    # silently drift out of sync with docs/tools/report-converter.md (see
+    # https://github.com/Ericsson/codechecker/issues/4992). Users can view
+    # it directly with 'report-converter --example <TOOL_NAME>'.
+    EXAMPLE_CMD: str = ''
+
     def transform(
         self,
         analyzer_result_file_paths: Iterable[str],

--- a/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy/analyzer_result.py
@@ -22,6 +22,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Clang Tidy'
     URL = 'https://clang.llvm.org/extra/clang-tidy'
 
+    EXAMPLE_CMD = """\
+# Run clang-tidy and redirect its console output to a file.
+clang-tidy my_file.cpp > ./clang-tidy_reports.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of clang-tidy.
+report-converter -t clang-tidy -o ./codechecker_clang_tidy_reports \
+    ./clang-tidy_reports.out
+
+# Store the clang-tidy reports with CodeChecker.
+CodeChecker store ./codechecker_clang_tidy_reports -n clang-tidy"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy_yaml/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/clang_tidy_yaml/analyzer_result.py
@@ -22,6 +22,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Clang Tidy'
     URL = 'https://clang.llvm.org/extra/clang-tidy'
 
+    EXAMPLE_CMD = """\
+# Run clang-tidy and export the fixes/diagnostics to a yaml file.
+clang-tidy --export-fixes=./clang-tidy_reports.yaml my_file.cpp
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of clang-tidy.
+report-converter -t clang-tidy-yaml \
+    -o ./codechecker_clang_tidy_reports ./clang-tidy_reports.yaml
+
+# Store the clang-tidy reports with CodeChecker.
+CodeChecker store ./codechecker_clang_tidy_reports -n clang-tidy"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/coccinelle/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/coccinelle/analyzer_result.py
@@ -21,6 +21,21 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Coccinelle'
     URL = 'https://github.com/coccinelle/coccinelle'
 
+    EXAMPLE_CMD = """\
+# Change directory to your project (e.g. the Linux kernel).
+cd path/to/linux/kernel/repository
+
+# Run Coccicheck and redirect the output to a file.
+make coccicheck MODE=report V=1 > ./coccinelle_reports.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Coccinelle.
+report-converter -t coccinelle -o ./codechecker_coccinelle_reports \
+    ./coccinelle_reports.out
+
+# Store the Coccinelle reports with CodeChecker.
+CodeChecker store ./codechecker_coccinelle_reports -n coccinelle"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/cppcheck/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/cppcheck/analyzer_result.py
@@ -29,6 +29,22 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Cppcheck'
     URL = 'http://cppcheck.sourceforge.net'
 
+    EXAMPLE_CMD = """\
+# Collect the compilation commands with absolute path conversion.
+CC_LOGGER_ABS_PATH=1 CodeChecker log -o compile_command.json -b "make"
+
+# Run Cppcheck using the generated compile command database.
+mkdir cppcheck_reports
+cppcheck --project=compile_command.json --plist-output=./cppcheck_reports
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Cppcheck.
+report-converter -t cppcheck -o ./codechecker_cppcheck_reports \
+    ./cppcheck_reports
+
+# Store the Cppcheck reports with CodeChecker.
+CodeChecker store ./codechecker_cppcheck_reports -n cppcheck"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         reports: List[Report] = []

--- a/tools/report-converter/codechecker_report_converter/analyzers/cpplint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/cpplint/analyzer_result.py
@@ -21,6 +21,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'cpplint'
     URL = 'https://github.com/cpplint/cpplint'
 
+    EXAMPLE_CMD = """\
+# Run cpplint and redirect the output to a file.
+cpplint sample.cpp > ./sample.out 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of cpplint.
+report-converter -t cpplint -o ./codechecker_cpplint_reports ./sample.out
+
+# Store the cpplint reports with CodeChecker.
+CodeChecker store ./codechecker_cpplint_reports -n cpplint"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/eslint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/eslint/analyzer_result.py
@@ -28,6 +28,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'ESLint'
     URL = 'https://eslint.org/'
 
+    EXAMPLE_CMD = """\
+# Run ESLint and generate a json output file.
+eslint -o ./eslint_reports.json -f json /path/to/my/project
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of ESLint.
+report-converter -t eslint -o ./codechecker_eslint_reports \
+    ./eslint_reports.json
+
+# Store the ESLint reports with CodeChecker.
+CodeChecker store ./codechecker_eslint_reports -n eslint"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         reports: List[Report] = []

--- a/tools/report-converter/codechecker_report_converter/analyzers/gcc/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/gcc/analyzer_result.py
@@ -25,6 +25,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'GNU Compiler Collection Static Analyzer'
     URL = 'https://gcc.gnu.org/wiki/StaticAnalyzer'
 
+    EXAMPLE_CMD = """\
+# Compile and analyze with GCC's static analyzer (GCC 13+), producing a
+# sarif output file.
+g++ -fanalyzer -fdiagnostics-format=sarif-file my_file.cpp
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of GCC's static analyzer.
+report-converter -t gcc -o ./codechecker_gcc_reports my_file.cpp.sarif
+
+# Store the gcc reports with CodeChecker.
+CodeChecker store ./codechecker_gcc_reports -n gcc"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result file. """
 

--- a/tools/report-converter/codechecker_report_converter/analyzers/golint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/golint/analyzer_result.py
@@ -21,6 +21,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Golint'
     URL = 'https://github.com/golang/lint'
 
+    EXAMPLE_CMD = """\
+# Run Golint and redirect the output to a file.
+golint /path/to/your/project > ./golint_reports.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Golint.
+report-converter -t golint -o ./codechecker_golint_reports ./golint_reports.out
+
+# Store the Golint reports with CodeChecker.
+CodeChecker store ./codechecker_golint_reports -n golint"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/infer/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/infer/analyzer_result.py
@@ -28,6 +28,19 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Facebook Infer'
     URL = 'https://fbinfer.com'
 
+    EXAMPLE_CMD = """\
+# Run Facebook Infer, which produces an 'infer-out' directory containing
+# a 'report.json' file.
+infer capture -- clang++ main.cpp
+infer analyze
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Facebook Infer.
+report-converter -t fbinfer -o ./codechecker_fbinfer_reports ./infer-out
+
+# Store the Infer reports with CodeChecker.
+CodeChecker store ./codechecker_fbinfer_reports -n fbinfer"""
+
     def __init__(self):
         super().__init__()
         self.__infer_out_parent_dir = None

--- a/tools/report-converter/codechecker_report_converter/analyzers/jscpd/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/jscpd/analyzer_result.py
@@ -21,6 +21,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'JSCPD'
     URL = 'https://www.npmjs.com/package/jscpd'
 
+    EXAMPLE_CMD = """\
+# Run jscpd and generate a json report.
+jscpd --reporters json -o ./jscpd_reports /path/to/my/project
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of jscpd.
+report-converter -t jscpd -o ./codechecker_jscpd_reports \
+    ./jscpd_reports/jscpd-report.json
+
+# Store the jscpd reports with CodeChecker.
+CodeChecker store ./codechecker_jscpd_reports -n jscpd"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/kerneldoc/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/kerneldoc/analyzer_result.py
@@ -21,6 +21,22 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Kernel-Doc'
     URL = 'https://github.com/torvalds/linux/blob/master/scripts/kernel-doc'
 
+    EXAMPLE_CMD = """\
+# Change directory to your kernel source repository.
+cd path/to/linux/kernel/repository
+
+# Run Kernel-Doc (via the Sphinx docs build) and redirect the output to a
+# file.
+make htmldocs 2>&1 | tee kernel-docs.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Kernel-Doc.
+report-converter -t kernel-doc -o ./codechecker_kernel_doc_reports \
+    ./kernel-docs.out
+
+# Store the Kernel-Doc reports with CodeChecker.
+CodeChecker store ./codechecker_kernel_doc_reports -n kernel-doc"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/markdownlint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/markdownlint/analyzer_result.py
@@ -21,6 +21,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Markdownlint'
     URL = 'https://github.com/markdownlint/markdownlint'
 
+    EXAMPLE_CMD = """\
+# Run Markdownlint and redirect the output to a file.
+mdl /path/to/your/project > ./mdl_reports.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Markdownlint.
+report-converter -t mdl -o ./codechecker_mdl_reports ./mdl_reports.out
+
+# Store the Markdownlint reports with CodeChecker.
+CodeChecker store ./codechecker_mdl_reports -n mdl"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/pmd/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/pmd/analyzer_result.py
@@ -25,6 +25,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = "PMD"
     URL = "https://pmd.github.io/"
 
+    EXAMPLE_CMD = """\
+# Run PMD and generate a json report.
+pmd check -d /path/to/my/project -R rulesets/java/quickstart.xml \\
+    -f json -r ./pmd_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of PMD.
+report-converter -t pmd -o ./codechecker_pmd_reports ./pmd_reports.json
+
+# Store the PMD reports with CodeChecker.
+CodeChecker store ./codechecker_pmd_reports -n pmd"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """Get reports from the given PMD JSON file."""
         return PMDParser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/pvs_studio/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/pvs_studio/analyzer_result.py
@@ -28,6 +28,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'PVS-Studio'
     URL = 'https://pvs-studio.com/en/'
 
+    EXAMPLE_CMD = """\
+# Run the PVS-Studio analysis (see https://pvs-studio.com/en/docs/ for the
+# full setup), producing a PVS-Studio.json report.
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# JSON report of PVS-Studio.
+report-converter -t pvs-studio -o ./codechecker_pvs_studio_reports \
+    ./PVS-Studio.json
+
+# Store the PVS-Studio reports with CodeChecker.
+CodeChecker store ./codechecker_pvs_studio_reports -n pvs_studio"""
+
     __severities = ["UNSPECIFIED", "HIGH", "MEDIUM", "LOW"]
 
     def get_reports(self, file_path: str) -> List[Report]:

--- a/tools/report-converter/codechecker_report_converter/analyzers/pyflakes/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/pyflakes/analyzer_result.py
@@ -21,6 +21,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Pyflakes'
     URL = 'https://github.com/PyCQA/pyflakes'
 
+    EXAMPLE_CMD = """\
+# Run Pyflakes and redirect the output to a file.
+pyflakes /path/to/your/project > ./pyflakes_reports.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Pyflakes.
+report-converter -t pyflakes -o ./codechecker_pyflakes_reports \
+    ./pyflakes_reports.out
+
+# Store the Pyflakes reports with CodeChecker.
+CodeChecker store ./codechecker_pyflakes_reports -n pyflakes"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/pylint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/pylint/analyzer_result.py
@@ -28,6 +28,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Pylint'
     URL = 'https://www.pylint.org'
 
+    EXAMPLE_CMD = """\
+# Run Pylint and generate a json output file.
+pylint -f json /path/to/my/project > ./pylint_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Pylint.
+report-converter -t pylint -o ./codechecker_pylint_reports \
+    ./pylint_reports.json
+
+# Store the Pylint reports with CodeChecker.
+CodeChecker store ./codechecker_pylint_reports -n pylint"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         reports: List[Report] = []

--- a/tools/report-converter/codechecker_report_converter/analyzers/roslynator/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/roslynator/analyzer_result.py
@@ -29,6 +29,21 @@ class AnalyzerResult(AnalyzerResultBase):
     URL = 'https://github.com/JosefPihrt/Roslynator' \
         + '#roslynator-command-line-tool-'
 
+    EXAMPLE_CMD = """\
+# Change directory to your project or solution.
+cd path/to/your/project_or_solution
+
+# Run Roslynator (use an .sln file instead of .csproj to analyze a
+# solution).
+roslynator analyze sample.csproj --output sample.xml
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Roslynator.
+report-converter -t roslynator -o ./codechecker_roslynator_reports ./sample.xml
+
+# Store the Roslynator reports with CodeChecker.
+CodeChecker store ./codechecker_roslynator_reports -n roslynator"""
+
     def __init__(self):
         super().__init__()
         self.__file_cache: Dict[str, File] = {}

--- a/tools/report-converter/codechecker_report_converter/analyzers/ruff/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/ruff/analyzer_result.py
@@ -27,6 +27,16 @@ class AnalyzerResult(AnalyzerResultBase):
     TOOL_NAME = 'ruff'
     NAME = 'ruff'
     URL = 'https://docs.astral.sh/ruff/'
+    EXAMPLE_CMD = """\
+# Run ruff and generate a json output file.
+ruff check --output-format json /path/to/my/project > ./ruff_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of ruff.
+report-converter -t ruff -o ./codechecker_ruff_reports ./ruff_reports.json
+
+# Store the ruff reports with CodeChecker.
+CodeChecker store ./codechecker_ruff_reports -n ruff"""
 
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/address/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/address/analyzer_result.py
@@ -21,6 +21,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'AddressSanitizer'
     URL = 'https://clang.llvm.org/docs/AddressSanitizer.html'
 
+    EXAMPLE_CMD = """\
+# Compile your program with debug info and a frame pointer.
+clang++ -fsanitize=address -g -fno-omit-frame-pointer asan.cpp
+
+# Run your program and redirect the output to a file.
+ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer \\
+./a.out > asan.output 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of AddressSanitizer.
+report-converter -t asan -o ./asan_results asan.output"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/leak/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/leak/analyzer_result.py
@@ -22,6 +22,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'LeakSanitizer'
     URL = 'https://clang.llvm.org/docs/LeakSanitizer.html'
 
+    EXAMPLE_CMD = """\
+# Compile your program with debug info and AddressSanitizer.
+clang -fsanitize=address -g lsan.c
+
+# Run your program and redirect the output to a file.
+ASAN_OPTIONS=detect_leaks=1 ./a.out > lsan.output 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of LeakSanitizer.
+report-converter -t lsan -o ./lsan_results lsan.output"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/memory/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/memory/analyzer_result.py
@@ -22,6 +22,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'MemorySanitizer'
     URL = 'https://clang.llvm.org/docs/MemorySanitizer.html'
 
+    EXAMPLE_CMD = """\
+# Compile your program with debug info and a frame pointer.
+clang++ -fsanitize=memory -g -fno-omit-frame-pointer msan.cpp
+
+# Run your program and redirect the output to a file.
+MSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer \\
+./a.out > msan.output 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of MemorySanitizer.
+report-converter -t msan -o ./msan_results msan.output"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/thread/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/thread/analyzer_result.py
@@ -21,6 +21,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'ThreadSanitizer'
     URL = 'https://clang.llvm.org/docs/ThreadSanitizer.html'
 
+    EXAMPLE_CMD = """\
+# Compile your program with debug info.
+clang++ -fsanitize=thread -g tsan.cpp
+
+# Run your program and redirect the output to a file.
+./a.out > tsan.output 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of ThreadSanitizer.
+report-converter -t tsan -o ./tsan_results tsan.output"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sanitizers/ub/analyzer_result.py
@@ -21,6 +21,19 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'UndefinedBehaviorSanitizer'
     URL = 'https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html'
 
+    EXAMPLE_CMD = """\
+# Compile your program with debug info and a frame pointer.
+clang++ -fsanitize=undefined -g -fno-omit-frame-pointer ubsanitizer.cpp
+
+# Run your program and redirect the output to a file.
+UBSAN_OPTIONS=print_stacktrace=1 \\
+UBSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer \\
+./a.out > ubsan.output 2>&1
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of UndefinedBehaviorSanitizer.
+report-converter -t ubsan -o ./ubsan_results ubsan.output"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser().get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/smatch/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/smatch/analyzer_result.py
@@ -21,6 +21,20 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Smatch'
     URL = 'https://repo.or.cz/w/smatch.git'
 
+    EXAMPLE_CMD = """\
+# Change directory to your kernel source repository.
+cd path/to/linux/kernel/repository
+
+# Run Smatch (warnings are written to smatch_warns.txt by default).
+path/to/smatch/smatch_scripts/test_kernel.sh
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Smatch.
+report-converter -t smatch -o ./codechecker_smatch_reports ./smatch_warns.txt
+
+# Store the Smatch reports with CodeChecker.
+CodeChecker store ./codechecker_smatch_reports -n smatch"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sparse/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sparse/analyzer_result.py
@@ -21,6 +21,20 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Sparse'
     URL = 'https://git.kernel.org/pub/scm/devel/sparse/sparse.git'
 
+    EXAMPLE_CMD = """\
+# Change directory to your kernel source repository.
+cd path/to/linux/kernel/repository
+
+# Run Sparse and redirect the output to a file.
+make C=1 2>&1 | tee sparse.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Sparse.
+report-converter -t sparse -o ./codechecker_sparse_reports ./sparse.out
+
+# Store the Sparse reports with CodeChecker.
+CodeChecker store ./codechecker_sparse_reports -n sparse"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/sphinx/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/sphinx/analyzer_result.py
@@ -21,6 +21,20 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'Sphinx'
     URL = 'https://github.com/sphinx-doc/sphinx'
 
+    EXAMPLE_CMD = """\
+# Change directory to your kernel source repository.
+cd path/to/linux/kernel/repository
+
+# Run Sphinx and redirect the output to a file.
+make htmldocs 2>&1 | tee sphinx.out
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of Sphinx.
+report-converter -t sphinx -o ./codechecker_sphinx_reports ./sphinx.out
+
+# Store the Sphinx reports with CodeChecker.
+CodeChecker store ./codechecker_sphinx_reports -n sphinx"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Get reports from the given analyzer result. """
         return Parser(file_path).get_reports(file_path)

--- a/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/spotbugs/analyzer_result.py
@@ -28,6 +28,17 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'spotbugs'
     URL = 'https://spotbugs.github.io'
 
+    EXAMPLE_CMD = """\
+# Run SpotBugs, generating xml output with messages.
+spotbugs -xml:withMessages -output ./bugs.xml -textui /path/to/your/project
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of SpotBugs.
+report-converter -t spotbugs -o ./codechecker_spotbugs_reports ./bugs.xml
+
+# Store the SpotBugs reports with CodeChecker.
+CodeChecker store ./codechecker_spotbugs_reports -n spotbugs"""
+
     def __init__(self):
         super().__init__()
         self.__project_paths = []

--- a/tools/report-converter/codechecker_report_converter/analyzers/tslint/analyzer_result.py
+++ b/tools/report-converter/codechecker_report_converter/analyzers/tslint/analyzer_result.py
@@ -28,6 +28,18 @@ class AnalyzerResult(AnalyzerResultBase):
     NAME = 'TSLint'
     URL = 'https://palantir.github.io/tslint'
 
+    EXAMPLE_CMD = """\
+# Run TSLint and generate a json output file.
+tslint --format json /path/to/my/ts/file -o ./tslint_reports.json
+
+# Use 'report-converter' to create a CodeChecker report directory from the
+# analyzer result of TSLint.
+report-converter -t tslint -o ./codechecker_tslint_reports \
+    ./tslint_reports.json
+
+# Store the TSLint reports with CodeChecker.
+CodeChecker store ./codechecker_tslint_reports -n tslint"""
+
     def get_reports(self, file_path: str) -> List[Report]:
         """ Parse the given analyzer result. """
         reports: List[Report] = []

--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -53,6 +53,31 @@ class RawDescriptionDefaultHelpFormatter(
     descriptions. """
 
 
+class PrintExampleCmdAction(argparse.Action):
+    """
+    Argparse action which immediately prints a usage example for the given
+    analyzer TYPE and exits - similarly to the built-in '--version'/'--help'
+    actions, this bypasses this program's other required arguments (input,
+    --output, --type), since the user is only asking for documentation, not
+    actually running a conversion.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        analyzer_result = supported_converters[values]
+
+        if not analyzer_result.EXAMPLE_CMD:
+            LOG.warning(
+                "No usage example is available yet for '%s'. Please see "
+                "docs/tools/report-converter.md for more information.",
+                values)
+        else:
+            print(f"Example commands to produce a '{values}' output which "
+                  "'report-converter' can parse:\n")
+            print(analyzer_result.EXAMPLE_CMD)
+
+        parser.exit()
+
+
 # Load supported converters dynamically.
 supported_converters = {}
 analyzers_dir_path = os.path.join(os.path.dirname(
@@ -263,6 +288,17 @@ Supported analyzers:
                          for tool_name in sorted(supported_converters)])),
         formatter_class=RawDescriptionDefaultHelpFormatter
     )
+
+    parser.add_argument('--example',
+                        action=PrintExampleCmdAction,
+                        metavar='TYPE',
+                        choices=supported_converters,
+                        default=argparse.SUPPRESS,
+                        help="Print an example command showing how to "
+                             "produce an analyzer result file of the given "
+                             "TYPE that 'report-converter' can parse, then "
+                             "exit. Currently supported types are: " +
+                             ', '.join(sorted(supported_converters)) + ".")
     __add_arguments_to_parser(parser)
 
     args = parser.parse_args()

--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -63,9 +63,9 @@ class PrintExampleCmdAction(argparse.Action):
     """
 
     def __call__(self, parser, namespace, values, option_string=None):
-        analyzer_result = supported_converters[values]
+        analyzer_parser = supported_converters[values]
 
-        if not analyzer_result.EXAMPLE_CMD:
+        if not analyzer_parser.EXAMPLE_CMD:
             LOG.warning(
                 "No usage example is available yet for '%s'. Please see "
                 "docs/tools/report-converter.md for more information.",
@@ -73,7 +73,7 @@ class PrintExampleCmdAction(argparse.Action):
         else:
             print(f"Example commands to produce a '{values}' output which "
                   "'report-converter' can parse:\n")
-            print(analyzer_result.EXAMPLE_CMD)
+            print(analyzer_parser.EXAMPLE_CMD)
 
         parser.exit()
 

--- a/tools/report-converter/codechecker_report_converter/cli.py
+++ b/tools/report-converter/codechecker_report_converter/cli.py
@@ -53,6 +53,31 @@ class RawDescriptionDefaultHelpFormatter(
     descriptions. """
 
 
+class PrintExampleCmdAction(argparse.Action):
+    """
+    Argparse action which immediately prints a usage example for the given
+    analyzer TYPE and exits - similarly to the built-in '--version'/'--help'
+    actions, this bypasses this program's other required arguments (input,
+    --output, --type), since the user is only asking for documentation, not
+    actually running a conversion.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        analyzer_parser = supported_converters[values]
+
+        if not analyzer_parser.EXAMPLE_CMD:
+            LOG.warning(
+                "No usage example is available yet for '%s'. Please see "
+                "docs/tools/report-converter.md for more information.",
+                values)
+        else:
+            print(f"Example commands to produce a '{values}' output which "
+                  "'report-converter' can parse:\n")
+            print(analyzer_parser.EXAMPLE_CMD)
+
+        parser.exit()
+
+
 # Load supported converters dynamically.
 supported_converters = {}
 analyzers_dir_path = os.path.join(os.path.dirname(
@@ -263,6 +288,17 @@ Supported analyzers:
                          for tool_name in sorted(supported_converters)])),
         formatter_class=RawDescriptionDefaultHelpFormatter
     )
+
+    parser.add_argument('--example',
+                        action=PrintExampleCmdAction,
+                        metavar='TYPE',
+                        choices=supported_converters,
+                        default=argparse.SUPPRESS,
+                        help="Print an example command showing how to "
+                             "produce an analyzer result file of the given "
+                             "TYPE that 'report-converter' can parse, then "
+                             "exit. Currently supported types are: " +
+                             ', '.join(sorted(supported_converters)) + ".")
     __add_arguments_to_parser(parser)
 
     args = parser.parse_args()

--- a/tools/report-converter/tests/unit/test_cli.py
+++ b/tools/report-converter/tests/unit/test_cli.py
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Tests for the report-converter CLI, specifically the '--example' flag and
+the EXAMPLE_CMD interface it relies on (see
+https://github.com/Ericsson/codechecker/issues/4992).
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from codechecker_report_converter import cli
+
+
+class ExampleCmdInterfaceTest(unittest.TestCase):
+    """
+    Ensures every supported analyzer parser defines a usage example, and
+    that no future parser can be added without one.
+    """
+
+    def test_all_analyzers_define_example_cmd(self):
+        for tool_name, analyzer_result in cli.supported_converters.items():
+            self.assertTrue(
+                analyzer_result.EXAMPLE_CMD,
+                f"'{tool_name}' must define a non-empty EXAMPLE_CMD class "
+                "attribute (see AnalyzerResultBase.EXAMPLE_CMD) so users "
+                "can discover how to produce compatible input via "
+                f"'report-converter --example {tool_name}'.")
+
+
+class ExampleFlagTest(unittest.TestCase):
+    """ Tests for the 'report-converter --example TYPE' flag. """
+
+    def test_example_flag_prints_example_and_exits_zero(self):
+        """
+        For an analyzer with an EXAMPLE_CMD, '--example' should print it
+        and exit successfully, without requiring the tool's other
+        required arguments (input, --output, --type).
+        """
+        out = io.StringIO()
+        with patch('sys.argv', ['report-converter', '--example', 'ruff']), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit) as ctx:
+                cli.main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn('ruff check', out.getvalue())
+        self.assertIn('report-converter -t ruff', out.getvalue())
+
+    def test_example_flag_on_analyzer_without_example_does_not_crash(self):
+        """
+        Every real analyzer currently defines an EXAMPLE_CMD, but the
+        fallback path for one that doesn't (e.g. a newly added parser
+        mid-development) must still exit cleanly with a warning instead
+        of crashing.
+        """
+        tool_name = next(iter(cli.supported_converters))
+        analyzer_result = cli.supported_converters[tool_name]
+        original_example_cmd = analyzer_result.EXAMPLE_CMD
+        analyzer_result.EXAMPLE_CMD = ''
+        try:
+            argv = ['report-converter', '--example', tool_name]
+            with patch('sys.argv', argv):
+                with self.assertRaises(SystemExit) as ctx:
+                    cli.main()
+        finally:
+            analyzer_result.EXAMPLE_CMD = original_example_cmd
+
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_example_flag_rejects_unknown_analyzer(self):
+        """
+        An unsupported TYPE should be rejected the same way argparse
+        rejects any other invalid 'choices' value.
+        """
+        argv = ['report-converter', '--example', 'not_a_real_analyzer']
+        with patch('sys.argv', argv):
+            with self.assertRaises(SystemExit) as ctx:
+                cli.main()
+
+        self.assertEqual(ctx.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/report-converter/tests/unit/test_cli.py
+++ b/tools/report-converter/tests/unit/test_cli.py
@@ -1,0 +1,115 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Tests for the report-converter CLI, specifically the '--example' flag and
+the EXAMPLE_CMD interface it relies on (see
+https://github.com/Ericsson/codechecker/issues/4992).
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from codechecker_report_converter import cli
+
+
+# TOOL_NAMEs of analyzers that do not yet provide an EXAMPLE_CMD.
+#
+# This list must not grow: any newly added parser is required to define a
+# non-empty EXAMPLE_CMD (see AnalyzerResultBase.EXAMPLE_CMD). Existing
+# parsers on this list predate that requirement and should have one added
+# as a follow-up; when a parser is updated, remove it from this list.
+LEGACY_ANALYZERS_WITHOUT_EXAMPLE_CMD = {
+    'clang-tidy', 'clang-tidy-yaml', 'coccinelle', 'cppcheck', 'cpplint',
+    'eslint', 'gcc', 'golint', 'fbinfer', 'jscpd', 'kernel-doc', 'mdl',
+    'pmd', 'pvs-studio', 'pyflakes', 'pylint', 'roslynator', 'smatch',
+    'sparse', 'sphinx', 'spotbugs', 'tslint',
+    'asan', 'lsan', 'msan', 'tsan', 'ubsan',
+}
+
+
+class ExampleCmdInterfaceTest(unittest.TestCase):
+    """
+    Ensures new analyzer parsers can't be added without a usage example,
+    while allowing existing ones to be migrated gradually.
+    """
+
+    def test_new_analyzers_must_define_example_cmd(self):
+        for tool_name, analyzer_result in cli.supported_converters.items():
+            if tool_name in LEGACY_ANALYZERS_WITHOUT_EXAMPLE_CMD:
+                continue
+
+            self.assertTrue(
+                analyzer_result.EXAMPLE_CMD,
+                f"'{tool_name}' must define a non-empty EXAMPLE_CMD class "
+                "attribute (see AnalyzerResultBase.EXAMPLE_CMD) so users "
+                "can discover how to produce compatible input via "
+                "'report-converter --example {tool_name}'.")
+
+    def test_legacy_exemption_list_has_no_stale_entries(self):
+        """
+        Keeps the exemption list itself honest: every entry must still
+        correspond to a supported analyzer that genuinely lacks an
+        EXAMPLE_CMD. Once a legacy parser is updated, it must be removed
+        from this list rather than left behind.
+        """
+        for tool_name in LEGACY_ANALYZERS_WITHOUT_EXAMPLE_CMD:
+            self.assertIn(tool_name, cli.supported_converters)
+            self.assertFalse(
+                cli.supported_converters[tool_name].EXAMPLE_CMD,
+                f"'{tool_name}' now defines an EXAMPLE_CMD - please remove "
+                "it from LEGACY_ANALYZERS_WITHOUT_EXAMPLE_CMD.")
+
+
+class ExampleFlagTest(unittest.TestCase):
+    """ Tests for the 'report-converter --example TYPE' flag. """
+
+    def test_example_flag_prints_example_and_exits_zero(self):
+        """
+        For an analyzer with an EXAMPLE_CMD, '--example' should print it
+        and exit successfully, without requiring the tool's other
+        required arguments (input, --output, --type).
+        """
+        out = io.StringIO()
+        with patch('sys.argv', ['report-converter', '--example', 'ruff']), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit) as ctx:
+                cli.main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn('ruff check', out.getvalue())
+        self.assertIn('report-converter -t ruff', out.getvalue())
+
+    def test_example_flag_on_legacy_analyzer_does_not_crash(self):
+        """
+        For an analyzer that doesn't have an EXAMPLE_CMD yet, '--example'
+        should exit cleanly (with a warning) instead of crashing.
+        """
+        with patch('sys.argv', ['report-converter', '--example', 'pylint']):
+            with self.assertRaises(SystemExit) as ctx:
+                cli.main()
+
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_example_flag_rejects_unknown_analyzer(self):
+        """
+        An unsupported TYPE should be rejected the same way argparse
+        rejects any other invalid 'choices' value.
+        """
+        argv = ['report-converter', '--example', 'not_a_real_analyzer']
+        with patch('sys.argv', argv):
+            with self.assertRaises(SystemExit) as ctx:
+                cli.main()
+
+        self.assertEqual(ctx.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #4992 by adding a standardized way for `report-converter` analyzers to expose example commands for generating compatible input.

### What changed

* Added the `EXAMPLE_CMD` interface field to `AnalyzerResultBase`.
* Added `EXAMPLE_CMD` to the Ruff analyzer parser.
* Added a new `--example <ANALYZER>` CLI option to `report-converter`.
* `--example` works independently of the other required CLI arguments, similarly to `--help` and `--version`.
* Added documentation for Ruff and the new `--example` functionality.
* Added a documentation note recommending `--example` as the up-to-date source for analyzer example commands.
* Added CLI/interface tests covering:

  * An analyzer with an `EXAMPLE_CMD`.
  * An analyzer without an `EXAMPLE_CMD`.
  * Invalid analyzer names.
  * Enforcement that newly added analyzer parsers define `EXAMPLE_CMD`.

### Validation

Manually verified:

* `report-converter --example ruff` prints the expected example command and exits successfully.
* `report-converter --example pylint` handles an analyzer without an example gracefully without crashing.
* Invalid analyzer names are rejected cleanly by argparse.

All 5 newly added tests pass.

The broader `report-converter` test suite also contains pre-existing/environment-related failures unrelated to this change, including fixture corruption and package metadata mismatches. These were verified against the unmodified codebase.

### Motivation

This provides a consistent interface for analyzer-specific example commands and prevents new analyzer parsers from being added without documenting how their compatible input can be generated.
