### PR TITLE
[gui] Show all checkers for related rules in Guideline Statistics

### DIFF
--- a/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
@@ -416,7 +416,7 @@
         <table>
           <tr v-for="checker in item.checkers" :key="checker.name">
             <td>
-              <severity-icon :status="checker.severity" />
+              <severity-icon :size="20" :status="checker.severity" />
             </td>
           </tr>
         </table>

--- a/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
+++ b/web/server/vue-cli/src/components/Statistics/Guideline/GuidelineStatistics.vue
@@ -101,7 +101,8 @@ import {
   Checker,
   Guideline,
   ReportFilter,
-  RunFilter
+  RunFilter,
+  Severity
 } from "@cc/report-server-types";
 import { computed, ref, watch } from "vue";
 import StatisticsDialog from "../StatisticsDialog";
@@ -194,41 +195,50 @@ function checker_stat(stat) {
           const filtered_stat = Object.keys(stat).filter(
             checkerId => rule.checkers.map(c => c.checkerName).includes(
               stat[checkerId].checkerName));
+
+          const matchedCheckerNames = new Set(
+            filtered_stat.map(checkerId => stat[checkerId].checkerName)
+          );
+
+          const matchedCheckers = filtered_stat.map(checkerId => {
+            return {
+              name: stat[checkerId].checkerName,
+              severity: stat[checkerId].severity,
+              enabledInAllRuns: stat[checkerId].disabled.length === 0
+                ? 1
+                : 0,
+              enabledRunLength: stat[checkerId].enabled.length,
+              disabledRunLength: stat[checkerId].disabled.length,
+              unknownRunLength: stat[checkerId].unknown.length,
+              closed: stat[checkerId].closed.toNumber(),
+              outstanding: stat[checkerId].outstanding.toNumber(),
+            };
+          });
+
+          const missingCheckers = rule.checkers
+            .filter(checker => !matchedCheckerNames.has(checker.checkerName))
+            .map(checker => {
+              return {
+                name: checker.checkerName,
+                severity: checker.severity !== null
+                  ? severity.severityFromStringToCode(checker.severity)
+                  : Severity.UNSPECIFIED,
+                enabledInAllRuns: 0,
+                enabledRunLength: 0,
+                disabledRunLength: runs.value.length,
+                unknownRunLength: 0,
+                closed: 0,
+                outstanding: 0,
+              };
+            });
+
           return {
             guidelineName: guideline,
             guidelineRule: rule.ruleId,
             guidelineUrl: rule.url,
             guidelineRuleTitle: rule.title,
             guidelineLevel: rule.level,
-            checkers: filtered_stat.length
-              ? filtered_stat.map(checkerId => {
-                return {
-                  name: stat[checkerId].checkerName,
-                  severity: stat[checkerId].severity,
-                  enabledInAllRuns: stat[checkerId].disabled.length === 0
-                    ? 1
-                    : 0,
-                  enabledRunLength: stat[checkerId].enabled.length,
-                  disabledRunLength: stat[checkerId].disabled.length,
-                  unknownRunLength: stat[checkerId].unknown.length,
-                  closed: stat[checkerId].closed.toNumber(),
-                  outstanding: stat[checkerId].outstanding.toNumber(),
-                };
-              })
-              : (rule.checkers.length ?
-                rule.checkers.map(checker => {
-                  return {
-                    name: checker.checkerName,
-                    severity: severity.severityFromStringToCode(
-                      checker.severity),
-                    enabledInAllRuns: 0,
-                    enabledRunLength: 0,
-                    disabledRunLength: runs.value.length,
-                    closed: 0,
-                    outstanding: 0,
-                  };
-                })
-                : [])
+            checkers: [ ...matchedCheckers, ...missingCheckers ]
           };
         })
       );


### PR DESCRIPTION
This change adds the previously missing checkers to Guideline Statistics table. Previously only those checkers were in the table which were in the given run(s). This was misleading so now all checkers are shown, the ones which were not in the run marked as disabled.