### PR TITLE
Fix 5031 remove run toctou

### DIFF
--- a/web/server/codechecker_server/api/report_server.py
+++ b/web/server/codechecker_server/api/report_server.py
@@ -4196,7 +4196,14 @@ class ThriftRequestHandler:
             if matched_run_ids:
                 check_remove_runs_lock(session, matched_run_ids)
 
-            q = process_run_filter(session, session.query(Run), run_filter)
+            # Delete exactly the runs that were resolved and lock-checked
+            # above, not whatever the filter happens to match now. Each
+            # delete below runs in its own committed transaction, so
+            # re-running the filter here could pick up a run that didn't
+            # exist (and so wasn't lock-checked) a moment ago - e.g. a
+            # run recreated under the same name with a fresh, active lock
+            # (see #5031).
+            q = session.query(Run).filter(Run.id.in_(matched_run_ids))
 
             # q.delete(synchronize_session=False) could also be used here,
             # however, a run deletion tends to be a slow operation due to

--- a/web/server/tests/unit/test_run_removal_lock.py
+++ b/web/server/tests/unit/test_run_removal_lock.py
@@ -22,24 +22,30 @@ whether the targeted run(s) were actually locked.
 
 import unittest
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter
 from codechecker_api_shared.ttypes import RequestFailed
 
 from codechecker_server.api.report_server import \
-    check_remove_runs_lock, get_run_ids_for_filter, process_run_filter
+    ThriftRequestHandler, check_remove_runs_lock, get_run_ids_for_filter
 from codechecker_server.database.run_db_model import \
     Base, Run, RunLock
 
 
 class RunRemovalLockTest(unittest.TestCase):
     def setUp(self):
-        self.engine = create_engine('sqlite:///:memory:')
+        self.engine = create_engine(
+            'sqlite:///:memory:',
+            connect_args={'check_same_thread': False},
+            poolclass=StaticPool)
         Base.metadata.create_all(self.engine)
-        self.session = sessionmaker(bind=self.engine)()
+        self.session_factory = sessionmaker(bind=self.engine)
+        self.session = self.session_factory()
 
         run1 = Run('locked_run', '1.0')
         run1.id = 1
@@ -102,7 +108,8 @@ class RunRemovalLockTest(unittest.TestCase):
         # expired/stale.
         check_remove_runs_lock(self.session, matched_run_ids)
 
-    def test_deletion_query_uses_resolved_ids_not_the_filter_again(self):
+    def test_remove_run_does_not_delete_a_run_recreated_during_the_call(
+            self):
         """
         Regression test for
         https://github.com/Ericsson/codechecker/issues/5031
@@ -116,45 +123,64 @@ class RunRemovalLockTest(unittest.TestCase):
         would still match the filter and get deleted without ever being
         lock-checked.
 
-        This test proves the fix: after 'unlocked_run' is resolved and
-        lock-checked (passing, since it's unlocked at that point), it
-        gets deleted and a *new* run is created under the same name with
-        an active lock, simulating a concurrent store starting in that
-        window. Querying by the already-resolved 'matched_run_ids' must
-        NOT match the new row, since it has a different id - unlike
-        re-running the name filter, which would incorrectly match it.
+        Unlike a test that re-implements the query being fixed, this
+        exercises the real 'removeRun()' method end-to-end: 'run_filter'
+        resolution is intercepted at exactly the point 'removeRun' calls
+        it, and a concurrent removal + recreation of 'unlocked_run' under
+        the same name (now with an active lock) is simulated right after
+        the real lock check has passed - simulating a second client
+        racing in between. The new, locked run must survive the call.
         """
         run_filter = RunFilter(names=['unlocked_run'], exactMatch=True)
-        matched_run_ids = get_run_ids_for_filter(self.session, run_filter)
-        self.assertEqual(matched_run_ids, [2])
+        real_get_run_ids_for_filter = get_run_ids_for_filter
 
-        # Should not raise: unlocked at preflight time.
-        check_remove_runs_lock(self.session, matched_run_ids)
+        prev_run_id = None
 
-        # Simulate a concurrent client: the original run is removed, and
-        # a new run is created under the *same name*, immediately locked
-        # (e.g. a fresh store starting), all before the deletion query
-        # runs.
-        self.session.query(Run).filter(Run.id == 2).delete()
-        new_run = Run('unlocked_run', '1.0')
-        new_run.id = 3
-        self.session.add(new_run)
-        self.session.add(RunLock('unlocked_run'))
-        self.session.commit()
+        def resolve_then_simulate_concurrent_removal(session, rf):
+            nonlocal prev_run_id
+            ids = real_get_run_ids_for_filter(session, rf)
 
-        # The fixed deletion query: built from the already-resolved,
-        # already lock-checked ids. It must not match the new, locked
-        # run.
-        fixed_query = self.session.query(Run) \
-            .filter(Run.id.in_(matched_run_ids))
-        self.assertEqual(fixed_query.all(), [])
+            concurrent_session = self.session_factory()
+            prev_run_id = concurrent_session.query(Run).filter(
+                Run.name == 'unlocked_run').first().id
+            concurrent_session.query(Run).filter(
+                Run.name == 'unlocked_run').delete()
+            new_run = Run('unlocked_run', '1.0')
+            new_run.id = prev_run_id + 1
+            concurrent_session.add(new_run)
+            concurrent_session.add(RunLock('unlocked_run'))
+            concurrent_session.commit()
+            concurrent_session.close()
 
-        # Demonstrates the bug this closes: re-running the *filter*
-        # instead would incorrectly match the new, locked run.
-        buggy_query = process_run_filter(
-            self.session, self.session.query(Run), run_filter)
-        matched_names = [r.name for r in buggy_query.all()]
-        self.assertIn('unlocked_run', matched_names)
+            return ids
+
+        handler = ThriftRequestHandler.__new__(ThriftRequestHandler)
+        handler._Session = self.session_factory
+        handler._product = MagicMock()
+        handler._config_database = MagicMock()
+        handler._auth_session = None
+
+        with patch.object(
+                ThriftRequestHandler, '_ThriftRequestHandler__require_store',
+                lambda self: None), \
+                patch('codechecker_server.api.report_server.db_cleanup'
+                      '.remove_unused_comments'), \
+                patch('codechecker_server.api.report_server.db_cleanup'
+                      '.remove_unused_analysis_info'), \
+                patch('codechecker_server.api.report_server'
+                      '.get_run_ids_for_filter',
+                      side_effect=resolve_then_simulate_concurrent_removal):
+            handler.removeRun(None, run_filter)
+
+        verify_session = self.session_factory()
+        remaining = verify_session.query(Run).filter(
+            Run.id == prev_run_id + 1).all()
+        verify_session.close()
+
+        self.assertEqual(
+            len(remaining), 1,
+            "The run recreated (with an active lock) during the "
+            "removeRun() call was incorrectly deleted.")
 
 
 if __name__ == "__main__":

--- a/web/server/tests/unit/test_run_removal_lock.py
+++ b/web/server/tests/unit/test_run_removal_lock.py
@@ -30,7 +30,7 @@ from codechecker_api.codeCheckerDBAccess_v6.ttypes import RunFilter
 from codechecker_api_shared.ttypes import RequestFailed
 
 from codechecker_server.api.report_server import \
-    check_remove_runs_lock, get_run_ids_for_filter
+    check_remove_runs_lock, get_run_ids_for_filter, process_run_filter
 from codechecker_server.database.run_db_model import \
     Base, Run, RunLock
 
@@ -101,6 +101,60 @@ class RunRemovalLockTest(unittest.TestCase):
         # Should not raise: the lock is old enough to be considered
         # expired/stale.
         check_remove_runs_lock(self.session, matched_run_ids)
+
+    def test_deletion_query_uses_resolved_ids_not_the_filter_again(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/5031
+
+        This is a follow-up to #1445/#4999: 'removeRun' resolves
+        'matched_run_ids' from the filter and lock-checks those ids, but
+        previously re-ran the *filter* (not the resolved ids) to build
+        the actual destructive query. Since each delete commits in its
+        own transaction, a run recreated under the same name between the
+        lock check and the deletion - now holding a fresh, active lock -
+        would still match the filter and get deleted without ever being
+        lock-checked.
+
+        This test proves the fix: after 'unlocked_run' is resolved and
+        lock-checked (passing, since it's unlocked at that point), it
+        gets deleted and a *new* run is created under the same name with
+        an active lock, simulating a concurrent store starting in that
+        window. Querying by the already-resolved 'matched_run_ids' must
+        NOT match the new row, since it has a different id - unlike
+        re-running the name filter, which would incorrectly match it.
+        """
+        run_filter = RunFilter(names=['unlocked_run'], exactMatch=True)
+        matched_run_ids = get_run_ids_for_filter(self.session, run_filter)
+        self.assertEqual(matched_run_ids, [2])
+
+        # Should not raise: unlocked at preflight time.
+        check_remove_runs_lock(self.session, matched_run_ids)
+
+        # Simulate a concurrent client: the original run is removed, and
+        # a new run is created under the *same name*, immediately locked
+        # (e.g. a fresh store starting), all before the deletion query
+        # runs.
+        self.session.query(Run).filter(Run.id == 2).delete()
+        new_run = Run('unlocked_run', '1.0')
+        new_run.id = 3
+        self.session.add(new_run)
+        self.session.add(RunLock('unlocked_run'))
+        self.session.commit()
+
+        # The fixed deletion query: built from the already-resolved,
+        # already lock-checked ids. It must not match the new, locked
+        # run.
+        fixed_query = self.session.query(Run) \
+            .filter(Run.id.in_(matched_run_ids))
+        self.assertEqual(fixed_query.all(), [])
+
+        # Demonstrates the bug this closes: re-running the *filter*
+        # instead would incorrectly match the new, locked run.
+        buggy_query = process_run_filter(
+            self.session, self.session.query(Run), run_filter)
+        matched_names = [r.name for r in buggy_query.all()]
+        self.assertIn('unlocked_run', matched_names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR was originally created by @mmido6039 

Fixes https://github.com/Ericsson/codechecker/issues/5031

Problem
A run protected by an active RunLock could still be permanently
deleted. removeRun() resolves matched_run_ids from the filter and
lock-checks those specific ids, but the actual deletion query re-ran
process_run_filter() with the original filter instead of reusing the
already-resolved ids.

Root cause
Since each delete commits in its own transaction, there's a window
between the lock check and the deletion query where a run matching
the same filter (e.g. same name, freshly recreated with a new active
lock - as when a store restarts under the same run name) could be
picked up by the deletion query without ever being lock-checked. This
is a follow-up to https://github.com/Ericsson/codechecker/issues/1445/https://github.com/Ericsson/codechecker/pull/4999, which fixed the lock check itself but
left the deletion query resolving the filter independently, so the
guarantee only held for rows that matched at preflight time.

Fix
Build the destructive query directly from the already lock-checked
matched_run_ids:

q = session.query(Run).filter(Run.id.in_(matched_run_ids))

instead of re-running process_run_filter(). This guarantees only the
exact rows that passed the lock check can be deleted, regardless of
what the filter would match afterward.

Testing
Added test_deletion_query_uses_resolved_ids_not_the_filter_again to
web/server/tests/unit/test_run_removal_lock.py, simulating the exact
race from the issue: resolve and lock-check an unlocked run, then
simulate a concurrent client deleting it and creating a new run under
the same name with an active lock. Confirms the fixed query
(Run.id.in_(matched_run_ids)) correctly excludes the new row, while
explicitly demonstrating that re-running the filter (the old buggy
pattern) would have matched it. All 5 tests in the file pass; no
regressions in the rest of the web unit suite; pycodestyle clean.