### PR TITLE
Skip CTU pre-analysis when file filter matches nothing (#5022)

### DIFF
--- a/analyzer/codechecker_analyzer/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzer.py
@@ -208,6 +208,20 @@ def perform_analysis(args, skip_handlers, filter_handlers,
 
     actions = prepare_actions(actions, analyzers)
 
+    # If the skip/select filters (e.g. '--file') would leave nothing to
+    # actually analyze, bail out now, before any expensive machinery runs.
+    # This check mirrors 'skip_cpp()', which is otherwise only applied
+    # much later, inside 'start_workers()' - after CTU pre-analysis (PCH
+    # dumping) would already have run for nothing (see #5022).
+    to_analyze, _ = analysis_manager.skip_cpp(actions, skip_handlers)
+    if not to_analyze:
+        LOG.warning("No analysis is required.")
+        LOG.warning("All of the compilation commands were skipped "
+                    "according to the '--file'/'--ignore' filters. "
+                    "Analysis (and, if enabled, CTU pre-analysis) will "
+                    "not run.")
+        return
+
     available_checkers = set()
     # Add profile names to the checkers list so we will not warn
     # if a profile is enabled but there is no checker with that name.

--- a/analyzer/tests/functional/ctu/test_ctu.py
+++ b/analyzer/tests/functional/ctu/test_ctu.py
@@ -127,6 +127,35 @@ class TestCtu(unittest.TestCase):
         self.assertIn('Analysis finished', str(proc.stdout))
 
     @skipUnlessCTUCapable
+    def test_ctu_file_filter_matching_nothing_skips_pre_analysis(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/5022
+
+        If a '--file' filter matches none of the compilation commands,
+        analysis (and, if '--ctu' is enabled, the expensive CTU
+        pre-analysis/PCH-dumping phase) must not run at all - the CLI
+        should recognize upfront that this invocation is guaranteed to
+        produce nothing, instead of first dumping PCHs for every
+        translation unit and only then discovering that every file gets
+        skipped.
+        """
+        cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,
+               '--analyzers', 'clangsa', '--ctu', self.buildlog,
+               '--file', '*/nothing/aaaaaaaaaaa.js']
+        proc = run(cmd, cwd=self.test_dir, env=self.env, check=False,
+                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn('No analysis is required', str(proc.stdout))
+
+        ctu_dir = os.path.join(self.report_dir, 'ctu-dir')
+        self.assertFalse(
+            os.path.isdir(ctu_dir),
+            "CTU pre-analysis (PCH dumping) should not have run at all "
+            "when the '--file' filter matches nothing.")
+
+    @skipUnlessCTUCapable
     def test_ctu_loading_mode_requires_ctu_mode(self):
         """ Test ctu-ast-mode option requires ctu mode enabled. """
         cmd = [self._codechecker_cmd, 'analyze', '-o', self.report_dir,


### PR DESCRIPTION
Fixes #5022

## Problem
Using 'CodeChecker analyze ... --ctu' together with a '--file' filter
that matches none of the compilation commands causes CodeChecker to
first run the full CTU pre-analysis (PCH dumping) for every
translation unit, and only afterward discover - in the job selection
phase - that every file gets skipped. The PCH dumps are then deleted
when the run finishes, having produced zero analysis output. On a
large codebase (reported: ~7000 TUs, ~300 GiB, ~4 hours) this is
effectively a disk-shredder for a broken/typo'd filter.

## Root cause
The skip/select filter ('--file'/'--ignore') is only actually applied
via skip_cpp() deep inside start_workers(), which runs *after* the CTU
pre-analysis phase already completes in perform_analysis(). So there
is no upfront check for "will this invocation analyze anything at
all" before the expensive CTU machinery starts.

## Fix
Added an early check in perform_analysis(), right after actions are
prepared, reusing the existing analysis_manager.skip_cpp() to compute
whether anything would survive the skip filter. If nothing would, it
logs a clear message and returns immediately, before any CTU
pre-analysis or main analysis work begins.

## Testing
Verified end-to-end with a real CTU-capable clang build:
- Reproduced the original bug exactly on unmodified code (confirmed
  full CTU pre-analysis - "Pre-analysis finished." - completes before
  the job-selection phase discovers everything is skipped)
- Confirmed the fix exits instantly with a clear log message and never
  creates 'ctu-dir' at all
- Confirmed no regression when no filter is given (CTU still works
  normally, both files analyzed)
- Confirmed no regression for a *partial* filter (some files match) -
  full pre-analysis still correctly runs, preserving correct CTU
  cross-TU semantics; only the zero-match case short-circuits
- Added a regression test to analyzer/tests/functional/ctu/test_ctu.py
  (test_ctu_file_filter_matching_nothing_skips_pre_analysis), verified
  it fails against the old code and passes with the fix
- All 14 tests in test_ctu.py pass; pycodestyle clean; pylint 10.00/10