### PR TITLE
[config] Point doc urls at live documentation

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -1210,7 +1210,7 @@
       "severity:MEDIUM"
     ],
     "cert-int09-c": [
-      "doc_url:https://clang.llmv.org/extra/clang-tidy/checks/cert/int09-c.html",
+      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/cert/int09-c.html",
       "severity:LOW"
     ],
     "cert-mem57-cpp": [
@@ -1659,7 +1659,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-binding-in-condition": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wbinding-in-condition",
+      "doc_url:https://releases.llvm.org/20.1.0/tools/clang/docs/DiagnosticsReference.html#wbinding-in-condition",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-bit-int-extension": [
@@ -2544,7 +2544,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-deprecated-static-analyzer-flag": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-deprecated-this-capture": [
@@ -2761,7 +2761,7 @@
       "severity:HIGH"
     ],
     "clang-diagnostic-enum-constexpr-conversion": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wenum-constexpr-conversion",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/DiagnosticsReference.html#wenum-constexpr-conversion",
       "severity:HIGH"
     ],
     "clang-diagnostic-enum-conversion": [
@@ -2818,15 +2818,15 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-experimental-lifetime-safety": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-lifetime-safety",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/DiagnosticsReference.html#wexperimental-lifetime-safety",
       "severity:HIGH"
     ],
     "clang-diagnostic-experimental-lifetime-safety-permissive": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-lifetime-safety-permissive",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/DiagnosticsReference.html#wexperimental-lifetime-safety-permissive",
       "severity:HIGH"
     ],
     "clang-diagnostic-experimental-lifetime-safety-strict": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-lifetime-safety-strict",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/DiagnosticsReference.html#wexperimental-lifetime-safety-strict",
       "severity:HIGH"
     ],
     "clang-diagnostic-explicit-initialize-call": [
@@ -2893,7 +2893,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-fixed-enum-extension": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-enum-extension",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/DiagnosticsReference.html#wfixed-enum-extension",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-fixed-point-overflow": [
@@ -3139,7 +3139,7 @@
       "severity:STYLE"
     ],
     "clang-diagnostic-generic-type-extension": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/DiagnosticsReference.html#wgeneric-type-extension",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-global-constructors": [
@@ -3300,7 +3300,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-higher-precision-fp": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/DiagnosticsReference.html#whigher-precision-fp",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-hip-omp-target-directives": [
@@ -3846,7 +3846,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-knl-knm-isa-support-removed": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-knr-promoted-parameter": [
@@ -4190,7 +4190,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-microsoft-static-assert": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-static-assert",
+      "doc_url:https://releases.llvm.org/20.1.0/tools/clang/docs/DiagnosticsReference.html#wmicrosoft-static-assert",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-microsoft-string-literal-from-predefined": [
@@ -6218,7 +6218,7 @@
       "severity:MEDIUM"
     ],
     "clang-diagnostic-undefined-arm-streaming": [
-      "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/DiagnosticsReference.html#wundefined-arm-streaming",
       "severity:MEDIUM"
     ],
     "clang-diagnostic-undefined-arm-za": [
@@ -7233,127 +7233,127 @@
       "severity:STYLE"
     ],
     "hicpp-avoid-c-arrays": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-c-arrays.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.html",
       "severity:LOW"
     ],
     "hicpp-avoid-goto": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-goto.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/avoid-goto.html",
       "severity:STYLE"
     ],
     "hicpp-braces-around-statements": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/braces-around-statements.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/braces-around-statements.html",
       "severity:STYLE"
     ],
     "hicpp-deprecated-headers": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/deprecated-headers.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/deprecated-headers.html",
       "severity:LOW"
     ],
     "hicpp-exception-baseclass": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/exception-baseclass.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/exception-baseclass.html",
       "severity:LOW"
     ],
     "hicpp-explicit-conversions": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/explicit-conversions.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/explicit-conversions.html",
       "severity:LOW"
     ],
     "hicpp-function-size": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/function-size.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/function-size.html",
       "severity:LOW"
     ],
     "hicpp-ignored-remove-result": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/ignored-remove-result.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.html",
       "severity:MEDIUM"
     ],
     "hicpp-invalid-access-moved": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/invalid-access-moved.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/invalid-access-moved.html",
       "severity:HIGH"
     ],
     "hicpp-member-init": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/member-init.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/member-init.html",
       "severity:LOW"
     ],
     "hicpp-move-const-arg": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/move-const-arg.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/move-const-arg.html",
       "severity:MEDIUM"
     ],
     "hicpp-multiway-paths-covered": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/multiway-paths-covered.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/multiway-paths-covered.html",
       "severity:STYLE"
     ],
     "hicpp-named-parameter": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/named-parameter.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/named-parameter.html",
       "severity:LOW"
     ],
     "hicpp-new-delete-operators": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/new-delete-operators.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/new-delete-operators.html",
       "severity:LOW"
     ],
     "hicpp-no-array-decay": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-array-decay.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/no-array-decay.html",
       "severity:LOW"
     ],
     "hicpp-no-assembler": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-assembler.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/no-assembler.html",
       "severity:LOW"
     ],
     "hicpp-no-malloc": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-malloc.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/no-malloc.html",
       "severity:LOW"
     ],
     "hicpp-noexcept-move": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/noexcept-move.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/noexcept-move.html",
       "severity:MEDIUM"
     ],
     "hicpp-signed-bitwise": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/signed-bitwise.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/signed-bitwise.html",
       "severity:LOW"
     ],
     "hicpp-special-member-functions": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/special-member-functions.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/special-member-functions.html",
       "severity:LOW"
     ],
     "hicpp-static-assert": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/static-assert.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/static-assert.html",
       "severity:LOW"
     ],
     "hicpp-undelegated-constructor": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/undelegated-constructor.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/undelegated-constructor.html",
       "severity:MEDIUM"
     ],
     "hicpp-uppercase-literal-suffix": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/uppercase-literal-suffix.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/uppercase-literal-suffix.html",
       "severity:STYLE"
     ],
     "hicpp-use-auto": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-auto.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-auto.html",
       "severity:STYLE"
     ],
     "hicpp-use-emplace": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-emplace.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-emplace.html",
       "severity:STYLE"
     ],
     "hicpp-use-equals-default": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-default.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-equals-default.html",
       "severity:LOW"
     ],
     "hicpp-use-equals-delete": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-delete.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-equals-delete.html",
       "severity:LOW"
     ],
     "hicpp-use-noexcept": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-noexcept.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-noexcept.html",
       "severity:STYLE"
     ],
     "hicpp-use-nullptr": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-nullptr.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-nullptr.html",
       "severity:LOW"
     ],
     "hicpp-use-override": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-override.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/use-override.html",
       "severity:LOW"
     ],
     "hicpp-vararg": [
-      "doc_url:https://clang.llvm.org/extra/clang-tidy/checks/hicpp/vararg.html",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/hicpp/vararg.html",
       "severity:LOW"
     ],
     "linuxkernel-must-check-errs": [

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -18,7 +18,7 @@
       "severity:HIGH"
     ],
     "alpha.core.CastSize": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-castsize-c",
+      "doc_url:https://releases.llvm.org/21.1.0/tools/clang/docs/analyzer/checkers.html#alpha-core-castsize-c",
       "severity:LOW"
     ],
     "alpha.core.CastToStruct": [
@@ -33,11 +33,11 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-dynamictypechecker-objc"
     ],
     "alpha.core.FixedAddr": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-fixedaddr-c",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/analyzer/checkers.html#alpha-core-fixedaddr-c",
       "severity:LOW"
     ],
     "alpha.core.IdenticalExpr": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-identicalexpr-c-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-core-identicalexpr-c-c",
       "severity:LOW"
     ],
     "alpha.core.PointerArithm": [
@@ -45,16 +45,16 @@
       "severity:LOW"
     ],
     "alpha.core.PointerSub": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-pointersub-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-core-pointersub-c",
       "severity:LOW"
     ],
     "alpha.core.PthreadLockBase": [],
     "alpha.core.SizeofPtr": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-sizeofptr-c",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/analyzer/checkers.html#alpha-core-sizeofptr-c",
       "severity:LOW"
     ],
     "alpha.core.StackAddressAsyncEscape": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-stackaddressasyncescape-c",
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-stackaddressasyncescape-objc",
       "severity:HIGH"
     ],
     "alpha.core.StdVariant": [
@@ -97,7 +97,7 @@
       "severity:MEDIUM"
     ],
     "alpha.cplusplus.MisusedMovedObject": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-cplusplus-misusedmovedobject-c"
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/analyzer/checkers.html#alpha-cplusplus-misusedmovedobject-c"
     ],
     "alpha.cplusplus.PlacementNew": [
       "severity:HIGH"
@@ -122,11 +122,11 @@
       "severity:LOW"
     ],
     "alpha.nondeterminism.PointerIteration": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-nondeterminism-pointeriteration-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-nondeterminism-pointeriteration-c",
       "severity:MEDIUM"
     ],
     "alpha.nondeterminism.PointerSorting": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-nondeterminism-pointersorting-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-nondeterminism-pointersorting-c",
       "severity:MEDIUM"
     ],
     "alpha.osx.cocoa.DirectIvarAssignment": [
@@ -151,19 +151,19 @@
       "severity:LOW"
     ],
     "alpha.security.ArrayBound": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-arraybound-c",
+      "doc_url:https://releases.llvm.org/20.1.0/tools/clang/docs/analyzer/checkers.html#alpha-security-arraybound-c",
       "severity:HIGH"
     ],
     "alpha.security.ArrayBoundV2": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-arrayboundv2-c",
+      "doc_url:https://releases.llvm.org/20.1.0/tools/clang/docs/analyzer/checkers.html#alpha-security-arrayboundv2-c",
       "severity:HIGH"
     ],
     "alpha.security.MallocOverflow": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-mallocoverflow-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-security-mallocoverflow-c",
       "severity:HIGH"
     ],
     "alpha.security.MmapWriteExec": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-mmapwriteexec-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-security-mmapwriteexec-c",
       "severity:MEDIUM"
     ],
     "alpha.security.ReturnPtrRange": [
@@ -175,11 +175,11 @@
       "severity:MEDIUM"
     ],
     "alpha.security.cert.pos.34c": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-security-cert-pos-34c",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/analyzer/checkers.html#alpha-security-cert-pos-34c",
       "severity:HIGH"
     ],
     "alpha.unix.Chroot": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-chroot-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-unix-chroot-c",
       "severity:MEDIUM"
     ],
     "alpha.unix.Errno": [
@@ -199,7 +199,7 @@
       "severity:HIGH"
     ],
     "alpha.unix.Stream": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-stream-c",
+      "doc_url:https://releases.llvm.org/18.1.1/tools/clang/docs/analyzer/checkers.html#alpha-unix-stream-c",
       "severity:MEDIUM"
     ],
     "alpha.unix.cstring.BufferOverlap": [
@@ -207,7 +207,7 @@
       "severity:HIGH"
     ],
     "alpha.unix.cstring.NotNullTerminated": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-cstring-notnullterminated-c",
+      "doc_url:https://releases.llvm.org/19.1.0/tools/clang/docs/analyzer/checkers.html#alpha-unix-cstring-notnullterminated-c",
       "severity:HIGH"
     ],
     "alpha.unix.cstring.OutOfBounds": [
@@ -215,7 +215,7 @@
       "severity:HIGH"
     ],
     "alpha.unix.cstring.UninitializedRead": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-unix-cstring-uninitializedread-c",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/analyzer/checkers.html#alpha-unix-cstring-uninitializedread-c",
       "severity:HIGH"
     ],
     "alpha.webkit.ForwardDeclChecker": [
@@ -236,7 +236,7 @@
       "severity:MEDIUM"
     ],
     "alpha.webkit.RetainPtrCtorAdoptChecker": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#alpha-webkit-retainptrctoradoptchecker",
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#webkit-retainptrctoradoptchecker",
       "severity:MEDIUM"
     ],
     "alpha.webkit.UncountedCallArgsChecker": [
@@ -318,7 +318,7 @@
     ],
     "core.FixedAddressDereference": [
       "cwe-top25:cwe-119",
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-fixedaddressdereference-c-c-objc",
+      "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/analyzer/checkers.html#core-fixedaddressdereference-c-c-objc",
       "guideline:cwe-top25-2024",
       "profile:default",
       "profile:extreme",
@@ -693,7 +693,7 @@
       "severity:HIGH"
     ],
     "nullability.NullReturnedFromNonnull": [
-      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull-objc",
+      "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull-c-c-objc",
       "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",

--- a/config/labels/analyzers/infer.json
+++ b/config/labels/analyzers/infer.json
@@ -116,7 +116,7 @@
         ],
         "infer-biabduction-memory-leak": [
             "description:See MEMORY_LEAK_C.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#biabduction_memory_leak",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#biabduction_memory_leak",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -217,7 +217,7 @@
         ],
         "infer-checkers-printf-args": [
             "description:This error is reported when the argument types to a printf method do not match the format string.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#checkers_printf_args",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#checkers_printf_args",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -268,13 +268,13 @@
         ],
         "infer-create-intent-from-uri": [
             "description:Create an intent/start a component using a (possibly user-controlled) URI. may or may not be an issue depending on where the URI comes from.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#create_intent_from_uri",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#create_intent_from_uri",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-cross-site-scripting": [
             "description:Untrusted data flows into HTML; XSS risk.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#cross_site_scripting",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#cross_site_scripting",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -291,7 +291,7 @@
         ],
         "infer-dangling-pointer-dereference": [
             "description:DATALOG_FACT",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#dangling_pointer_dereference",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#dangling_pointer_dereference",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -326,7 +326,7 @@
         ],
         "infer-divide-by-zero": [
             "description:EMPTY_VECTOR_ACCESS",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#divide_by_zero",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#divide_by_zero",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -337,7 +337,7 @@
         ],
         "infer-empty-vector-access": [
             "description:This error type is reported only in C++, in versions >= C++11.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#empty_vector_access",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#empty_vector_access",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -373,7 +373,7 @@
         ],
         "infer-exposed-insecure-intent-handling": [
             "description:Undocumented.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#exposed_insecure_intent_handling",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#exposed_insecure_intent_handling",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -443,7 +443,7 @@
         ],
         "infer-insecure-intent-handling": [
             "description:Undocumented.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#insecure_intent_handling",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#insecure_intent_handling",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -502,7 +502,7 @@
         ],
         "infer-javascript-injection": [
             "description:Untrusted data flows into JavaScript.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#javascript_injection",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#javascript_injection",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -526,7 +526,7 @@
         ],
         "infer-logging-private-data": [
             "description:Undocumented.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#logging_private_data",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#logging_private_data",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -738,7 +738,7 @@
         ],
         "infer-null-dereference": [
             "description:See NULLPTR_DEREFERENCE.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#null_dereference",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#null_dereference",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -766,7 +766,7 @@
         ],
         "infer-premature-nil-termination-argument": [
             "description:This error type is reported in C and Objective-C. In many variadic methods, nil is used to signify the end of the list of input objects. This is similar to nil-termination of C strings. If one of the arguments that is not the last argument to the method is nil as well, Infer reports an error because that may lead to unexpected behavior.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#premature_nil_termination_argument",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#premature_nil_termination_argument",
             "profile:unknown",
             "severity:MEDIUM"
         ],
@@ -904,7 +904,7 @@
         ],
         "infer-quandary-taint-error": [
             "description:Generic taint error when nothing else fits.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#quandary_taint_error",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#quandary_taint_error",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -916,7 +916,7 @@
         ],
         "infer-resource-leak": [
             "description:Infer reports resource leaks in C, Objective-C and Java. In general, resources are entities such as files, sockets, connections, etc, that need to be closed after being used.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#resource_leak",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#resource_leak",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -946,13 +946,13 @@
         ],
         "infer-shell-injection": [
             "description:Environment variable or file data flowing to shell.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#shell_injection",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#shell_injection",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-shell-injection-risk": [
             "description:Code injection if the caller of the endpoint doesn't sanitize on its end.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#shell_injection_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#shell_injection_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -963,13 +963,13 @@
         ],
         "infer-sql-injection": [
             "description:Untrusted and unescaped data flows to SQL.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#sql_injection",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#sql_injection",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-sql-injection-risk": [
             "description:Untrusted and unescaped data flows to SQL.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#sql_injection_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#sql_injection_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -1039,67 +1039,67 @@
         ],
         "infer-untrusted-buffer-access": [
             "description:Untrusted data of any kind flowing to buffer.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_buffer_access",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_buffer_access",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-deserialization": [
             "description:User-controlled deserialization.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_deserialization",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_deserialization",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-deserialization-risk": [
             "description:User-controlled deserialization",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_deserialization_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_deserialization_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-environment-change-risk": [
             "description:User-controlled environment mutation.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_environment_change_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_environment_change_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-file": [
             "description:User-controlled file creation; may be vulnerable to path traversal and more.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_file",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_file",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-file-risk": [
             "description:User-controlled file creation; may be vulnerable to path traversal and more.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_file_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_file_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-heap-allocation": [
             "description:Untrusted data of any kind flowing to heap allocation. this can cause crashes or DOS.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_heap_allocation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_heap_allocation",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-intent-creation": [
             "description:Creating an Intent from user-controlled data.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_intent_creation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_intent_creation",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-url-risk": [
             "description:Untrusted flag, environment variable, or file data flowing to URL.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_url_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_url_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-untrusted-variable-length-array": [
             "description:Untrusted data of any kind flowing to stack buffer allocation. Trying to allocate a stack buffer that's too large will cause a stack overflow.",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#untrusted_variable_length_array",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#untrusted_variable_length_array",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-user-controlled-sql-risk": [
             "description:Untrusted data flows to SQL (no injection risk).",
-            "doc_url:https://fbinfer.com/docs/all-issue-types#user_controlled_sql_risk",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#user_controlled_sql_risk",
             "profile:unknown",
             "severity:HIGH"
         ],
@@ -1163,237 +1163,237 @@
             "severity:HIGH"
         ],
         "infer-assign-pointer-MEDIUM": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#assign_pointer_MEDIUM",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#assign_pointer_warning",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-autoreleasepool-size-complexity-increase": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#autoreleasepool_size_complexity_increase",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#autoreleasepool_size_complexity_increase",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-autoreleasepool-size-complexity-increase-ui-thread": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#autoreleasepool_size_complexity_increase_ui_thread",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#autoreleasepool_size_complexity_increase_ui_thread",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-autoreleasepool-size-unreachable-at-exit": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#autoreleasepool_size_unreachable_at_exit",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#autoreleasepool_size_unreachable_at_exit",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-bad-pointer-comparison": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#bad_pointer_comparison",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#bad_pointer_comparison",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-checkers-annotation-reachability-HIGH": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#checkers_annotation_reachability_HIGH",
+            "doc_url:https://fbinfer.com/docs/all-issue-types#checkers_annotation_reachability_error",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-checkers-immutable-cast": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#checkers_immutable_cast",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#checkers_immutable_cast",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-component-with-multiple-factory-methods": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#component_with_multiple_factory_methods",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#component_with_multiple_factory_methods",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-config-checks-between-markers": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#config_checks_between_markers",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#config_checks_between_markers",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-cxx-reference-captured-in-objc-block": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#cxx_reference_captured_in_objc_block",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#cxx_reference_captured_in_objc_block",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-direct-atomic-property-access": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#direct_atomic_property_access",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#direct_atomic_property_access",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-discouraged-weak-property-custom-setter": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#discouraged_weak_property_custom_setter",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#discouraged_weak_property_custom_setter",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-dotnet-resource-leak": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#dotnet_resource_leak",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#dotnet_resource_leak",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-eradicate-annotation-graph": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_annotation_graph",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_annotation_graph",
             "profile:unknown",
             "severity:STYLE"
         ],
         "infer-eradicate-bad-nested-class-annotation": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_bad_nested_class_annotation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_bad_nested_class_annotation",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-condition-redundant": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_condition_redundant",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_condition_redundant",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-eradicate-field-not-initialized": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_field_not_initialized",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_field_not_initialized",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-field-not-nullable": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_field_not_nullable",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_field_not_nullable",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-field-over-annotated": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_field_over_annotated",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_field_over_annotated",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-eradicate-inconsistent-subclass-parameter-annotation": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_inconsistent_subclass_parameter_annotation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_inconsistent_subclass_parameter_annotation",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-inconsistent-subclass-return-annotation": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_inconsistent_subclass_return_annotation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_inconsistent_subclass_return_annotation",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-meta-class-can-be-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_meta_class_can_be_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_meta_class_can_be_nullsafe",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-eradicate-meta-class-is-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_meta_class_is_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_meta_class_is_nullsafe",
             "profile:unknown",
             "severity:STYLE"
         ],
         "infer-eradicate-meta-class-needs-improvement": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_meta_class_needs_improvement",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_meta_class_needs_improvement",
             "profile:unknown",
             "severity:STYLE"
         ],
         "infer-eradicate-nullable-dereference": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_nullable_dereference",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_nullable_dereference",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-parameter-not-nullable": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_parameter_not_nullable",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_parameter_not_nullable",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-redundant-nested-class-annotation": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_redundant_nested_class_annotation",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_redundant_nested_class_annotation",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-eradicate-return-not-nullable": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_return_not_nullable",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_return_not_nullable",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-eradicate-return-over-annotated": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_return_over_annotated",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_return_over_annotated",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-eradicate-unchecked-usage-in-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_unchecked_usage_in_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_unchecked_usage_in_nullsafe",
             "profile:unknown",
             "severity:UNSPECIFIED"
         ],
         "infer-eradicate-unvetted-third-party-in-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#eradicate_unvetted_third_party_in_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#eradicate_unvetted_third_party_in_nullsafe",
             "profile:unknown",
             "severity:UNSPECIFIED"
         ],
         "infer-expensive-autoreleasepool-size": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#expensive_autoreleasepool_size",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#expensive_autoreleasepool_size",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-global-variable-initialized-with-function-or-method-call": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#global_variable_initialized_with_function_or_method_call",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#global_variable_initialized_with_function_or_method_call",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-guardedby-violation-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#guardedby_violation_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#guardedby_violation_nullsafe",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-infinite-autoreleasepool-size": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#infinite_autoreleasepool_size",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#infinite_autoreleasepool_size",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-ivar-not-null-checked": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#ivar_not_null_checked",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#ivar_not_null_checked",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-memory-leak": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#memory_leak",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#memory_leak",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-mutable-local-variable-in-component-file": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#mutable_local_variable_in_component_file",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#mutable_local_variable_in_component_file",
             "profile:unknown",
             "severity:LOW"
         ],
         "infer-parameter-not-null-checked": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#parameter_not_null_checked",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#parameter_not_null_checked",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-pointer-to-const-objc-class": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#pointer_to_const_objc_class",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#pointer_to_const_objc_class",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-quandary-taint-HIGH": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#quandary_taint_HIGH",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#quandary_taint_error",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-strong-delegate-MEDIUM": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#strong_delegate_MEDIUM",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#strong_delegate_warning",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-thread-safety-violation-nullsafe": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#thread_safety_violation_nullsafe",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#thread_safety_violation_nullsafe",
             "profile:unknown",
             "severity:MEDIUM"
         ],
         "infer-topl-HIGH": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#topl_HIGH",
+            "doc_url:https://fbinfer.com/docs/all-issue-types#topl_error",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-uninitialized-value": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types#uninitialized_value",
+            "doc_url:https://fbinfer.com/docs/1.1.0/all-issue-types#uninitialized_value",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-internal-HIGH": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types##",
+            "doc_url:https://fbinfer.com/docs/all-issue-types",
             "profile:unknown",
             "severity:HIGH"
         ],
         "infer-symexec-memory-HIGH": [
-            "doc_url:https://fbinfer.com/docs/all-issue-types##",
+            "doc_url:https://fbinfer.com/docs/all-issue-types",
             "profile:unknown",
             "severity:HIGH"
         ]

--- a/config/labels/analyzers/mdl.json
+++ b/config/labels/analyzers/mdl.json
@@ -158,7 +158,7 @@
       "severity:STYLE"
     ],
     "MD055": [
-      "doc_url:https://github.com/markdownlint/markdownlint/blob/v0.13.0/docs/RULES.md#md055---table-row-doesnt-begin-end-with-pipes",
+      "doc_url:https://github.com/markdownlint/markdownlint/blob/v0.13.0/docs/RULES.md#md055---table-row-doesnt-beginend-with-pipes",
       "severity:STYLE"
     ],
     "MD056": [
@@ -166,7 +166,7 @@
       "severity:STYLE"
     ],
     "MD057": [
-      "doc_url:https://github.com/markdownlint/markdownlint/blob/v0.13.0/docs/RULES.md#md057---table-has-missing-or-invalid-header-separation",
+      "doc_url:https://github.com/markdownlint/markdownlint/blob/v0.13.0/docs/RULES.md#md057---table-has-missing-or-invalid-header-separation-second-row",
       "severity:STYLE"
     ]
   }


### PR DESCRIPTION
Checked every doc_url in the label files and 146 were dead: upstream
rebuilds its docs from trunk, so when a checker is renamed or dropped,
the link rots silently.
Where the checker is still documented but under a changed anchor, the
url is re-anchored.
Where it is gone from trunk, the url is pinned to the last version's url
that had the docs for that checker.
The hicpp check pages are no longer generated on trunk at all, so those
are pinned as well.
There was also one mistyped host and two wrong markdownlint anchors.

Five infer entries had CodeChecker's severity token substituted into the
anchor as well as into the checker name, so they get infer's own token
back, and two more carried a stray empty fragment.
The two entries left alone point at issue types that no published
version of the infer docs describes.