### PR TITLE
Pass --allow-no-checks to clang-tidy 19+

### DIFF
--- a/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
+++ b/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py
@@ -504,6 +504,12 @@ class ClangTidy(analyzer_base.SourceAnalyzer):
                 # so no globbing should occur even if the checks argument
                 # contains characters that would trigger globbing in the shell.
                 analyzer_cmd.append(f"-checks={','.join(checks)}")
+            else:
+                # clang-tidy 19+ treats an empty resolved check set as a fatal
+                # error; here the checks come from the config instead.
+                version = ClangTidy.get_binary_version()
+                if version and version.major >= 19:
+                    analyzer_cmd.append("--allow-no-checks")
 
             analyzer_cmd.extend(config.analyzer_extra_arguments)
 

--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -14,9 +14,13 @@ Test the handling of implicitly and explicitly handled checkers in analyzers
 from codechecker_common.util import strtobool
 import os
 import re
+import shutil
 import tempfile
 import unittest
 from argparse import Namespace
+from unittest import mock
+
+from semver.version import Version
 
 from codechecker_analyzer.analyzers.clangsa.analyzer import ClangSA
 from codechecker_analyzer.analyzers.clangtidy.analyzer import ClangTidy
@@ -781,6 +785,41 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
         # -Wno-unused-value.
         self.assertEqual(cmd.count('-Wvla'), 1)
         self.assertEqual(cmd.count('-Wvla-extension'), 1)
+
+
+@unittest.skipIf(shutil.which('clang-tidy') is None,
+                 "clang-tidy is not available")
+class ClangTidyAllowNoChecksTest(unittest.TestCase):
+    """
+    With no -checks passed, clang-tidy 19+ errors on an empty check set, so
+    --allow-no-checks must be added for those versions only.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        context = analyzer_context.get_context()
+        context._checker_labels = MockClangTidyCheckerLabels()
+
+    def _cmd_with(self, version):
+        analyzer = create_analyzer_tidy()
+        result_handler = create_result_handler(analyzer)
+        with mock.patch.object(ClangTidy, 'get_checker_list',
+                               return_value=([], [])), \
+                mock.patch.object(ClangTidy, 'get_binary_version',
+                                  return_value=version):
+            return analyzer.construct_analyzer_cmd(result_handler)
+
+    def test_added_for_tidy_19(self):
+        cmd = self._cmd_with(Version.parse('19.1.0'))
+        self.assertIn('--allow-no-checks', cmd)
+
+    def test_not_added_for_tidy_18(self):
+        cmd = self._cmd_with(Version.parse('18.1.8'))
+        self.assertNotIn('--allow-no-checks', cmd)
+
+    def test_not_added_when_version_unknown(self):
+        cmd = self._cmd_with(None)
+        self.assertNotIn('--allow-no-checks', cmd)
 
 
 def create_analyzer_cppcheck(args, workspace):


### PR DESCRIPTION
When checks come from the config, no `-checks` is passed. clang-tidy 19+
treats the resulting empty check set as a fatal error ("no checks
enabled"). Add `--allow-no-checks` on those versions only.
