### PR TITLE
[gui] Fix statistics expand panels & coloring

### DIFF
--- a/web/server/vue-cli/src/components/Report/SourceComponent/ListSourceComponents.vue
+++ b/web/server/vue-cli/src/components/Report/SourceComponent/ListSourceComponents.vue
@@ -40,7 +40,7 @@
       </v-toolbar>
     </template>
 
-    <template #item.value="{ item }">
+    <template #item.key="{ item }">
       <ul class="component-value">
         <li
           v-for="value in item.$values"
@@ -101,22 +101,22 @@ const itemsPerPageOptions = [
 const headers = [
   {
     title: "Name",
-    value: "name",
+    key: "name",
     sortable: true
   },
   {
     title: "Value",
-    value: "value",
+    key: "value",
     sortable: true
   },
   {
     title: "Description",
-    value: "description",
+    key: "description",
     sortable: true
   },
   {
     title: "Actions",
-    value: "actions",
+    key: "actions",
     sortable: false
   },
 ];

--- a/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/BaseStatisticsTable.vue
@@ -1,6 +1,7 @@
 <template>
   <v-data-table
-    v-bind="{ ...$props }"
+    v-bind="tableProps"
+    v-model:expanded="expandedModel"
     :row-props="getRowProps"
     :disable-pagination="true"
     :hide-default-footer="true"
@@ -583,10 +584,26 @@ const props = defineProps({
       "falsePositive", "intentional", "suppressed","reports" ]
   },
   necessaryTotal: { type: Boolean, default: false },
-  itemClass: { type: Function, default: null }
+  itemClass: { type: Function, default: null },
+  expanded: { type: Array, default: () => [] }
 });
 
-defineEmits([ "enabled-click" ]);
+const emit = defineEmits([ "enabled-click", "update:expanded" ]);
+
+const expandedModel = computed({
+  get() {
+    return props.expanded;
+  },
+  set(value) {
+    emit("update:expanded", value);
+  }
+});
+
+const tableProps = computed(function() {
+  // eslint-disable-next-line no-unused-vars
+  const { expanded, ...rest } = props;
+  return rest;
+});
 
 const route = useRoute();
 const reportStatus = useReportStatus();

--- a/web/server/vue-cli/src/components/Statistics/Component/ComponentStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Component/ComponentStatisticsTable.vue
@@ -9,13 +9,15 @@
     :total-columns="totalColumns"
     loading-text="Loading component statistics..."
     no-data-text="No component statistics available"
-    item-key="component"
+    item-value="component"
     show-expand
+    return-object
     :necessary-total="true"
-    @item-expanded="itemExpanded"
   >
-    <template v-slot:expanded-item="{ item }">
-      <expanded-item :item="item" :colspan="headers.length" />
+    <template v-slot:expanded-row="{ item }">
+      <tr>
+        <expanded-item :item="item" :colspan="headers.length" />
+      </tr>
     </template>
 
     <template
@@ -49,76 +51,83 @@ const expanded = ref([]);
 const headers = [
   {
     text: "",
-    value: "data-table-expand"
+    key: "data-table-expand"
   },
   {
     text: "Component",
-    value: "component",
+    key: "component",
     align: "center"
   },
   {
     text: "Unreviewed",
-    value: "unreviewed.count",
+    key: "unreviewed.count",
     align: "center"
   },
   {
     text: "Confirmed bug",
-    value: "confirmed.count",
+    key: "confirmed.count",
     align: "center"
   },
   {
     text: "Outstanding reports",
-    value: "outstanding.count",
+    key: "outstanding.count",
     align: "center"
   },
   {
     text: "False positive",
-    value: "falsePositive.count",
+    key: "falsePositive.count",
     align: "center"
   },
   {
     text: "Intentional",
-    value: "intentional.count",
+    key: "intentional.count",
     align: "center"
   },
   {
     text: "Suppressed reports",
-    value: "suppressed.count",
+    key: "suppressed.count",
     align: "center"
   },
   {
     text: "All reports",
-    value: "reports.count",
+    key: "reports.count",
     align: "center"
   }
 ];
+
+watch(expanded, function(newVal, oldVal) {
+  const added = newVal.find(_item => !oldVal.includes(_item));
+  if (added) {
+    loadCheckerStatistics(added);
+  }
+});
 
 watch(function() { return props.loading; }, function() {
   if (props.loading) return;
 
   expanded.value.forEach(_e => {
     const _item = props.items.find(_i => _i.component === _e.component);
-    itemExpanded({ item : _item });
+    if (_item) loadCheckerStatistics(_item);
   });
 });
 
-async function itemExpanded(expandedItem) {
-  if (expandedItem.item.checkerStatistics) return;
+async function loadCheckerStatistics(item) {
+  if (!item || item.checkerStatistics) return;
 
-  expandedItem.item.loading = true;
+  item.loading = true;
 
-  const _component = expandedItem.item.component;
+  const _component = item.component;
   const _runIds = props.filters.runIds;
   const _reportFilter = new ReportFilter(props.filters.reportFilter);
   _reportFilter["componentNames"] = [ _component ];
   const _cmpData = props.filters.cmpData;
 
   const _stats = await getCheckerStatistics(_runIds, _reportFilter, _cmpData);
-  expandedItem.item.checkerStatistics = _stats.map(_stat => ({
+  item.checkerStatistics = _stats.map(_stat => ({
     ..._stat,
     $queryParams: { "source-component": _component }
   }));
-  expandedItem.item.loading = false;
+  item.loading = false;
 }
 </script>
 

--- a/web/server/vue-cli/src/components/Statistics/Severity/ComponentSeverityStatistics/ComponentSeverityStatisticsTable.vue
+++ b/web/server/vue-cli/src/components/Statistics/Severity/ComponentSeverityStatistics/ComponentSeverityStatisticsTable.vue
@@ -9,13 +9,15 @@
     :total-columns="totalColumns"
     loading-text="Loading component statistics..."
     no-data-text="No component statistics available"
-    item-key="component"
+    item-value="component"
     show-expand
+    return-object
     :necessary-total="true"
-    @item-expanded="itemExpanded"
   >
-    <template v-slot:expanded-item="{ item }">
-      <expanded-item :item="item" :colspan="headers.length" />
+    <template v-slot:expanded-row="{ item }">
+      <tr>
+        <expanded-item :item="item" :colspan="headers.length" />
+      </tr>
     </template>
 
     <template
@@ -93,6 +95,13 @@ const headers = [
   }
 ];
 
+watch(expanded, function(newVal, oldVal) {
+  const added = newVal.find(_item => !oldVal.includes(_item));
+  if (added) {
+    loadCheckerStatistics(added);
+  }
+});
+
 watch(
   () => props.loading,
   () => {
@@ -100,28 +109,28 @@ watch(
 
     expanded.value.forEach(_e => {
       const _item = props.items.find(_i => _i.component === _e.component);
-      itemExpanded({ item : _item });
+      if (_item) loadCheckerStatistics(_item);
     });
   }
 );
 
-async function itemExpanded(expandedItem) {
-  if (expandedItem.item.checkerStatistics) return;
+async function loadCheckerStatistics(item) {
+  if (!item || item.checkerStatistics) return;
 
-  expandedItem.item.loading = true;
+  item.loading = true;
 
-  const _component = expandedItem.item.component;
+  const _component = item.component;
   const _runIds = props.filters.runIds;
   const _reportFilter = new ReportFilter(props.filters.reportFilter);
   _reportFilter["componentNames"] = [ _component ];
   const _cmpData = props.filters.cmpData;
 
   const _stats = await getCheckerStatistics(_runIds, _reportFilter, _cmpData);
-  expandedItem.item.checkerStatistics = _stats.map(_stat => ({
+  item.checkerStatistics = _stats.map(_stat => ({
     ..._stat,
     $queryParams: { "source-component": _component }
   }));
-  expandedItem.item.loading = false;
+  item.loading = false;
 }
 </script>
 

--- a/web/server/vue-cli/src/components/Statistics/_colored-columns.scss
+++ b/web/server/vue-cli/src/components/Statistics/_colored-columns.scss
@@ -23,11 +23,13 @@ $darken: 2;
 
 $tr: "tr:not(.v-data-table__expanded__content):not(.total-row)";
 
+$table: "#{$class-name} > .v-table__wrapper > table";
+
 @mixin set-cells-color($cols...) {
-  #{$class-name} table {
+  #{$table} {
     @each $col in $cols {
-      th:nth-child(#{$col}),
-      tbody #{$tr} td:nth-child(#{$col}) {
+      & > thead > tr > th:nth-child(#{$col}),
+      & > tbody > #{$tr} > td:nth-child(#{$col}) {
         @content;
       }
     }
@@ -35,9 +37,9 @@ $tr: "tr:not(.v-data-table__expanded__content):not(.total-row)";
 }
 
 @mixin set-total-row-color($cols...) {
-  #{$class-name} table tbody tr.total-row {
+  #{$table} > tbody > tr.total-row {
     @each $col in $cols {
-      td:nth-child(#{$col - $total-row-offset}) {
+      & > td:nth-child(#{$col - $total-row-offset}) {
         @content;
       }
     }
@@ -56,9 +58,9 @@ $tr: "tr:not(.v-data-table__expanded__content):not(.total-row)";
   }
 
   // Hover state for regular rows
-  #{$class-name} table tbody #{$tr}:hover {
+  #{$table} > tbody > #{$tr}:hover {
     @each $col in $cols {
-      td:nth-child(#{$col}) {
+      & > td:nth-child(#{$col}) {
         background-color: darken($bg-color, 5%);
       }
     }
@@ -86,7 +88,7 @@ $tr: "tr:not(.v-data-table__expanded__content):not(.total-row)";
   }
 }
 
-#{$class-name} > table {
+#{$table} {
   & > thead > tr:not(:last-child) > th:not(.v-data-table__mobile-row),
   & > tbody > tr:not(:last-child) > td:not(.v-data-table__mobile-row) {
     border-bottom: thin solid rgba(0, 0, 0, 0.12);

--- a/web/server/vue-cli/src/views/Reports.vue
+++ b/web/server/vue-cli/src/views/Reports.vue
@@ -493,26 +493,26 @@ const sortBy = ref(
 const headers = [
   {
     title: "",
-    value: "data-table-expand"
+    key: "data-table-expand"
   },
   {
     title: "Report hash",
-    value: "bugHash",
+    key: "bugHash",
     sortable: false
   },
   {
     title: "File",
-    value: "checkedFile",
+    key: "checkedFile",
     sortable: true
   },
   {
     title: "Message",
-    value: "checkerMsg",
+    key: "checkerMsg",
     sortable: false
   },
   {
     title: "Checker name",
-    value: "checkerId",
+    key: "checkerId",
     sortable: true
   },
   {
@@ -528,37 +528,37 @@ const headers = [
   },
   {
     title: "Bug path length",
-    value: "bugPathLength",
+    key: "bugPathLength",
     align: "center",
     sortable: true
   },
   {
     title: "Latest review status",
-    value: "reviewData",
+    key: "reviewData",
     align: "center",
     sortable: true
   },
   {
     title: "Latest detection status",
-    value: "detectionStatus",
+    key: "detectionStatus",
     align: "center",
     sortable: true
   },
   {
     title: "Timestamp",
-    value: "timestamp",
+    key: "timestamp",
     align: "center",
     sortable: true
   },
   {
     title: "Chronological order",
-    value: "chronological_order",
+    key: "chronological_order",
     align: "center",
     sortable: true
   },
   {
     title: "Testcase",
-    value: "testcase",
+    key: "testcase",
     align: "center",
     sortable: true
   }
@@ -601,25 +601,25 @@ const tableHeaders = computed(function() {
   if (!headers || !reportFilter.value) return [];
 
   return headers.filter(_header => {
-    if (_header.value === "detectionStatus") {
+    if (_header.key === "detectionStatus") {
       return !reportFilter.value.isUnique;
     }
 
-    if (_header.value === "data-table-expand") {
+    if (_header.key === "data-table-expand") {
       return reportFilter.value.isUnique;
     }
 
-    if (_header.value === "timestamp") {
+    if (_header.key === "timestamp") {
       return hasTimeStamp.value &&
         !reportFilter.value.isUnique;
     }
 
-    if (_header.value === "testcase") {
+    if (_header.key === "testcase") {
       return hasTestCase.value &&
         !reportFilter.value.isUnique;
     }
 
-    if (_header.value === "chronological_order") {
+    if (_header.key === "chronological_order") {
       return hasChronologicalOrder.value &&
         !reportFilter.value.isUnique;
     }


### PR DESCRIPTION
This change fixes two critical issues found in CodeChecker GUI:
* The expandable tables are not working for Component Severity Statistics and Component Statistics tables.
* The coloring for the expanded tables are shifted.