### PR TITLE
[gui] Fix stuck scroll on navigating back to runs

### DIFF
--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -421,7 +421,15 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from "vue";
+import {
+  computed,
+  onActivated,
+  onDeactivated,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useStore } from "vuex";
 import { Pane, Splitpanes } from "splitpanes";
@@ -1127,13 +1135,22 @@ function prettifyDate(date) {
 function getBugPathLenColor(length) {
   return gradientColor.getGradientColor(length);
 }
+
+function lockBodyScroll() {
+  document.body.style.overflow = "hidden";
+}
+
+function unlockBodyScroll() {
+  document.body.style.overflow = "";
+}
+
+onMounted(lockBodyScroll);
+onActivated(lockBodyScroll);
+onUnmounted(unlockBodyScroll);
+onDeactivated(unlockBodyScroll);
 </script>
 
 <style lang="scss">
-
-body {
-  overflow: hidden;
-}
 
 .height-constraint {
   height: calc(100vh - 100px);

--- a/web/server/vue-cli/src/views/Statistics.vue
+++ b/web/server/vue-cli/src/views/Statistics.vue
@@ -54,7 +54,16 @@
 </template>
 
 <script setup>
-import { computed, nextTick, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onActivated,
+  onDeactivated,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch
+} from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
 import { Pane, Splitpanes } from "splitpanes";
@@ -223,13 +232,22 @@ function refreshCurrentTab() {
 function setRefreshFilterState(state) {
   refreshFilterState.value = state;
 }
+
+function lockBodyScroll() {
+  document.body.style.overflow = "hidden";
+}
+
+function unlockBodyScroll() {
+  document.body.style.overflow = "";
+}
+
+onMounted(lockBodyScroll);
+onActivated(lockBodyScroll);
+onUnmounted(unlockBodyScroll);
+onDeactivated(unlockBodyScroll);
 </script>
 
 <style lang="scss" scoped>
-body {
-  overflow: hidden;
-}
-
 .height-constraint {
   height: calc(100vh - 100px);
 }


### PR DESCRIPTION
This change fixes an issue with the runs page where the scroll function is being stuck after navigating back to it from the reports page.

The issue was caused by a non-scoped css rule in Reports.vue to hide the overflowing content. Since the application uses keep-alive in the main App.vue this unscoped rule persisted across document navigation.

The change removes the non-scoped rule and introduces lifecycle policies which manages the scrolling behaviour.