### PR TITLE
[fix] Analysis info command overflow

### DIFF
--- a/web/server/vue-cli/src/components/AnalysisInfoDialog.vue
+++ b/web/server/vue-cli/src/components/AnalysisInfoDialog.vue
@@ -29,7 +29,7 @@
     </template>
     <template v-slot:content>
       <span>Analysis command</span>
-      <div class="pa-0 pt-2">
+      <div class="analyze-command-container pa-0 pt-2">
         <!-- eslint-disable vue/no-v-html -->
         <div
           v-for="cmd in highlightedCmds"
@@ -261,6 +261,11 @@ async function getAnalysisInfo() {
 </script>
 
 <style lang="scss">
+.analyze-command-container {
+  max-height: 60vh;
+  overflow-y: scroll;
+}
+
 .analyze-command {
   .param {
     background-color: rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
On the GUI, the analysis info page now includes the full content of analysis configuration files, e.g. skipfiles. Thus, the div can grow large in height and the user had to scroll to the bottom of the page to see used checkers. This patch fixes this issue: a maximum height is set to the div and also a scrollbar to handle content overflow.