### PR TITLE
[analyzer] Deprecate --z3 constraint solver flag

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -61,9 +61,17 @@ def is_z3_capable():
     if not enabled_analyzers:
         return False
 
-    return host_check.has_analyzer_option(ClangSA.analyzer_binary(),
-                                          ['-Xclang',
-                                           '-analyzer-constraints=z3'])
+    # Newer clang (>= 23) renamed -analyzer-constraints=z3 to
+    # -analyzer-constraints=unsupported-z3. Try the new name first,
+    # then fall back to the old name for older clang versions.
+    if host_check.has_analyzer_option(
+            ClangSA.analyzer_binary(),
+            ['-Xclang', '-analyzer-constraints=unsupported-z3']):
+        return True
+
+    return host_check.has_analyzer_option(
+        ClangSA.analyzer_binary(),
+        ['-Xclang', '-analyzer-constraints=z3'])
 
 
 def is_z3_refutation_capable():

--- a/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangsa/analyzer.py
@@ -554,11 +554,7 @@ class ClangSA(analyzer_base.SourceAnalyzer):
                     '-Xclang',
                     'aggressive-binary-operation-simplification=true'])
 
-            # Enable the z3 solver backend.
-            if config.enable_z3:
-                analyzer_cmd.extend(['-Xclang', '-analyzer-constraints=z3'])
-
-            if config.enable_z3_refutation and not config.enable_z3:
+            if config.enable_z3_refutation:
                 analyzer_cmd.extend(['-Xclang',
                                      '-analyzer-config',
                                      '-Xclang',
@@ -747,6 +743,12 @@ class ClangSA(analyzer_base.SourceAnalyzer):
             if 'report_hash' in args else None
 
         handler.enable_z3 = 'enable_z3' in args and args.enable_z3 == 'on'
+        if handler.enable_z3:
+            LOG.warning("The '--z3' flag is deprecated and has no effect. "
+                        "The Z3 constraint solver backend is no longer "
+                        "supported by upstream Clang. This flag will be "
+                        "removed in CodeChecker 6.30. Use "
+                        "'--z3-refutation' instead.")
 
         handler.enable_z3_refutation = 'enable_z3_refutation' in args and \
             args.enable_z3_refutation == 'on'

--- a/analyzer/codechecker_analyzer/cli/analyze.py
+++ b/analyzer/codechecker_analyzer/cli/analyze.py
@@ -513,14 +513,13 @@ def add_arguments_to_parser(parser):
                                dest='enable_z3',
                                choices=['on', 'off'],
                                default='off',
-                               help="Enable Z3 as the solver backend. "
-                                    "This allows reasoning over more "
-                                    "complex queries, but performance is "
-                                    "much worse than the default "
-                                    "range-based constraint solver "
-                                    "system. WARNING: Z3 as the only "
-                                    "backend is a highly experimental "
-                                    "and likely unstable feature.")
+                               help="[DEPRECATED] This flag has no effect "
+                                    "and will be removed in CodeChecker "
+                                    "6.30. The Z3 constraint solver "
+                                    "backend is no longer supported by "
+                                    "upstream Clang. Use '--z3-refutation' "
+                                    "for Z3-based false positive "
+                                    "reduction instead.")
 
     clang_has_z3_refutation = analyzer_types.is_z3_refutation_capable()
 
@@ -1231,11 +1230,12 @@ def check_satisfied_capabilities(args):
         LOG.info("hint: Clang 11.0.0 is the earliest version to support it")
         has_error = True
 
-    if 'enable_z3' in args and args.enable_z3 == 'on' and not \
-            analyzer_types.is_z3_capable():
-        LOG.error("Z3 solver cannot be enabled as Clang was not compiled with "
-                  "Z3!")
-        has_error = True
+    if 'enable_z3' in args and args.enable_z3 == 'on':
+        LOG.warning("The '--z3' flag is deprecated and has no effect. "
+                    "The Z3 constraint solver backend is no longer "
+                    "supported by upstream Clang. This flag will be "
+                    "removed in CodeChecker 6.30. Use "
+                    "'--z3-refutation' instead.")
 
     if 'enable_z3_refutation' in args and args.enable_z3_refutation == 'on' \
             and not analyzer_types.is_z3_capable():

--- a/analyzer/codechecker_analyzer/cli/check.py
+++ b/analyzer/codechecker_analyzer/cli/check.py
@@ -480,14 +480,13 @@ used to generate a log file on the fly.""")
                                dest='enable_z3',
                                choices=['on', 'off'],
                                default='off',
-                               help="Enable Z3 as the solver backend. "
-                                    "This allows reasoning over more "
-                                    "complex queries, but performance is "
-                                    "much worse than the default "
-                                    "range-based constraint solver "
-                                    "system. WARNING: Z3 as the only "
-                                    "backend is a highly experimental "
-                                    "and likely unstable feature.")
+                               help="[DEPRECATED] This flag has no effect "
+                                    "and will be removed in CodeChecker "
+                                    "6.30. The Z3 constraint solver "
+                                    "backend is no longer supported by "
+                                    "upstream Clang. Use '--z3-refutation' "
+                                    "for Z3-based false positive "
+                                    "reduction instead.")
 
     clang_has_z3_refutation = analyzer_types.is_z3_refutation_capable()
 

--- a/analyzer/tests/functional/z3/test_z3.py
+++ b/analyzer/tests/functional/z3/test_z3.py
@@ -127,15 +127,19 @@ class TestSkeleton(unittest.TestCase):
         print(output)
         print(err)
 
-        # Get if the package is z3 compatible.
+        # Probe z3 capability by trying --z3-refutation on.  If the
+        # analyzer exits with an error about Z3 not being available,
+        # the tests that need actual Z3 support will be skipped.
         cmd = [self._codechecker_cmd,
                'analyze', 'compile_command.json',
                '-o', 'reports',
-               '--z3', 'on']
+               '--z3-refutation', 'on']
         test_project_path = self._testproject_data['project_path']
-        output, _, _ = call_command(cmd, cwd=test_project_path, env=self.env)
-        self.z3_capable = 'Z3 solver cannot be enabled' not in output
-        print(f"'analyze' reported z3 compatibility? {self.z3_capable}")
+        output, _, ret = call_command(
+            cmd, cwd=test_project_path, env=self.env)
+        self.z3_capable = ret == 0
+        print(f"z3-refutation probe exit code: {ret}, "
+              f"z3 capable: {self.z3_capable}")
 
         if not self.z3_capable:
             try:
@@ -146,9 +150,7 @@ class TestSkeleton(unittest.TestCase):
                 pass
 
     def test_z3(self):
-        """ Enable z3 during analysis. """
-        if not self.z3_capable:
-            self.skipTest(NO_Z3_MESSAGE)
+        """ Test that --z3 flag emits deprecation warning. """
 
         test_project_path = self._testproject_data['project_path']
 
@@ -161,7 +163,8 @@ class TestSkeleton(unittest.TestCase):
         output, _, ret = call_command(
             cmd, cwd=test_project_path, env=self.env)
         self.assertEqual(ret, 0)
-        self.assertIn("-analyzer-constraints=z3", output)
+        self.assertNotIn("-analyzer-constraints=z3", output)
+        self.assertIn("deprecated", output)
 
     def test_z3_refutation(self):
         """ Enable z3 refutation during analysis. """

--- a/docs/analyzer/checker_and_analyzer_configuration.md
+++ b/docs/analyzer/checker_and_analyzer_configuration.md
@@ -95,10 +95,10 @@ inconsistent (according to the more accurate constraint tracking of Z3).
 * This Z3 refutation mode (which is also known as Z3 validation and Z3
   crosschecking) should not be confused with the "Z3 as the constraint solver"
   mode where Z3 completely replaces the builtin constraint modeling of the
-  analyzer. Unfortunately this "Z3 as constraint solver" mode is a failed
-  experiment: it produces many crashes, increases the runtime by an order of
-  magnitude and there are no plans to improve it in the foreseeable future.
-  Passing `--z3 on` to `CodeChecker analyze` enables this broken mode.
+  analyzer. This mode was removed from upstream Clang (replaced by
+  `-analyzer-constraints=unsupported-z3`), and the `--z3 on` flag in
+  CodeChecker is deprecated with no effect. It will be removed in
+  CodeChecker 6.30.
 * If the `clang` used by CodeChecker does not support Z3, then CodeChecker does
   not recognize the Z3-specific options, which produces confusing errors like
   `error: argument input: File doesn't exist: <SOMEPATH>/on` (because the value

--- a/docs/analyzer/user_guide.md
+++ b/docs/analyzer/user_guide.md
@@ -323,11 +323,11 @@ analyzer arguments:
                         analysis of a particular file takes longer than this
                         time, the analyzer is killed and the analysis is
                         considered as a failed one.
-  --z3 {on,off}         Enable Z3 as the solver backend. This allows reasoning
-                        over more complex queries, but performance is much worse
-                        than the default range-based constraint solver system.
-                        WARNING: Z3 as the only backend is a highly
-                        experimental and likely unstable feature. (default: off)
+  --z3 {on,off}         [DEPRECATED] This flag has no effect and will be
+                        removed in CodeChecker 6.30. The Z3 constraint solver
+                        backend is no longer supported by upstream Clang. Use
+                        '--z3-refutation' for Z3-based false positive reduction
+                        instead. (default: off)
   --z3-refutation {on,off}
                         Switch on/off the Z3 SMT Solver backend to reduce
                         false positives. The results of the ranged based
@@ -1278,11 +1278,11 @@ analyzer arguments:
                         analysis of a particular file takes longer than this
                         time, the analyzer is killed and the analysis is
                         considered as a failed one.
-  --z3 {on,off}         Enable Z3 as the solver backend. This allows reasoning
-                        over more complex queries, but performance is much worse
-                        than the default range-based constraint solver system.
-                        WARNING: Z3 as the only backend is a highly
-                        experimental and likely unstable feature. (default: off)
+  --z3 {on,off}         [DEPRECATED] This flag has no effect and will be
+                        removed in CodeChecker 6.30. The Z3 constraint solver
+                        backend is no longer supported by upstream Clang. Use
+                        '--z3-refutation' for Z3-based false positive reduction
+                        instead. (default: off)
   --z3-refutation {on,off}
                         Switch on/off the Z3 SMT Solver backend to reduce
                         false positives. The results of the ranged based


### PR DESCRIPTION
Upstream Clang removed -analyzer-constraints=z3, replacing it with
unsupported-z3 (llvm/llvm-project#205370). CodeChecker no longer
injects this flag into the analyzer command line.

- --z3 flag is kept but deprecated (no-op with warning), removal in 6.30
- is_z3_capable() probes both unsupported-z3 and z3 for older clangs
- Z3 refutation (--z3-refutation) is unaffected