### PR TITLE
[analyzer][report-converter] Track and display per-file analysis dura…

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -13,13 +13,15 @@ import shlex
 import shutil
 import signal
 import sys
+import time
 import traceback
 import zipfile
 
 from functools import lru_cache
-from threading import Timer
+from threading import Event, Thread, Timer
 
 import multiprocess  # type: ignore
+import psutil
 
 from codechecker_common.logger import get_logger
 from codechecker_common.process import kill_process_tree
@@ -62,7 +64,8 @@ def worker_result_handler(results, metadata_tool, output_path):
     skipped_num = 0
     reanalyzed_num = 0
     metadata_analyzers = metadata_tool['analyzers']
-    for res, skipped, reanalyzed, analyzer_type, _, sources in results:
+    for res, skipped, reanalyzed, analyzer_type, _, sources, duration, \
+            peak_memory in results:
         statistics = metadata_analyzers[analyzer_type]['analyzer_statistics']
         if skipped:
             skipped_num += 1
@@ -76,6 +79,9 @@ def worker_result_handler(results, metadata_tool, output_path):
             else:
                 statistics['failed'] += 1
                 statistics['failed_sources'].append(sources)
+
+            statistics['duration_of_sources'].append(
+                (sources, duration, peak_memory))
 
     LOG.info("----==== Summary ====----")
     print_analyzer_statistic_summary(metadata_analyzers,
@@ -407,6 +413,55 @@ def setup_process_timeout(proc, timeout,
     return __cleanup_timeout
 
 
+def setup_process_memory_watcher(proc, poll_interval=0.05):
+    """
+    Sample the resident memory usage (RSS) of `proc` and all of its child
+    processes in a background thread, keeping track of the observed peak.
+
+    :param proc: The subprocess.Popen object representing the process to
+      watch.
+    :param poll_interval: How often, in seconds, memory usage is sampled.
+
+    :return: A function which should be called once the client code knows
+      the watched process has terminated. Calling it stops the background
+      thread and returns the peak combined RSS observed, in bytes. Returns
+      0 if peak memory usage could not be determined (e.g. the process
+      psutil handle could not be created, or it exited too quickly to be
+      sampled).
+    """
+    try:
+        ps_proc = psutil.Process(proc.pid)
+    except psutil.NoSuchProcess:
+        return lambda: 0
+
+    peak_rss = [0]
+    stop_event = Event()
+
+    def __sample():
+        try:
+            procs = [ps_proc] + ps_proc.children(recursive=True)
+            rss = sum(
+                p.memory_info().rss for p in procs if p.is_running())
+            peak_rss[0] = max(peak_rss[0], rss)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    def __poll():
+        while not stop_event.is_set():
+            __sample()
+            stop_event.wait(poll_interval)
+
+    watcher = Thread(target=__poll, daemon=True)
+    watcher.start()
+
+    def __get_peak_memory():
+        stop_event.set()
+        watcher.join(timeout=poll_interval * 4)
+        return peak_rss[0]
+
+    return __get_peak_memory
+
+
 def collect_ctu_involved_files(result_handler, source_analyzer, output_dir):
     """
     This function collects the list of source files involved by CTU analysis.
@@ -479,25 +534,33 @@ def check(check_data):
         # later. To work around scoping issues, we use a list here so the
         # "function pointer" is captured by reference.
         timeout_cleanup = [lambda: False]
+        memory_getter = [lambda: 0]
 
         if analysis_timeout and analysis_timeout > 0:
             def __create_timeout(analyzer_process):
                 """
                 Once the analyzer process is started, this method is
-                called. Set up a timeout for the analysis.
+                called. Set up a timeout for the analysis and start
+                watching its memory usage.
                 """
                 timeout_cleanup[0] = setup_process_timeout(
                     analyzer_process, analysis_timeout)
+                memory_getter[0] = setup_process_memory_watcher(
+                    analyzer_process)
         else:
-            def __create_timeout(_):
-                # If no timeout is given by the client, this callback
-                # shouldn't do anything.
-                pass
+            def __create_timeout(analyzer_process):
+                # No timeout is given by the client, only start watching
+                # the analyzer process' memory usage.
+                memory_getter[0] = setup_process_memory_watcher(
+                    analyzer_process)
 
         result_file_exists = os.path.exists(rh.analyzer_result_file)
 
+        analysis_start = time.monotonic()
         # Fills up the result handler with the analyzer information.
         source_analyzer.analyze(analyzer_cmd, rh, __create_timeout)
+        duration = time.monotonic() - analysis_start
+        peak_memory = memory_getter[0]()
 
         # If execution reaches this line, the analyzer process has quit.
         if timeout_cleanup[0]():
@@ -608,7 +671,10 @@ def check(check_data):
 
                 # Fills up the result handler with
                 # the analyzer information.
-                source_analyzer.analyze(analyzer_cmd, rh)
+                reanalysis_start = time.monotonic()
+                source_analyzer.analyze(analyzer_cmd, rh, __create_timeout)
+                duration += time.monotonic() - reanalysis_start
+                peak_memory = max(peak_memory, memory_getter[0]())
 
                 return_codes = rh.analyzer_returncode
                 if rh.analyzer_returncode == 0:
@@ -647,13 +713,13 @@ def check(check_data):
         PROGRESS_CHECKED_NUM.value += 1
 
         return return_codes, False, reanalyzed, action.analyzer_type, \
-            result_file, action.source
+            result_file, action.source, duration, peak_memory
 
     except Exception as e:
         LOG.debug(str(e))
         traceback.print_exc(file=sys.stdout)
         return 1, False, reanalyzed, action.analyzer_type, None, \
-            action.source
+            action.source, 0.0, 0
 
 
 def skip_cpp(compile_actions, skip_handlers):

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -271,6 +271,7 @@ def perform_analysis(args, skip_handlers, filter_handlers,
                 "failed_sources": [],
                 "successful": 0,
                 "successful_sources": [],
+                "duration_of_sources": [],
                 "version": None}}
 
         for check, data in config_map[analyzer].checks().items():

--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -12,6 +12,7 @@ Prepare and start different analysis types
 
 from collections import defaultdict
 from string import Template
+from typing import Any, Dict
 import os
 import shutil
 import signal
@@ -264,7 +265,7 @@ def perform_analysis(args, skip_handlers, filter_handlers,
 
     # Save some metadata information.
     for analyzer in analyzers:
-        metadata_info = {
+        metadata_info: Dict[str, Any] = {
             'checkers': {},
             'analyzer_statistics': {
                 "failed": 0,

--- a/analyzer/codechecker_analyzer/cli/parse.py
+++ b/analyzer/codechecker_analyzer/cli/parse.py
@@ -184,6 +184,16 @@ def add_arguments_to_parser(parser):
                         help="Print the steps the analyzers took in finding "
                              "the reported defect.")
 
+    parser.add_argument('--perf-stats',
+                        dest="print_perf_stats",
+                        action="store_true",
+                        required=False,
+                        default=argparse.SUPPRESS,
+                        help="Print the top 10 slowest and most "
+                             "memory-hungry files to analyze, based on the "
+                             "per-file analyzer duration and peak memory "
+                             "usage recorded during 'CodeChecker analyze'.")
+
     parser.add_argument('--trim-path-prefix',
                         type=str,
                         nargs='*',
@@ -627,7 +637,8 @@ def main(args):
                 sys.exit(1)
 
         metadata = get_metadata(dir_path)
-        statistics.add_analyzer_durations(metadata)
+        if 'print_perf_stats' in args:
+            statistics.add_analyzer_durations(metadata)
 
         if metadata and 'files' in args:
             # Mapping plists when files are specified to speed up parsing

--- a/analyzer/codechecker_analyzer/cli/parse.py
+++ b/analyzer/codechecker_analyzer/cli/parse.py
@@ -627,6 +627,7 @@ def main(args):
                 sys.exit(1)
 
         metadata = get_metadata(dir_path)
+        statistics.add_analyzer_durations(metadata)
 
         if metadata and 'files' in args:
             # Mapping plists when files are specified to speed up parsing

--- a/tools/report-converter/codechecker_report_converter/report/statistics.py
+++ b/tools/report-converter/codechecker_report_converter/report/statistics.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 from collections import defaultdict, namedtuple
+from typing import Dict, Optional, Tuple
 
 from codechecker_report_converter import twodim
 from codechecker_report_converter.report import Report
@@ -30,6 +31,11 @@ class Statistics:
         self.severity_statistics = defaultdict(int)
         self.checker_statistics = defaultdict(int)
         self.file_statistics = defaultdict(int)
+
+        # analyzer name -> {source file: (duration in seconds,
+        #                                  peak memory usage in bytes)}.
+        self.duration_statistics: \
+            Dict[str, Dict[str, Tuple[float, float]]] = defaultdict(dict)
 
     def _write_severity_statistics(self, out=sys.stdout):
         """ Print severity statistics if it's available. """
@@ -66,6 +72,71 @@ class Statistics:
             for (file_path, n) in self.file_statistics.items()]))
         out.write("\n----=================----\n")
 
+    def _write_per_file_table(
+        self, out, title: str, subtitle: str,
+        get_value, format_value
+    ):
+        """ Print a per-file, per-analyzer top-10 table built from
+        'duration_statistics', if available. """
+        if not self.duration_statistics:
+            return
+
+        analyzer_names = list(self.duration_statistics.keys())
+
+        def _value(a: str, f: str) -> float:
+            return get_value(self.duration_statistics[a].get(f, (0.0, 0.0)))
+
+        all_files = sorted(
+            {f for d in self.duration_statistics.values() for f in d},
+            key=lambda f: sum(_value(a, f) for a in analyzer_names),
+            reverse=True
+        )[:10]
+
+        if not all_files:
+            return
+
+        header = ["File"] + analyzer_names + ["Total"]
+        rows = []
+        for src in all_files:
+            total = sum(_value(a, src) for a in analyzer_names)
+            rows.append(
+                [src] +
+                [format_value(_value(a, src)) for a in analyzer_names] +
+                [format_value(total)])
+
+        analyzer_sums = [
+            sum(get_value(v) for v in self.duration_statistics[a].values())
+            for a in analyzer_names]
+        rows.append(
+            ["Sum"] +
+            [format_value(s) for s in analyzer_sums] +
+            [format_value(sum(analyzer_sums))])
+
+        out.write(f"\n----==== {title} ====----\n")
+        out.write(subtitle + "\n")
+        out.write(twodim.to_table(
+            [header] + rows,
+            ellipsis_columns=range(len(header)),
+            keep_suffix_columns=[0]))
+        out.write("\n----=================----\n")
+
+    def _write_duration_statistics(self, out=sys.stdout):
+        """ Print the top 10 slowest files to analyze, if available. """
+        self._write_per_file_table(
+            out, "Per-File Analysis Duration Statistics",
+            "Top 10 slowest files (seconds):",
+            get_value=lambda t: t[0],
+            format_value=lambda v: f"{v:.2f}s")
+
+    def _write_memory_statistics(self, out=sys.stdout):
+        """ Print the top 10 most memory-hungry files to analyze,
+        if available. """
+        self._write_per_file_table(
+            out, "Per-File Analysis Memory Statistics",
+            "Top 10 most memory-hungry files (MB):",
+            get_value=lambda t: t[1] / 2**20,
+            format_value=lambda v: f"{v:.1f}MB")
+
     def _write_summary(self, out=sys.stdout):
         """ Print summary. """
         out.write("\n----======== Summary ========----\n")
@@ -82,6 +153,8 @@ class Statistics:
         self._write_severity_statistics()
         self._write_checker_statistics()
         self._write_file_statistics()
+        self._write_duration_statistics()
+        self._write_memory_statistics()
         self._write_summary()
 
     def add_report(self, report: Report):
@@ -91,3 +164,18 @@ class Statistics:
         self.checker_statistics[
             Checker(report.checker_name, report.severity)] += 1
         self.file_statistics[report.file.original_path] += 1
+
+    def add_analyzer_durations(self, metadata: Optional[Dict]):
+        """ Collect per-file analyzer durations and peak memory usage from
+        an analysis 'metadata.json' contents. """
+        if not metadata:
+            return
+
+        for tool in metadata.get('tools', []):
+            for analyzer_name, analyzer_data in \
+                    tool.get('analyzers', {}).items():
+                durations = analyzer_data.get(
+                    'analyzer_statistics', {}).get('duration_of_sources', [])
+                for src, duration, peak_memory in durations:
+                    self.duration_statistics[analyzer_name][src] = \
+                        (duration, peak_memory)

--- a/tools/report-converter/codechecker_report_converter/twodim.py
+++ b/tools/report-converter/codechecker_report_converter/twodim.py
@@ -15,7 +15,7 @@ import os
 import shutil
 
 from operator import itemgetter
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
 from prettytable import HRuleStyle, PrettyTable, TableStyle
 
@@ -234,7 +234,7 @@ def _fit_table_to_width(
 
     if trunc_cols:
         leftover = max(available - sum(wrap_assigned.values()),
-                        len(trunc_cols) * min_col_width)
+                       len(trunc_cols) * min_col_width)
         trunc_assigned = _assign_widths(
             trunc_cols, nat_widths, leftover, min_col_width)
         for i, w in trunc_assigned.items():
@@ -307,7 +307,7 @@ def _make_table(
 
 
 def to_table(
-    lines: Iterable[str],
+    lines: Iterable[Iterable[Any]],
     separate_head=True,
     separate_footer=False,
     ellipsis_columns: Optional[Iterable[int]] = None,

--- a/tools/report-converter/codechecker_report_converter/twodim.py
+++ b/tools/report-converter/codechecker_report_converter/twodim.py
@@ -245,7 +245,7 @@ def _fit_table_to_width(
         # letting PrettyTable wrap them onto extra lines. Columns not
         # listed still wrap normally via max_width.
         truncated_rows = [
-            [_truncate(cell, assigned[i], keep_suffix=(i in keep_suffix_cols))
+            [_truncate(cell, assigned[i], keep_suffix=i in keep_suffix_cols)
              if i in ellipsis_cols else cell
              for i, cell in enumerate(row)]
             for row in data_rows

--- a/tools/report-converter/codechecker_report_converter/twodim.py
+++ b/tools/report-converter/codechecker_report_converter/twodim.py
@@ -98,9 +98,61 @@ def to_rows(lines: Iterable[str]) -> str:
     return '\n'.join(str_parts)
 
 
+def _truncate(text, width: int, keep_suffix: bool = False) -> str:
+    """
+    Shorten ``text`` to ``width`` characters, adding an ellipsis. By default
+    the end of the string is cut off; if ``keep_suffix`` is set, the start
+    is cut off instead (useful for file paths, where the meaningful part -
+    the file name - is at the end).
+    """
+    s = str(text)
+    if len(s) <= width:
+        return s
+    if keep_suffix:
+        return '…' + s[-(width - 1):]
+    return s[:max(0, width - 1)] + '…'
+
+
+def _assign_widths(indices, nat_widths, budget, min_col_width):
+    assigned = {}
+    unassigned = list(indices)
+    remaining = budget
+
+    for _ in range(len(indices) + 1):
+        if not unassigned:
+            break
+
+        equal_share = remaining // len(unassigned)
+        locked_this_round = [
+            i for i in unassigned if nat_widths[i] <= equal_share
+        ]
+
+        if not locked_this_round:
+            break
+
+        for i in locked_this_round:
+            assigned[i] = nat_widths[i]
+            remaining -= nat_widths[i]
+            unassigned.remove(i)
+
+    if unassigned:
+        nat_sum = sum(nat_widths[i] for i in unassigned)
+        for i in unassigned:
+            if nat_sum > 0:
+                share = max(min_col_width,
+                            int(nat_widths[i] / nat_sum * remaining))
+            else:
+                share = max(min_col_width, remaining // len(unassigned))
+            assigned[i] = share
+
+    return assigned
+
+
 def _fit_table_to_width(
     table: PrettyTable,
     terminal_width: int,
+    ellipsis_columns: Optional[Iterable[int]] = None,
+    keep_suffix_columns: Optional[Iterable[int]] = None,
 ) -> str:
     """
     Render ``table`` so that it fits within ``terminal_width`` columns.
@@ -158,46 +210,72 @@ def _fit_table_to_width(
     # Available content budget (sum of column widths must be <= this).
     available = max(terminal_width - overhead, num_cols * min_col_width)
 
+    ellipsis_cols = set(ellipsis_columns) if ellipsis_columns else set()
+    keep_suffix_cols = set(keep_suffix_columns) if keep_suffix_columns \
+        else set()
+    wrap_cols = [i for i in range(num_cols) if i not in ellipsis_cols]
+    trunc_cols = [i for i in range(num_cols) if i in ellipsis_cols]
+
     # --- Iterative fixpoint ---
     # assigned[i] holds the final max_width for column i once locked.
     # Initialised to 0; every entry is guaranteed to be set before use.
     assigned: List[int] = [0] * num_cols
-    unassigned = list(range(num_cols))
-    remaining = available
 
     # Each iteration locks columns whose natural width is <= the equal
     # share they would receive if the remaining budget were split evenly
     # among the still-unassigned columns.  This guarantees that short
     # columns always keep their full natural width, and only the genuinely
     # wide columns are shortened.
-    for _ in range(num_cols + 1):
-        if not unassigned:
-            break
+    wrap_assigned = _assign_widths(
+        wrap_cols, nat_widths,
+        available - len(trunc_cols) * min_col_width, min_col_width)
+    for i, w in wrap_assigned.items():
+        assigned[i] = w
 
-        equal_share = remaining // len(unassigned)
-        locked_this_round = [
-            i for i in unassigned if nat_widths[i] <= equal_share
+    if trunc_cols:
+        leftover = max(available - sum(wrap_assigned.values()),
+                        len(trunc_cols) * min_col_width)
+        trunc_assigned = _assign_widths(
+            trunc_cols, nat_widths, leftover, min_col_width)
+        for i, w in trunc_assigned.items():
+            assigned[i] = w
+
+    if ellipsis_columns:
+        # Hard-truncate the requested columns with an ellipsis instead of
+        # letting PrettyTable wrap them onto extra lines. Columns not
+        # listed still wrap normally via max_width.
+        truncated_rows = [
+            [_truncate(cell, assigned[i], keep_suffix=(i in keep_suffix_cols))
+             if i in ellipsis_cols else cell
+             for i, cell in enumerate(row)]
+            for row in data_rows
+        ]
+        truncated_headers = [
+            _truncate(h, assigned[i]) if i in ellipsis_cols else h
+            for i, h in enumerate(field_names)
         ]
 
-        if not locked_this_round:
-            break  # Nothing new was locked; exit early.
-
-        for i in locked_this_round:
-            assigned[i] = nat_widths[i]
-            remaining -= nat_widths[i]
-            unassigned.remove(i)
-
-    # Distribute remaining budget among columns still unassigned
-    # (those that need truncation), proportionally to natural widths.
-    if unassigned:
-        nat_sum = sum(nat_widths[i] for i in unassigned)
-        for i in unassigned:
-            if nat_sum > 0:
-                share = max(min_col_width,
-                            int(nat_widths[i] / nat_sum * remaining))
+        # PrettyTable requires unique field names; disambiguate any
+        # collisions created by truncation.
+        seen: dict = {}
+        unique_headers = []
+        for h in truncated_headers:
+            if h in seen:
+                seen[h] += 1
+                unique_headers.append(f"{h[:max(0, len(h) - 1)]}{seen[h]}")
             else:
-                share = max(min_col_width, remaining // len(unassigned))
-            assigned[i] = share
+                seen[h] = 0
+                unique_headers.append(h)
+
+        table = _make_table(
+            unique_headers, truncated_rows, show_header, table.hrules)
+
+        for i, fn in enumerate(table.field_names):
+            table.max_width[fn] = assigned[i]  # type: ignore[index]
+
+        table.max_table_width = terminal_width
+
+        return table.get_string()
 
     # Apply per-column max_width constraints.
     for i, fn in enumerate(table.field_names):
@@ -231,7 +309,9 @@ def _make_table(
 def to_table(
     lines: Iterable[str],
     separate_head=True,
-    separate_footer=False
+    separate_footer=False,
+    ellipsis_columns: Optional[Iterable[int]] = None,
+    keep_suffix_columns: Optional[Iterable[int]] = None,
 ) -> str:
     """
     Pretty-prints the given two-dimensional array's lines using PrettyTable.
@@ -245,6 +325,13 @@ def to_table(
     The first row is used as the header when ``separate_head`` is True.
     When ``separate_footer`` is True, the last data row is visually separated
     from the rest by drawing a horizontal rule between every row.
+
+    By default, columns that don't fit are wrapped onto extra lines within
+    the same row. ``ellipsis_columns`` selects column indices (0-based) that
+    should instead be hard-truncated with an ellipsis ('…') and kept on a
+    single line. Of those, ``keep_suffix_columns`` selects the ones where the
+    start (rather than the end) is cut off (useful for file paths, where the
+    file name at the end is the meaningful part).
     """
     lns: List[List[str]] = [
         ['' if e is None else str(e) for e in line] for line in lines]
@@ -276,7 +363,8 @@ def to_table(
     else:
         table = _make_table(field_names, data_rows, show_header)
 
-    return _fit_table_to_width(table, terminal_width)
+    return _fit_table_to_width(
+        table, terminal_width, ellipsis_columns, keep_suffix_columns)
 
 
 def to_csv(lines: Iterable[str]) -> str:

--- a/web/server/codechecker_server/metadata.py
+++ b/web/server/codechecker_server/metadata.py
@@ -23,6 +23,7 @@ AnalyzerStatistics = Any
 AnalyzerList = List[str]
 CheckCommands = List[str]
 CheckDurations = List[float]
+DurationOfSources = List[tuple]
 CheckerNamesView = Iterable[str]
 CheckerToAnalyzer = Dict[str, str]
 CodeCheckerVersion = Optional[str]
@@ -59,6 +60,7 @@ class MetadataInfoParser:
         self.cc_version: CodeCheckerVersion = None
         self.check_commands: CheckCommands = []
         self.check_durations: CheckDurations = []
+        self.duration_of_sources: DurationOfSources = []
         self.analyzer_statistics: AnalyzerStatistics = {}
 
         self.checkers: MetadataCheckers = {}
@@ -153,6 +155,10 @@ class MetadataInfoParser:
                 dest[analyzer_name]['successful_sources'].extend(
                     source.get('successful_sources', []))
 
+            if 'duration_of_sources' in dest[analyzer_name]:
+                dest[analyzer_name]['duration_of_sources'].extend(
+                    source.get('duration_of_sources', []))
+
             dest[analyzer_name]['version'].update([source['version']])
         else:
             dest[analyzer_name] = source
@@ -230,6 +236,10 @@ class MetadataInfoParser:
                 stats['successful'] = len(stats['successful_sources'])
 
             stats['version'] = '; '.join(stats['version'])
+
+        for stats in self.analyzer_statistics.values():
+            self.duration_of_sources.extend(
+                stats.get('duration_of_sources', []))
 
         # FIXME: if multiple report directories are stored created by different
         # codechecker versions there can be multiple results with OFF detection


### PR DESCRIPTION
…tion/memory stats

Records per-source analysis duration and peak RSS during 'CodeChecker analyze', persists them in metadata.json, and has 'CodeChecker parse' render top-10 slowest/most memory-hungry files as PrettyTable output. Also extends twodim.to_table() with ellipsis-truncated columns so wide per-analyzer tables stay readable in a terminal.