### PR TITLE
Handle Windows path separators in compilation database commands (#4277)

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/log_parser.py
+++ b/analyzer/codechecker_analyzer/buildlog/log_parser.py
@@ -283,6 +283,37 @@ PRECOMPILATION_OPTION = re.compile('-(E|M[G|T|Q|F|J|P|V|M]*)$')
 # Match for all of the compiler flags.
 CLANG_OPTIONS = re.compile('.*')
 
+# A Windows drive-letter path, e.g. 'C:\\tools\\gcc.exe'. Used only to
+# detect that a compilation command uses Windows-style paths at all.
+WINDOWS_DRIVE_PATH = re.compile(r'[A-Za-z]:\\')
+
+# A backslash acting as a Windows path separator, i.e. one directly
+# followed by a "path-ish" character. This deliberately does NOT match a
+# backslash that escapes a quote (\") or a space (\ ), because those are
+# meaningful POSIX escapes emitted by ld-logger and intercept-build.
+WINDOWS_PATH_SEP = re.compile(r'\\(?=[A-Za-z0-9_.\-])')
+
+
+def normalize_windows_paths(command):
+    """
+    Convert Windows path separators in a compilation command to forward
+    slashes, so the command can be split with POSIX-mode shlex.
+
+    Compilation databases generated on Windows (e.g. by CMake) contain
+    backslash-separated paths. 'shlex.split()' runs in POSIX mode, where a
+    backslash is an escape character, so those separators would be eaten:
+    'A:\\tools\\gcc.exe' becomes 'A:toolsgcc.exe' (see #4277).
+
+    Forward slashes are accepted as path separators by Windows itself, so
+    converting is safe. This is only applied when the command actually
+    contains a Windows drive-letter path, leaving POSIX commands - and the
+    backslash escapes they legitimately use - completely untouched.
+    """
+    if not WINDOWS_DRIVE_PATH.search(command):
+        return command
+
+    return WINDOWS_PATH_SEP.sub('/', command)
+
 
 def filter_compiler_includes_extra_args(compiler_flags):
     """Return the list of flags which affect the list of implicit includes.
@@ -1011,7 +1042,8 @@ def parse_options(compilation_db_entry,
         details['original_command'] = shlex.join(gcc_command)
     elif 'command' in compilation_db_entry:
         details['original_command'] = compilation_db_entry['command']
-        gcc_command = shlex.split(compilation_db_entry['command'])
+        gcc_command = shlex.split(
+            normalize_windows_paths(compilation_db_entry['command']))
     else:
         raise KeyError("No valid 'command' or 'arguments' entry found!")
 
@@ -1188,7 +1220,8 @@ def extend_compilation_database_entries(compilation_database):
             source_dir = entry['directory']
             response_files = set()
 
-            options = shlex.split(entry['command'])
+            options = shlex.split(
+                normalize_windows_paths(entry['command']))
             for opt in options:
                 if opt.startswith('@'):
                     response_file = os.path.join(source_dir, opt[1:])

--- a/analyzer/tests/unit/test_log_parser.py
+++ b/analyzer/tests/unit/test_log_parser.py
@@ -11,6 +11,7 @@
 
 import json
 import os
+import shlex
 import shutil
 import tempfile
 import unittest
@@ -120,6 +121,71 @@ class LogParserTest(unittest.TestCase):
         build_action = log_parser.parse_options(entry)
 
         self.assertEqual(build_action.target, 'aarch64-linux-gnu')
+
+    def test_windows_paths_in_command(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/4277
+
+        Compilation databases generated on Windows (e.g. by CMake) contain
+        backslash-separated paths. Since 'shlex.split()' runs in POSIX
+        mode - where a backslash is an escape character - those separators
+        used to be eaten, mangling
+        'A:\\tools\\...\\arm-zephyr-eabi-gcc.exe' into
+        'A:toolsarm-zephyr-eabi-gcc.exe' and making the compiler
+        undetectable.
+        """
+        command = (r'A:\tools\zephyr\zephyr-sdk-0.16.8\arm-zephyr-eabi'
+                   r'\bin\arm-zephyr-eabi-gcc.exe -c main.c')
+
+        self.assertEqual(
+            shlex.split(log_parser.normalize_windows_paths(command))[0],
+            'A:/tools/zephyr/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/'
+            'arm-zephyr-eabi-gcc.exe')
+
+    def test_windows_paths_in_include_options(self):
+        """
+        Regression test for
+        https://github.com/Ericsson/codechecker/issues/4277
+
+        Windows path separators must also survive in the compile options
+        themselves, not just in the compiler's own path.
+        """
+        entry = {
+            'directory': '/tmp',
+            'command':
+                r'gcc -DDEBUG '
+                r'-IA:\projects\div\grp\board\firmware\modules\board\inc '
+                r'-c main.c',
+            'file': 'main.c'}
+        build_action = log_parser.parse_options(entry)
+
+        # The include path is made absolute relative to 'directory' when
+        # running the tests on a non-Windows host (where 'A:/...' is not
+        # an absolute path), so check that the separators survived rather
+        # than matching the whole option.
+        self.assertTrue(
+            any('A:/projects/div/grp/board/firmware/modules/board/inc' in opt
+                for opt in build_action.analyzer_options),
+            f"Windows separators were mangled: "
+            f"{build_action.analyzer_options}")
+
+    def test_posix_escapes_are_not_treated_as_windows_paths(self):
+        """
+        Companion to the tests above: a POSIX compilation command must be
+        left completely untouched. A blanket 'shlex.split(posix=False)'
+        would break these, which is why the conversion is gated on the
+        command actually containing a Windows drive-letter path.
+        """
+        posix_commands = [
+            r'g++ -DVARIABLE=\"some value\" -c main.cpp',
+            'g++ -I/home/my\\ dir -c main.cpp',
+            'g++ -DNAME="some value" -c main.cpp']
+
+        for command in posix_commands:
+            self.assertEqual(
+                log_parser.normalize_windows_paths(command), command,
+                f"POSIX command was modified: {command}")
 
     def test_new_ldlogger(self):
         """


### PR DESCRIPTION
Fixes #4277

## Problem
Compilation databases generated on Windows (e.g. by CMake, as used by
Zephyr RTOS and STM32CubeCLT projects) contain backslash-separated
paths. CodeChecker mangles them, e.g.

  A:\tools\zephyr\...\arm-zephyr-eabi-gcc.exe

is parsed as

  A:toolszephyrarm-zephyr-eabi-gcc.exe

making the compiler undetectable and blocking analysis entirely.

## Root cause
'shlex.split()' runs in POSIX mode by default, where a backslash is an
escape character, so Windows path separators are consumed during
parsing.

## Fix
Added 'normalize_windows_paths()', which converts Windows path
separators to forward slashes before POSIX splitting. Forward slashes
are accepted as path separators by Windows itself, so this is safe on
the target platform.

Two gates keep the change non-invasive:
- It only applies when the command actually contains a Windows
  drive-letter path (e.g. 'C:\'), so POSIX commands are untouched.
- The regex only matches a backslash followed by a path-ish character,
  so POSIX escapes like '\"' and '\ ' - legitimately emitted by
  ld-logger and intercept-build - are preserved.

Applied at the two 'shlex.split()' call sites that parse compilation
database commands (parse_options and
extend_compilation_database_entries). The 'file' field is resolved via
pathlib rather than shlex, so it is unaffected.

## Note on the existing draft PR (#4374)
That PR proposes 'shlex.split(..., posix=False)'. I tested that
approach and it breaks 6 existing tests in test_log_parser.py: it
leaves literal quote characters in arguments, splits on spaces inside
quotes, and breaks POSIX escaped spaces - regressing Linux/macOS
users. The normalization approach here fixes the Windows case without
changing POSIX behaviour at all.

## Testing
Added 3 regression tests using the exact data from the issue report
(the Zephyr and STM32 compilation database entries), plus a companion
test asserting POSIX commands are left byte-for-byte unchanged.
Verified the new tests fail against unfixed code and pass with the
fix. All 30 tests in test_log_parser.py pass; pycodestyle clean;
pylint 10.00/10.

I don't have a Windows machine, so this was developed and verified on
Linux using the compilation database entries from the report - happy
to adjust if someone with a Windows setup finds edge cases.