### PR TITLE
Suppress bugs using relative lines

### DIFF
--- a/web/client/codechecker_client/cli/store.py
+++ b/web/client/codechecker_client/cli/store.py
@@ -51,6 +51,7 @@ except ImportError:
         raise NotImplementedError()
 
 from codechecker_client import client as libclient, product
+from codechecker_client.cmd_line_client import print_banner
 from codechecker_client.task_client import await_task_termination
 from codechecker_common import arg, logger, cmd_config
 from codechecker_common.checker_labels import CheckerLabels
@@ -937,6 +938,7 @@ def main(args):
     client = libclient.setup_client(args.product_url)
     protocol, host, port, product_name = \
         product.split_product_url(args.product_url)
+    print_banner(protocol, host, port)
     prod_client = libclient.setup_product_client(protocol,
                                                  host,
                                                  port,

--- a/web/client/codechecker_client/cli/store.py
+++ b/web/client/codechecker_client/cli/store.py
@@ -938,7 +938,7 @@ def main(args):
     client = libclient.setup_client(args.product_url)
     protocol, host, port, product_name = \
         product.split_product_url(args.product_url)
-    print_banner(protocol, host, port)
+    print_banner(protocol, host, port, LOG)
     prod_client = libclient.setup_product_client(protocol,
                                                  host,
                                                  port,

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -44,7 +44,7 @@ from codechecker_web.shared import convert, webserver_context
 from codechecker_client import report_type_converter
 from .client import login_user, setup_client, init_config_client
 from .cmd_line import CmdLineOutputEncoder
-from .product import split_server_url
+from .product import split_product_url, split_server_url
 
 from .filter_defaults import DEFAULT_FILTER_VALUES
 
@@ -1470,6 +1470,9 @@ def handle_diff_results(args):
                       args.product_url)
             raise sexit
 
+        protocol, host, port, _ = split_product_url(args.product_url)
+        print_banner(protocol, host, port)
+
     if 'component' in args:
         check_existing_source_components(client, args.component)
 
@@ -1826,15 +1829,19 @@ def get_announcement_msg(protocol, host, port):
     return config_client.getNotificationBannerText()
 
 
+def print_banner(protocol, host, port):
+    """Fetch and print the server banner if one is set."""
+    encoded = get_announcement_msg(protocol, host, port)
+    if encoded:
+        LOG.info("Announcement: %s", convert.from_b64(encoded))
+
+
 def handle_login(args):
 
     init_logger(args.verbose if 'verbose' in args else None)
 
     protocol, host, port = split_server_url(args.server_url)
-    encoded_announcement_msg = get_announcement_msg(protocol, host, port)
-    if encoded_announcement_msg:
-        announcement_msg = convert.from_b64(encoded_announcement_msg)
-        LOG.info(f"Announcement: {announcement_msg}")
+    print_banner(protocol, host, port)
     login_user(protocol, host, port, args.username,
                login='logout' not in args)
 

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -1829,11 +1829,11 @@ def get_announcement_msg(protocol, host, port):
     return config_client.getNotificationBannerText()
 
 
-def print_banner(protocol, host, port):
+def print_banner(protocol, host, port, log=None):
     """Fetch and print the server banner if one is set."""
     encoded = get_announcement_msg(protocol, host, port)
     if encoded:
-        LOG.info("Announcement: %s", convert.from_b64(encoded))
+        (log or LOG).info("Announcement: %s", convert.from_b64(encoded))
 
 
 def handle_login(args):

--- a/web/tests/functional/authentication/test_authentication.py
+++ b/web/tests/functional/authentication/test_authentication.py
@@ -765,7 +765,7 @@ class DictAuth(unittest.TestCase):
     def test_announcement_showing_in_cli(self):
         """
         Test if the announcement message posted on the CodeChecker GUI shows
-        up in cli.
+        up in the login, store, and diff CLI commands.
         """
         # Authenticate (SU permission required)
         auth_client = env.setup_auth_client(self._test_workspace,
@@ -777,20 +777,54 @@ class DictAuth(unittest.TestCase):
 
         auth_client.addPermission(Permission.SUPERUSER, "root", False, "")
 
-        # Set announcement message
+        # Set announcement message.
         su_config_client = env.setup_config_client(self._test_workspace,
                                                    session_token=session_token)
 
         su_config_client.setNotificationBannerText(
             convert.to_b64('Test announcement msg!'))
 
-        # Check if the message shows up
+        codechecker_cfg = self._test_cfg['codechecker_cfg']
+
+        # Check if the message shows up in login.
         f = io.StringIO()
         with contextlib.redirect_stdout(f):
-            codechecker.login(self._test_cfg['codechecker_cfg'],
+            codechecker.login(codechecker_cfg,
                               self._test_workspace,
                               'root',
                               'root')
-        output = f.getvalue()
+        self.assertIn("Announcement: Test announcement msg!", f.getvalue())
 
-        self.assertIn("Announcement: Test announcement msg!", output)
+        # Check if the message shows up in store.
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        report_file = os.path.join(test_dir, 'clang-5.0-trunk.plist')
+        store_cmd = [env.codechecker_cmd(), 'store', '--name', 'auth',
+                     '--url', env.parts_to_url(codechecker_cfg),
+                     '--verbose', 'debug',
+                     report_file]
+        store_out = subprocess.run(
+            store_cmd,
+            env=codechecker_cfg['check_env'],
+            encoding="utf-8",
+            errors="ignore",
+            capture_output=True,
+            check=False)
+        self.assertIn("Announcement: Test announcement msg!",
+                      store_out.stderr)
+
+        # Check if the message shows up in diff (remote run vs remote run).
+        diff_cmd = [env.codechecker_cmd(), 'cmd', 'diff',
+                    '--url', env.parts_to_url(codechecker_cfg),
+                    '--basename', 'auth',
+                    '--newname', 'auth',
+                    '--unresolved',
+                    '--verbose', 'debug']
+        diff_out = subprocess.run(
+            diff_cmd,
+            env=codechecker_cfg['check_env'],
+            encoding="utf-8",
+            errors="ignore",
+            capture_output=True,
+            check=False)
+        self.assertIn("Announcement: Test announcement msg!",
+                      diff_out.stderr)

--- a/web/tests/functional/authentication/test_authentication.py
+++ b/web/tests/functional/authentication/test_authentication.py
@@ -810,7 +810,7 @@ class DictAuth(unittest.TestCase):
             capture_output=True,
             check=False)
         self.assertIn("Announcement: Test announcement msg!",
-                      store_out.stderr)
+                      store_out.stdout)
 
         # Check if the message shows up in diff (remote run vs remote run).
         diff_cmd = [env.codechecker_cmd(), 'cmd', 'diff',


### PR DESCRIPTION
Fixes #340.

Allow suppress comments to target a relative line, e.g. line+3 or line-1, instead of only the immediately previous line.