### PR TITLE
Re-introduce --details flag for "CodeChecker cmd results"

### DIFF
--- a/docs/web/user_guide.md
+++ b/docs/web/user_guide.md
@@ -1093,10 +1093,6 @@ usage: CodeChecker cmd results [-h] [--details] [--uniqueing {on,off}]
 
 Show the analysis reports which match the optional filters.
 
-In JSON format all available information is shown. In plaintext/table only the
-report position, checker name, severity, analyzer name, report message,
-detection and review status and Git blame information is displayed.
-
 positional arguments:
   RUN_NAMES             Names of the analysis runs to show result summaries
                         of. This has the following format: <run_name_1>
@@ -1109,7 +1105,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --details             DEPRECATED. Get report details for reports such as bug
+  --details             Get report details for reports such as bug
                         path events, bug report points etc. Detailed view
                         contains Git information if it was available and stored
                         for the queried project.

--- a/web/client/codechecker_client/cli/cmd.py
+++ b/web/client/codechecker_client/cli/cmd.py
@@ -498,7 +498,7 @@ def __register_results(parser):
                         action="store_true",
                         required=False,
                         default=argparse.SUPPRESS,
-                        help="DEPRECATED. Get report details for reports such "
+                        help="Get report details for reports such "
                              "as bug path events, bug report points etc. "
                              "Detailed view contains Git information if it "
                              "was available and stored for the queried "

--- a/web/client/codechecker_client/cmd_line_client.py
+++ b/web/client/codechecker_client/cmd_line_client.py
@@ -811,9 +811,8 @@ def handle_list_results(args):
 
     report_filter = parse_report_filter(client, args)
 
-    # TODO: JSON format contains detailed information either way. --details
-    # flag is deprecated in 6.28.0 and should be removed in 6.29.0.
-    query_report_details = 'details' in args or args.output_format == 'json'
+    query_report_details = 'details' in args and args.details and \
+        args.output_format == 'json'
 
     all_results = get_run_results(client,
                                   run_ids,


### PR DESCRIPTION
"CodeChecker cmd results" contains the git blame info by default. However, this can be a really slow query on the server side in case of big result set. For this reason, the --details flag has been re-introduced. The JSON output format contains these detailed information.