### PR TITLE
[gui] Fix frontend getRunData calls

### DIFF
--- a/web/server/vue-cli/src/composables/useAnalysisInfo.js
+++ b/web/server/vue-cli/src/composables/useAnalysisInfo.js
@@ -39,13 +39,15 @@ function decideNegativeCheckerStatusAvailability(
     const filter = new RunFilter({
       ids: [ runId ]
     });
-    ccService.getClient().getRunData(filter, 1).then(runDataList => {
-      if (runDataList.length !== 1) return;
+    ccService.getClient().getRunData(filter, 1, 0, null,
+      handleThriftError(runDataList => {
+        if (runDataList.length !== 1) return;
 
-      setCheckerStatusUnavailableDueToVersion(
-        analysisInfo,
-        runDataList[0].codeCheckerVersion);
-    });
+        setCheckerStatusUnavailableDueToVersion(
+          analysisInfo,
+          runDataList[0].codeCheckerVersion
+        );
+      }));
   } else if (runId && runHistoryId) {
     const filter = new RunHistoryFilter({
       tagNames: [],

--- a/web/server/vue-cli/src/services/api/cc.service.js
+++ b/web/server/vue-cli/src/services/api/cc.service.js
@@ -49,18 +49,21 @@ class CodeCheckerService extends BaseService {
           const runFilter = new RunFilter({
             ids: reports.map(report => report.runId)
           });
-          this.getClient().getRunData(runFilter, MAX_QUERY_SIZE).then(runs => {
-            resolve(reports.map(report => {
-              const run =
-                runs.find(run => run.runId.equals(report.runId)) || {};
+          this.getClient().getRunData(runFilter, MAX_QUERY_SIZE, 0, null,
+            handleThriftError(runs => {
+              resolve(reports.map(report => {
+                const run =
+                  runs.find(run => run.runId.equals(report.runId)) || {};
 
-              return {
-                ...report,
-                "$runName": run.name
-              };
-            }));
-          });
-        }));
+                return {
+                  ...report,
+                  "$runName": run.name
+                };
+              }));
+            })
+          );
+        })
+      );
     });
   }
 


### PR DESCRIPTION
This change fixes the getRunData calls made by vue so it uses the handleThriftError as it is used everywhere else in the code for thrift made functions.