### PR TITLE
[gui] Add the missing rules and guidelines to the checkers

### DIFF
--- a/config/labels/analyzers/clang-tidy.json
+++ b/config/labels/analyzers/clang-tidy.json
@@ -3905,7 +3905,9 @@
     ],
     "clang-diagnostic-lifetime-safety": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
@@ -3919,31 +3921,39 @@
     ],
     "clang-diagnostic-lifetime-safety-dangling-field": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-dangling-field",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-dangling-field-moved": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-dangling-field-moved",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-dangling-global": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-dangling-global",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-dangling-global-moved": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-dangling-global-moved",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
@@ -3953,7 +3963,9 @@
     ],
     "clang-diagnostic-lifetime-safety-invalidation": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-invalidation",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
@@ -3967,16 +3979,20 @@
     ],
     "clang-diagnostic-lifetime-safety-return-stack-addr": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-return-stack-addr",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-return-stack-addr-moved": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-return-stack-addr-moved",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
@@ -3990,25 +4006,31 @@
     ],
     "clang-diagnostic-lifetime-safety-use-after-free": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-use-after-free",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-use-after-scope": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-use-after-scope",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],
     "clang-diagnostic-lifetime-safety-use-after-scope-moved": [
       "doc_url:https://clang.llvm.org/docs/DiagnosticsReference.html#wlifetime-safety-use-after-scope-moved",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH"
     ],

--- a/config/labels/analyzers/clangsa.json
+++ b/config/labels/analyzers/clangsa.json
@@ -277,6 +277,7 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage-c-c-objc",
       "guideline:cwe-top-25-2024",
       "guideline:owasp-top-10-2025",
+      "guideline:memory-safety",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
       "profile:default",
@@ -286,6 +287,7 @@
       "cwe-top-25-2024:cwe-476",
       "cwe-vulnerability:cwe-476",
       "owasp-top-10-2025:owasp-A10-2025",
+      "memory-safety:cwe-476",
       "sei-cert-c:dcl41-c",
       "sei-cert-c:exp30-c",
       "sei-cert-c:exp33-c",
@@ -323,9 +325,9 @@
       "severity:MEDIUM"
     ],
     "core.FixedAddressDereference": [
-      "cwe-top25:cwe-119",
+      "cwe-top-25-2024:cwe-119",
       "doc_url:https://releases.llvm.org/22.1.0/tools/clang/docs/analyzer/checkers.html#core-fixedaddressdereference-c-c-objc",
-      "guideline:cwe-top25-2024",
+      "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",
       "profile:security",
@@ -336,6 +338,7 @@
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker-c-c-objc",
       "guideline:cwe-top-25-2024",
       "guideline:owasp-top-10-2025",
+      "guideline:memory-safety",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
       "profile:default",
@@ -345,6 +348,7 @@
       "cwe-top-25-2024:cwe-476",
       "cwe-vulnerability:cwe-476",
       "owasp-top-10-2025:owasp-A10-2025",
+      "memory-safety:cwe-476",
       "sei-cert-c:exp34-c",
       "sei-cert-cpp:exp34-c",
       "severity:HIGH"
@@ -532,24 +536,28 @@
     "cplusplus.InnerPointer": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer-c",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-416",
+      "memory-safety:cwe-416",
       "sei-cert-cpp:mem50-cpp",
       "sei-cert-cpp:str52-cpp",
       "severity:HIGH"
     ],
     "cplusplus.Move": [
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-416",
+      "memory-safety:cwe-416",
       "sei-cert-cpp:exp63-cpp",
       "severity:HIGH"
     ],
@@ -618,6 +626,7 @@
     "cplusplus.StringChecker": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker-c",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-cpp",
       "profile:default",
       "profile:extreme",
@@ -625,6 +634,7 @@
       "profile:sensitive",
       "cwe-top-25-2024:cwe-119",
       "cwe-top-25-2024:cwe-476",
+      "memory-safety:cwe-476",
       "sei-cert-cpp:str51-cpp",
       "severity:HIGH"
     ],
@@ -709,11 +719,13 @@
     "nullability.NullReturnedFromNonnull": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull-c-c-objc",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-476",
       "cwe-vulnerability:cwe-476",
+      "memory-safety:cwe-476",
       "severity:HIGH"
     ],
     "nullability.NullabilityBase": [
@@ -749,12 +761,12 @@
     ],
     "optin.core.FixedAddressDereference": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-fixedaddressdereference-c-c-objc",
-      "guideline:cwe-top25-2024",
+      "guideline:cwe-top-25-2024",
       "profile:default",
       "profile:extreme",
       "profile:security",
       "profile:sensitive",
-      "cwe-top25:cwe-119",
+      "cwe-top-25-2024:cwe-119",
       "severity:HIGH"
     ],
     "optin.core.UnconditionalVAArg": [
@@ -1286,6 +1298,7 @@
     "unix.StdCLibraryFunctions": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions-c",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-c",
       "profile:default",
       "profile:extreme",
@@ -1295,6 +1308,7 @@
       "cwe-top-25-2024:cwe-125",
       "cwe-top-25-2024:cwe-476",
       "cwe-top-25-2024:cwe-787",
+      "memory-safety:cwe-476",
       "sei-cert-c:arr38-c",
       "sei-cert-c:err33-c",
       "sei-cert-c:pos52-c",
@@ -1355,6 +1369,7 @@
     "unix.cstring.NullArg": [
       "doc_url:https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg-c",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
       "profile:default",
@@ -1362,6 +1377,7 @@
       "profile:security",
       "profile:sensitive",
       "cwe-top-25-2024:cwe-476",
+      "memory-safety:cwe-476",
       "sei-cert-c:exp34-c",
       "sei-cert-cpp:exp34-c",
       "severity:HIGH"

--- a/config/labels/analyzers/cppcheck.json
+++ b/config/labels/analyzers/cppcheck.json
@@ -298,8 +298,10 @@
     "cppcheck-ctunullpointer": [
       "cwe-top-25-2024:cwe-476",
       "guideline:cwe-top-25-2024",
+      "guideline:memory-safety",
       "guideline:sei-cert-c",
       "guideline:sei-cert-cpp",
+      "memory-safety:cwe-476",
       "profile:security",
       "sei-cert-c:exp34-c",
       "sei-cert-cpp:exp34-c",
@@ -345,10 +347,12 @@
       "severity:HIGH"
     ],
     "cppcheck-deallocuse": [
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:default",
       "profile:extreme",
       "profile:sensitive",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH",
       "sei-cert-c:mem30-c",

--- a/config/labels/analyzers/gcc.json
+++ b/config/labels/analyzers/gcc.json
@@ -140,8 +140,10 @@
     ],
     "gcc-null-dereference": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-null-dereference",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:extreme",
+      "cwe-top-25-2024:cwe-476",
       "memory-safety:cwe-476",
       "severity:HIGH",
       "sei-cert-c:exp34-c"
@@ -242,8 +244,10 @@
     ],
     "gcc-use-after-free": [
       "doc_url:https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html#index-Wanalyzer-use-after-free",
+      "guideline:cwe-top-25-2024",
       "guideline:memory-safety",
       "profile:extreme",
+      "cwe-top-25-2024:cwe-416",
       "memory-safety:cwe-416",
       "severity:HIGH",
       "sei-cert-c:mem30-c"


### PR DESCRIPTION
Guideline Statistics shows different checkers for the same rules across different guidelines. This is not how it should be.

This change fixes this and adds the same rules for all guidelines which applicable to the checkers.