### PR TITLE
[fix] Re-add CodeChecker cmd runs --details flag

### DIFF
--- a/web/client/codechecker_client/cli/cmd.py
+++ b/web/client/codechecker_client/cli/cmd.py
@@ -1181,6 +1181,13 @@ def __register_runs(parser):
                         default=default_sort_type,
                         help="Sort run data by this column.")
 
+    parser.add_argument('--details',
+                        action='store_true',
+                        required=False,
+                        help="Adds extra details to the run information in "
+                             "JSON format, such as the list of enabled "
+                             "checkers.")
+
     # Get available order types.
     order_type_names = list(ttypes.Order._NAMES_TO_VALUES.keys())
     order_types = [s.lower() for s in order_type_names]

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -717,10 +717,15 @@ def handle_list_runs(args):
 
     runs = get_run_data(client, run_filter, sort_mode)
 
-    if args.output_format == 'json':
+    if args.output_format == 'json' and 'details' in args and args.details:
         # This json is different from the json format printed by the
         # parse command. This json converts the ReportData type report
         # to a json format.
+        #
+        # Showing the enabled checkers and additional analyzer statistics
+        # is significantly slower because additional API queries are needed
+        # (getAnalysisInfo, getAnalysisStatistics). Therefore, this output is
+        # behind the --details flag.
         results = []
         for run in runs:
             enabled_checkers: Dict[str, Set[str]] = {}
@@ -741,7 +746,11 @@ def handle_list_runs(args):
                 stat.enabledCheckers = sorted(
                     list(enabled_checkers.get(analyzer, set())))
             results.append({run.name: run})
-        print(json.dumps(results, cls=CmdLineOutputEncoder, indent=4))
+        json.dump(results, sys.stdout, cls=CmdLineOutputEncoder, indent=4)
+
+    elif args.output_format == 'json':
+        results = [{r.name: r} for r in runs]
+        json.dump(results, sys.stdout, cls=CmdLineOutputEncoder, indent=4)
 
     else:  # plaintext, csv
         header = ['Name', 'Number of unresolved reports',

--- a/web/client/tests/unit/test_cmd_line_client.py
+++ b/web/client/tests/unit/test_cmd_line_client.py
@@ -66,7 +66,8 @@ class ListRunsEnabledCheckersTest(unittest.TestCase):
             product_url="dummy",
             sort_type="name",
             sort_order="asc",
-            output_format="json"
+            output_format="json",
+            details=True
         )
 
         buf = io.StringIO()

--- a/web/tests/functional/cmdline/test_cmdline.py
+++ b/web/tests/functional/cmdline/test_cmdline.py
@@ -228,7 +228,7 @@ class TestCmdline(unittest.TestCase):
         environ = self._test_config['codechecker_cfg']['check_env']
 
         res_cmd = [self._codechecker_cmd, 'cmd', 'runs',
-                   '-o', 'json', '--url', str(self.server_url)]
+                   '-o', 'json', '--url', str(self.server_url), '--details']
         ret, res, _ = run_cmd(res_cmd, environ=environ)
 
         self.assertEqual(0, ret)


### PR DESCRIPTION
Previously, this --details flag was removed from the CodeChecker cmd runs -o json command, and the extra run information was queried from the server every time the output was specified as JSON.

While this change simplified the command-line interface, these extra API calls significantly slowed down the command execution.

In this patch, the --details flag is now re-added, and the extra information is only shown if the flag is specified.