### PR TITLE
[fix] Cleanup expired sessions from the database

### DIFF
--- a/web/server/codechecker_server/api/authentication.py
+++ b/web/server/codechecker_server/api/authentication.py
@@ -23,10 +23,12 @@ import sqlalchemy
 import string
 
 from collections import defaultdict
+from typing import Optional
 
 from codechecker_api.Authentication_v6.ttypes import AccessControl, \
     AuthorisationList, HandshakeInformation, Permissions, \
     PersonalAccessToken, SessionTokenData
+from sqlalchemy.orm import sessionmaker
 
 from codechecker_common.logger import get_logger
 
@@ -39,7 +41,8 @@ from ..database.database import DBSession
 from ..permissions import handler_from_scope_params as make_handler, \
     require_manager, require_permission
 from ..server import permissions
-from ..session_manager import generate_session_token
+from ..session_manager import (SessionManager, generate_session_token,
+                               _Session)
 
 
 LOG = get_logger('server')
@@ -51,6 +54,9 @@ class ThriftAuthHandler:
     """
     Handle Thrift authentication requests.
     """
+    __manager: SessionManager
+    __auth_session: Optional[_Session]
+    __config_db: sessionmaker
 
     def __init__(self, manager, auth_session, config_database):
         self.__manager = manager

--- a/web/server/codechecker_server/database/config_db_model.py
+++ b/web/server/codechecker_server/database/config_db_model.py
@@ -223,7 +223,8 @@ class OAuthToken(Base):
                              ForeignKey('auth_sessions.id',
                                         deferrable=False,
                                         ondelete='CASCADE'),
-                             nullable=False)
+                             nullable=False,
+                             index=True)
 
     def __init__(self, access_token, expires_at, refresh_token,
                  auth_session_id):

--- a/web/server/codechecker_server/migrations/config/versions/635389f535cd_add_index_oauth_tokens_auth_session_id.py
+++ b/web/server/codechecker_server/migrations/config/versions/635389f535cd_add_index_oauth_tokens_auth_session_id.py
@@ -1,0 +1,26 @@
+"""
+Add index oauth_tokens(auth_session_id)
+
+Revision ID: 635389f535cd
+Revises:     511b1b37de2e
+Create Date: 2026-08-17 15:28:04.316623
+"""
+
+from alembic import op
+
+
+# Revision identifiers, used by Alembic.
+revision = '635389f535cd'
+down_revision = '511b1b37de2e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_oauth_tokens_auth_session_id'),
+                    'oauth_tokens', ['auth_session_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_oauth_tokens_auth_session_id'),
+                  table_name='oauth_tokens')

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -1051,6 +1051,14 @@ def start_server(config_directory: str, workspace_directory: str,
     server_secrets_file = os.path.join(config_directory, 'server_secrets.json')
 
     if not skip_db_cleanup:
+        # TODO:
+        # Perform a cleanup on the config database as well.
+        # - Do a garbage collection on table auth_sessions and
+        # remove expired sessions. Currently, this cleanup is only
+        # performed when a user logs in. Therefore, expired sessions
+        # can accumulate for users who no longer interact with the
+        # server.
+
         all_success, fails = _do_db_cleanups(config_sql_server,
                                              context,
                                              check_env)

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -14,7 +14,7 @@ import os
 import re
 import uuid
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import hashlib
 from typing import Optional
 
@@ -32,6 +32,7 @@ from .database.config_db_model import Session as SessionRecord
 from .database.config_db_model import OAuthToken
 from .database.config_db_model import PersonalAccessToken
 from .database.config_db_model import SystemPermission
+from .database.database import DBSession
 from .permissions import SUPERUSER
 
 import codechecker_api_shared
@@ -858,6 +859,25 @@ class SessionManager:
             self.__refresh_time, is_root, self.__config_db_sessionmaker,
             last_access)
 
+    def __cleanup_expired_auth_sessions(self, user_name: str):
+        """
+        Cleanup expired auth_sessions of a user from the database.
+        """
+        with DBSession(self.__config_db_sessionmaker) as session:
+            try:
+                cutoff_date = (datetime.now() - timedelta(
+                    seconds=self.__auth_config['session_lifetime']))
+                session.query(SessionRecord) \
+                       .filter(SessionRecord.user_name == user_name) \
+                       .filter(SessionRecord.last_access < cutoff_date) \
+                       .delete(synchronize_session=False)
+
+                session.commit()
+            except Exception as e:
+                LOG.error("Failed to cleanup expired auth sessions "
+                          "from the database:")
+                LOG.error(str(e))
+
     def create_session(self, auth_string):
         """ Creates a new session for the given auth-string. """
         if not self.__auth_config['enabled']:
@@ -888,6 +908,9 @@ class SessionManager:
         user_name = validation.get('username')
         groups = validation.get('groups', [])
         is_root = validation.get('root', False)
+
+        if user_name:
+            self.__cleanup_expired_auth_sessions(user_name)
 
         local_session = self.__create_local_session(token, user_name,
                                                     groups, is_root)
@@ -952,6 +975,8 @@ class SessionManager:
                      'token': codechecker_session_token,
                      'groups': groups,
                      'is_root': False}
+
+        self.__cleanup_expired_auth_sessions(username)
 
         local_session = self.__create_local_session(
             codechecker_session_token,


### PR DESCRIPTION
Previously, expired auth_sessions were not deleted from the database. This patch addresses this issue.

Due to CASCADE DELETE on table oauth_tokens, this operation could be slow. Therefore, an index was added to the relevant column: oauth_tokens(auth_session_id).

Currently, this patch only removes expired sessions when a user logs in. A TODO comment is added for future work.