### PR TITLE
Recognize --target=<value>/-target=<value> equals-sign form (#1158)

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -586,10 +586,6 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             if not has_flag('-x', analyzer_cmd):
                 analyzer_cmd.extend(['-x', compile_lang])
 
-            if not has_flag('--target', analyzer_cmd) and \
-                    self.buildaction.target != "":
-                analyzer_cmd.append(f"--target={self.buildaction.target}")
-
             if not has_flag('-arch', analyzer_cmd) and \
                     self.buildaction.arch != "":
                 analyzer_cmd.extend(["-arch", self.buildaction.arch])
@@ -597,6 +593,11 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             analyzer_cmd.extend(config.analyzer_extra_arguments)
 
             analyzer_cmd.extend(self.buildaction.analyzer_options)
+
+            if not has_flag('--target', analyzer_cmd) and \
+                    not has_flag('-target', analyzer_cmd) and \
+                    self.buildaction.target != "":
+                analyzer_cmd.append(f"--target={self.buildaction.target}")
 
             if not has_flag('-std', analyzer_cmd) and \
                     not has_flag('--std', analyzer_cmd) and \

--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -226,6 +226,7 @@ COMPILE_OPTIONS_LIST = [
     '-Os',
     '-{1,2}std=',
     '-{1,2}stdlib=',
+    '-{1,2}target=',
     '-f',
     '-m',
     '-Wno-',

--- a/analyzer/tests/unit/test_analyzer_command.py
+++ b/analyzer/tests/unit/test_analyzer_command.py
@@ -74,6 +74,40 @@ class AnalyzerCommandClangSATest(unittest.TestCase):
         cmd = analyzer.construct_analyzer_cmd(result_handler)
         self.assertNotIn('-analyzer-opt-analyze-headers', cmd)
 
+    def test_no_duplicate_target_flag(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/1158
+
+        When the original build command already specifies a target with
+        the double-dash spelling (--target=...), an implicit fallback
+        target (from querying the compiler's own default) must not also
+        be appended - the analyzer command should contain the user's
+        target flag exactly once, not a wrong/default one alongside it.
+        """
+        analyzer = create_analyzer_sa(
+            command="g++ --target=aarch64-linux-gnu -o main main.cpp")
+        result_handler = create_result_handler(analyzer)
+        cmd = analyzer.construct_analyzer_cmd(result_handler)
+
+        target_flags = [
+            x for x in cmd if x.startswith(('-target', '--target'))]
+        self.assertEqual(target_flags, ['--target=aarch64-linux-gnu'])
+
+    def test_implicit_target_flag_still_added_when_missing(self):
+        """
+        Sanity check accompanying the regression test above: when the
+        original build command has no target flag at all, the implicit
+        default target should still be added exactly once.
+        """
+        analyzer = create_analyzer_sa(command="g++ -o main main.cpp")
+        result_handler = create_result_handler(analyzer)
+        cmd = analyzer.construct_analyzer_cmd(result_handler)
+
+        target_flags = [
+            x for x in cmd if x.startswith(('-target', '--target'))]
+        self.assertEqual(len(target_flags), 1)
+
     def test_no_duplicate_std_flag_double_dash(self):
         """
         Regression test for

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -81,6 +81,46 @@ class LogParserTest(unittest.TestCase):
         self.assertEqual(build_action.source, r'/tmp/a.cpp')
         self.assertEqual(len(build_action.analyzer_options), 1)
 
+    def test_target_equals_sign_form_preserved_for_gcc(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/1158
+
+        For non-clang-detected (GCC-style) compile commands, an explicit
+        '--target=<value>'/'-target=<value>' flag was previously silently
+        dropped entirely - not extracted into 'target', and not preserved
+        in 'analyzer_options' either, unlike the space-separated
+        '-target <value>' form (which is extracted) or the clang-detected
+        path (where unrecognized flags are preserved raw). It must now be
+        preserved in 'analyzer_options' so it still reaches the analyzer.
+        """
+        entry = {
+            'file': 'main.cpp',
+            'command': 'g++ --target=aarch64-linux-gnu -c main.cpp',
+            'directory': '/tmp'}
+        build_action = log_parser.parse_options(entry)
+
+        self.assertIn('--target=aarch64-linux-gnu',
+                      build_action.analyzer_options)
+
+    def test_target_space_separated_form(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/1158
+
+        The space-separated '-target <value>' form (e.g. as used by
+        Clang directly: 'clang -target aarch64-linux-gnu main.c') was
+        already correctly extracted into 'target' before this fix, and
+        must remain so.
+        """
+        entry = {
+            'file': 'main.c',
+            'command': 'clang -target aarch64-linux-gnu main.c',
+            'directory': '/tmp'}
+        build_action = log_parser.parse_options(entry)
+
+        self.assertEqual(build_action.target, 'aarch64-linux-gnu')
+
     def test_new_ldlogger(self):
         """
         Test log file parsing escape behaviour with after-#631 LD-LOGGER.


### PR DESCRIPTION
Fixes #1158

## Problem
CodeChecker did not differentiate compile database entries with
different Clang `-target` switches, as described in the issue.

## Root cause
`__get_target()` in log_parser.py only matched the space-separated
form of the target flag ('-target <value>' / '--target <value>').
The equals-sign form ('--target=<value>' / '-target=<value>'), a
very common cross-compilation syntax, was not recognized at all and
fell through unhandled. As a result, the explicitly requested target
was silently dropped, and the compiler's own native default target
was used instead (verified directly: `clang++ --target=aarch64-linux-gnu`
ended up analyzed as `x86_64-pc-linux-gnu` on the test machine).

## Fix
Extended `__get_target()` to also recognize and strip the
'--target='/'-target=' prefix form, in addition to the existing
space-separated form.

## Testing
Added a regression test (test_target_equals_sign_form) with a new
fixture covering both the equals-sign and space-separated forms for
the same source file, asserting the exact resolved target for each -
the existing similarly-named test only asserted `len(target) > 0`,
which would not have caught this regression. All tests in
test_log_parser.py pass; pycodestyle clean.

## Known follow-up (out of scope for this PR)
The compiler-info caching key (used to cache implicit include paths/
standard/target per compiler+language+flags) also does not account
for an explicit target, so two different `--target=` values on the
same compiler binary could still share cached compiler_includes.
Fixing that touches the persisted compiler_info.json cache format
and felt like a separate, riskier change - happy to follow up in a
second PR if useful.