### PR TITLE
[test] No hicpp in the latest clang-tidy

### DIFF
--- a/analyzer/tests/unit/test_checker_handling.py
+++ b/analyzer/tests/unit/test_checker_handling.py
@@ -643,7 +643,7 @@ class CheckerHandlingClangTidyTest(unittest.TestCase):
             analyzer.construct_analyzer_cmd(result_handler)))
 
         analyzer.config_handler.checker_config = \
-            '{"Checks": "hicpp-use-nullptr"}'
+            '{"Checks": "modernize-use-nullptr"}'
 
         self.assertTrue(self._is_disabled(
             'clang-analyzer',

--- a/web/tests/functional/detection_status/test_detection_status.py
+++ b/web/tests/functional/detection_status/test_detection_status.py
@@ -422,24 +422,25 @@ int main()
 
     def test_detection_status_off_with_cfg(self):
         """ Test detection status with .clang-tidy config file. """
-        # Explicitly disable all hicpp checkers from the command line but
-        # enable all hicpp and modernize checkers from the .clang-tidy file.
-        # If we store the results to the server than no reports will be marked
-        # as OFF.
+        # Explicitly disable all readability checkers from the command line but
+        # enable all readability and modernize checkers from the .clang-tidy
+        # file. If we store the results to the server, then no reports will be
+        # marked as OFF.
         cfg = dict(self._codechecker_cfg)
-        cfg['checkers'] = ['-d', 'hicpp']
+        cfg['checkers'] = ['-d', 'readability']
         cfg['analyzer_config'] = ['clang-tidy:take-config-from-directory=true']
 
         self._create_source_file(1)
-        self._create_clang_tidy_cfg_file(['-*', 'hicpp-*', 'modernize-*'])
+        self._create_clang_tidy_cfg_file(
+            ['-*', 'readability-*', 'modernize-*'])
         return_code = self._check_source_file(cfg)
         self.assertEqual(return_code, 0)
         reports = self._cc_client.getRunResults(
             None, 100, 0, [], ReportFilter(), None, False)
 
-        hicpp_results = [r for r in reports
-                         if r.checkerId.startswith('hicpp')]
-        self.assertTrue(hicpp_results)
+        readability_results = [
+            r for r in reports if r.checkerId.startswith('readability')]
+        self.assertTrue(readability_results)
 
         modernize_results = [r for r in reports
                              if r.checkerId.startswith('modernize')]


### PR DESCRIPTION
In the latest clang-tidy version there are no hicpp-* checkers. A different checker group should be used for testing.