### PR TITLE
[gui] Fix compared to run filter disappearing from the url

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToRunFilter.vue
@@ -177,6 +177,8 @@ const selectTagMenu = ref(false);
 const selectTagForRun = ref(null);
 const prevSelectedRuns = ref([]);
 const prevSelectedTagItems = ref([]);
+const selectedRunIds = ref([]);
+const selectedTagIds = ref([]);
 const search = ref({
   placeHolder: "Search for run names (e.g.: myrun*)...",
   regexLabel: "Filter by wildcard pattern (e.g.: myrun*)",
@@ -307,6 +309,7 @@ async function initByUrl() {
   if (_runs.length || _tags.length) {
     let _selectedTags = [];
     if (_tags.length) {
+      selectedTagIds.value = _tags;
       _selectedTags = await getSelectedTagItems(_tags);
 
       // Add runs related to tags.
@@ -316,6 +319,7 @@ async function initByUrl() {
       _runs = [ ...new Set(_runs) ];
     }
 
+    selectedRunIds.value = _runs;
     const _selectedRuns = await getSelectedRunItems(_runs);
 
     await setSelectedItems(_selectedRuns, _selectedTags, false);
@@ -343,6 +347,8 @@ function applyTagSelection(selected) {
 }
 
 async function clear(updateUrl) {
+  selectedRunIds.value = [];
+  selectedTagIds.value = [];
   await setSelectedItems([], [], updateUrl);
 }
 
@@ -351,11 +357,21 @@ function selectRunTags(selectedItems) {
 }
 
 function getUrlState() {
-  const _runState = baseSelectOptionFilter.selectedItems.value.map(
+  let _runState = selectedRunIds.value;
+  const _newRunState = baseSelectOptionFilter.selectedItems.value.map(
     item => baseSelectOptionFilter.encodeValue.value(item.id)
   );
 
-  const _tagState = runFilter.selectedTagItems.value.map(item => item.id);
+  if (_newRunState.length) {
+    _runState = _newRunState;
+  }
+
+  let _tagState = selectedTagIds.value;
+  const _newTagState = runFilter.selectedTagItems.value.map(item => item.id);
+
+  if (_newTagState.length) {
+    _tagState = _newTagState;
+  }
 
   return {
     [id]: _runState.length ? _runState : undefined,


### PR DESCRIPTION
This change applies the same one that was done to the run name filter to prevent the variable 'newcheck' disappearing from the url on page load.