### PR TITLE
[analyzer] Collect analysis time statistics per translation unit (#718)

### DIFF
--- a/analyzer/codechecker_analyzer/analysis_manager.py
+++ b/analyzer/codechecker_analyzer/analysis_manager.py
@@ -13,9 +13,11 @@ import shlex
 import shutil
 import signal
 import sys
+import time
 import traceback
 import zipfile
 
+from collections import defaultdict
 from functools import lru_cache
 from threading import Timer
 
@@ -35,6 +37,10 @@ from .analyzers.clangsa.analyzer import ClangSA
 from .analyzers.config_handler import CheckerState
 
 LOG = get_logger('analyzer')
+
+# Number of the slowest translation units stored in the metadata
+# file for each analyzer.
+SLOWEST_TU_COUNT = 10
 
 
 def print_analyzer_statistic_summary(metadata_analyzers, status, msg=None):
@@ -57,16 +63,64 @@ def print_analyzer_statistic_summary(metadata_analyzers, status, msg=None):
             LOG.info("  %s: %s", analyzer_type, res)
 
 
+def collect_duration_statistics(durations):
+    """
+    Summarize the analysis time of the translation units of a single analyzer.
+
+    durations -- List of (source file, analysis duration in seconds) tuples.
+
+    Returns the total, the shortest, the longest and the average analysis
+    time of the translation units, and the slowest ones of them. Returns
+    None if no translation unit was analyzed.
+    """
+    if not durations:
+        return None
+
+    times = [duration for _, duration in durations]
+    slowest = sorted(durations, key=lambda d: d[1], reverse=True)
+
+    return {
+        'total': round(sum(times), 3),
+        'min': round(min(times), 3),
+        'max': round(max(times), 3),
+        'avg': round(sum(times) / len(times), 3),
+        'slowest': [{'file': source, 'duration': round(duration, 3)}
+                    for source, duration in slowest[:SLOWEST_TU_COUNT]]}
+
+
+def print_analysis_time_summary(metadata_analyzers):
+    """
+    Print how much time each analyzer spent on the analysis.
+
+    Every line starts with the same phrase, so these lines can easily be
+    filtered out from the output of the analysis.
+    """
+    for analyzer_type, analyzer in metadata_analyzers.items():
+        duration = analyzer.get('analyzer_statistics', {}).get('duration')
+        if not duration:
+            continue
+
+        slowest = duration['slowest'][0]
+        LOG.info("Analysis time of %s: total %.2f sec, average %.2f sec, "
+                 "longest %.2f sec (%s)", analyzer_type, duration['total'],
+                 duration['avg'], duration['max'],
+                 os.path.basename(slowest['file']))
+
+
 def worker_result_handler(results, metadata_tool, output_path):
     """ Print the analysis summary. """
     skipped_num = 0
     reanalyzed_num = 0
     metadata_analyzers = metadata_tool['analyzers']
-    for res, skipped, reanalyzed, analyzer_type, _, sources in results:
+    durations = defaultdict(list)
+    for res, skipped, reanalyzed, analyzer_type, _, sources, duration \
+            in results:
         statistics = metadata_analyzers[analyzer_type]['analyzer_statistics']
         if skipped:
             skipped_num += 1
         else:
+            durations[analyzer_type].append((sources, duration))
+
             if reanalyzed:
                 reanalyzed_num += 1
 
@@ -77,6 +131,10 @@ def worker_result_handler(results, metadata_tool, output_path):
                 statistics['failed'] += 1
                 statistics['failed_sources'].append(sources)
 
+    for analyzer_type, analyzer_durations in durations.items():
+        metadata_analyzers[analyzer_type]['analyzer_statistics']['duration'] \
+            = collect_duration_statistics(analyzer_durations)
+
     LOG.info("----==== Summary ====----")
     print_analyzer_statistic_summary(metadata_analyzers,
                                      'successful',
@@ -85,6 +143,8 @@ def worker_result_handler(results, metadata_tool, output_path):
     print_analyzer_statistic_summary(metadata_analyzers,
                                      'failed',
                                      'Failed to analyze')
+
+    print_analysis_time_summary(metadata_analyzers)
 
     if reanalyzed_num:
         LOG.info("Reanalyzed compilation commands: %d", reanalyzed_num)
@@ -449,6 +509,10 @@ def check(check_data):
     success_dir = output_dirs["success"]
     reproducer_dir = output_dirs["reproducer"]
 
+    # Wall clock time spent on this translation unit. A monotonic clock is
+    # used, because the system time may be adjusted during the analysis.
+    tu_start_time = time.monotonic()
+
     try:
         # If one analysis fails the check fails.
         return_codes = 0
@@ -647,13 +711,13 @@ def check(check_data):
         PROGRESS_CHECKED_NUM.value += 1
 
         return return_codes, False, reanalyzed, action.analyzer_type, \
-            result_file, action.source
+            result_file, action.source, time.monotonic() - tu_start_time
 
     except Exception as e:
         LOG.debug(str(e))
         traceback.print_exc(file=sys.stdout)
         return 1, False, reanalyzed, action.analyzer_type, None, \
-            action.source
+            action.source, time.monotonic() - tu_start_time
 
 
 def skip_cpp(compile_actions, skip_handlers):

--- a/analyzer/tests/functional/analyze/test_analyze.py
+++ b/analyzer/tests/functional/analyze/test_analyze.py
@@ -621,6 +621,70 @@ class TestAnalyze(unittest.TestCase):
         self.__analyze_incremental(simple_file_content, build_json,
                                    reports_dir, 1, 0)
 
+    def test_analysis_time_statistics(self):
+        """
+        The analysis time of the translation units is measured and written
+        into the metadata file.
+        """
+        build_json = os.path.join(self.test_workspace, "build_duration.json")
+        reports_dir = os.path.join(self.test_workspace, "reports_duration")
+
+        source_files = []
+        build_log = []
+        for i in range(2):
+            source_file = os.path.join(
+                self.test_workspace, f"duration{i}.cpp")
+            with open(source_file, 'w',
+                      encoding="utf-8", errors="ignore") as source:
+                source.write("int main() { return 0; }")
+
+            source_files.append(source_file)
+            build_log.append({"directory": self.test_workspace,
+                              "command": "g++ -c " + source_file,
+                              "file": source_file})
+
+        with open(build_json, 'w',
+                  encoding="utf-8", errors="ignore") as outfile:
+            json.dump(build_log, outfile)
+
+        analyze_cmd = [self._codechecker_cmd, "analyze", build_json,
+                       "--analyzers", "clangsa", "-o", reports_dir]
+
+        process = subprocess.Popen(
+            analyze_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=self.test_dir,
+            encoding="utf-8",
+            errors="ignore")
+        out, _ = process.communicate()
+
+        self.assertEqual(process.returncode, 0)
+        self.assertIn("Analysis time of clangsa:", out)
+
+        with open(os.path.join(reports_dir, "metadata.json"), 'r',
+                  encoding="utf-8", errors="ignore") as metadata_file:
+            metadata = json.load(metadata_file)
+
+        statistics = \
+            metadata["tools"][0]["analyzers"]["clangsa"]["analyzer_statistics"]
+        duration = statistics["duration"]
+
+        self.assertEqual(statistics["successful"], len(source_files))
+
+        # Every analyzed translation unit took some time.
+        self.assertGreater(duration["total"], 0)
+        self.assertGreater(duration["min"], 0)
+        self.assertLessEqual(duration["min"], duration["avg"])
+        self.assertLessEqual(duration["avg"], duration["max"])
+
+        # The slowest translation units are reported with their file names.
+        self.assertEqual(len(duration["slowest"]), len(source_files))
+        self.assertEqual(
+            sorted(tu["file"] for tu in duration["slowest"]),
+            sorted(source_files))
+        self.assertEqual(duration["slowest"][0]["duration"], duration["max"])
+
     def test_relative_include_paths(self):
         """
         Test if the build json contains relative paths.

--- a/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
+++ b/analyzer/tests/functional/analyze_and_parse/test_analyze_and_parse.py
@@ -217,6 +217,9 @@ class AnalyzeParseTestCase(
 
         post_processed_output = []
         skip_prefixes = ["[] - Analysis length:",
+                         # The analysis time of the translation units
+                         # differs from run to run.
+                         "[] - Analysis time of ",
                          "[] - Previous analysis results",
                          "[] - Skipping input file",
                          # Enabled checkers are listed in the beginning of

--- a/analyzer/tests/unit/test_analysis_time_statistics.py
+++ b/analyzer/tests/unit/test_analysis_time_statistics.py
@@ -1,0 +1,141 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+
+"""
+Test the collection of the analysis time of the translation units.
+"""
+
+
+import tempfile
+import unittest
+
+from codechecker_analyzer.analysis_manager import \
+    SLOWEST_TU_COUNT, collect_duration_statistics, worker_result_handler
+
+
+def create_metadata(*analyzers):
+    """ Create a metadata dictionary for the given analyzers. """
+    return {
+        'result_source_files': {},
+        'analyzers': {
+            analyzer: {
+                'analyzer_statistics': {
+                    'failed': 0,
+                    'failed_sources': [],
+                    'successful': 0,
+                    'successful_sources': [],
+                    'version': 'x.y.z'}}
+            for analyzer in analyzers}}
+
+
+def create_result(analyzer, source, duration, returncode=0, skipped=False):
+    """ Create a single analysis result of a worker process. """
+    return (returncode, skipped, False, analyzer, source + '.plist', source,
+            duration)
+
+
+class AnalysisTimeStatisticsTest(unittest.TestCase):
+    """
+    Test that the analysis time of the translation units is measured and
+    summarized per analyzer.
+    """
+
+    def test_duration_statistics(self):
+        """ The summary of the durations is calculated correctly. """
+        stats = collect_duration_statistics(
+            [('a.cpp', 1.0), ('b.cpp', 4.0), ('c.cpp', 1.0)])
+
+        self.assertEqual(stats['total'], 6.0)
+        self.assertEqual(stats['min'], 1.0)
+        self.assertEqual(stats['max'], 4.0)
+        self.assertEqual(stats['avg'], 2.0)
+        self.assertEqual(stats['slowest'][0],
+                         {'file': 'b.cpp', 'duration': 4.0})
+
+    def test_no_duration_statistics(self):
+        """ No statistics are calculated if nothing was analyzed. """
+        self.assertIsNone(collect_duration_statistics([]))
+
+    def test_slowest_translation_units_are_limited(self):
+        """ Only the slowest translation units are kept. """
+        stats = collect_duration_statistics(
+            [(f'{i}.cpp', float(i)) for i in range(SLOWEST_TU_COUNT + 10)])
+
+        slowest = stats['slowest']
+        self.assertEqual(len(slowest), SLOWEST_TU_COUNT)
+
+        # The slowest translation units come first.
+        durations = [tu['duration'] for tu in slowest]
+        self.assertEqual(durations, sorted(durations, reverse=True))
+        self.assertEqual(slowest[0]['file'],
+                         f'{SLOWEST_TU_COUNT + 9}.cpp')
+
+    def test_durations_land_in_metadata(self):
+        """
+        The analysis time of the translation units is collected per analyzer
+        and stored in the metadata.
+        """
+        metadata = create_metadata('clangsa', 'clang-tidy')
+        results = [
+            create_result('clangsa', 'a.cpp', 2.0),
+            create_result('clangsa', 'b.cpp', 6.0),
+            create_result('clang-tidy', 'a.cpp', 1.0),
+            # A failed analysis takes time too.
+            create_result('clang-tidy', 'b.cpp', 3.0, returncode=1)]
+
+        with tempfile.TemporaryDirectory() as output_path:
+            worker_result_handler(results, metadata, output_path)
+
+        analyzers = metadata['analyzers']
+
+        clangsa = analyzers['clangsa']['analyzer_statistics']['duration']
+        self.assertEqual(clangsa['total'], 8.0)
+        self.assertEqual(clangsa['max'], 6.0)
+        self.assertEqual(clangsa['avg'], 4.0)
+        self.assertEqual([tu['file'] for tu in clangsa['slowest']],
+                         ['b.cpp', 'a.cpp'])
+
+        tidy = analyzers['clang-tidy']['analyzer_statistics']['duration']
+        self.assertEqual(tidy['total'], 4.0)
+        self.assertEqual(tidy['max'], 3.0)
+        self.assertEqual([tu['file'] for tu in tidy['slowest']],
+                         ['b.cpp', 'a.cpp'])
+
+    def test_skipped_files_have_no_duration(self):
+        """ Skipped translation units are left out of the statistics. """
+        metadata = create_metadata('clangsa')
+        results = [
+            create_result('clangsa', 'a.cpp', 2.0),
+            create_result('clangsa', 'b.cpp', 9.0, skipped=True)]
+
+        with tempfile.TemporaryDirectory() as output_path:
+            worker_result_handler(results, metadata, output_path)
+
+        duration = \
+            metadata['analyzers']['clangsa']['analyzer_statistics']['duration']
+        self.assertEqual(duration['total'], 2.0)
+        self.assertEqual(duration['max'], 2.0)
+        self.assertEqual([tu['file'] for tu in duration['slowest']], ['a.cpp'])
+
+    def test_analyzer_without_analyzed_file(self):
+        """
+        No duration statistics are stored for an analyzer which did not
+        analyze anything.
+        """
+        metadata = create_metadata('clangsa', 'clang-tidy')
+
+        with tempfile.TemporaryDirectory() as output_path:
+            worker_result_handler(
+                [create_result('clangsa', 'a.cpp', 2.0)],
+                metadata, output_path)
+
+        analyzers = metadata['analyzers']
+        self.assertIn(
+            'duration', analyzers['clangsa']['analyzer_statistics'])
+        self.assertNotIn(
+            'duration', analyzers['clang-tidy']['analyzer_statistics'])

--- a/docs/report_directory.md
+++ b/docs/report_directory.md
@@ -115,6 +115,14 @@ The `metadata.json` file contains comprehensive information about the analysis r
   - `successful` - Count of successful analyses
   - `successful_sources` - List of successfully analyzed source files
   - `version` - Analyzer version
+  - `duration` - Analysis time of the translation units in seconds. Note that
+    the sum of these is usually more than the wall clock time of the whole
+    analysis, because the translation units are analyzed in parallel.
+    - `total` - Time spent on analyzing all translation units
+    - `min` - Analysis time of the fastest translation unit
+    - `max` - Analysis time of the slowest translation unit
+    - `avg` - Average analysis time of a translation unit
+    - `slowest` - The slowest translation units with their analysis time
 
 ### Example
 
@@ -153,7 +161,19 @@ The `metadata.json` file contains comprehensive information about the analysis r
           "successful_sources": [
             "/workspace/project/src/file.c"
           ],
-          "version": "20.0.0"
+          "version": "20.0.0",
+          "duration": {
+            "total": 7.523,
+            "min": 0.912,
+            "max": 5.204,
+            "avg": 2.508,
+            "slowest": [
+              {
+                "file": "/workspace/project/src/file.c",
+                "duration": 5.204
+              }
+            ]
+          }
         }
       }
     },


### PR DESCRIPTION
Fixes #718

## Problem

There is no way to tell how the analysis time is distributed. If an analysis is
slow, the user cannot find out which analyzer or which translation units are
responsible for it, so there is nothing concrete to optimize.

## What was missing

The issue asks for five things, and two of them are already available today:

- **The whole analysis time** is already reported (`Analysis length: X sec`) and
  stored in `metadata.json` under `timestamps`.
- **Re-running the analysis on a single translation unit** is already possible
  with `CodeChecker analyze --file <path>`.

The remaining three - time per analyzer, average per translation unit, and the
slowest translation units - all need the same missing piece: `check()` in
`analysis_manager.py` analyzes one translation unit per worker process, but it
never measures how long that takes. Its result tuple carries the return code,
the result file and the source file, but no timing, so nothing downstream can
aggregate it.

## Fix

Measure the wall clock time of every translation unit in `check()` and return it
with the rest of the result. `worker_result_handler()` groups these per analyzer
and stores the summary in `metadata.json` under `analyzer_statistics`:

```json
"duration": {
  "total": 7.523,
  "min": 0.912,
  "max": 5.204,
  "avg": 2.508,
  "slowest": [ { "file": "/path/to/file.c", "duration": 5.204 } ]
}
```

The analysis summary also prints one line per analyzer:

```
Analysis time of clangsa: total 12.30 sec, average 4.10 sec, longest 8.12 sec (parser.c)
```

Notes on the approach:

- The statistics are **not** stored in the database. As suggested in the issue,
  they are generated by the `analyze` command and kept with the reports, so they
  can be inspected in the terminal without running a server. No server, schema or
  migration changes are needed - the new key is simply ignored by the store logic.
- A monotonic clock is used, because the system time may be adjusted while the
  analysis runs.
- The sum per analyzer is normally larger than the wall clock length of the
  analysis, since translation units are analyzed in parallel. This is documented.
- The new summary line is added to `skip_prefixes` in the `analyze_and_parse`
  test, because the measured times differ from run to run. It removes only the
  new lines, so the existing expected outputs are unchanged.

## Testing

- New unit test `analyzer/tests/unit/test_analysis_time_statistics.py`: the
  summary calculation, the cap on the slowest translation units, aggregation per
  analyzer into the metadata, skipped files being left out, and analyzers that
  analyzed nothing.
- New functional test `test_analysis_time_statistics` in
  `tests/functional/analyze/test_analyze.py`: runs a real analysis and checks
  both the printed line and the contents of `metadata.json`.
- Verified fails-then-passes by removing only the aggregation while keeping the
  helper functions - the wiring tests then fail and the calculation tests still
  pass.
- `tests/unit` and `tests/functional/analyze` show no new failures against a
  clean-tree baseline.
- `pycodestyle` clean and `pylint` 10.00/10 on every changed file.

## Out of scope / follow-ups

- An exception raised inside the `map_async` callback (`worker_result_handler`)
  is swallowed and the analysis then waits on the pool's ~1 year timeout, so a
  bug there hangs the analysis instead of failing. Worth handling separately.
- The `skipped` flag in the result tuple of `check()` is always `False`; the
  branch handling it in `worker_result_handler` looks vestigial.
- Storing or displaying these statistics on the server/GUI side, and profiling
  the `store` command, are deliberately left out - the issue discussion argues
  against putting this in the database.