### PR TITLE
[gui] Only call fetchStatistics if the filters are ready

### DIFF
--- a/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
+++ b/web/server/vue-cli/src/components/Report/ReportFilter/ReportFilter.vue
@@ -702,7 +702,7 @@ function beforeInit() {
 }
 
 function afterInit() {
-  emit("refresh");
+  emit("refresh", "filter-init");
   registerWatchers();
   syncGroupPanels();
 }
@@ -729,20 +729,20 @@ function registerWatchers() {
   reportFilterUnwatch.value = store.watch(
     state => state.reportFilter, () => {
       if (!isInitializing.value)
-        emit("refresh");
+        emit("refresh", "filter-change");
 
     }, { deep: true });
 
   runIdsUnwatch.value = store.watch(
     state => state.runIds, () => {
       if (!isInitializing.value)
-        emit("refresh");
+        emit("refresh", "filter-change");
     });
 
   cmpDataUnwatch.value = store.watch(
     state => state.cmpData, () => {
       if (!isInitializing.value)
-        emit("refresh");
+        emit("refresh", "filter-change");
     }, { deep: true });
 }
 
@@ -828,7 +828,7 @@ function updateAllFilters() {
   if (!_filters?.length) return;
 
   _filters.forEach(filter => filter?.update?.() );
-  emit("refresh");
+  emit("refresh", "filter-change");
 }
 
 onBeforeUnmount(() => {

--- a/web/server/vue-cli/src/components/Statistics/Overview/OutstandingReportsChart.vue
+++ b/web/server/vue-cli/src/components/Statistics/Overview/OutstandingReportsChart.vue
@@ -62,7 +62,7 @@ const chart = ref();
 const dates = ref([]);
 const filterDateFormat = ref("");
 
-const refreshHandler = () => fetchDataHandler();
+const refreshHandler = () => fetchData(dates.value);
 
 const options = ref({
   plugins: {
@@ -192,10 +192,6 @@ onActivated(function() {
 onDeactivated(function() {
   props.bus.off("refresh", refreshHandler);
 });
-
-function fetchDataHandler() {
-  fetchData(dates.value);
-}
 
 /* eslint-disable no-unused-vars */
 function setChartDataOld() {

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -12,7 +12,7 @@
           :report-count="reportCount"
           :refresh-filter="refreshFilterState"
           :hidden-filters="hiddenFilters"
-          @refresh="refresh"
+          @refresh="refreshByReportFilter"
           @set-refresh-filter-state="setRefreshFilterState"
         />
       </div>
@@ -146,6 +146,7 @@ const tabs = [
 const refreshFilterState = ref(false);
 const reportCount = ref(0);
 const tab = ref(null);
+const reportFiltersReady = ref(false);
 
 const bus = mitt();
 
@@ -169,10 +170,6 @@ const reportFilter = computed(function() {
 });
 
 watch(() => tab.value, async () => {
-  // FIXME: At page reload, this
-  // event triggers, but the report filter
-  // is not ready yet.
-
   if (tab.value == null) return;
 
   const currentTab = tabs[tab.value];
@@ -183,11 +180,29 @@ watch(() => tab.value, async () => {
     ...currentTab.hiddenFiltersByTab
   ];
 
+  if (!reportFiltersReady.value) return;
+
   await nextTick();
-  refreshCurrentTab();
+  emitRefreshStatistics();
 });
 
-function refresh() {
+function refreshByReportFilter(reason) {
+  if (reason === "filter-change" && !reportFiltersReady.value) {
+    return;
+  }
+
+  if (reason === "filter-init") {
+    reportFiltersReady.value = true;
+    getRunResultCount();
+    emitRefreshStatistics();
+    return;
+  }
+
+  getRunResultCount();
+  emitRefreshStatistics();
+}
+
+function getRunResultCount() {
   ccService.getClient().getRunResultCount(
     runIds.value,
     reportFilter.value,
@@ -202,11 +217,9 @@ function refresh() {
       refreshTabs[_resolve.route.name] = true;
     }
   });
-
-  refreshCurrentTab();
 }
 
-function refreshCurrentTab() {
+function emitRefreshStatistics() {
   bus.emit("refresh");
 
   if (tab.value == null) return;


### PR DESCRIPTION
This change fixes an issue where fetchStatistics were called multiple times even before the reports filters were ready. This made the UI unresponsive at times.