### PR TITLE
[server] Store SQLite product database paths relative to workspace

### DIFF
--- a/web/server/codechecker_server/api/mass_store_run.py
+++ b/web/server/codechecker_server/api/mass_store_run.py
@@ -45,7 +45,7 @@ from codechecker_report_converter.report.hash import get_report_path_hash
 
 from ..database import db_cleanup
 from ..database.config_db_model import Product
-from ..database.database import DBSession
+from ..database.database import DBSession, SQLServer
 from ..database.run_db_model import \
     AnalysisInfo, AnalysisInfoFile, AnalyzerStatistic, \
     ReportPathData, ReportPathDataFile, \
@@ -649,10 +649,14 @@ class MassStoreRunTask(AbstractTask):
             if not db_product:
                 raise KeyError(f"No product with ID '{self._product_id}'")
 
+            connection_string = SQLServer.resolve_sqlite_relative_path(
+                db_product.connection,
+                self._package_context.codechecker_workspace)
+
             self._product = ServerProduct(db_product.id,
                                           db_product.endpoint,
                                           db_product.display_name,
-                                          db_product.connection,
+                                          connection_string,
                                           self._package_context,
                                           tm.environment)
 

--- a/web/server/codechecker_server/api/product_server.py
+++ b/web/server/codechecker_server/api/product_server.py
@@ -31,7 +31,8 @@ from codechecker_web.shared import convert
 
 from .. import permissions
 from ..database.config_db_model import IDENTIFIER, Product, ProductPermission
-from ..database.database import DBSession, SQLServer, conv, escape_like
+from ..database.database import DBSession, SQLServer, SQLiteDatabase, \
+    conv, escape_like
 from ..routing import is_valid_product_endpoint
 
 from .thrift_enum_helper import confidentiality_enum, \
@@ -592,8 +593,10 @@ class ThriftProductHandler:
                     codechecker_api_shared.ttypes.ErrorCode.DATABASE,
                     "SQLite database must be given by relative path!")
 
-            dbc.database = path_for_fake_root(os.path.join(
+            resolved_path = path_for_fake_root(os.path.join(
                 "/", dbc.database), self.__server.workspace_directory)
+            dbc.database = os.path.relpath(
+                resolved_path, self.__server.workspace_directory)
 
         # Check if the database is already in use by another product.
         db_in_use = self.__server.is_database_used(product)
@@ -631,20 +634,23 @@ class ThriftProductHandler:
                              'dbusername': dbuser,
                              'dbpassword': dbpass,
                              'dbname': dbc.database}
+            conn_str = SQLServer \
+                .from_cmdline_args(conn_str_args, product.endpoint,
+                                   IDENTIFIER, None, False, None) \
+                .get_connection_string()
         elif dbc.engine == 'sqlite':
-            conn_str_args = {'postgresql': False,
-                             'sqlite': dbc.database}
+            # Built directly (bypassing from_cmdline_args) so the relative
+            # path is preserved instead of being resolved against the
+            # server process's current working directory.
+            conn_str = SQLiteDatabase(
+                product.endpoint, dbc.database, IDENTIFIER, None) \
+                .get_connection_string()
         else:
             msg = f"Database engine '{dbc.engine}' unknown!"
             LOG.error(msg)
             raise codechecker_api_shared.ttypes.RequestFailed(
                 codechecker_api_shared.ttypes.ErrorCode.GENERAL,
                 msg)
-
-        conn_str = SQLServer \
-            .from_cmdline_args(conn_str_args, product.endpoint, IDENTIFIER,
-                               None, False, None) \
-            .get_connection_string()
 
         is_rws_change_disabled = product.isReviewStatusChangeDisabled
 
@@ -767,14 +773,30 @@ class ThriftProductHandler:
             # preserved as is, if they are unchanged.
 
             old_args = SQLServer.connection_string_to_args(product.connection)
-            if dbc.engine == 'sqlite' and dbc.database != old_args['sqlite']:
-                if os.path.isabs(dbc.database):
-                    raise codechecker_api_shared.ttypes.RequestFailed(
-                        codechecker_api_shared.ttypes.ErrorCode.DATABASE,
-                        "SQLite database must be given by relative path!")
-                dbc.database = path_for_fake_root(
-                    os.path.join("/", dbc.database),
-                    self.__server.workspace_directory)
+            if dbc.engine == 'sqlite':
+                # Old products may still have an absolute path stored from
+                # before relative paths were introduced. Normalize it the
+                # same way toProduct() does when exposing it to clients, so
+                # an unchanged path is correctly detected as unchanged.
+                old_sqlite_path = old_args.get('sqlite')
+                if old_sqlite_path and os.path.isabs(old_sqlite_path):
+                    config_dir = os.path.normpath(
+                        self.__server.workspace_directory) + "/"
+                    if old_sqlite_path.startswith(config_dir):
+                        old_sqlite_path = \
+                            old_sqlite_path[len(config_dir):]
+
+                if dbc.database != old_sqlite_path:
+                    if os.path.isabs(dbc.database):
+                        raise codechecker_api_shared.ttypes.RequestFailed(
+                            codechecker_api_shared.ttypes.ErrorCode.DATABASE,
+                            "SQLite database must be given by relative "
+                            "path!")
+                    resolved_path = path_for_fake_root(
+                        os.path.join("/", dbc.database),
+                        self.__server.workspace_directory)
+                    dbc.database = os.path.relpath(
+                        resolved_path, self.__server.workspace_directory)
 
             # Some values come encoded as Base64, decode these.
             displayed_name = convert.from_b64(new_config.displayedName_b64) \
@@ -809,9 +831,17 @@ class ThriftProductHandler:
                                  'dbusername': dbuser,
                                  'dbpassword': dbpass,
                                  'dbname': dbc.database}
+                conn_str = SQLServer \
+                    .from_cmdline_args(conn_str_args, product.endpoint,
+                                       IDENTIFIER, None, False, None) \
+                    .get_connection_string()
             elif dbc.engine == 'sqlite':
-                conn_str_args = {'postgresql': False,
-                                 'sqlite': dbc.database}
+                # Built directly (bypassing from_cmdline_args) so the
+                # relative path is preserved instead of being resolved
+                # against the server process's current working directory.
+                conn_str = SQLiteDatabase(
+                    product.endpoint, dbc.database, IDENTIFIER, None) \
+                    .get_connection_string()
             else:
                 msg = f"Database engine '{dbc.engine}' unknown!"
                 LOG.error(msg)
@@ -819,17 +849,19 @@ class ThriftProductHandler:
                     codechecker_api_shared.ttypes.ErrorCode.GENERAL,
                     msg)
 
-            conn_str = SQLServer \
-                .from_cmdline_args(conn_str_args, product.endpoint,
-                                   IDENTIFIER, None, False, None) \
-                .get_connection_string()
-
             # If endpoint or database arguments change, the product
             # configuration has changed so severely, that it needs
-            # to be reconnected.
+            # to be reconnected. Resolve SQLite paths to their absolute
+            # form first, so a merely different (relative vs. legacy
+            # absolute) representation of the same path isn't seen as
+            # a change.
+            old_connection_resolved = SQLServer.resolve_sqlite_relative_path(
+                product.connection, self.__server.workspace_directory)
+            new_connection_resolved = SQLServer.resolve_sqlite_relative_path(
+                conn_str, self.__server.workspace_directory)
             product_needs_reconnect = \
                 product.endpoint != new_config.endpoint or \
-                product.connection != conn_str
+                old_connection_resolved != new_connection_resolved
             old_endpoint = product.endpoint
 
             if product_needs_reconnect:

--- a/web/server/codechecker_server/cli/server.py
+++ b/web/server/codechecker_server/cli/server.py
@@ -460,7 +460,8 @@ def get_schema_version_from_package(migration_root):
     return pckg_schema_ver.get_current_head()
 
 
-def check_product_db_status(cfg_sql_server, migration_root, environ):
+def check_product_db_status(cfg_sql_server, migration_root, environ,
+                            workspace_directory):
     """
     Check the products for database statuses.
 
@@ -495,7 +496,9 @@ def check_product_db_status(cfg_sql_server, migration_root, environ):
 
     prod_status = {}
     for pd in products:
-        db = database.SQLServer.from_connection_string(pd.connection,
+        connection_str = database.SQLServer.resolve_sqlite_relative_path(
+            pd.connection, workspace_directory)
+        db = database.SQLServer.from_connection_string(connection_str,
                                                        pd.endpoint,
                                                        RUN_META,
                                                        migration_root,
@@ -521,7 +524,7 @@ def check_product_db_status(cfg_sql_server, migration_root, environ):
 
 
 def __db_status_check(cfg_sql_server, migration_root, environ,
-                      product_name=None) -> int:
+                      workspace_directory, product_name=None) -> int:
     """
     Check and print database statuses for the given product.
     """
@@ -531,7 +534,7 @@ def __db_status_check(cfg_sql_server, migration_root, environ,
     LOG.debug("Checking database status for %s product.", product_name)
 
     prod_statuses = check_product_db_status(cfg_sql_server, migration_root,
-                                            environ)
+                                            environ, workspace_directory)
 
     if product_name != "all":
         avail = prod_statuses.get(product_name)
@@ -596,7 +599,7 @@ def __db_migration(migration_root,
 
 
 def __db_migration_multiple(
-    cfg_sql_server, migration_root, environ,
+    cfg_sql_server, migration_root, environ, workspace_directory,
     products_requested_for_upgrade: Optional[list[str]] = None,
     force_upgrade: bool = False
 ) -> int:
@@ -611,7 +614,8 @@ def __db_migration_multiple(
 
     prod_statuses = check_product_db_status(cfg_sql_server,
                                             migration_root,
-                                            environ)
+                                            environ,
+                                            workspace_directory)
     products_to_upgrade: list[str] = []
     for endpoint in (products_requested_for_upgrade or []):
         avail = prod_statuses.get(endpoint)
@@ -644,7 +648,9 @@ def __db_migration_multiple(
                 if product is None:
                     raise NonExistentProductError(endpoint)
 
-                connection_str = product.connection
+                connection_str = database.SQLServer \
+                    .resolve_sqlite_relative_path(
+                        product.connection, workspace_directory)
             except NonExistentProductError as nepe:
                 LOG.error("Attempted to upgrade product '%s', but it was not "
                           "found in the server's configuration database.",
@@ -901,8 +907,10 @@ def server_init_start(args):
         LOG.info("'--force-authentication' was passed as a command-line "
                  "option. The server will ask for users to authenticate!")
 
+    workspace_dir = os.path.abspath(args.workspace)
+
     context = webserver_context.get_context()
-    context.codechecker_workspace = args.workspace
+    context.codechecker_workspace = workspace_dir
     context.db_username = args.dbusername
 
     environ = env.extend(context.path_env_extra,
@@ -968,6 +976,7 @@ def server_init_start(args):
             ret = __db_status_check(cfg_sql_server,
                                     context.migration_root,
                                     environ,
+                                    workspace_dir,
                                     args.status)
             sys.exit(ret)
     except AttributeError:
@@ -979,6 +988,7 @@ def server_init_start(args):
                 cfg_sql_server,
                 context.migration_root,
                 environ,
+                workspace_dir,
                 [args.product_to_upgrade]
                 if args.product_to_upgrade != "all" else None,
                 force_upgrade)
@@ -988,7 +998,6 @@ def server_init_start(args):
 
     # Create the main database link from the arguments passed over the
     # command line.
-    workspace_dir = os.path.abspath(args.workspace)
     default_product_path = os.path.join(workspace_dir, 'Default.sqlite')
 
     # The 'Default' product should only be auto-created when the config
@@ -1022,7 +1031,12 @@ def server_init_start(args):
                 LOG.error("Failed to configure default product")
                 sys.exit(1)
 
-        product_conn_string = prod_server.get_connection_string()
+        # Store the database path relative to the workspace directory, so
+        # moving the workspace/config directory elsewhere does not break
+        # the product's database connection (see #3081).
+        product_conn_string = database.SQLiteDatabase(
+            "Default", 'Default.sqlite', RUN_META,
+            context.run_migration_root, environ).get_connection_string()
 
         server.add_initial_run_database(
             cfg_sql_server, product_conn_string)
@@ -1032,7 +1046,8 @@ def server_init_start(args):
 
     prod_statuses = check_product_db_status(cfg_sql_server,
                                             context.run_migration_root,
-                                            environ)
+                                            environ,
+                                            workspace_dir)
 
     upgrade_available = {}
     for k, v in prod_statuses.items():
@@ -1046,12 +1061,14 @@ def server_init_start(args):
         __db_migration_multiple(cfg_sql_server,
                                 context.run_migration_root,
                                 environ,
+                                workspace_dir,
                                 None,
                                 force_upgrade)
 
         prod_statuses = check_product_db_status(cfg_sql_server,
                                                 context.run_migration_root,
-                                                environ)
+                                                environ,
+                                                workspace_dir)
     print_prod_status(prod_statuses)
 
     non_ok_db = False
@@ -1079,7 +1096,7 @@ def server_init_start(args):
 
     try:
         return server.start_server(args.config_directory,
-                                   args.workspace,
+                                   workspace_dir,
                                    package_data,
                                    args.view_port,
                                    cfg_sql_server,

--- a/web/server/codechecker_server/database/database.py
+++ b/web/server/codechecker_server/database/database.py
@@ -441,6 +441,25 @@ class SQLServer(metaclass=ABCMeta):
         return args
 
     @staticmethod
+    def resolve_sqlite_relative_path(
+        connection_string: str, workspace_directory: str
+    ) -> str:
+        """
+        If connection_string is an SQLite connection with a relative
+        database path, resolve that path against workspace_directory and
+        return the resulting connection string. PostgreSQL connection
+        strings, and SQLite ones that already use an absolute path, are
+        returned unchanged.
+        """
+        url = make_url(connection_string)
+        if 'sqlite' not in url.drivername or not url.database or \
+                os.path.isabs(url.database):
+            return connection_string
+
+        return str(url.set(
+            database=os.path.join(workspace_directory, url.database)))
+
+    @staticmethod
     def from_connection_string(connection_string: str,
                                name_in_log: str,
                                model_meta,

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -609,7 +609,7 @@ def _do_db_cleanups(config_database, context, check_env,
         for product, result in \
                 zip(products, executor.map(
                     partial(_do_db_cleanup, context, check_env,
-                           workspace_directory),
+                            workspace_directory),
                     *zip(*products))):
             success, reason = result
             if not success:

--- a/web/server/codechecker_server/server.py
+++ b/web/server/codechecker_server/server.py
@@ -65,7 +65,7 @@ from .api.server_info_handler import \
 from .api.tasks import ThriftTaskHandler as TaskHandler_v6
 from .database.config_db_model import Product as ORMProduct, \
     Configuration as ORMConfiguration
-from .database.database import DBSession
+from .database.database import DBSession, SQLServer
 from .database.run_db_model import Run
 from .database import db_cleanup
 from .product import Product
@@ -547,11 +547,13 @@ class RequestHandler(SimpleHTTPRequestHandler):
         self.send_error(405, "No permission to list directory")
 
 
-def _do_db_cleanup(context, check_env,
+def _do_db_cleanup(context, check_env, workspace_directory,
                    id_: int, endpoint: str, display_name: str,
                    connection_str: str) -> tuple[Optional[bool], str]:
     # This functions is a concurrent job handler!
     try:
+        connection_str = SQLServer.resolve_sqlite_relative_path(
+            connection_str, workspace_directory)
         prod = Product(id_, endpoint, display_name, connection_str,
                        context, check_env)
         prod.connect(init_db=False)
@@ -572,7 +574,8 @@ def _do_db_cleanup(context, check_env,
         return False, str(e)
 
 
-def _do_db_cleanups(config_database, context, check_env) \
+def _do_db_cleanups(config_database, context, check_env,
+                    workspace_directory) \
         -> tuple[bool, list[tuple[str, str]]]:
     """
     Performs on-demand start-up database cleanup on all the products present
@@ -605,7 +608,8 @@ def _do_db_cleanups(config_database, context, check_env) \
                  thr_count)
         for product, result in \
                 zip(products, executor.map(
-                    partial(_do_db_cleanup, context, check_env),
+                    partial(_do_db_cleanup, context, check_env,
+                           workspace_directory),
                     *zip(*products))):
             success, reason = result
             if not success:
@@ -851,10 +855,13 @@ class CCSimpleHttpServer(HTTPServer):
 
         LOG.debug("Setting up product '%s'", orm_product.endpoint)
 
+        connection_string = SQLServer.resolve_sqlite_relative_path(
+            orm_product.connection, self.workspace_directory)
+
         prod = Product(orm_product.id,
                        orm_product.endpoint,
                        orm_product.display_name,
-                       orm_product.connection,
+                       connection_string,
                        self.context,
                        self.check_env)
 
@@ -903,16 +910,23 @@ class CCSimpleHttpServer(HTTPServer):
         driver = \
             'pysqlite' if conn.connection.engine == 'sqlite' else 'psycopg2'
 
+        db_name = conn.connection.database
+        if conn.connection.engine == 'sqlite' and \
+                not os.path.isabs(db_name):
+            db_name = os.path.join(self.workspace_directory, db_name)
+
         # create a tuple of database that is going to be added for comparison
         to_add = (
             f"{conn.connection.engine}+{driver}",
-            conn.connection.database,
+            db_name,
             conn.connection.host,
             conn.connection.port)
 
         # create a tuple of database that is already connected for comparison
         def to_tuple(product):
-            url = make_url(product.connection)
+            connection_string = SQLServer.resolve_sqlite_relative_path(
+                product.connection, self.workspace_directory)
+            url = make_url(connection_string)
             return url.drivername, url.database, url.host, url.port
         # creates a list of currently connected databases
         current_connected_databases = list(map(
@@ -1074,7 +1088,8 @@ def start_server(config_directory: str, workspace_directory: str,
 
         all_success, fails = _do_db_cleanups(config_sql_server,
                                              context,
-                                             check_env)
+                                             check_env,
+                                             workspace_directory)
         if not all_success:
             LOG.error("Failed to perform automatic cleanup on %d products! "
                       "Earlier logs might contain additional detailed "

--- a/web/server/tests/unit/test_sqlite_relative_path.py
+++ b/web/server/tests/unit/test_sqlite_relative_path.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+#
+#  Part of the CodeChecker project, under the Apache License v2.0 with
+#  LLVM Exceptions. See LICENSE for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# -------------------------------------------------------------------------
+""" Unit tests for resolving SQLite product database paths. """
+
+
+import unittest
+
+from codechecker_server.database.database import SQLServer
+
+
+class SqliteRelativePathTest(unittest.TestCase):
+    """
+    Tests for SQLServer.resolve_sqlite_relative_path, which turns a
+    workspace-relative SQLite connection string back into an absolute one
+    at connect time (see #3081: product database paths used to be stored
+    as absolute paths, breaking when the workspace directory was moved).
+    """
+
+    def test_resolves_relative_sqlite_path(self):
+        connection_string = 'sqlite+pysqlite:///foo.sqlite'
+        resolved = SQLServer.resolve_sqlite_relative_path(
+            connection_string, '/work/cfg')
+        self.assertEqual(resolved, 'sqlite+pysqlite:////work/cfg/foo.sqlite')
+
+    def test_leaves_absolute_sqlite_path_unchanged(self):
+        connection_string = 'sqlite+pysqlite:////abs/foo.sqlite'
+        resolved = SQLServer.resolve_sqlite_relative_path(
+            connection_string, '/work/cfg')
+        self.assertEqual(resolved, connection_string)
+
+    def test_leaves_postgresql_connection_unchanged(self):
+        connection_string = \
+            'postgresql+psycopg2://user:pass@host:5432/dbname'
+        resolved = SQLServer.resolve_sqlite_relative_path(
+            connection_string, '/work/cfg')
+        self.assertEqual(resolved, connection_string)


### PR DESCRIPTION
## Summary
- `config.sqlite` stored absolute paths for each product's SQLite database. Copying/moving a server's config or workspace directory elsewhere (e.g. to test as a different user, per the reproduction steps in #3081) left the server trying to reach the old, now-inaccessible location for every product except `config.sqlite` itself.
- New and edited SQLite-backed products now have their database path stored relative to the workspace directory, and it's resolved back to an absolute path everywhere the server actually connects to a product: normal startup (`add_product`), background config-db cleanup, background `massStoreRun` tasks, and the CLI's migration/status-check paths.
- Existing rows with an absolute path are left untouched and continue to work (no DB migration needed); editing such a product will naturally migrate it to a relative path going forward.

## Test plan
- [x] Added `web/server/tests/unit/test_sqlite_relative_path.py` covering the new `SQLServer.resolve_sqlite_relative_path` helper (relative sqlite path resolves against workspace dir; absolute sqlite path and postgres connection strings pass through unchanged).
- [x] Full existing unit suite (`web/server/tests/unit`) passes.
- [x] Functional test `tests/functional/products/test_products.py::test_add_invalid_product` passes against a live server.
- [x] Manually reproduced the exact issue scenario: started a server, confirmed `config.sqlite` stores a relative path (`sqlite+pysqlite:///Default.sqlite`), copied the whole workspace directory to a new path (simulating copying to a different user's home), and confirmed a fresh server instance pointed at the copy connects to its own database with no reference to the original path anywhere in the logs.

Fixes #3081