### PR TITLE
[fix] Cleanup expired auth sessions during server start

### DIFF
--- a/web/server/codechecker_server/database/db_cleanup.py
+++ b/web/server/codechecker_server/database/db_cleanup.py
@@ -10,9 +10,10 @@ Contains housekeeping routines that are used to remove expired, obsolete,
 or dangling records from the database.
 """
 from datetime import datetime, timedelta
-from typing import Dict
+from typing import Dict, Optional
 
 import sqlalchemy
+from sqlalchemy.orm import sessionmaker
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import Severity
 
@@ -27,6 +28,7 @@ from .run_db_model import \
     Comment, Checker, \
     File, FileContent, \
     Report, ReportAnalysisInfo, RunHistoryAnalysisInfo, RunLock
+from .config_db_model import Session as SessionRecord
 
 LOG = get_logger('server')
 RUN_LOCK_TIMEOUT_IN_DATABASE = 30 * 60  # 30 minutes.
@@ -414,3 +416,42 @@ def add_foreign_keys(session, table_name, foreign_keys):
             f"REFERENCES {referred_table}({referred_columns});"
         ))
     session.commit()
+
+
+def delete_expired_auth_sessions(config_db_sessionmaker: sessionmaker,
+                                 session_lifetime: int,
+                                 user_name: Optional[str]):
+    """
+    Cleanup expired auth_sessions from the config database.
+    If 'user_name' is specified, we only remove expired auth_sessions
+    of that particular user.
+    If 'user_name' is specified as None, we remove all expired auth_sessions
+    from the database.
+    """
+    if user_name:
+        LOG.debug("Cleaning up expired auth sessions of user '%s' ...",
+                  user_name)
+    else:
+        LOG.debug("Cleaning up all expired auth sessions ...")
+
+    with DBSession(config_db_sessionmaker) as session:
+        try:
+            cutoff_date = (datetime.now() - timedelta(
+                seconds=session_lifetime))
+
+            if user_name:
+                session.query(SessionRecord) \
+                       .filter(SessionRecord.user_name == user_name) \
+                       .filter(SessionRecord.last_access < cutoff_date) \
+                       .delete(synchronize_session=False)
+            else:
+                session.query(SessionRecord) \
+                       .filter(SessionRecord.last_access < cutoff_date) \
+                       .delete(synchronize_session=False)
+
+            session.commit()
+            LOG.debug("Finished cleanup of expired auth sessions.")
+        except Exception as e:
+            LOG.error("Failed to cleanup expired auth sessions "
+                      "from the database:")
+            LOG.error(str(e))

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -67,6 +67,7 @@ from .database.config_db_model import Product as ORMProduct, \
     Configuration as ORMConfiguration
 from .database.database import DBSession
 from .database.run_db_model import Run
+from .database import db_cleanup
 from .product import Product
 from .task_executors.main import executor as background_task_executor
 from .task_executors.task_manager import \
@@ -651,7 +652,8 @@ class CCSimpleHttpServer(HTTPServer):
                  server_secrets_file,
                  force_auth,
                  api_handler_processes,
-                 task_worker_processes):
+                 task_worker_processes,
+                 skip_db_cleanup):
 
         LOG.debug("Initializing HTTP server...")
 
@@ -687,6 +689,9 @@ class CCSimpleHttpServer(HTTPServer):
         except ValueError as verr:
             LOG.error(verr)
             sys.exit(1)
+
+        if not skip_db_cleanup:
+            self.cleanup_config_database()
 
         self.__task_queue = task_queue
         self.task_manager = BackgroundTaskManager(
@@ -991,6 +996,17 @@ class CCSimpleHttpServer(HTTPServer):
             if ep not in endpoints_to_keep:
                 self.remove_product(ep)
 
+    def cleanup_config_database(self):
+        """
+        Do garbage collection on the config database.
+        """
+        LOG.info("Starting garbage collection on the config database ...")
+        db_cleanup.delete_expired_auth_sessions(
+                self.config_session,
+                self.manager.session_lifetime_duration,
+                None)
+        LOG.info("Finished garbage collection on the config database.")
+
 
 class CCSimpleHttpServerIPv6(CCSimpleHttpServer):
     """
@@ -1052,12 +1068,9 @@ def start_server(config_directory: str, workspace_directory: str,
 
     if not skip_db_cleanup:
         # TODO:
-        # Perform a cleanup on the config database as well.
-        # - Do a garbage collection on table auth_sessions and
-        # remove expired sessions. Currently, this cleanup is only
-        # performed when a user logs in. Therefore, expired sessions
-        # can accumulate for users who no longer interact with the
-        # server.
+        # Move these product database cleanups to the
+        # CCSimpleHttpServer class. The config database
+        # is also cleaned up during server class __init__.
 
         all_success, fails = _do_db_cleanups(config_sql_server,
                                              context,
@@ -1133,7 +1146,8 @@ def start_server(config_directory: str, workspace_directory: str,
                                server_secrets_file,
                                force_auth,
                                api_handler_processes,
-                               task_worker_processes)
+                               task_worker_processes,
+                               skip_db_cleanup)
 
     api_processes: Dict[int, Process] = {}
     bg_processes: Dict[int, Process] = {}

--- a/web/server/codechecker_server/session_manager.py
+++ b/web/server/codechecker_server/session_manager.py
@@ -14,7 +14,7 @@ import os
 import re
 import uuid
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import hashlib
 from typing import Optional
 
@@ -32,7 +32,7 @@ from .database.config_db_model import Session as SessionRecord
 from .database.config_db_model import OAuthToken
 from .database.config_db_model import PersonalAccessToken
 from .database.config_db_model import SystemPermission
-from .database.database import DBSession
+from .database import db_cleanup
 from .permissions import SUPERUSER
 
 import codechecker_api_shared
@@ -859,25 +859,6 @@ class SessionManager:
             self.__refresh_time, is_root, self.__config_db_sessionmaker,
             last_access)
 
-    def __cleanup_expired_auth_sessions(self, user_name: str):
-        """
-        Cleanup expired auth_sessions of a user from the database.
-        """
-        with DBSession(self.__config_db_sessionmaker) as session:
-            try:
-                cutoff_date = (datetime.now() - timedelta(
-                    seconds=self.__auth_config['session_lifetime']))
-                session.query(SessionRecord) \
-                       .filter(SessionRecord.user_name == user_name) \
-                       .filter(SessionRecord.last_access < cutoff_date) \
-                       .delete(synchronize_session=False)
-
-                session.commit()
-            except Exception as e:
-                LOG.error("Failed to cleanup expired auth sessions "
-                          "from the database:")
-                LOG.error(str(e))
-
     def create_session(self, auth_string):
         """ Creates a new session for the given auth-string. """
         if not self.__auth_config['enabled']:
@@ -910,7 +891,10 @@ class SessionManager:
         is_root = validation.get('root', False)
 
         if user_name:
-            self.__cleanup_expired_auth_sessions(user_name)
+            db_cleanup.delete_expired_auth_sessions(
+                    self.__config_db_sessionmaker,
+                    self.session_lifetime_duration,
+                    user_name)
 
         local_session = self.__create_local_session(token, user_name,
                                                     groups, is_root)
@@ -976,7 +960,9 @@ class SessionManager:
                      'groups': groups,
                      'is_root': False}
 
-        self.__cleanup_expired_auth_sessions(username)
+        db_cleanup.delete_expired_auth_sessions(self.__config_db_sessionmaker,
+                                                self.session_lifetime_duration,
+                                                username)
 
         local_session = self.__create_local_session(
             codechecker_session_token,
@@ -1072,6 +1058,11 @@ class SessionManager:
     def get_keepalive_max_probe(self):
         """ Get keepalive max probe count. """
         return self.__keepalive_config.get('max_probe')
+
+    @property
+    def session_lifetime_duration(self) -> int:
+        """ Get session lifetime duration from server configuration. """
+        return self.__auth_config['session_lifetime']
 
     def __get_local_session_from_db(self, token) -> Optional[_Session]:
         """


### PR DESCRIPTION
This patch is a continuation of the work started in commit 14fe5f89042089d8c79d722612a2acbd2c9df9fd.
With this change, expired auth sessions are now removed from the database during server startups for all users if garbage collection is not skipped.