### PR TITLE
Introduce decorators for all permission types

### DIFF
--- a/web/server/codechecker_server/api/common.py
+++ b/web/server/codechecker_server/api/common.py
@@ -5,6 +5,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # -------------------------------------------------------------------------
+import functools
+
 import sqlalchemy
 
 from codechecker_api_shared.ttypes import RequestFailed, ErrorCode
@@ -46,4 +48,24 @@ def exc_to_thrift_reqfail(function):
             # pylint: disable=raise-missing-from
             raise RequestFailed(ErrorCode.GENERAL, msg)
 
+    return wrapper
+
+
+def requires_view(function):
+    """
+    Decorator for Thrift API methods that require view permission on the
+    current product. Calls into the handler's __require_view() helper
+    before invoking the wrapped method.
+
+    The helper is accessed via getattr because Python name-mangles
+    double-underscore attribute access at compile time, and the
+    decorator lives outside the handler class. Computing the mangled
+    name from the instance's class lets the same decorator work for any
+    handler that defines a __require_view() method.
+    """
+    @functools.wraps(function)
+    def wrapper(self, *args, **kwargs):
+        mangled = f'_{type(self).__name__}__require_view'
+        getattr(self, mangled)()
+        return function(self, *args, **kwargs)
     return wrapper

--- a/web/server/codechecker_server/api/common.py
+++ b/web/server/codechecker_server/api/common.py
@@ -54,18 +54,11 @@ def exc_to_thrift_reqfail(function):
 def requires_view(function):
     """
     Decorator for Thrift API methods that require view permission on the
-    current product. Calls into the handler's __require_view() helper
+    current product. Calls into the handler's _require_view() helper
     before invoking the wrapped method.
-
-    The helper is accessed via getattr because Python name-mangles
-    double-underscore attribute access at compile time, and the
-    decorator lives outside the handler class. Computing the mangled
-    name from the instance's class lets the same decorator work for any
-    handler that defines a __require_view() method.
     """
     @functools.wraps(function)
     def wrapper(self, *args, **kwargs):
-        mangled = f'_{type(self).__name__}__require_view'
-        getattr(self, mangled)()
+        self._require_view()
         return function(self, *args, **kwargs)
     return wrapper

--- a/web/server/codechecker_server/api/common.py
+++ b/web/server/codechecker_server/api/common.py
@@ -9,9 +9,12 @@ import functools
 
 import sqlalchemy
 
+import codechecker_api_shared
 from codechecker_api_shared.ttypes import RequestFailed, ErrorCode
 
 from codechecker_common.logger import get_logger
+from codechecker_server import permissions
+from codechecker_server.database.database import DBSession
 
 
 LOG = get_logger("server")
@@ -51,14 +54,87 @@ def exc_to_thrift_reqfail(function):
     return wrapper
 
 
+def __requires_permission(self, required):
+    """
+    Helper method to raise an UNAUTHORIZED exception if the user does not
+    have any of the given permissions.
+    """
+
+    with DBSession(self._config_database) as session:
+        args = dict({ 'productID': self._product.id })
+        args['config_db_session'] = session
+
+        if not any(permissions.require_permission(
+                perm, args, self._auth_session,
+                self._manager.is_enabled)
+                for perm in required):
+            raise codechecker_api_shared.ttypes.RequestFailed(
+                codechecker_api_shared.ttypes.ErrorCode.UNAUTHORIZED,
+                "You are not authorized to execute this action.")
+
+        return True
+
+
+def requires_permission(required):
+    """
+    Decorator for Thrift API methods that require one of the given permissions
+    on the current product.
+    """
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(self, *args, **kwargs):
+            __requires_permission(self, required)
+            return function(self, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
 def requires_view(function):
     """
     Decorator for Thrift API methods that require view permission on the
-    current product. Calls into the handler's _require_view() helper
-    before invoking the wrapped method.
+    current product.
     """
     @functools.wraps(function)
     def wrapper(self, *args, **kwargs):
-        self._require_view()
+        __requires_permission(self, [
+            permissions.PRODUCT_VIEW,
+            permissions.PERMISSION_VIEW
+        ])
+        return function(self, *args, **kwargs)
+    return wrapper
+
+
+def requires_store(function):
+    """
+    Decorator for Thrift API methods that require store permission on the
+    current product.
+    """
+    @functools.wraps(function)
+    def wrapper(self, *args, **kwargs):
+        __requires_permission(self, [permissions.PRODUCT_STORE])
+        return function(self, *args, **kwargs)
+    return wrapper
+
+
+def requires_access(function):
+    """
+    Decorator for Thrift API methods that require access permission on the
+    current product.
+    """
+    @functools.wraps(function)
+    def wrapper(self, *args, **kwargs):
+        __requires_permission(self, [permissions.PRODUCT_ACCESS])
+        return function(self, *args, **kwargs)
+    return wrapper
+
+
+def requires_admin(function):
+    """
+    Decorator for Thrift API methods that require admin permission on the
+    current product.
+    """
+    @functools.wraps(function)
+    def wrapper(self, *args, **kwargs):
+        __requires_permission(self, [permissions.PRODUCT_ADMIN])
         return function(self, *args, **kwargs)
     return wrapper

--- a/web/server/codechecker_server/api/permission_coverage.py
+++ b/web/server/codechecker_server/api/permission_coverage.py
@@ -1,0 +1,219 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Static enforcement that every Thrift API method on the report server has
+some form of permission check.
+
+This is a security boundary: a Thrift method that lacks any permission
+check is reachable by any authenticated user, which would allow an
+unprivileged user to invoke functionality reserved for product admins,
+superusers, or even unauthenticated callers in principle.
+
+The check is run from two places:
+
+  * From a unit test, so that a PR that introduces an unprotected method
+    fails CI before being merged.
+
+  * From the server's start_server() function, so that even if such a PR
+    were merged anyway, the server refuses to start instead of serving
+    an exploitable endpoint.
+
+The same logic is used in both, so they can never disagree.
+
+A method is considered "protected" if any of the following hold:
+
+  * It has the @requires_view decorator applied.
+  * One of its first few statements calls into one of the existing
+    self.__require_*() permission helpers (admin, access, store,
+    permission, etc.).
+  * It is listed in _DELEGATED_PROTECTION and the named delegate
+    helper itself satisfies one of the above conditions.
+
+The set of Thrift methods to check is read from the generated Thrift
+Python module (codechecker_api.codeCheckerDBAccess_v6.codeCheckerDBAccess),
+which is shipped with both development and deployed installations.
+"""
+import ast
+import inspect
+from pathlib import Path
+from typing import List, Set
+
+from codechecker_api.codeCheckerDBAccess_v6 import codeCheckerDBAccess
+
+
+# Path to the handler implementing codeCheckerDBAccess_v6.
+# Resolved relative to this file so it works in both source and built
+# layouts.
+_HANDLER_PATH = Path(__file__).parent / "report_server.py"
+
+# Name of the Python class that implements the Thrift Iface.
+_HANDLER_CLASS_NAME = "ThriftRequestHandler"
+
+# Statement positions to inspect for an in-body permission check.
+# Most methods place the check as their first non-docstring statement,
+# but a handful do per-argument preprocessing first; three is a safe
+# limit.
+_MAX_PROLOGUE_STATEMENTS = 3
+
+# Decorator names that count as a permission check on their own.
+_PERMISSION_DECORATORS = frozenset({
+    "requires_view",
+})
+
+# Substrings inside an attribute access that indicate a permission
+# helper was called. We match on suffix rather than equality because
+# Python's name-mangling rewrites `self.__require_view` to e.g.
+# `self._ThriftRequestHandler__require_view` at parse time as well.
+_PERMISSION_CHECK_SUFFIXES = (
+    "_require_view",
+    "__require_view",
+    "__require_admin",
+    "__require_access",
+    "__require_store",
+    "__require_permission",
+    "__require_supermission",
+    "__require_privilaged_access",
+    "__require_permission_view",
+)
+
+# Thrift methods that delegate their permission check to a helper
+# rather than performing it as one of their own first statements.
+#
+# Each entry maps the Thrift method name to the helper method it
+# delegates to. The check below verifies that the named helper itself
+# performs a permission check; if a future change removes that helper's
+# check, the delegation entry will fail and the Thrift method will be
+# reported as unprotected.
+_DELEGATED_PROTECTION = {
+    # Both massStoreRun variants share the same upload pipeline,
+    # __massStoreRun_common, which calls self.__require_store() before
+    # touching any data.
+    "massStoreRun": "__massStoreRun_common",
+    "massStoreRunAsynchronous": "__massStoreRun_common",
+}
+
+
+def _thrift_method_names() -> Set[str]:
+    """Return the names of all methods on the Thrift service Iface."""
+    iface = codeCheckerDBAccess.Iface
+    return {
+        name
+        for name, _ in inspect.getmembers(iface, inspect.isfunction)
+    }
+
+
+def _is_permission_decorator(decorator_node: ast.expr) -> bool:
+    """Return True if the AST decorator node names a known permission
+    decorator."""
+    if isinstance(decorator_node, ast.Name):
+        return decorator_node.id in _PERMISSION_DECORATORS
+    if isinstance(decorator_node, ast.Attribute):
+        return decorator_node.attr in _PERMISSION_DECORATORS
+    return False
+
+
+def _statement_is_permission_check(stmt: ast.stmt) -> bool:
+    """Return True if the statement is a self.__require_*()-style
+    call."""
+    if not isinstance(stmt, ast.Expr):
+        return False
+    if not isinstance(stmt.value, ast.Call):
+        return False
+    func = stmt.value.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    return any(func.attr.endswith(suffix)
+               for suffix in _PERMISSION_CHECK_SUFFIXES)
+
+
+def _method_is_protected(method_node: ast.FunctionDef) -> bool:
+    """Return True if the method has either a permission decorator or
+    a permission-check call in its first few statements."""
+    for decorator in method_node.decorator_list:
+        if _is_permission_decorator(decorator):
+            return True
+    # Skip a leading docstring, then look at the next few statements.
+    body = method_node.body
+    if body and isinstance(body[0], ast.Expr) \
+            and isinstance(body[0].value, ast.Constant) \
+            and isinstance(body[0].value.value, str):
+        body = body[1:]
+    for stmt in body[:_MAX_PROLOGUE_STATEMENTS]:
+        if _statement_is_permission_check(stmt):
+            return True
+    return False
+
+
+def _build_method_index(class_node: ast.ClassDef) -> dict:
+    """Map method name -> FunctionDef node for a class."""
+    return {
+        m.name: m
+        for m in class_node.body
+        if isinstance(m, ast.FunctionDef)
+    }
+
+
+def find_unprotected_methods() -> List[str]:
+    """Return a list of Thrift method names on ThriftRequestHandler
+    that have no detectable permission check. Empty list means
+    everything is protected."""
+    thrift_methods = _thrift_method_names()
+    tree = ast.parse(_HANDLER_PATH.read_text(encoding="utf-8"))
+
+    unprotected: List[str] = []
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        if cls.name != _HANDLER_CLASS_NAME:
+            continue
+
+        methods_by_name = _build_method_index(cls)
+
+        for member in cls.body:
+            if not isinstance(member, ast.FunctionDef):
+                continue
+            if member.name not in thrift_methods:
+                continue
+
+            if _method_is_protected(member):
+                continue
+
+            # Not directly protected; consult the delegation map.
+            delegate_name = _DELEGATED_PROTECTION.get(member.name)
+            if delegate_name is not None:
+                # Look up the delegate by its mangled name as it would
+                # appear inside the same class (double-underscore
+                # methods are name-mangled).
+                mangled = f"_{_HANDLER_CLASS_NAME}{delegate_name}"
+                delegate_node = (
+                    methods_by_name.get(delegate_name)
+                    or methods_by_name.get(mangled))
+                if delegate_node is not None \
+                        and _method_is_protected(delegate_node):
+                    continue
+                # Delegation declared but delegate missing or itself
+                # unprotected -- fall through, this method is
+                # unprotected.
+
+            unprotected.append(member.name)
+
+    return sorted(unprotected)
+
+
+def assert_all_thrift_methods_protected() -> None:
+    """Raise RuntimeError listing any Thrift methods that are not
+    permission-protected. Called from both the unit test and from
+    start_server() at server startup."""
+    unprotected = find_unprotected_methods()
+    if unprotected:
+        raise RuntimeError(
+            "Thrift API methods without a detectable permission check "
+            "were found. Add either an @requires_view decorator, an "
+            "in-body self.__require_*() call, or a "
+            "_DELEGATED_PROTECTION entry for each:\n  "
+            + "\n  ".join(unprotected))

--- a/web/server/codechecker_server/api/permission_coverage.py
+++ b/web/server/codechecker_server/api/permission_coverage.py
@@ -63,6 +63,10 @@ _MAX_PROLOGUE_STATEMENTS = 3
 # Decorator names that count as a permission check on their own.
 _PERMISSION_DECORATORS = frozenset({
     "requires_view",
+    "requires_store",
+    "requires_access",
+    "requires_admin",
+    "requires_permission",
 })
 
 # Substrings inside an attribute access that indicate a permission
@@ -70,11 +74,6 @@ _PERMISSION_DECORATORS = frozenset({
 # Python's name-mangling rewrites `self.__require_view` to e.g.
 # `self._ThriftRequestHandler__require_view` at parse time as well.
 _PERMISSION_CHECK_SUFFIXES = (
-    "_require_view",
-    "__require_view",
-    "__require_admin",
-    "__require_access",
-    "__require_store",
     "__require_permission",
     "__require_supermission",
     "__require_privilaged_access",
@@ -91,8 +90,7 @@ _PERMISSION_CHECK_SUFFIXES = (
 # reported as unprotected.
 _DELEGATED_PROTECTION = {
     # Both massStoreRun variants share the same upload pipeline,
-    # __massStoreRun_common, which calls self.__require_store() before
-    # touching any data.
+    # __massStoreRun_common, which has a @requires_store decorator.
     "massStoreRun": "__massStoreRun_common",
     "massStoreRunAsynchronous": "__massStoreRun_common",
 }
@@ -114,6 +112,8 @@ def _is_permission_decorator(decorator_node: ast.expr) -> bool:
         return decorator_node.id in _PERMISSION_DECORATORS
     if isinstance(decorator_node, ast.Attribute):
         return decorator_node.attr in _PERMISSION_DECORATORS
+    if isinstance(decorator_node, ast.Call):
+        return _is_permission_decorator(decorator_node.func)
     return False
 
 
@@ -213,7 +213,7 @@ def assert_all_thrift_methods_protected() -> None:
     if unprotected:
         raise RuntimeError(
             "Thrift API methods without a detectable permission check "
-            "were found. Add either an @requires_view decorator, an "
-            "in-body self.__require_*() call, or a "
-            "_DELEGATED_PROTECTION entry for each:\n  "
+            "were found. Add either an @requires_<permission> decorator, an "
+            "in-body self.__require_*() call, or a _DELEGATED_PROTECTION "
+            "entry for each:\n  "
             + "\n  ".join(unprotected))

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -74,7 +74,7 @@ from ..database.run_db_model import \
     Run, RunHistory, RunHistoryAnalysisInfo, RunLock, \
     SourceComponent, SourceComponentFile, FilterPreset
 
-from .common import exc_to_thrift_reqfail
+from .common import exc_to_thrift_reqfail, requires_view
 from .thrift_enum_helper import detection_status_enum, \
     detection_status_str, report_status_enum, \
     review_status_enum, review_status_str, report_extended_data_type_enum
@@ -1547,9 +1547,8 @@ class ThriftRequestHandler:
                        date or datetime.now())
 
     @timeit
+    @requires_view
     def getRunData(self, run_filter, limit, offset, sort_mode):
-        self.__require_view()
-
         limit = verify_limit_range(limit)
 
         with DBSession(self._Session) as session:

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -74,7 +74,8 @@ from ..database.run_db_model import \
     Run, RunHistory, RunHistoryAnalysisInfo, RunLock, \
     SourceComponent, SourceComponentFile, FilterPreset
 
-from .common import exc_to_thrift_reqfail, requires_view
+from .common import exc_to_thrift_reqfail, requires_access, requires_admin, \
+    requires_permission, requires_store, requires_view
 from .thrift_enum_helper import detection_status_enum, \
     detection_status_str, report_status_enum, \
     review_status_enum, review_status_str, report_extended_data_type_enum
@@ -1491,50 +1492,12 @@ class ThriftRequestHandler:
         self.__client_version = client_version
         self._Session = Session
         self._context = context
-        self.__permission_args = {
-            'productID': product.id
-        }
 
     def _get_username(self):
         """
         Returns the actually logged in user name.
         """
         return self._auth_session.user if self._auth_session else "Anonymous"
-
-    def __require_permission(self, required):
-        """
-        Helper method to raise an UNAUTHORIZED exception if the user does not
-        have any of the given permissions.
-        """
-
-        with DBSession(self._config_database) as session:
-            args = dict(self.__permission_args)
-            args['config_db_session'] = session
-
-            if not any(permissions.require_permission(
-                    perm, args, self._auth_session,
-                    self._manager.is_enabled)
-                    for perm in required):
-                raise codechecker_api_shared.ttypes.RequestFailed(
-                    codechecker_api_shared.ttypes.ErrorCode.UNAUTHORIZED,
-                    "You are not authorized to execute this action.")
-
-            return True
-
-    def __require_admin(self):
-        self.__require_permission([permissions.PRODUCT_ADMIN])
-
-    def __require_access(self):
-        self.__require_permission([permissions.PRODUCT_ACCESS])
-
-    def __require_store(self):
-        self.__require_permission([permissions.PRODUCT_STORE])
-
-    def _require_view(self):
-        self.__require_permission([
-            permissions.PRODUCT_VIEW,
-            permissions.PERMISSION_VIEW
-        ])
 
     def __add_comment(self, bug_id, message, kind=CommentKindValue.USER,
                       date=None):
@@ -1659,6 +1622,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def storeFilterPreset(self, filterpreset):
         """
         Store a configured FilterPreset.
@@ -1669,7 +1633,6 @@ class ThriftRequestHandler:
                 - name (str): Human readable name of preset
                 - reportFilter: ReportFilter object itself
         """
-        self.__require_admin()
         LOG.info("Storing filter preset in backend: %s", filterpreset.name)
         try:
             filter_id = filterpreset.id
@@ -1720,6 +1683,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def renameFilterPreset(self, preset_id: int, name: str):
         """
         Rename a filter preset.
@@ -1727,7 +1691,6 @@ class ThriftRequestHandler:
         Raises an error if id/name is empty or if
         a preset with the new name already exists.
         """
-        self.__require_admin()
         try:
             with DBSession(self._Session) as session:
 
@@ -1779,13 +1742,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def deleteFilterPreset(self, preset_id):
         """
         Delete a filter preset based on preset_id.
         Returns the ID of the deleted preset. Raises an error if the
         preset does not exist or could not be deleted.
         """
-        self.__require_admin()
         LOG.info("Deleting filter preset by ID: %s", preset_id)
         try:
             with DBSession(self._Session) as session:
@@ -2774,13 +2737,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_permission([
+        permissions.PRODUCT_ACCESS,
+        permissions.PRODUCT_STORE])
     def changeReviewStatus(self, report_id, status, message):
         """
         Change the review status of a report by report id.
         """
-        self.__require_permission([permissions.PRODUCT_ACCESS,
-                                   permissions.PRODUCT_STORE])
-
         with DBSession(self._Session) as session:
             report = session.get(Report, report_id)
             if report:
@@ -2881,9 +2844,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def removeReviewStatusRules(self, rule_filter):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             q = get_rs_rule_query(session, rule_filter)
             for review_status, _ in q:
@@ -2912,10 +2874,10 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_permission([
+        permissions.PRODUCT_ACCESS,
+        permissions.PRODUCT_STORE])
     def addReviewStatusRule(self, report_hash, review_status, message):
-        self.__require_permission([permissions.PRODUCT_ACCESS,
-                                   permissions.PRODUCT_STORE])
-
         if self.isReviewStatusChangeDisabled():
             msg = "Review status change is disabled!"
             raise codechecker_api_shared.ttypes.RequestFailed(
@@ -2979,10 +2941,9 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_access
     def addComment(self, report_id, comment_data):
         """ Add new comment for the given bug. """
-        self.__require_access()
-
         if not comment_data.message or not comment_data.message.strip():
             raise codechecker_api_shared.ttypes.RequestFailed(
                 codechecker_api_shared.ttypes.ErrorCode.GENERAL,
@@ -3005,14 +2966,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_access
     def updateComment(self, comment_id, content):
         """
             Update the given comment message with new content. We allow
             comments to be updated by it's original author only, except for
             Anyonymous comments that can be updated by anybody.
         """
-        self.__require_access()
-
         if not content.strip():
             raise codechecker_api_shared.ttypes.RequestFailed(
                 codechecker_api_shared.ttypes.ErrorCode.GENERAL,
@@ -3055,14 +3015,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_access
     def removeComment(self, comment_id):
         """
             Remove the comment. We allow comments to be removed by it's
             original author only, except for Anyonymous comments that can be
             updated by anybody.
         """
-        self.__require_access()
-
         user = self._get_username()
 
         with DBSession(self._Session) as session:
@@ -4105,8 +4064,8 @@ class ThriftRequestHandler:
     # -----------------------------------------------------------------------
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def removeRunResults(self, run_ids):
-        self.__require_store()
 
         failed = False
         for run_id in run_ids:
@@ -4120,9 +4079,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def removeRunReports(self, run_ids, report_filter, cmp_data):
-        self.__require_store()
-
         if not run_ids:
             run_ids = []
 
@@ -4175,9 +4133,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def removeRun(self, run_id, run_filter):
-        self.__require_store()
-
         # Remove the whole run.
         with DBSession(self._Session) as session:
             if not run_filter:
@@ -4247,9 +4204,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def updateRunData(self, run_id, new_run_name):
-        self.__require_store()
-
         if not new_run_name:
             msg = 'No new run name was given to update the run.'
             LOG.error(msg)
@@ -4288,21 +4244,21 @@ class ThriftRequestHandler:
         return True
 
     @exc_to_thrift_reqfail
+    @requires_access
     def getSuppressFile(self):
         """
         DEPRECATED the server is not started with a suppress file anymore.
         Returning empty string.
         """
-        self.__require_access()
         return ''
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def addSourceComponent(self, name, value, description):
         """
         Adds a new source if it does not exist or updates an old one.
         """
-        self.__require_admin()
         with DBSession(self._Session) as session:
             component = session.get(SourceComponent, name)
             user = self._auth_session.user if self._auth_session else None
@@ -4362,12 +4318,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def removeSourceComponent(self, name):
         """
         Removes a source component.
         """
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             component = session.get(SourceComponent, name)
             if component:
@@ -4383,9 +4338,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def getMissingContentHashes(self, file_hashes):
-        self.__require_store()
-
         if not file_hashes:
             return []
 
@@ -4400,9 +4354,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def getMissingContentHashesForBlameInfo(self, file_hashes):
-        self.__require_store()
-
         if not file_hashes:
             return []
 
@@ -4416,9 +4369,9 @@ class ThriftRequestHandler:
             return list(set(file_hashes) -
                         set(fc.content_hash for fc in q))
 
+    @requires_store
     def __massStoreRun_common(self, is_async: bool, zipfile_blob: str,
                               store_opts: SubmittedRunOptions) -> str:
-        self.__require_store()
         if not store_opts.runName:
             raise ValueError("A run name is needed to know where to store!")
 
@@ -4509,16 +4462,14 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def allowsStoringAnalysisStatistics(self):
-        self.__require_store()
-
         return bool(self._manager.get_analysis_statistics_dir())
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def getAnalysisStatisticsLimits(self):
-        self.__require_store()
-
         cfg = {}
 
         # Get the limit of failure zip size.
@@ -4537,9 +4488,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_store
     def storeAnalysisStatistics(self, run_name, b64zip):
-        self.__require_store()
-
         report_dir_store = self._manager.get_analysis_statistics_dir()
         if report_dir_store:
             try:
@@ -4649,8 +4599,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def importData(self, exportData):
-        self.__require_admin()
         with DBSession(self._Session) as session:
 
             # Logic for importing comments
@@ -4703,9 +4653,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def addCleanupPlan(self, name, description, dueDate):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = session.query(CleanupPlan) \
                 .filter(CleanupPlan.name == name) \
@@ -4731,9 +4680,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def updateCleanupPlan(self, cleanup_plan_id, name, description, dueDate):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
             cleanup_plan.name = name
@@ -4790,8 +4738,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def removeCleanupPlan(self, cleanup_plan_id):
-        self.__require_admin()
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
             name = cleanup_plan.name
@@ -4806,9 +4754,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def closeCleanupPlan(self, cleanup_plan_id):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
 
@@ -4823,9 +4770,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def reopenCleanupPlan(self, cleanup_plan_id):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
 
@@ -4838,9 +4784,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def setCleanupPlan(self, cleanup_plan_id, reportHashes):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
 
@@ -4861,9 +4806,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_admin
     def unsetCleanupPlan(self, cleanup_plan_id, reportHashes):
-        self.__require_admin()
-
         with DBSession(self._Session) as session:
             cleanup_plan = get_cleanup_plan(session, cleanup_plan_id)
 

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1530,7 +1530,7 @@ class ThriftRequestHandler:
     def __require_store(self):
         self.__require_permission([permissions.PRODUCT_STORE])
 
-    def __require_view(self):
+    def _require_view(self):
         self.__require_permission([
             permissions.PRODUCT_VIEW,
             permissions.PERMISSION_VIEW

--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -1812,11 +1812,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getFilterPreset(self, preset_id: int):
         """
         Returns the FilterPreset identified by preset_id.
         """
-        self.__require_view()
         LOG.info("Returning filter preset by ID: %s", preset_id)
 
         with DBSession(self._Session) as session:
@@ -1838,11 +1838,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def listFilterPreset(self):
         """
         Returns all filter presets stored for the product repository
         """
-        self.__require_view()
         LOG.info("List back filter presets")
 
         try:
@@ -1871,8 +1871,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunCount(self, run_filter):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             query = session.query(Run.id)
@@ -1881,9 +1881,9 @@ class ThriftRequestHandler:
         return query.count()
 
     # DEPRECATED: use getAnalysisInfo API function instead of this function.
+    @requires_view
     def getCheckCommand(self, run_history_id, run_id):
         """ Get analyzer command based on the given filter. """
-        self.__require_view()
 
         limit = None
         offset = 0
@@ -1899,9 +1899,9 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getAnalysisInfo(self, analysis_info_filter, limit, offset):
         """ Get analysis information based on the given filter. """
-        self.__require_view()
 
         res: List[ttypes.AnalysisInfo] = []
         if not analysis_info_filter:
@@ -1971,8 +1971,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunHistory(self, run_ids, limit, offset, run_history_filter):
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -2011,8 +2011,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunHistoryCount(self, run_ids, run_history_filter):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             query = session.query(RunHistory.id)
@@ -2024,8 +2024,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReport(self, reportId):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
 
@@ -2067,9 +2067,9 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getDiffResultsHash(self, run_ids, report_hashes, diff_type,
                            skip_detection_statuses, tag_ids):
-        self.__require_view()
 
         # FIXME: This getDiffResultsHash() function is returning a set of
         # reports based on what are they compared to in a "CodeChecker cmd
@@ -2180,9 +2180,9 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunResults(self, run_ids, limit, offset, sort_types,
                       report_filter, cmp_data, get_details):
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -2524,8 +2524,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReportAnnotations(self, run_ids, report_filter, cmp_data):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
@@ -2567,13 +2567,13 @@ class ThriftRequestHandler:
         return list(map(lambda x: x[0], result))
 
     @timeit
+    @requires_view
     def getRunReportCounts(self, run_ids, report_filter, limit, offset):
         """
           Count the results separately for multiple runs.
           If an empty run id list is provided the report
           counts will be calculated for all of the available runs.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -2619,8 +2619,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunResultCount(self, run_ids, report_filter, cmp_data):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
@@ -2646,12 +2646,12 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReportDetails(self, reportId):
         """
         Parameters:
          - reportId
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             return get_report_details(session, [reportId])[reportId]
 
@@ -2762,11 +2762,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def isReviewStatusChangeDisabled(self):
         """
         Return True if review status change is disabled.
         """
-        self.__require_view()
 
         with DBSession(self._config_database) as session:
             product = session.get(Product, self._product.id)
@@ -2824,8 +2824,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReviewStatusRules(self, rule_filter, sort_mode, limit, offset):
-        self.__require_view()
         if not sort_mode:
             sort_mode = ReviewStatusRuleSortMode(
                 type=ReviewStatusRuleSortType.DATE,
@@ -2872,8 +2872,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReviewStatusRulesCount(self, rule_filter):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             q = get_rs_rule_query(session, rule_filter)
@@ -2929,11 +2929,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getComments(self, report_id):
         """
             Return the list of comments for the given bug.
         """
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             report = session.get(Report, report_id)
@@ -2962,11 +2962,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCommentCount(self, report_id):
         """
             Return the number of comments for the given bug.
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             report = session.get(Report, report_id)
             commentCount = 0
@@ -3088,22 +3088,22 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCheckerDoc(self, _):
         """
         Parameters:
          - checkerId
         """
-        self.__require_view()
         return ""
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCheckerLabels(
         self,
         checkers: List[ttypes.Checker]
     ) -> List[List[str]]:
         """ Return the list of labels to each checker. """
-        self.__require_view()
 
         labels = []
         for checker in checkers:
@@ -3122,12 +3122,12 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getGuidelineRules(
         self,
         guidelines: List[ttypes.Guideline]
     ):
         """ Return the list of rules to each guideline that given. """
-        self.__require_view()
 
         guideline_rules = defaultdict(list)
         for guideline in guidelines:
@@ -3154,6 +3154,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getSourceFileData(self, fileId, fileContent, encoding):
         """
         Parameters:
@@ -3161,7 +3162,6 @@ class ThriftRequestHandler:
          - fileContent
          - enum Encoding
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             sourcefile = session.get(File, fileId)
 
@@ -3195,9 +3195,9 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getBlameInfo(self, fileId):
         """ Get blame information for the given file. """
-        self.__require_view()
 
         with DBSession(self._Session) as session:
             sourcefile = session.get(File, fileId)
@@ -3246,8 +3246,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getLinesInSourceFileContents(self, lines_in_files_requested, encoding):
-        self.__require_view()
         with DBSession(self._Session) as session:
             res = defaultdict(lambda: defaultdict(str))
 
@@ -3286,6 +3286,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCheckerCounts(self, run_ids, report_filter, cmp_data, limit,
                          offset):
         """
@@ -3293,7 +3294,6 @@ class ThriftRequestHandler:
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -3358,8 +3358,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCheckerStatusVerificationDetails(self, run_ids, report_filter):
-        self.__require_view()
 
         # Queries for all checkers available in CodeChecker
         with DBSession(self._Session) as session:
@@ -3487,6 +3487,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getAnalyzerNameCounts(self, run_ids, report_filter, cmp_data, limit,
                               offset):
         """
@@ -3494,7 +3495,6 @@ class ThriftRequestHandler:
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -3550,13 +3550,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getSeverityCounts(self, run_ids, report_filter, cmp_data):
         """
           If the run id list is empty the metrics will be counted
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
         results = {}
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
@@ -3602,6 +3602,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCheckerMsgCounts(self, run_ids, report_filter, cmp_data, limit,
                             offset):
         """
@@ -3609,7 +3610,6 @@ class ThriftRequestHandler:
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -3663,13 +3663,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReportStatusCounts(self, run_ids, report_filter, cmp_data):
         """
           If the run id list is empty the metrics will be counted
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
                 session, run_ids, report_filter, cmp_data)
@@ -3728,13 +3728,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getReviewStatusCounts(self, run_ids, report_filter, cmp_data):
         """
           If the run id list is empty the metrics will be counted
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
                 session, run_ids, report_filter, cmp_data)
@@ -3772,13 +3772,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getFileCounts(self, run_ids, report_filter, cmp_data, limit, offset):
         """
           If the run id list is empty the metrics will be counted
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -3825,6 +3825,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getFileCountsSummary(self, run_ids, report_filter, cmp_data,
                              limit, offset):
         """
@@ -3832,7 +3833,6 @@ class ThriftRequestHandler:
           The inner map contains total report count ("reports") and
           counts per severity, review status and detection status.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -3910,6 +3910,7 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getRunHistoryTagCounts(self, run_ids, report_filter, cmp_data, limit,
                                offset):
         """
@@ -3917,7 +3918,6 @@ class ThriftRequestHandler:
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
 
         limit = verify_limit_range(limit)
 
@@ -4000,13 +4000,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getDetectionStatusCounts(self, run_ids, report_filter, cmp_data):
         """
           If the run id list is empty the metrics will be counted
           for all of the runs and in compare mode all of the runs
           will be used as a baseline excluding the runs in compare data.
         """
-        self.__require_view()
         results = {}
         with DBSession(self._Session) as session:
             filter_expression, join_tables = process_report_filter(
@@ -4048,13 +4048,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getFailedFilesCount(self, run_ids):
         """
         Count the number of uniqued failed files in the latest storage of each
         given run. If the run id list is empty the number of failed files will
         be counted for all of the runs.
         """
-        self.__require_view()
 
         # Unfortunately we can't distinct the failed file paths by using SQL
         # queries because the list of failed files for a run / analyzer are
@@ -4064,13 +4064,13 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getFailedFiles(self, run_ids):
         """
         Get files which failed to analyze in the latest storage of the given
         runs. For each files it will return a list where each element contains
         information in which run the failure happened.
         """
-        self.__require_view()
 
         res = defaultdict(list)
         with DBSession(self._Session) as session:
@@ -4097,8 +4097,8 @@ class ThriftRequestHandler:
 
     # -----------------------------------------------------------------------
     @timeit
+    @requires_view
     def getPackageVersion(self):
-        self.__require_view()
 
         return self.__package_version
 
@@ -4326,11 +4326,11 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getSourceComponents(self, component_filter):
         """
         Returns the available source components.
         """
-        self.__require_view()
         with DBSession(self._Session) as session:
             q = session.query(SourceComponent)
 
@@ -4570,8 +4570,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getAnalysisStatistics(self, run_id, run_history_id):
-        self.__require_view()
 
         analyzer_statistics = {}
 
@@ -4599,8 +4599,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def exportData(self, run_filter):
-        self.__require_view()
 
         with DBSession(self._Session) as session:
 
@@ -4751,8 +4751,8 @@ class ThriftRequestHandler:
 
     @exc_to_thrift_reqfail
     @timeit
+    @requires_view
     def getCleanupPlans(self, cleanup_plan_filter):
-        self.__require_view()
         with DBSession(self._Session) as session:
             q = session \
                 .query(CleanupPlan) \

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -1102,6 +1102,15 @@ def start_server(config_directory: str, workspace_directory: str,
                  "by a previous server instance matching machine ID '%s'.",
                  dropped_tasks, machine_id)
 
+    # Defense in depth: refuse to start if any Thrift API method
+    # lacks a permission check. The same check is also run as a unit
+    # test for PR CI; the startup variant guarantees that even if an
+    # unprotected method somehow lands in master, the server will
+    # not serve it.
+    from .api.permission_coverage import (
+        assert_all_thrift_methods_protected,
+    )
+    assert_all_thrift_methods_protected()
     server_clazz = CCSimpleHttpServer
     if ':' in listen_address:
         # IPv6 address specified for listening.

--- a/web/server/tests/unit/test_thrift_permission_coverage.py
+++ b/web/server/tests/unit/test_thrift_permission_coverage.py
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+"""
+Verify that every Thrift API method on the report server has a
+detectable permission check.
+
+This guards against a class of security bug: a Thrift method that is
+exposed to the JavaScript client but lacks a permission check, allowing
+an unprivileged user to invoke functionality reserved for product
+admins or other higher-privileged roles.
+
+The same check is also run at server startup; this test exists to fail
+PR CI early, before such a regression can be merged.
+"""
+import unittest
+
+from codechecker_server.api.permission_coverage import (
+    assert_all_thrift_methods_protected,
+)
+
+
+class ThriftPermissionCoverageTest(unittest.TestCase):
+    def test_all_thrift_methods_protected(self):
+        """Every Thrift method on ThriftRequestHandler is protected by
+        either an @requires_view decorator, a self.__require_*() call
+        in its first few statements, or an audited entry in
+        _DELEGATED_PROTECTION."""
+        # Raises RuntimeError listing offenders if any method is
+        # unprotected; the unittest framework converts the raise into
+        # a test failure with that message visible.
+        assert_all_thrift_methods_protected()


### PR DESCRIPTION
In a previous commit the __requires_view() permission check has been implemented by a decorator function.
In this commit __requires_store, __requires_access, __requires_admin are all transformed to decorators. Also, there is @requires_premission for custom permission levels.

These decorators are used in report_server.py in a uniform way.