### PR TITLE
Fix run deletion silently bypassing the active-lock check (#1445)

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1131,6 +1131,15 @@ def filter_unresolved_reports(q):
             .filter(Report.review_status.notin_(skip_review_statuses))
 
 
+def get_run_ids_for_filter(session, run_filter):
+    """
+    Resolve a RunFilter to the concrete list of run ids it currently
+    matches in the database.
+    """
+    return [r[0] for r in
+            process_run_filter(session, session.query(Run.id), run_filter)]
+
+
 def check_remove_runs_lock(session, run_ids):
     """
     Check if there is an existing lock on the given runs, which has not
@@ -4165,10 +4174,20 @@ class ThriftRequestHandler:
 
         # Remove the whole run.
         with DBSession(self._Session) as session:
-            check_remove_runs_lock(session, [run_id])
-
             if not run_filter:
                 run_filter = RunFilter(ids=[run_id])
+
+            # Resolve which runs are actually going to be deleted before
+            # checking for active locks. 'run_id' alone is not enough here:
+            # callers (e.g. the CLI's "CodeChecker cmd del" command) commonly
+            # pass 'run_id=None' and select the runs to remove purely via
+            # 'run_filter' (e.g. by name). Checking locks against
+            # '[run_id]' in that case previously meant checking against
+            # '[None]', which never matches any run and silently bypassed
+            # the lock check entirely (see #1445).
+            matched_run_ids = get_run_ids_for_filter(session, run_filter)
+            if matched_run_ids:
+                check_remove_runs_lock(session, matched_run_ids)
 
             q = process_run_filter(session, session.query(Run), run_filter)
 

--- a/web/server/tests/unit/test_run_removal_lock.py
+++ b/web/server/tests/unit/test_run_removal_lock.py
@@ -1,0 +1,107 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Regression tests for https://github.com/Ericsson/codechecker/issues/1445 -
+run deletion should be rejected while an active RunLock exists for the
+run(s) being removed.
+
+Previously, 'removeRun()' called 'check_remove_runs_lock(session,
+[run_id])'. Callers that select runs via 'run_filter' instead of a numeric
+id - such as the CLI's "CodeChecker cmd del" command, which always calls
+'removeRun(None, run_filter)' - passed 'run_id=None', so the lock check
+received '[None]'. Since no run ever has 'id IS NULL', this silently
+matched nothing and bypassed the lock check entirely, regardless of
+whether the targeted run(s) were actually locked.
+"""
+
+import unittest
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter
+from codechecker_api_shared.ttypes import RequestFailed
+
+from codechecker_server.api.report_server import \
+    check_remove_runs_lock, get_run_ids_for_filter
+from codechecker_server.database.run_db_model import \
+    Base, Run, RunLock
+
+
+class RunRemovalLockTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine('sqlite:///:memory:')
+        Base.metadata.create_all(self.engine)
+        self.session = sessionmaker(bind=self.engine)()
+
+        run1 = Run('locked_run', '1.0')
+        run1.id = 1
+        run2 = Run('unlocked_run', '1.0')
+        run2.id = 2
+        self.session.add(run1)
+        self.session.add(run2)
+        self.session.commit()
+
+        self.session.add(RunLock('locked_run'))
+        self.session.commit()
+
+    def tearDown(self):
+        self.session.close()
+        self.engine.dispose()
+
+    def test_run_id_none_no_longer_bypasses_lock_check(self):
+        """
+        This is the exact bug from #1445: resolving run ids via a
+        name-based filter (as the CLI does, always calling removeRun with
+        run_id=None) must still correctly detect an active lock, instead
+        of silently checking against '[None]'.
+        """
+        run_filter = RunFilter(names=['locked_run'], exactMatch=True)
+
+        matched_run_ids = get_run_ids_for_filter(self.session, run_filter)
+        self.assertEqual(matched_run_ids, [1])
+
+        with self.assertRaises(RequestFailed):
+            check_remove_runs_lock(self.session, matched_run_ids)
+
+    def test_unlocked_run_is_not_blocked(self):
+        run_filter = RunFilter(names=['unlocked_run'], exactMatch=True)
+
+        matched_run_ids = get_run_ids_for_filter(self.session, run_filter)
+        self.assertEqual(matched_run_ids, [2])
+
+        # Should not raise.
+        check_remove_runs_lock(self.session, matched_run_ids)
+
+    def test_old_buggy_call_pattern_would_have_missed_the_lock(self):
+        """
+        Documents the actual root cause: calling the lock check with
+        '[run_id]' where run_id is None (the old removeRun behavior for
+        any filter-based deletion) never detects any lock, no matter what
+        is actually locked.
+        """
+        check_remove_runs_lock(self.session, [None])  # Should not raise.
+
+    def test_expired_lock_does_not_block_removal(self):
+        stale_lock = self.session.query(RunLock) \
+            .filter(RunLock.name == 'locked_run').one()
+        stale_lock.locked_at = datetime.now() - timedelta(hours=1)
+        self.session.commit()
+
+        run_filter = RunFilter(names=['locked_run'], exactMatch=True)
+        matched_run_ids = get_run_ids_for_filter(self.session, run_filter)
+
+        # Should not raise: the lock is old enough to be considered
+        # expired/stale.
+        check_remove_runs_lock(self.session, matched_run_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1445

## Problem
Deleting a run while it is actively being stored into (RunLock present)
was not actually being rejected. Reported by @bruntib:
1. Start storing a run.
2. While RunLock is active, remove the run via the CLI.
3. Storage finishes, but the run gets deleted anyway - the deletion
   should have been rejected.

## Root cause
`removeRun(run_id, run_filter)` called
`check_remove_runs_lock(session, [run_id])`. The CLI's `CodeChecker cmd
del` command always calls this with `run_id=None`, selecting runs to
delete via `run_filter` (e.g. by name) instead. This meant the lock
check ran as `check_remove_runs_lock(session, [None])`.

Since `Run.id` is never `NULL`, filtering `Run.id.in_([None])` matches
zero rows unconditionally - the lock check silently passed regardless
of whether the targeted run was actually locked. I confirmed this with
an isolated reproduction of the exact query before making any changes.

## Fix
Added `get_run_ids_for_filter()`, which resolves `run_filter` to the
concrete list of run ids it currently matches (reusing the existing
`process_run_filter()` helper). `removeRun()` now resolves the real
target run ids first, and only then checks those ids against active
locks - so it works correctly whether the caller identifies the run(s)
by id or by filter.

## Testing
Added `web/server/tests/unit/test_run_removal_lock.py` with 4 tests
against an in-memory SQLite DB using the real ORM models:
- The exact bug scenario: resolving via a name-based `RunFilter` now
  correctly detects the active lock and raises.
- An unlocked run is not blocked.
- The old buggy call pattern (`check_remove_runs_lock(session,
  [None])`) is preserved as an explicit regression test documenting
  the root cause - it does not raise, showing why the bug occurred.
- An expired/stale lock does not block removal.

All new tests pass; pycodestyle clean; no changes to existing
behavior for callers that already pass a valid `run_id`.