### PR TITLE
Server accepts invalid/non-existent run name

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -405,8 +405,7 @@ async function updateReportFilter() {
   );
   // Pass [-1] if the user selected a non-existent run,
   // to avoid removing the filter.
-  const hasSelection =
-    baseSelectOptionFilter.selectedItems.value.length > 0;
+  const hasSelection = baseSelectOptionFilter.selectedItems.value.length > 0;
   baseSelectOptionFilter.setRunIds(
     _selectedRunIds.length
       ? _selectedRunIds

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/BaselineRunFilter.vue
@@ -403,8 +403,14 @@ async function updateReportFilter() {
   const _selectedRunIds = await runFilter.getSelectedRunIds(
     baseSelectOptionFilter.selectedItems
   );
+  // Pass [-1] if the user selected a non-existent run,
+  // to avoid removing the filter.
+  const hasSelection =
+    baseSelectOptionFilter.selectedItems.value.length > 0;
   baseSelectOptionFilter.setRunIds(
-    _selectedRunIds.length ? _selectedRunIds : null
+    _selectedRunIds.length
+      ? _selectedRunIds
+      : hasSelection ? [ -1 ] : null
   );
 
   const _selectedTagIds = runFilter.selectedTagItems.value.map(t => t.id);

--- a/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToRunFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/Filters/ComparedToRunFilter.vue
@@ -401,11 +401,19 @@ async function updateReportFilter() {
     baseSelectOptionFilter.selectedItems
   );
   const _selectedTagIds = runFilter.selectedTagItems.value.map(t => t.id);
+  const hasSelection = baseSelectOptionFilter.selectedItems.value.length > 0;
 
   if (_selectedRunIds.length || _selectedTagIds.length) {
     baseSelectOptionFilter.setCmpData({
       runIds: _selectedRunIds.length ? _selectedRunIds : null,
       runTag: _selectedTagIds.length ? _selectedTagIds : null
+    });
+  } else if (hasSelection) {
+    // Pass [-1] if the user selected a non-existent run,
+    // to avoid removing the filter.
+    baseSelectOptionFilter.setCmpData({
+      runIds: [ -1 ],
+      runTag: null
     });
   } else {
     baseSelectOptionFilter.setCmpData(null);


### PR DESCRIPTION
When navigating to /reports?run=bogus-run with a non-existent run name, all reports from all runs were displayed instead of an empty result.

In BaselineRunFilter.vue, resolving a non-existent run name returns an empty run ID array, which was passed as null to setRunIds() — meaning 'no filter', so the server returned everything.

The fix passes [-1] as the run ID when the user selected a run that resolved to nothing. Since run IDs are auto-increment primary keys (always positive), -1 never matches a real run. The server applies WHERE run_id IN (-1), returns an empty list, and raises no errors.

Same fix applied to ComparedToRunFilter.vue.

Fixes #4472