### PR TITLE
Execution order of the static analyzers

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -149,6 +149,14 @@ def perform_analysis(args, skip_handlers, filter_handlers,
     analyzers, errored = \
         analyzer_types.check_available_analyzers(args.analyzers)
 
+    # Sort analyzers according to the order defined in supported_analyzers.
+    # Longer-running analyzers (e.g. clangsa) come first so they are
+    # scheduled earlier in parallel execution, reducing total wall-clock time.
+    analyzer_order = list(analyzer_types.supported_analyzers.keys())
+    analyzers = sorted(analyzers,
+                       key=lambda a: analyzer_order.index(a)
+                       if a in analyzer_order else len(analyzer_order))
+
     ctu_collect = False
     ctu_analyze = False
     ctu_dir = ''

--- a/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
+++ b/analyzer/codechecker_analyzer/analyzers/analyzer_types.py
@@ -29,6 +29,11 @@ from .infer.analyzer import Infer
 
 LOG = get_logger('analyzer')
 
+# The order of this dictionary determines the default execution order of
+# analyzers. Longer-running analyzers (e.g. clangsa) should come first so
+# that they are scheduled earlier in parallel execution, reducing total
+# wall-clock time. Do not change the order without considering the impact
+# on analysis scheduling.
 supported_analyzers = {ClangSA.ANALYZER_NAME: ClangSA,
                        ClangTidy.ANALYZER_NAME: ClangTidy,
                        Cppcheck.ANALYZER_NAME: Cppcheck,


### PR DESCRIPTION
The order in which analyzers (clangsa, clang-tidy, etc.) were scheduled for execution was non-deterministic because check_supported_analyzers() used a set to collect enabled analyzers. This meant that on some runs clang-tidy tasks would be dispatched before clangsa tasks.

This change replaces the set with a list, preserving the iteration order from the supported_analyzers dict. This guarantees clangsa actions are always dispatched to the worker pool first, followed by clang-tidy, cppcheck, etc.

For users with long-running clangsa analyses (e.g. 90+ minutes per file), this ensures those heavy tasks start immediately on available cores, reducing total wall-clock time.

Fixes #4362