### PR TITLE
fix: strip ANSI escapes from clang-tidy output when collecting mentioned files

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -570,6 +570,11 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
 
         # A line mentioning a file in Clang-Tidy's output looks like this:
         # /home/.../.cpp:L:C: warning: foobar.
+        # With the UseColor option enabled Clang-Tidy wraps the diagnostics
+        # in ANSI escape sequences, so they have to be removed first,
+        # otherwise they would become part of the matched path.
+        ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
+
         regex = re.compile(
             # File path followed by a ':'.
             r'^(?P<path>[\S ]+?):'
@@ -581,7 +586,7 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
         paths = []
 
         for line in output.splitlines():
-            match = re.match(regex, line)
+            match = re.match(regex, ansi_escape.sub('', line))
             if match:
                 paths.append(match.group('path'))
 

--- a/analyzer/tests/unit/test_checker_option_parsing.py
+++ b/analyzer/tests/unit/test_checker_option_parsing.py
@@ -11,6 +11,7 @@ Test the parsing of checker options reported by the analyzers
 """
 
 import unittest
+from codechecker_analyzer.analyzers.clangtidy.analyzer import ClangTidy
 from codechecker_analyzer.analyzers.clangtidy.analyzer \
     import parse_checker_config as clangtidy_parse_checker_config
 
@@ -88,3 +89,34 @@ CheckOptions:
         self.assertIn(
             ["readability-suspicious-call-argument:PrefixSimilarAbove", "30"],
             result)
+
+
+class ClangTidyMentionedFilesTest(unittest.TestCase):
+    """
+    Test that the files mentioned in clang-tidy's output are collected
+    correctly.
+    """
+
+    def test_plain_output(self):
+        """
+        Test collecting the mentioned files from an uncolored output.
+        """
+        output = \
+            "/path/to/main.cpp:64:9: error: variable name 'i' is too short"
+
+        self.assertEqual(
+            ClangTidy.get_analyzer_mentioned_files(None, output),
+            {"/path/to/main.cpp"})
+
+    def test_colored_output(self):
+        """
+        Test collecting the mentioned files when the UseColor option is
+        enabled, so the diagnostics are wrapped in ANSI escape sequences.
+        """
+        output = \
+            "\x1b[1m/path/to/main.cpp:64:9: \x1b[0m\x1b[0;1;31merror: " \
+            "\x1b[0mvariable name 'i' is too short"
+
+        self.assertEqual(
+            ClangTidy.get_analyzer_mentioned_files(None, output),
+            {"/path/to/main.cpp"})


### PR DESCRIPTION
Closes #4411

With `UseColor: true`, clang-tidy wraps its diagnostics in ANSI escape sequences, so `ClangTidy.get_analyzer_mentioned_files()` captured the leading `\x1b[1m` as part of the file path and the debug-zip generation then failed with `FileNotFoundError` on a path prefixed by the escape code. The escapes are now stripped before the line is matched.

Unit tests for the plain and the colored output were added to `analyzer/tests/unit/test_checker_option_parsing.py`; the colored one fails without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
