### PR TITLE
log_parser: forward target/arch flags to implicit compiler info detection

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -289,13 +289,23 @@ def filter_compiler_includes_extra_args(compiler_flags):
 
     compiler_flags -- A list of compiler flags which may affect the list
                       of implicit compiler include paths, like -std=,
-                      --sysroot=, -m32, -m64, -nostdinc or -stdlib=.
+                      --sysroot=, -m32, -m64, -nostdinc, -stdlib= or the
+                      target selection flags (--target=, -mcpu=, -march=,
+                      -mfloat-abi=, ...).
     """
     # If these options are present in the original build command, they must
     # be forwarded to get_compiler_includes and get_compiler_defines so the
     # resulting includes point to the target that was used in the build.
+    # Target and architecture selection flags are especially important for
+    # multi-target compilers (e.g. clang): they select the multilib whose
+    # system headers provide the implicit include paths. Without forwarding
+    # them the query resolves the compiler's default (usually host) target,
+    # so the wrong include paths (or none at all) are reported.
     pattern = re.compile(
-        '-m(32|64)|-{1,2}std=|-{1,2}stdlib=|-nostdinc|--driver-mode=')
+        r'-m(32|64)|-{1,2}std=|-{1,2}stdlib=|-nostdinc|--driver-mode='
+        r'|--target=|-march=|-mcpu=|-mtune=|-mfpu=|-mabi='
+        r'|-mfloat-abi=|-mendian=|-mthumb|-marm'
+        r'|-mbig-endian|-mlittle-endian')
     extra_opts = list(filter(pattern.match, compiler_flags))
 
     pos = next((pos for pos, val in enumerate(compiler_flags)
@@ -305,6 +315,14 @@ def filter_compiler_includes_extra_args(compiler_flags):
             extra_opts.append('--sysroot=' + compiler_flags[pos + 1])
         else:
             extra_opts.append(compiler_flags[pos])
+
+    # The target triple may also be given as two separate arguments
+    # ("-target <triple>" or "--target <triple>"). Forward the value in the
+    # "--target=<triple>" form which both gcc and clang accept.
+    pos = next((pos for pos, val in enumerate(compiler_flags)
+                if val in ('-target', '--target')), None)
+    if pos is not None and pos + 1 < len(compiler_flags):
+        extra_opts.append('--target=' + compiler_flags[pos + 1])
 
     return extra_opts
 
@@ -452,14 +470,19 @@ class ImplicitCompilerInfo:
         return list(map(os.path.normpath, include_dirs))
 
     @staticmethod
-    def get_compiler_target(compiler):
+    def get_compiler_target(compiler, compiler_flags=None):
         """
         Returns the target triple of the given compiler as a string.
 
         compiler -- The compiler binary of which the target architecture is
                     fetched.
+        compiler_flags -- The compilation flags which may change the target
+                    triple of a multi-target compiler (e.g. --target, -mcpu).
+                    They are forwarded to the query so the reported triple
+                    matches the one used during the build.
         """
-        lines = ImplicitCompilerInfo.__get_compiler_err([compiler, '-v'])
+        cmd = [compiler, *(compiler_flags or []), '-v']
+        lines = ImplicitCompilerInfo.__get_compiler_err(cmd)
 
         if lines is None:
             return ""
@@ -602,7 +625,8 @@ class ImplicitCompilerInfo:
                         iisk.compiler, iisk.language, iisk.compiler_flags),
                     'compiler_standard': ICI.get_compiler_standard(
                         iisk.compiler, iisk.language),
-                    'target': ICI.get_compiler_target(iisk.compiler)
+                    'target': ICI.get_compiler_target(
+                        iisk.compiler, iisk.compiler_flags)
                 }
 
         for k, v in ICI.compiler_info.get(iisk, {}).items():

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -366,6 +366,53 @@ class LogParserTest(unittest.TestCase):
         filtered = log_parser.filter_compiler_includes_extra_args(flags)
         self.assertEqual(filtered, ["--sysroot=/usr/mysysroot"])
 
+    def test_compiler_implicit_include_flags_target_arch(self):
+        """
+        Target and architecture selection flags must be forwarded so the
+        implicit include paths are queried for the target used during the
+        build (multi-target compilers select the multilib headers based on
+        these flags).
+        """
+
+        flags = ["-I", "/usr/include",
+                 "--target=arm-none-eabi", "-mcpu=cortex-m4",
+                 "-march=armv7e-m", "-mfloat-abi=hard", "-mfpu=fpv4-sp-d16",
+                 "-mthumb", "-mabi=aapcs", "-mtune=cortex-m4",
+                 "-mendian=little", "-mbig-endian", "-mlittle-endian",
+                 "-marm", "-c"]
+        filtered = log_parser.filter_compiler_includes_extra_args(flags)
+        self.assertEqual(
+            filtered,
+            ["--target=arm-none-eabi", "-mcpu=cortex-m4", "-march=armv7e-m",
+             "-mfloat-abi=hard", "-mfpu=fpv4-sp-d16", "-mthumb", "-mabi=aapcs",
+             "-mtune=cortex-m4", "-mendian=little", "-mbig-endian",
+             "-mlittle-endian", "-marm"])
+
+    def test_compiler_implicit_include_flags_target_two_args(self):
+        """
+        The target triple may be given as two separate arguments
+        ('-target <triple>' or '--target <triple>'). It should be forwarded
+        in the '--target=<triple>' form accepted by both gcc and clang.
+        """
+
+        flags = ["-I", "/usr/include", "-target", "arm-none-eabi", "-c"]
+        filtered = log_parser.filter_compiler_includes_extra_args(flags)
+        self.assertEqual(filtered, ["--target=arm-none-eabi"])
+
+        flags = ["--target", "x86_64-pc-linux-gnu", "-O2"]
+        filtered = log_parser.filter_compiler_includes_extra_args(flags)
+        self.assertEqual(filtered, ["--target=x86_64-pc-linux-gnu"])
+
+    def test_compiler_implicit_include_flags_target_two_args_no_value(self):
+        """
+        A trailing '-target' without a value must not raise and must not be
+        forwarded.
+        """
+
+        flags = ["-I", "/usr/include", "-target"]
+        filtered = log_parser.filter_compiler_includes_extra_args(flags)
+        self.assertEqual(filtered, [])
+
     def test_skip_everything_from_parse(self):
         """Same skip file for pre analysis and analysis. Skip everything."""
         cmp_cmd_json = [


### PR DESCRIPTION
CodeChecker detects a compiler's implicit include paths and target triple by invoking the compiler, but `filter_compiler_includes_extra_args()` only forwards a small whitelist of flags (`-m32`/`-m64`, `-std=`, `-stdlib=`, `-nostdinc`, `--driver-mode=`, `--sysroot`). Target-selection flags such as `--target`, `-mcpu`, `-march`, `-mfloat-abi`, `-mfpu`, `-mabi` and `-mthumb` are dropped.

For a multi-target compiler (e.g. clang) this makes the include/target probe run for the compiler's default (usually host) target instead of the target used in the build. The multilib system headers of the real target are therefore never added, and analyzing a cross-compiled translation unit fails with errors like `unknown type name 'uint64_t'` because `#include <stdint.h>` cannot be resolved.

Forward the target and architecture selection flags to both `get_compiler_includes()` and `get_compiler_target()` so the reported include paths and triple match the build.