### PR TITLE
[gui] Make report filters hideable

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -140,14 +140,18 @@
 
     <v-divider />
 
-    <div>
+    <div
+      v-if="!hiddenFilters.includes('unique-filter')"
+    >
       <unique-filter
         :ref="setFilterRef"
         @update:url="updateUrl"
       />
     </div>
 
-    <v-divider />
+    <v-divider
+      v-if="!hiddenFilters.includes('unique-filter')"
+    />
 
     <v-list
       density="compact"
@@ -155,7 +159,10 @@
       :rounded="false"
       elevation="0"
     >
-      <v-list-item class="pl-0 border-sm border-solid border-opacity">
+      <v-list-item
+        v-if="!hiddenFilters.includes('group:baseline')"
+        class="pl-0 border-sm border-solid border-opacity"
+      >
         <v-expansion-panels
           v-model="activeBaselinePanelId"
           eager
@@ -181,13 +188,21 @@
             </v-expansion-panel-title>
             <v-expansion-panel-text class="pa-1">
               <baseline-run-filter
+                v-if="!hiddenFilters.includes('baseline-run-filter')"
                 :ref="setBaselineRunFilterRef"
                 @update:url="updateUrl"
               />
 
-              <v-divider />
+              <v-divider
+                v-if="!hiddenFilters.includes(
+                  'baseline-open-reports-date-filter'
+                )"
+              />
 
               <baseline-open-reports-date-filter
+                v-if="!hiddenFilters.includes(
+                  'baseline-open-reports-date-filter'
+                )"
                 :ref="setBaselineOpenReportsDateFilterRef"
                 @update:url="updateUrl"
               />
@@ -197,7 +212,7 @@
       </v-list-item>
 
       <v-list-item
-        v-if="showCompareTo"
+        v-if="!hiddenFilters.includes('group:compareTo')"
         class="pl-0 border-sm border-solid border-opacity border-t-0"
       >
         <v-expansion-panels
@@ -226,21 +241,33 @@
             </v-expansion-panel-title>
             <v-expansion-panel-text class="pa-1">
               <compared-to-run-filter
+                v-if="!hiddenFilters.includes(
+                  'compared-to-run-filter'
+                )"
                 :ref="setComparedToRunFilterRef"
                 @update:url="updateUrl"
               />
 
-              <v-divider />
+              <v-divider
+                v-if="!hiddenFilters.includes(
+                  'compared-to-open-reports-date-filter'
+                )"
+              />
 
               <compared-to-open-reports-date-filter
+                v-if="!hiddenFilters.includes(
+                  'compared-to-open-reports-date-filter'
+                )"
                 :ref="setComparedToOpenReportsDateFilterRef"
                 @update:url="updateUrl"
               />
 
-              <v-divider v-if="showDiffType" />
+              <v-divider
+                v-if="!hiddenFilters.includes('compared-to-diff-type-filter')"
+              />
 
               <compared-to-diff-type-filter
-                v-if="showDiffType"
+                v-if="!hiddenFilters.includes('compared-to-diff-type-filter')"
                 :ref="setComparedToDiffTypeFilterRef"
                 @update:url="updateUrl"
               />
@@ -249,44 +276,64 @@
         </v-expansion-panels>
       </v-list-item>
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('file-path-filter')"
+        class="pl-1"
+      >
         <file-path-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('file-path-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('checker-name-filter')"
+        class="pl-1"
+      >
         <checker-name-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('checker-name-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('severity-filter')"
+        class="pl-1"
+      >
         <severity-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('severity-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('report-status-filter')"
+        class="pl-1"
+      >
         <report-status-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider v-if="showReviewStatus" />
+      <v-divider
+        v-if="!hiddenFilters.includes('report-status-filter')"
+      />
 
       <v-list-item
-        v-if="showReviewStatus"
+        v-if="!hiddenFilters.includes('review-status-filter')"
         class="pl-1"
       >
         <review-status-filter
@@ -295,52 +342,80 @@
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('review-status-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('detection-status-filter')"
+        class="pl-1"
+      >
         <detection-status-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('detection-status-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('analyzer-name-filter')"
+        class="pl-1"
+      >
         <analyzer-name-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('analyzer-name-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('source-component-filter')"
+        class="pl-1"
+      >
         <source-component-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('source-component-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('cleanup-plan-filter')"
+        class="pl-1"
+      >
         <cleanup-plan-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('cleanup-plan-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('checker-message-filter')"
+        class="pl-1"
+      >
         <checker-message-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
         />
       </v-list-item>
 
-      <v-list-item class="pl-0 border-sm border-solid border-opacity">
+      <v-list-item
+        v-if="!hiddenFilters.includes('group:dateFilter')"
+        class="pl-0 border-sm border-solid border-opacity"
+      >
         <v-expansion-panels
           v-model="activeDatePanelId"
           hover
@@ -367,14 +442,19 @@
             </v-expansion-panel-title>
             <v-expansion-panel-text class="pa-1">
               <detection-date-filter
+                v-if="!hiddenFilters.includes('detection-date-filter')"
                 id="detection-date-filter"
                 :ref="setDetectionDateFilterRef"
                 @update:url="updateUrl"
               />
 
-              <v-divider class="mt-2" />
+              <v-divider
+                v-if="!hiddenFilters.includes('fix-date-filter')"
+                class="mt-2"
+              />
 
               <fix-date-filter
+                v-if="!hiddenFilters.includes('fix-date-filter')"
                 id="fix-date-filter"
                 :ref="setFixDateFilterRef"
                 @update:url="updateUrl"
@@ -384,7 +464,10 @@
         </v-expansion-panels>
       </v-list-item>
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('report-hash-filter')"
+        class="pl-1"
+      >
         <report-hash-filter
           id="report-hash-filter"
           :ref="setFilterRef"
@@ -392,9 +475,14 @@
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('report-hash-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('bug-path-length-filter')"
+        class="pl-1"
+      >
         <bug-path-length-filter
           id="bug-path-length-filter"
           :ref="setFilterRef"
@@ -402,9 +490,14 @@
         />
       </v-list-item>
 
-      <v-divider />
+      <v-divider
+        v-if="!hiddenFilters.includes('bug-path-length-filter')"
+      />
 
-      <v-list-item class="pl-1">
+      <v-list-item
+        v-if="!hiddenFilters.includes('testcase-filter')"
+        class="pl-1"
+      >
         <testcase-filter
           :ref="setFilterRef"
           @update:url="updateUrl"
@@ -423,6 +516,13 @@
         @update="updateAllFilters"
       />
     </div>
+    <v-alert
+      v-if="hiddenFilters.length"
+      class="mr-4 text-subtitle-2"
+      text="Unavailable filters are hidden for this page."
+      type="info"
+      variant="tonal"
+    />
   </div>
 </template>
 
@@ -477,12 +577,10 @@ import {
 import { Permission } from "@cc/shared-types";
 
 const props = defineProps({
-  showCompareTo: { type: Boolean, default: true },
-  showReviewStatus: { type: Boolean, default: true },
   showRemoveFilteredReports: { type: Boolean, default: true },
-  showDiffType: { type: Boolean, default: true },
   reportCount: { type: Number, required: true },
-  refreshFilter: { type: Boolean, default: false }
+  refreshFilter: { type: Boolean, default: false },
+  hiddenFilters: { type: Array, default: () => [] }
 });
 
 const emit = defineEmits([ "set-refresh-filter-state", "refresh" ]);

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -10,9 +10,8 @@
         <ReportFilter
           :show-remove-filtered-reports="false"
           :report-count="reportCount"
-          :show-diff-type="false"
-          :show-compare-to="showCompareTo"
           :refresh-filter="refreshFilterState"
+          :hidden-filters="hiddenFilters"
           @refresh="refresh"
           @set-refresh-filter-state="setRefreshFilterState"
         />
@@ -76,43 +75,76 @@ const tabs = [
     name: "Product Overview",
     icon: "mdi-briefcase-outline",
     to: { name: "product-overview" },
-    showCompareTo: true
+    hiddenFiltersByTab: []
   },
   {
     name: "Checker Statistics",
     icon: "mdi-card-account-details",
     to: { name: "checker-statistics" },
-    showCompareTo: true
+    hiddenFiltersByTab: []
   },
   {
     name: "Severity Statistics",
     icon: "mdi-speedometer",
     to: { name: "severity-statistics" },
-    showCompareTo: true
+    hiddenFiltersByTab: []
   },
   {
     name: "Component Statistics",
     icon: "mdi-puzzle-outline",
     to: { name: "component-statistics" },
-    showCompareTo: true
+    hiddenFiltersByTab: []
   },
   {
     name: "Checker Coverage",
     icon: "mdi-clipboard-check-outline",
     to: { name: "checker-coverage-statistics" },
-    showCompareTo: false
+    hiddenFiltersByTab: [
+      "baseline-open-reports-date-filter",
+      "group:compareTo",
+      "file-path-filter",
+      "checker-name-filter",
+      "severity-filter",
+      "report-status-filter",
+      "review-status-filter",
+      "detection-status-filter",
+      "analyzer-name-filter",
+      "source-component-filter",
+      "cleanup-plan-filter",
+      "checker-message-filter",
+      "group:dateFilter",
+      "report-hash-filter",
+      "bug-path-length-filter",
+      "testcase-filter"
+    ]
   },
   {
     name: "Guideline Statistics",
     icon: "mdi-clipboard-text-outline",
     to: { name: "guideline-statistics" },
-    showCompareTo: false
+    hiddenFiltersByTab: [
+      "baseline-open-reports-date-filter",
+      "group:compareTo",
+      "file-path-filter",
+      "checker-name-filter",
+      "severity-filter",
+      "report-status-filter",
+      "review-status-filter",
+      "detection-status-filter",
+      "analyzer-name-filter",
+      "source-component-filter",
+      "cleanup-plan-filter",
+      "checker-message-filter",
+      "group:dateFilter",
+      "report-hash-filter",
+      "bug-path-length-filter",
+      "testcase-filter"
+    ]
   },
 ];
 
 const refreshFilterState = ref(false);
 const reportCount = ref(0);
-const showCompareTo = ref(true);
 const tab = ref(null);
 
 const bus = mitt();
@@ -124,6 +156,9 @@ const refreshTabs = tabs.reduce((map, _tab) => {
   }
   return map;
 }, {});
+
+const hiddenFilters = ref([]);
+const baseHiddenFilters = ref([ "compared-to-diff-type-filter" ]);
 
 const runIds = computed(function() {
   return store.getters.getRunIds;
@@ -143,7 +178,10 @@ watch(() => tab.value, async () => {
   const currentTab = tabs[tab.value];
   if (!currentTab) return;
 
-  showCompareTo.value = currentTab.showCompareTo;
+  hiddenFilters.value = [
+    ...baseHiddenFilters.value,
+    ...currentTab.hiddenFiltersByTab
+  ];
 
   await nextTick();
   refreshCurrentTab();


### PR DESCRIPTION
This change adds the ability to hide certain filters for Reports and for Statistics page. On the Statistics page it is broken down to every tab which is shown.

This change also introduces the hiding of most filters for CheckerCoverage and for GuidelineStatistics pages which are not usable on those pages.